### PR TITLE
fix: revert secret keys to SCREAMING_SNAKE_CASE and bump SHA to v2.0.0

### DIFF
--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   todos:
-    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@3273c09293df3e99d4aa9601de31d0f51279120c # v1.33.0
+    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@a7c930391dcd50fcb1721153c5fb08f7dbfc9ee8 # v2.0.0
     secrets:
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Fixes incorrect secret key rename from #1498 and bumps SHA to the final v2.0.0 release.

Secret keys must remain in SCREAMING_SNAKE_CASE because dual-trigger workflows need secret keys matching repo secret names (devantler-tech/reusable-workflows#188).

## Changes
 `APP_PRIVATE_KEY:` (todos.yaml)
- SHA bumped from `3273c09... # v1.33.0` to `a7c9303... # v2.0.0`