### PR TITLE
feat: add maintenance submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,7 @@
 	path = projects/ksail
 	url = git@github.com:devantler-tech/ksail.git
 	branch = main
+[submodule "github/devantler-tech/maintenance"]
+	path = github/devantler-tech/maintenance
+	url = git@github.com:devantler-tech/maintenance.git
+	branch = main


### PR DESCRIPTION
Adds the `devantler-tech/maintenance` repository as a git submodule so maintenance-related configs and workflows are co-located with the rest of the org's tooling in this monorepo.

- Submodule path: `github/devantler-tech/maintenance`
- Tracks: `main` branch
- Remote: `git@github.com:devantler-tech/maintenance.git`