### PR TITLE
chore: pin reusable-workflows to v2.2.0 SHA

### DIFF
--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   todos:
-    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@a7c930391dcd50fcb1721153c5fb08f7dbfc9ee8 # v2.0.0
+    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@9ec9792d6c140612f6b5bafa5dc786e751b5ff1a # v2.2.0
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Description

Updates the `devantler-tech/reusable-workflows` callsite in `.github/workflows/todos.yaml` to use the SHA for the latest semver release (`v2.2.0`).

### Changes

| File | Old | New |
|------|-----|-----|
| `.github/workflows/todos.yaml` | `@a7c930391dcd50fcb1721153c5fb08f7dbfc9ee8` (`v2.0.0`) | `@9ec9792d6c140612f6b5bafa5dc786e751b5ff1a` (`v2.2.0`) |