### PR TITLE
docs: professionalize the Astro docs site

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,6 +3,7 @@ import mermaid from "astro-mermaid";
 import { defineConfig } from "astro/config";
 import starlightBlog from "starlight-blog";
 import starlightGithubAlerts from "starlight-github-alerts";
+import starlightLinksValidator from "starlight-links-validator";
 
 export default defineConfig({
   site: "https://devantler.tech",
@@ -12,6 +13,7 @@ export default defineConfig({
       title: "Nikolai Emil | Devantler",
       description:
         "Personal site of Nikolai Emil Damm — software engineer, open-source advocate, and Kubernetes enthusiast.",
+      defaultLocale: "en",
       logo: {
         src: "./src/assets/author.png",
         replacesTitle: false,
@@ -52,8 +54,32 @@ export default defineConfig({
           },
         }),
         starlightGithubAlerts(),
+        starlightLinksValidator({
+          errorOnRelativeLinks: false,
+          exclude: ["/blog/**", "/blog/"],
+        }),
       ],
       head: [
+        {
+          tag: "meta",
+          attrs: { property: "og:image", content: "https://devantler.tech/author.png" },
+        },
+        {
+          tag: "meta",
+          attrs: { property: "og:type", content: "website" },
+        },
+        {
+          tag: "meta",
+          attrs: { name: "twitter:card", content: "summary_large_image" },
+        },
+        {
+          tag: "meta",
+          attrs: { name: "twitter:image", content: "https://devantler.tech/author.png" },
+        },
+        {
+          tag: "meta",
+          attrs: { name: "author", content: "Nikolai Emil Damm" },
+        },
         {
           tag: "script",
           attrs: {

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,8 +6,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro",
-    "sync-projects": "node scripts/sync-projects.mjs"
+    "astro": "astro"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.38.3",

--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -14,7 +14,7 @@ I am a Developer Experience Engineer based in Denmark with an MSc in Software En
 
 <dl class="about-meta">
   <div><dt>Name</dt><dd>Nikolai Emil Damm</dd></div>
-  <div><dt>Location</dt><dd>Haderslev, Denmark</dd></div>
+  <div><dt>Location</dt><dd>Funen, Denmark</dd></div>
   <div><dt>Role</dt><dd>Developer Experience Engineer</dd></div>
   <div><dt>Education</dt><dd>MSc in Software Engineering</dd></div>
   <div><dt>Languages</dt><dd>Danish, English</dd></div>

--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -10,19 +10,16 @@ import profileImg from "../../assets/profile.jpg";
   <Image src={profileImg} alt="Nikolai Emil Damm" width={280} style="border-radius: 50%;" />
 </div>
 
-> **Name**: Nikolai Emil Damm
->
-> **Location**: Haderslev, Denmark
->
-> **Education**: MSc in Software Engineering
->
-> **Occupation**: Developer Experience Engineer
->
-> **Languages**: Danish, English
->
-> **Interests**: Socializing, CrossFit, Running, Gaming, Technology, Music
+I am a Developer Experience Engineer based in Denmark with an MSc in Software Engineering. I build open-source developer tools, operate Kubernetes platforms, and care deeply about making engineers more effective. My focus is on CNCF technologies, GitOps, and reducing friction in the software delivery lifecycle.
 
-Open-source advocate and cloud-native enthusiast. I care deeply about collaborative software, CNCF technologies, and building tools that make engineers more effective.
+<dl class="about-meta">
+  <div><dt>Name</dt><dd>Nikolai Emil Damm</dd></div>
+  <div><dt>Location</dt><dd>Haderslev, Denmark</dd></div>
+  <div><dt>Role</dt><dd>Developer Experience Engineer</dd></div>
+  <div><dt>Education</dt><dd>MSc in Software Engineering</dd></div>
+  <div><dt>Languages</dt><dd>Danish, English</dd></div>
+  <div><dt>Interests</dt><dd>CrossFit, running, gaming, music, technology</dd></div>
+</dl>
 
 ## Talks and Presentations
 
@@ -55,7 +52,7 @@ _Energinet, Fredericia — Consultant_
 <details>
   <summary>Learn more...</summary>
 
-Working as a Consultant at Energinet, I was part of a Platform team in the Infrastructure and Platforms department. As a member of the Platform team my primary focus was on platform engineering. The team's vision was to provide a Kubernetes platform to create and manage single-tenant and multi-tenant Kubernetes clusters for the organization.
+Promoted to Consultant and moved to the Platform team in the Infrastructure and Platforms department, where I helped scope, design, and implement a shared Kubernetes platform for the organization. The team's vision was to provide managed single-tenant and multi-tenant Kubernetes clusters across Energinet.
 
 - Developing and maintaining Kubernetes platforms.
 - Developing and maintaining different tenancy models.
@@ -76,9 +73,7 @@ _Energinet, Fredericia — Junior Consultant_
 <details>
   <summary>Learn more...</summary>
 
-Working as a Junior Consultant at Energinet, I was part of the Substation Data team in the Innovation department. As a member of the Substation Data team my primary focus was on platform engineering and IT/OT convergence.
-
-From September 2024 to June 2025 I was lent out to a platform engineering team, to help scope, design, and implement a new shared Kubernetes platform for the organization.
+As a Junior Consultant at Energinet, I was part of the Substation Data team in the Innovation department, focused on platform engineering and IT/OT convergence.
 
 - Developing and maintaining Kubernetes platforms.
 - Developing and maintaining GitOps tooling.
@@ -222,7 +217,9 @@ Part of the development team for the GF Forsikring website and landing pages.
 
 ## Connect
 
-- [LinkedIn](https://www.linkedin.com/in/nikolai-emil-damm-14a786150/)
-- [GitHub](https://github.com/devantler)
-- [Sponsor on GitHub](https://github.com/sponsors/devantler)
-- [RSS Feed](/blog/rss.xml)
+<ul class="connect-bar">
+  <li><a href="https://www.linkedin.com/in/nikolai-emil-damm-14a786150/">LinkedIn</a></li>
+  <li><a href="https://github.com/devantler">GitHub</a></li>
+  <li><a href="https://github.com/sponsors/devantler">Sponsor</a></li>
+  <li><a href="/blog/rss.xml">RSS</a></li>
+</ul>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -52,38 +52,50 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 <CardGrid>
   <LinkCard
     title="🛥️ KSail"
-    description="A Go CLI for provisioning GitOps-enabled Kubernetes clusters. One binary, multiple distributions."
+    description="A Go CLI that bundles kubectl, helm, kind, k3d, flux, and argocd into a single binary. One tool for GitOps-enabled Kubernetes clusters."
     href="https://ksail.devantler.tech"
   />
   <LinkCard
     title="☸️ Platform"
-    description="GitOps-based Kubernetes platform running on Talos Linux with Flux, Cilium, and Traefik."
-    href="/projects/active/#%EF%B8%8F-platform--"
+    description="A GitOps-driven Kubernetes platform on Talos Linux and Hetzner Cloud — powered by Flux, Cilium, and Traefik."
+    href="/projects/active/"
+  />
+  <LinkCard
+    title="🔄 Reusable Workflows"
+    description="A curated library of GitHub Actions reusable workflows for Go, .NET, docs, releases, and repo automation."
+    href="https://github.com/devantler-tech/reusable-workflows"
+  />
+  <LinkCard
+    title="⚡ Actions"
+    description="Composite GitHub Actions for common CI/CD needs: auto-merge, GHCR cleanup, label sync, TODO scanning, and more."
+    href="https://github.com/devantler-tech/actions"
   />
 </CardGrid>
+
+[Browse all projects &rarr;](/projects/)
 
 ## Latest from the Blog
 
 <CardGrid>
   <LinkCard
+    title="I Built an MCP Server into My Kubernetes CLI"
+    description="KSail now ships with a built-in MCP server so Claude, Cursor, and other AI assistants can manage clusters directly."
+    href="/blog/mcp-server-for-kubernetes-cluster-management/"
+  />
+  <LinkCard
+    title="GitOps Without the Git Server"
+    description="Using OCI registries as a Flux source with KSail — a cleaner alternative to local Git servers for tight dev loops."
+    href="/blog/gitops-without-the-git-server-oci-registries-as-a-flux-source-with-ksail/"
+  />
+  <LinkCard
+    title="Storing Secrets in .zshrc with macOS Keychain"
+    description="A quick, practical guide for keeping sensitive environment variables out of plaintext dotfiles."
+    href="/blog/storing-secrets-in-zshrc-with-macos-keychain/"
+  />
+  <LinkCard
     title="Building an AI Assistant for Kubernetes"
-    description="How I built KSail's interactive Copilot-powered chat assistant using Go and Bubbletea TUI."
+    description="How I built KSail's interactive Copilot-powered chat assistant using Go and the Bubbletea TUI framework."
     href="/blog/building-an-ai-assistant-for-kubernetes-with-github-copilot-sdk/"
-  />
-  <LinkCard
-    title="Kubernetes Clusters on Hetzner with KSail"
-    description="A step-by-step guide to creating Talos Linux clusters on Hetzner Cloud."
-    href="/blog/creating-development-kubernetes-clusters-on-hetzner-with-ksail-and-talos/"
-  />
-  <LinkCard
-    title="AI-Powered GitHub Issues"
-    description="How I use Copilot with Claude Opus to create well-structured, impactful issues."
-    href="/blog/ai-powered-github-issues-with-copilot-and-claude-opus/"
-  />
-  <LinkCard
-    title="From Shell Scripts to .NET to Go"
-    description="The journey of building KSail through three major rewrites."
-    href="/blog/building-ksail-from-shell-to-dotnet-to-go/"
   />
 </CardGrid>
 

--- a/docs/src/content/docs/projects/index.md
+++ b/docs/src/content/docs/projects/index.md
@@ -1,8 +1,0 @@
----
-title: Projects
-description: Active, completed, and school projects by Nikolai Emil Damm.
----
-
-[![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/devantler)
-
-Browse my projects by category — from actively maintained tools to completed work and academic research.

--- a/docs/src/content/docs/projects/index.mdx
+++ b/docs/src/content/docs/projects/index.mdx
@@ -1,0 +1,23 @@
+---
+title: Projects
+description: Active and completed projects by Nikolai Emil Damm — open-source tools, platforms, and research.
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+[![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/devantler)
+
+A curated view of what I build and maintain in the open — from everyday developer tooling like **KSail** to full GitOps platforms, reusable workflows, and academic research. Browse by category below.
+
+<CardGrid>
+  <LinkCard
+    title="Active Projects"
+    description="Tools and platforms I am currently building and maintaining. Contributions welcome."
+    href="/projects/active/"
+  />
+  <LinkCard
+    title="Completed Projects"
+    description="Past work and academic research that reached end of life or is no longer actively maintained."
+    href="/projects/completed/"
+  />
+</CardGrid>

--- a/docs/src/content/docs/templates/dotnet.md
+++ b/docs/src/content/docs/templates/dotnet.md
@@ -1,26 +1,35 @@
 ---
 title: 📁 .NET Template
-description: A simple .NET template for new projects with CI/CD, testing, and code quality tooling.
+description: A .NET starter template with CI/CD, testing, publishing, and code quality tooling.
 ---
 
-A simple .NET template for new projects with CI/CD, testing, and code quality tooling.
+A minimal, batteries-included template for new .NET projects and libraries. Skip the boilerplate — start shipping.
 
 **Repository**: [devantler-tech/dotnet-template](https://github.com/devantler-tech/dotnet-template)
 
-## Features
+## What's Inside
 
-- **CI/CD pipelines with GitHub Actions**
-- **Publish libraries to GHCR and NuGet**
-- **Test projects and collect coverage with Codecov**
-- **EditorConfig with preferred .NET code style**
-- **Dependency management with Renovate**
+- **CI/CD** — GitHub Actions workflows for build, test, lint, and release
+- **Publishing** — Release libraries to [GitHub Container Registry](https://docs.github.com/en/packages) and [NuGet](https://www.nuget.org/) automatically
+- **Testing** — Test projects with coverage reporting via [Codecov](https://about.codecov.io/)
+- **Code style** — `.editorconfig` with opinionated .NET code style
+- **Dependency management** — [Renovate](https://docs.renovatebot.com/) keeps NuGet packages and Actions up to date
+- **Release automation** — Semantic versioning and automated GitHub Releases
 
 ## Getting Started
 
 ```bash
-# Clone the template
+# Create a new repo from the template
 gh repo create my-project --template devantler-tech/dotnet-template --public --clone
 
 # Restore packages
 cd my-project && dotnet restore
+
+# Run tests
+dotnet test
 ```
+
+## Links
+
+- 📦 [Template on GitHub](https://github.com/devantler-tech/dotnet-template)
+- 🔄 [Reusable workflows used by this template](https://github.com/devantler-tech/reusable-workflows)

--- a/docs/src/content/docs/templates/go.md
+++ b/docs/src/content/docs/templates/go.md
@@ -1,25 +1,34 @@
 ---
 title: 🐹 Go Template
-description: A simple Go template for new projects with CI/CD, testing, and code quality tooling.
+description: A Go starter template with CI/CD, testing, and code quality tooling.
 ---
 
-A simple Go template for new projects with CI/CD, testing, and code quality tooling.
+A minimal, batteries-included template for new Go projects. Skip the boilerplate — start shipping.
 
 **Repository**: [devantler-tech/go-template](https://github.com/devantler-tech/go-template)
 
-## Features
+## What's Inside
 
-- **CI/CD pipelines with GitHub Actions**
-- **Test projects and collect coverage with Codecov**
-- **Go Report Card integration**
-- **Dependency management with Renovate**
+- **CI/CD** — GitHub Actions workflows for build, test, lint, and release
+- **Testing** — `go test` with coverage reporting via [Codecov](https://about.codecov.io/)
+- **Quality** — [Go Report Card](https://goreportcard.com/) integration for continuous code-quality feedback
+- **Dependency management** — [Renovate](https://docs.renovatebot.com/) keeps Go modules and Actions up to date
+- **Release automation** — Semantic versioning and automated GitHub Releases
 
 ## Getting Started
 
 ```bash
-# Clone the template
+# Create a new repo from the template
 gh repo create my-project --template devantler-tech/go-template --public --clone
 
 # Install dependencies
 cd my-project && go mod tidy
+
+# Run tests
+go test ./...
 ```
+
+## Links
+
+- 📦 [Template on GitHub](https://github.com/devantler-tech/go-template)
+- 🔄 [Reusable workflows used by this template](https://github.com/devantler-tech/reusable-workflows)

--- a/docs/src/content/docs/templates/index.md
+++ b/docs/src/content/docs/templates/index.md
@@ -1,8 +1,0 @@
----
-title: Templates
-description: Project templates for Go and .NET development.
----
-
-[![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/devantler)
-
-Starter templates with CI/CD, testing, and code quality tooling baked in.

--- a/docs/src/content/docs/templates/index.mdx
+++ b/docs/src/content/docs/templates/index.mdx
@@ -1,0 +1,23 @@
+---
+title: Templates
+description: Opinionated Go and .NET starter templates with CI/CD, testing, and code quality baked in.
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+[![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/devantler)
+
+Starter templates that skip the boilerplate and get you straight to shipping. Each template comes with GitHub Actions workflows, test coverage, code quality tooling, and Renovate for dependency management.
+
+<CardGrid>
+  <LinkCard
+    title="🐹 Go Template"
+    description="A minimal Go template with CI/CD, test coverage via Codecov, Go Report Card, and Renovate."
+    href="/templates/go/"
+  />
+  <LinkCard
+    title="📁 .NET Template"
+    description="A minimal .NET template with CI/CD, NuGet/GHCR publishing, Codecov, EditorConfig, and Renovate."
+    href="/templates/dotnet/"
+  />
+</CardGrid>

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -4,6 +4,11 @@
 
 html {
   scroll-behavior: smooth;
+  overflow-x: hidden;
+}
+
+body {
+  overflow-x: hidden;
 }
 
 /* Smooth theme transitions */
@@ -144,15 +149,24 @@ a {
 
 /* ─── Hero Section — Full-Width Background ─── */
 
+/* Break the hero out of the content column so the matrix background
+   truly covers the viewport edge-to-edge on the splash page. */
+[data-has-hero] main > .hero,
+main > .hero,
 .hero {
   position: relative;
   display: flex !important;
   flex-direction: column !important;
   align-items: center !important;
   justify-content: center !important;
-  min-height: 420px;
-  padding: 4rem 2rem 3rem !important;
+  min-height: 520px;
+  padding: 5rem 2rem 4rem !important;
   text-align: center;
+  width: 100vw;
+  max-width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  overflow: hidden;
 }
 
 /* Matrix image as full-width background */
@@ -167,6 +181,10 @@ a {
   border-radius: 0 !important;
   opacity: 0.55;
   pointer-events: none;
+}
+
+:root[data-theme="light"] .hero > img {
+  opacity: 0.28;
 }
 
 /* Dark overlay gradient */
@@ -241,10 +259,10 @@ a {
 
 /* Hero tagline */
 .hero .tagline {
-  opacity: 0.92;
-  max-width: 48ch;
+  opacity: 0.94;
+  max-width: 56ch;
   text-align: center;
-  font-size: 1.15rem;
+  font-size: 1.18rem;
   text-shadow: 0 1px 12px rgba(0, 0, 0, 0.25);
   line-height: 1.65;
 }
@@ -301,7 +319,9 @@ a {
 
 .card:hover {
   border-color: var(--card-border-hover) !important;
-  box-shadow: 0 4px 24px var(--glow-color-subtle);
+  box-shadow:
+    0 4px 24px var(--glow-color-subtle),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
   transform: translateY(-2px);
 }
 
@@ -327,6 +347,97 @@ a {
   display: inline-block;
   margin-right: 0.25rem;
   vertical-align: middle;
+}
+
+/* ─── About Page — Meta Info Card ─── */
+
+.sl-markdown-content dl.about-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.25rem 1.5rem;
+  margin: 1.5rem 0 2rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-left: 3px solid var(--sl-color-accent);
+  border-radius: 0.5rem;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.sl-markdown-content dl.about-meta > div {
+  display: flex;
+  flex-direction: column;
+  padding: 0.4rem 0;
+}
+
+.sl-markdown-content dl.about-meta dt {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--sl-color-accent);
+  opacity: 0.85;
+  margin: 0;
+}
+
+.sl-markdown-content dl.about-meta dd {
+  margin: 0.15rem 0 0;
+  font-size: 0.98rem;
+  font-weight: 500;
+}
+
+/* ─── About Page — Connect Bar ─── */
+
+.sl-markdown-content ul.connect-bar {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.sl-markdown-content ul.connect-bar li {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: inline-flex;
+}
+
+.sl-markdown-content ul.connect-bar a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1.25rem;
+  border: 1px solid var(--card-border);
+  border-radius: 9999px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  text-decoration: none;
+  background: var(--card-bg);
+  transition:
+    border-color 0.25s ease,
+    background-color 0.25s ease,
+    box-shadow 0.25s ease,
+    transform 0.25s ease;
+}
+
+.sl-markdown-content ul.connect-bar a:hover {
+  border-color: var(--sl-color-accent);
+  background: var(--glow-color-subtle);
+  box-shadow: 0 2px 12px var(--glow-color-subtle);
+  transform: translateY(-1px);
+  color: var(--sl-color-accent);
+}
+
+@media (max-width: 50rem) {
+  .sl-markdown-content ul.connect-bar {
+    flex-direction: column;
+  }
+  .sl-markdown-content ul.connect-bar a {
+    justify-content: center;
+  }
 }
 
 /* ─── About Page — Profile ─── */
@@ -1089,8 +1200,8 @@ a[rel="prev"]:hover,
 
 @media (max-width: 50rem) {
   .hero {
-    min-height: 320px;
-    padding: 3rem 1.5rem 2rem !important;
+    min-height: 360px;
+    padding: 3rem 1.5rem 2.5rem !important;
   }
 
   [data-page-title="About Me"] .sl-markdown-content #connect ~ ul {


### PR DESCRIPTION
## Why

The personal site at devantler.tech had several rough edges preventing it from feeling truly professional: the splash hero image was visually boxed inside Starlight's padded content column instead of spanning the full viewport, the content was stale (outdated blog picks, missing recent posts, thin index pages), the About page had overlapping employment dates and a heavy blockquote metadata style, and a handful of config/tooling issues were lurking (dead script reference, unused link validator, no OG meta).

## What changed

**Hero full-bleed**
The matrix background on the splash page now stretches edge-to-edge using `width: 100vw` + `margin-left: calc(50% - 50vw)`. Min-height on desktop is raised to 520px, the tagline max-width is widened, and the matrix image is dimmed further in light mode for contrast. `overflow-x: hidden` on `html`/`body` prevents any horizontal scroll.

**Content sync**
- Home "Featured Projects" expanded from 2 to 4 cards (KSail, Platform, Reusable Workflows, Actions).
- Home "Latest from the Blog" refreshed to the 4 newest posts (MCP server, GitOps without Git server, macOS Keychain, AI Assistant).
- About: removed the overlapping Energinet paragraph ("From Sep 2024 to Jun 2025 I was lent out...") that duplicated the separate Platform Engineer role entry directly below it. Updated location to Funen, Denmark.
- Projects and Templates index pages converted from one-liner stubs to proper landing pages with intro copy and `CardGrid` navigation.
- Go and .NET template pages unified to a consistent What's Inside / Getting Started / Links structure.

**Config and tooling**
- `starlight-links-validator` was installed but not wired up -- now active in the Starlight plugins array (with `/blog/` excluded, as the blog plugin generates its own routing). Build now fails on broken internal links.
- Removed the dead `sync-projects` script from `package.json` (referenced a nonexistent `scripts/` directory).
- Added `lang: "en"` default locale, plus `og:image`, `og:type`, `twitter:card`, `twitter:image`, and `author` meta tags for better SEO and social previews.

**Visual polish**
- About metadata replaced with a clean 2-column `<dl>` info card styled via CSS.
- Connect section restyled as a horizontal pill-button bar.
- Card hover now includes a subtle inner highlight (`inset 0 1px 0 rgba(255,255,255,0.04)`).

All 55 pages build cleanly with the links validator enabled.