### PR TITLE
ci: use require-checks-in-pr action for CI gate job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,7 @@ jobs:
         run: npm audit --omit=dev
 
   status:
+    name: "CI - Required Checks"
     runs-on: ubuntu-latest
     if: always()
     needs:
@@ -111,12 +112,8 @@ jobs:
           egress-policy: audit
 
       - name: Check job results
-        run: |
-          results=("${{ needs.build-docs.result }}" "${{ needs.audit-docs.result }}")
-          for result in "${results[@]}"; do
-            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
-              echo "One or more jobs failed or were cancelled."
-              exit 1
-            fi
-          done
-          echo "All jobs passed or were skipped."
+        uses: devantler-tech/actions/require-checks-in-pr@1f66c91d45d374ceac9fe830a783444ebc9be958 # v3.2.0
+        with:
+          job-results: >-
+            ${{ needs.build-docs.result }}
+            ${{ needs.audit-docs.result }}


### PR DESCRIPTION
## Summary

Replace inline bash result-checking in the CI workflow's `status` gate job with the org-wide [`devantler-tech/actions/require-checks-in-pr`](https://github.com/devantler-tech/actions/tree/main/require-checks-in-pr) composite action and set the job name to `"CI - Required Checks"` to satisfy the org-wide ruleset.

## Changes

- **`.github/workflows/ci.yaml`**: Replace the `status` job's inline bash loop with `devantler-tech/actions/require-checks-in-pr@v3.2.0` and add `name: "CI - Required Checks"`

## Aggregation review

All PR-triggered workflows were reviewed — the current `build-docs` + `audit-docs` aggregation is complete. No additional checks need to be added.