### PR TITLE
chore: add aggregate-job-results to all multi-job workflows

### DIFF
--- a/.github/workflows/agentics-maintenance.yml
+++ b/.github/workflows/agentics-maintenance.yml
@@ -235,16 +235,3 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/create_labels.cjs');
             await main();
 
-  status:
-    name: "Agentic Maintenance - Required Checks"
-    runs-on: ubuntu-latest
-    needs: [close-expired-entities, run_operation, apply_safe_outputs, create_labels]
-    if: ${{ always() }}
-    steps:
-      - uses: tv2/gh-shared-actions/actions/aggregate-job-results@v0
-        with:
-          job-results: >-
-            ${{ needs.close-expired-entities.result }}
-            ${{ needs.run_operation.result }}
-            ${{ needs.apply_safe_outputs.result }}
-            ${{ needs.create_labels.result }}

--- a/.github/workflows/agentics-maintenance.yml
+++ b/.github/workflows/agentics-maintenance.yml
@@ -234,3 +234,17 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/create_labels.cjs');
             await main();
+
+  status:
+    name: "Agentic Maintenance - Required Checks"
+    runs-on: ubuntu-latest
+    needs: [close-expired-entities, run_operation, apply_safe_outputs, create_labels]
+    if: ${{ always() }}
+    steps:
+      - uses: tv2/gh-shared-actions/actions/aggregate-job-results@v0
+        with:
+          job-results: >-
+            ${{ needs.close-expired-entities.result }}
+            ${{ needs.run_operation.result }}
+            ${{ needs.apply_safe_outputs.result }}
+            ${{ needs.create_labels.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
       - audit-docs
     permissions: {}
     steps:
-      - uses: tv2/gh-shared-actions/actions/aggregate-job-results@v0
+      - uses: tv2/gh-shared-actions/actions/aggregate-job-results@e8fcd9dc6887d34bb7624b3490b7ece4568b91b5 # v0
         with:
           job-results: >-
             ${{ needs.build-docs.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,14 +85,13 @@ jobs:
   status:
     name: "CI - Required Checks"
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ always() }}
     needs:
       - build-docs
       - audit-docs
     permissions: {}
     steps:
-      - name: Check job results
-        uses: devantler-tech/actions/require-checks-in-pr@17691ce06f7c2324d7a41a60ec9cc3baf471bfea # v3.2.4
+      - uses: tv2/gh-shared-actions/actions/aggregate-job-results@v0
         with:
           job-results: >-
             ${{ needs.build-docs.result }}

--- a/.github/workflows/publish-pages.yaml
+++ b/.github/workflows/publish-pages.yaml
@@ -57,3 +57,15 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
+  ci-required-checks:
+    name: CI - Required Checks
+    runs-on: ubuntu-latest
+    needs: [build, deploy]
+    if: ${{ always() }}
+    steps:
+      - uses: tv2/gh-shared-actions/actions/aggregate-job-results@v0
+        with:
+          job-results: >-
+            ${{ needs.build.result }}
+            ${{ needs.deploy.result }}

--- a/.github/workflows/publish-pages.yaml
+++ b/.github/workflows/publish-pages.yaml
@@ -58,14 +58,4 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
-  ci-required-checks:
-    name: CI - Required Checks
-    runs-on: ubuntu-latest
-    needs: [build, deploy]
-    if: ${{ always() }}
-    steps:
-      - uses: tv2/gh-shared-actions/actions/aggregate-job-results@v0
-        with:
-          job-results: >-
-            ${{ needs.build.result }}
-            ${{ needs.deploy.result }}
+


### PR DESCRIPTION
Add `tv2/gh-shared-actions/actions/aggregate-job-results@v0` to all multi-job workflows.

## Changes

- **`publish-pages.yaml`**: Added new `ci-required-checks` job that aggregates `build` and `deploy` results
- **`ci.yaml`**: Replaced `devantler-tech/actions/require-checks-in-pr` with the shared action in the existing `status` job; also normalized `if: always()` to `if: ${{ always() }}`
- **`agentics-maintenance.yml`**: Added new `status` job aggregating all 4 existing jobs

Fixes tv2/dvt-engineering#1178