### PR TITLE
docs(about): Add Side Projects section for VS Code & Copilot backstage

### DIFF
--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -180,6 +180,12 @@ Part of the development team for the GF Forsikring website and landing pages.
 
 </details>
 
+## Side Projects
+
+### VS Code & GitHub Copilot Backstage <span style="float:right">Member</span>
+
+Member of the VS Code and GitHub Copilot backstage group, where I get early access to their latest offerings, test pre-release features, and provide feedback directly to the teams behind them. I take part out of a genuine interest in the field of AI, and to stay ahead of industry standards and trends in developer tooling.
+
 ## Achievements
 
 ### Certificates


### PR DESCRIPTION
## Summary
- Adds a **Side Projects** section to the About Me page, between Professional Experience and Achievements
- Highlights membership in the VS Code & GitHub Copilot backstage group — early access to pre-release features, providing feedback to the teams, motivated by interest in AI and keeping current with developer-tooling industry standards
- Reuses the existing `### Title <span style="float:right">…</span>` heading pattern from the rest of the page

## Test plan
- [ ] Run the docs dev server and confirm the new section renders correctly and the "Member" tag floats right