### PR TITLE
docs(about): Reflect TV2 team rename to Development Platform

### DIFF
--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -43,7 +43,7 @@ The talk also presents the roadmap for KSail along with an open invitation to th
 
 _TV2, Odense_
 
-As a Senior Engineer in Developer Tooling at TV2, I am responsible for improving the developer experience for the product teams at TV2. This includes working on internal tools and platforms, as well as providing support and guidance to the teams on best practices for software development and operations. I work closely with the teams to understand their needs and challenges, and I strive to find solutions that make their work easier and more efficient. I also collaborate with other enabling teams within the organization to ensure that our tools and platforms are aligned with the overall goals and strategies of TV2.
+As a Senior Engineer at TV2, I am responsible for improving the developer experience for the product teams at TV2. On 4 May 2026, our team was renamed from **Developer Tooling** to **Development Platform**, reflecting how our responsibilities grew to cover Developer Experience across all areas of software development — extending beyond internal tools and platforms to also include operational concerns like running and securing the software. I work closely with the teams to understand their needs and challenges, and I strive to find solutions that make their work easier and more efficient. I also collaborate with other enabling teams within the organization to ensure that our tools and platforms are aligned with the overall goals and strategies of TV2.
 
 ### Platform Engineer and Open Source Community Facilitator <span style="float:right">Nov 2024 — Jun 2025</span>
 


### PR DESCRIPTION
## Summary
- Updates the TV2 entry on the About Me page to reflect the team rename from **Developer Tooling** to **Development Platform** on 4 May 2026
- Emphasizes the broadened scope: Developer Experience across all areas of software development, now including operational concerns like running and securing the software

## Test plan
- [ ] Run the docs dev server and confirm the TV2 paragraph renders with the bolded team names