### PR TITLE
docs(about): Collapse student roles under "Previous experiences"

### DIFF
--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -87,7 +87,7 @@ As a Junior Consultant at Energinet, I was part of the Substation Data team in t
 </details>
 
 <details>
-  <summary>Previous experiences</summary>
+  <summary><strong>Previous experiences</strong> (2018 — 2023)</summary>
 
 ### Teaching Assistant <span style="float:right">Sep 2022 — Aug 2023</span>
 

--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -86,6 +86,9 @@ As a Junior Consultant at Energinet, I was part of the Substation Data team in t
 
 </details>
 
+<details>
+  <summary>Previous experiences</summary>
+
 ### Teaching Assistant <span style="float:right">Sep 2022 — Aug 2023</span>
 
 _University of Southern Denmark, Odense_
@@ -177,6 +180,8 @@ Part of the development team for the GF Forsikring website and landing pages.
 - Working with AngularJS and many other front-end technologies.
 - Working with SQL Server.
 - Working with the Marketing team to quickly create landing pages for campaigns.
+
+</details>
 
 </details>
 


### PR DESCRIPTION
## Summary
- Wraps the six student / teaching-assistant roles (Sep 2022 Teaching Assistant down through GF Forsikring) in a single `<details>` block labeled **Previous experiences**, collapsed by default
- Keeps each role's existing per-entry "Learn more..." details intact inside the wrapper, so the section stays compact when expanded
- Recent professional roles (TV2, Energinet) remain visible at the top

## Notes
- Interpreted "student jobs" as the roles titled *Student Software Developer* and *Teaching Assistant*; the Energinet roles are treated as professional and left visible.
- This is the first time markdown headings appear inside a `<details>` on this page — the required `build-docs` CI check (full `astro build`) validates the MDX.

## Test plan
- [ ] CI `build-docs` passes
- [ ] On the rendered page, "Previous experiences" is collapsed by default and expands to reveal the student roles