### PR TITLE
docs(about): Add Skills section (technical and personal)

### DIFF
--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -21,6 +21,27 @@ I am a Developer Experience Engineer based in Denmark with an MSc in Software En
   <div><dt>Interests</dt><dd>CrossFit, running, gaming, music, technology</dd></div>
 </dl>
 
+## Skills
+
+### Technical
+
+<dl class="about-meta">
+  <div><dt>Cloud Native</dt><dd>Kubernetes, GitOps (Flux), Cilium, CNCF ecosystem</dd></div>
+  <div><dt>Platform & DevEx</dt><dd>Developer platforms, multi-tenancy, self-service portals, internal tooling</dd></div>
+  <div><dt>Automation</dt><dd>CI/CD, GitHub Actions, Terraform (IaC), Docker</dd></div>
+  <div><dt>Languages</dt><dd>C#, .NET, Blazor, Bash, SQL</dd></div>
+  <div><dt>Cloud & Operations</dt><dd>Azure, on-prem operations and monitoring</dd></div>
+</dl>
+
+### Personal
+
+<dl class="about-meta">
+  <div><dt>Communication</dt><dd>Public speaking, technical writing, Danish and English</dd></div>
+  <div><dt>Collaboration</dt><dd>Cross-team enablement, stakeholder engagement</dd></div>
+  <div><dt>Leadership</dt><dd>Open-source community facilitation, mentoring and teaching</dd></div>
+  <div><dt>Mindset</dt><dd>Continuous learning, pragmatism, ownership</dd></div>
+</dl>
+
 ## Talks and Presentations
 
 ### KSail — a tool for creating, maintaining and operating Kubernetes clusters with ease <span style="float:right">KCD Denmark 2024</span>


### PR DESCRIPTION
## Summary
- Adds a **Skills** section to the About Me page, placed just below the intro/bio card and above Talks
- Split into **Technical** (Cloud Native, Platform & DevEx, Automation, Languages, Cloud & Operations) and **Personal** (Communication, Collaboration, Leadership, Mindset)
- Reuses the existing `dl.about-meta` card style — no CSS changes needed

## Notes
- Skills were derived from the experience already on the page; adjust any specifics to taste (e.g. add languages/tools I missed).

## Test plan
- [ ] CI `build-docs` passes
- [ ] Both skill cards render with the same styling as the bio card