### PR TITLE
docs(about): Move Skills below Professional Experience and expand

### DIFF
--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -21,27 +21,6 @@ I am a Developer Experience Engineer based in Denmark with an MSc in Software En
   <div><dt>Interests</dt><dd>CrossFit, running, gaming, music, technology</dd></div>
 </dl>
 
-## Skills
-
-### Technical
-
-<dl class="about-meta">
-  <div><dt>Cloud Native</dt><dd>Kubernetes, GitOps (Flux), Cilium, CNCF ecosystem</dd></div>
-  <div><dt>Platform & DevEx</dt><dd>Developer platforms, multi-tenancy, self-service portals, internal tooling</dd></div>
-  <div><dt>Automation</dt><dd>CI/CD, GitHub Actions, Terraform (IaC), Docker</dd></div>
-  <div><dt>Languages</dt><dd>C#, .NET, Blazor, Bash, SQL</dd></div>
-  <div><dt>Cloud & Operations</dt><dd>Azure, on-prem operations and monitoring</dd></div>
-</dl>
-
-### Personal
-
-<dl class="about-meta">
-  <div><dt>Communication</dt><dd>Public speaking, technical writing, Danish and English</dd></div>
-  <div><dt>Collaboration</dt><dd>Cross-team enablement, stakeholder engagement</dd></div>
-  <div><dt>Leadership</dt><dd>Open-source community facilitation, mentoring and teaching</dd></div>
-  <div><dt>Mindset</dt><dd>Continuous learning, pragmatism, ownership</dd></div>
-</dl>
-
 ## Talks and Presentations
 
 ### KSail — a tool for creating, maintaining and operating Kubernetes clusters with ease <span style="float:right">KCD Denmark 2024</span>
@@ -205,6 +184,27 @@ Part of the development team for the GF Forsikring website and landing pages.
 </details>
 
 </details>
+
+## Skills
+
+### Technical
+
+<dl class="about-meta">
+  <div><dt>Cloud Native</dt><dd>Kubernetes, GitOps (Flux), Cilium, CNCF ecosystem</dd></div>
+  <div><dt>Platform & DevEx</dt><dd>Developer platforms, multi-tenancy, self-service portals, internal tooling</dd></div>
+  <div><dt>Automation</dt><dd>CI/CD, GitHub Actions, Terraform (IaC), Docker</dd></div>
+  <div><dt>Languages</dt><dd>C#, .NET, Go, Blazor, Bash, SQL</dd></div>
+  <div><dt>Cloud & Operations</dt><dd>Azure, AWS, on-prem operations and monitoring</dd></div>
+</dl>
+
+### Personal
+
+<dl class="about-meta">
+  <div><dt>Communication</dt><dd>Public speaking, technical writing, Danish and English</dd></div>
+  <div><dt>Collaboration</dt><dd>Cross-team enablement, inner & open source collaboration, stakeholder engagement</dd></div>
+  <div><dt>Leadership</dt><dd>Driving initiatives, open-source community facilitation, mentoring and teaching</dd></div>
+  <div><dt>Mindset</dt><dd>Continuous learning, pragmatism, ownership, accountability, integrity, honesty, principled</dd></div>
+</dl>
 
 ## Side Projects
 


### PR DESCRIPTION
## Summary
- Moves the **Skills** section from the top of the page to below **Professional Experience** (just above Side Projects)
- Expands the entries:
  - **Languages**: add Go
  - **Cloud & Operations**: add AWS
  - **Collaboration**: add inner & open source collaboration
  - **Leadership**: add driving initiatives
  - **Mindset**: add accountability, integrity, honesty, principled

## Test plan
- [ ] CI `build-docs` passes
- [ ] Skills renders below Professional Experience with the updated entries