### PR TITLE
docs(about): Give earlier roles their own Previous Experience section

### DIFF
--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -107,8 +107,10 @@ As a Junior Consultant at Energinet, I was part of the Substation Data team in t
 
 </details>
 
+## Previous Experience
+
 <details>
-  <summary><strong>Previous experiences</strong> (2018 — 2023)</summary>
+  <summary><strong>Student & teaching assistant roles</strong> (2018 — 2023)</summary>
 
 ### Teaching Assistant <span style="float:right">Sep 2022 — Aug 2023</span>
 


### PR DESCRIPTION
## Summary
- Adds a top-level **Previous Experience** `##` section heading before the collapsed student/teaching-assistant block, so the `<details>` no longer visually reads as belonging to the preceding "Software Engineer..." role
- Relabels the collapsible to **Student & teaching assistant roles (2018 — 2023)** since the new section heading now carries the "previous" framing (avoids duplicate wording)

## Test plan
- [ ] CI `build-docs` passes
- [ ] "Previous Experience" renders as its own section, clearly separated from the Energinet role above