### PR TITLE
style(about): Modernize meta & skills cards into a bento grid

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -349,42 +349,69 @@ main > .hero,
   vertical-align: middle;
 }
 
-/* ─── About Page — Meta Info Card ─── */
+/* ─── About Page — Meta & Skills Cards ─── */
 
 .sl-markdown-content dl.about-meta {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 0.25rem 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(232px, 1fr));
+  gap: 0.75rem;
   margin: 1.5rem 0 2rem;
-  padding: 1.25rem 1.5rem;
-  background: var(--card-bg);
-  border: 1px solid var(--card-border);
-  border-left: 3px solid var(--sl-color-accent);
-  border-radius: 0.5rem;
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
+  padding: 0;
 }
 
 .sl-markdown-content dl.about-meta > div {
+  position: relative;
   display: flex;
   flex-direction: column;
-  padding: 0.4rem 0;
+  gap: 0.3rem;
+  padding: 0.85rem 1rem 0.9rem 1.15rem;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 0.65rem;
+  overflow: hidden;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  transition:
+    border-color 0.25s ease,
+    box-shadow 0.25s ease,
+    transform 0.25s ease;
+}
+
+/* Accent rail along the left edge — brightens on hover */
+.sl-markdown-content dl.about-meta > div::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--sl-color-accent);
+  opacity: 0.4;
+  transition: opacity 0.25s ease;
+}
+
+.sl-markdown-content dl.about-meta > div:hover {
+  border-color: var(--card-border-hover);
+  box-shadow: 0 6px 22px var(--glow-color-subtle);
+  transform: translateY(-2px);
+}
+
+.sl-markdown-content dl.about-meta > div:hover::before {
+  opacity: 1;
 }
 
 .sl-markdown-content dl.about-meta dt {
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
+  margin: 0;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
   text-transform: uppercase;
   color: var(--sl-color-accent);
-  opacity: 0.85;
-  margin: 0;
 }
 
 .sl-markdown-content dl.about-meta dd {
-  margin: 0.15rem 0 0;
-  font-size: 0.98rem;
+  margin: 0;
+  font-size: 0.95rem;
   font-weight: 500;
+  line-height: 1.5;
 }
 
 /* ─── About Page — Connect Bar ─── */


### PR DESCRIPTION
## Summary
Modernizes the boxes used for personal info and skills on the About page. Instead of one flat bordered box with a single left accent bar, each fact/skill is now its own glassy **bento-style card** in a responsive grid:
- 3px neon-green accent rail per card that brightens on hover
- Subtle lift + glow on hover, consistent with the site's existing card language
- Tighter label/value typography and even card spacing
- Applies to all three `dl.about-meta` groups (bio facts, Technical, Personal)

Pure CSS change in `custom.css`; uses existing theme tokens, so it adapts to both dark and light modes.

## Verification
Previewed locally with the Astro dev server:
- Desktop: 2-column responsive grid of cards
- Mobile: single-column stack
- Inspected computed styles — card bg/border/radius/blur and the green rail confirmed in **both dark and light** themes

## Test plan
- [ ] CI `build-docs` passes
- [ ] Cards render as a modern grid on the deployed About page (light + dark)