### PR TITLE
fix(about): Align meta & skills cards to equal height

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -354,12 +354,17 @@ main > .hero,
 .sl-markdown-content dl.about-meta {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(232px, 1fr));
+  grid-auto-rows: 1fr;
+  align-items: stretch;
   gap: 0.75rem;
   margin: 1.5rem 0 2rem;
   padding: 0;
 }
 
 .sl-markdown-content dl.about-meta > div {
+  /* Override Starlight's markdown flow-margin, which otherwise lands on
+     every card but the first and breaks grid row alignment. */
+  margin: 0;
   position: relative;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
Fixes the uneven card heights / misalignment in the bio and skills grids reported after the bento-card change.

## Root cause
Starlight's markdown vertical-rhythm rule applies `margin-top: 16px` to every flow sibling **except the first**. Since the cards are `<div>` grid items, all-but-the-first inherited that margin. In CSS Grid the margin inflates the row track and is subtracted from the stretched height, so the first card in each row grew ~16px taller and the others bottom-aligned — producing the ragged look.

## Fix
- `margin: 0` on the grid items to drop the inherited flow-margin
- `grid-auto-rows: 1fr` + explicit `align-items: stretch` so every card shares a uniform height and tops/bottoms align across the row

## Verification
Measured live in the Astro dev server before/after:
- Before: first card per grid = 115px, rest = 99px, mismatched `y` within rows
- After: **all cards 99px, identical `y` per row, even row pitch** — confirmed across all three grids (bio facts, Technical, Personal) in dark + light

## Test plan
- [ ] CI `build-docs` passes
- [ ] Cards render as a uniform aligned grid on the deployed About page