### PR TITLE
docs(about): Add AI skill card & sharpen Platform & DevEx

### DIFF
--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -193,8 +193,9 @@ Part of the development team for the GF Forsikring website and landing pages.
 
 <dl class="about-meta">
   <div><dt>Cloud Native</dt><dd>Kubernetes, GitOps (Flux), Cilium, CNCF ecosystem</dd></div>
-  <div><dt>Platform & DevEx</dt><dd>Developer platforms, multi-tenancy, self-service portals, internal tooling</dd></div>
+  <div><dt>Platform & DevEx</dt><dd>Self-service via CLI, declarative files, AI assistants, or ClickOps portals (Backstage, Port); multi-tenancy and golden paths</dd></div>
   <div><dt>Automation</dt><dd>CI/CD, GitHub Actions, Terraform (IaC), Docker</dd></div>
+  <div><dt>AI-Assisted Engineering</dt><dd>Agentic coding assistants, AI-driven planning & implementation, and automating chores, fixes, and specified changes to focus on high-impact work</dd></div>
   <div><dt>Languages</dt><dd>C#, .NET, Go, Blazor, Bash, SQL</dd></div>
   <div><dt>Cloud & Operations</dt><dd>Azure, AWS, on-prem operations and monitoring</dd></div>
 </dl>


### PR DESCRIPTION
## Summary
Two updates to the **Technical** skills group:
- **New "AI-Assisted Engineering" card** — highlights using AI to plan and implement work and to automate routine tasks (chores, fixes, already-specified changes) so effort goes to high-impact work: _"Agentic coding assistants, AI-driven planning & implementation, and automating chores, fixes, and specified changes to focus on high-impact work."_
- **Sharpened "Platform & DevEx" card** — replaces the generic copy with concrete self-service modalities: _"Self-service via CLI, declarative files, AI assistants, or ClickOps portals (Backstage, Port); multi-tenancy and golden paths."_

This also brings the Technical grid to 6 cards, so it lays out as a balanced 3×2 (no lone card).

## Verification
Previewed in the Astro dev server (on top of the merged alignment fix): all 6 Technical cards render at a uniform 145px height, aligned in a clean 3×2 grid, dark + light.

## Test plan
- [ ] CI `build-docs` passes
- [ ] AI card and reworked Platform & DevEx card render correctly