### PR TITLE
docs(about): Refocus Languages on cloud-native stack & add TypeScript

### DIFF
--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -196,7 +196,7 @@ Part of the development team for the GF Forsikring website and landing pages.
   <div><dt>Platform & DevEx</dt><dd>Self-service via CLI, declarative files, AI assistants, or ClickOps portals (Backstage, Port); multi-tenancy and golden paths</dd></div>
   <div><dt>Automation</dt><dd>CI/CD, GitHub Actions, Terraform (IaC), Docker</dd></div>
   <div><dt>AI-Assisted Engineering</dt><dd>Agentic coding assistants, AI-driven planning & implementation, and automating chores, fixes, and specified changes to focus on high-impact work</dd></div>
-  <div><dt>Languages</dt><dd>C#, .NET, Go, Blazor, Bash, SQL</dd></div>
+  <div><dt>Languages</dt><dd>Go, YAML, TypeScript, Bash, C#/.NET, SQL</dd></div>
   <div><dt>Cloud & Operations</dt><dd>Azure, AWS, on-prem operations and monitoring</dd></div>
 </dl>
 


### PR DESCRIPTION
## Summary
Reworks the Technical **Languages** card to match the actual focus:
- Leads with **Go** and **YAML** (cloud-native stack)
- Adds **TypeScript** (frontend apps + TypeScript GitHub Actions)
- De-emphasizes .NET by folding it into a single **C#/.NET** entry lower in the list

Before: `C#, .NET, Go, Blazor, Bash, SQL`
After: `Go, YAML, TypeScript, Bash, C#/.NET, SQL`

Note: dropped the standalone **Blazor** entry — it's subsumed under C#/.NET and ran counter to de-emphasizing the .NET stack. Happy to add it back if you'd like it called out.

## Test plan
- [ ] CI `build-docs` passes