### PR TITLE
docs: fix broken Sidero Omni link on active projects page

### DIFF
--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -18,7 +18,7 @@ These are the projects I am currently working on and actively maintaining. I'm a
 A tool that bundles common Kubernetes tooling into a single binary. It provides a **VSCode Extension**, **CLI**, **AI-Enabled Chat TUI**, or **MCP interface** to create clusters, deploy workloads, and operate cloud-native stacks across different distributions and providers.
 
 - **One Binary**: Embeds cluster provisioning, GitOps engines, and deployment tooling — no tool sprawl
-- **Simple Clusters**: Spin up Vanilla, K3s, Talos, VCluster, or KWOK clusters with one command across Docker, [Hetzner Cloud](https://www.hetzner.com/cloud/), or [Sidero Omni](https://www.siderolabs.com/platform/saas-for-kubernetes/)
+- **Simple Clusters**: Spin up Vanilla, K3s, Talos, VCluster, or KWOK clusters with one command across Docker, [Hetzner Cloud](https://www.hetzner.com/cloud/), or [Sidero Omni](https://omni.siderolabs.com/)
 - **No Lock-In**: Uses native configs (`kind.yaml`, `k3d.yaml`, Talos patches, `vcluster.yaml`) — run clusters with or without KSail
 - **Mirror Registries**: Avoid rate limits and store images once — same mirrors used by different clusters
 - **Everything as Code**: Cluster settings, distribution configs, and workloads in version-controlled files


### PR DESCRIPTION
> 🤖 Generated by Monorepo AI Assistant

## Summary

The **Sidero Omni** link on the Active Projects page ([`docs/src/content/docs/projects/active.mdx:21`](https://github.com/devantler-tech/monorepo/blob/main/docs/src/content/docs/projects/active.mdx#L21)) pointed at `https://www.siderolabs.com/platform/saas-for-kubernetes/`, which has been returning **HTTP 500** server-side.

This was first observed in an earlier link-check run and placed on a watch list as "possibly transient." It is still failing on recheck (the `siderolabs.com` root and other pages return 200, but the entire `/platform/*` subtree 500s), so it is now treated as a real broken link rather than a transient blip.

## Fix

Repoint to **`https://omni.siderolabs.com/`** (HTTP 200):
- It is the canonical Sidero Omni product/docs entry point.
- It matches the existing **"Sidero Omni"** link text exactly.

## Verification

- `npm run build` in `docs/` succeeds; Astro internal-link validation reports all internal links valid.
- Target URL returns HTTP 200; old URL returns HTTP 500.

No other content changed.