### PR TITLE
docs: trim KSail section on active projects page to brief summary + link

### DIFF
--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -15,17 +15,7 @@ These are the projects I am currently working on and actively maintaining. I'm a
 
 <Image src={ksailImg} alt="KSail CLI" />
 
-A tool that bundles common Kubernetes tooling into a single binary. It provides a **VSCode Extension**, **CLI**, **AI-Enabled Chat TUI**, or **MCP interface** to create clusters, deploy workloads, and operate cloud-native stacks across different distributions and providers.
-
-- **One Binary**: Embeds cluster provisioning, GitOps engines, and deployment tooling — no tool sprawl
-- **Simple Clusters**: Spin up Vanilla, K3s, Talos, VCluster, or KWOK clusters with one command across Docker, [Hetzner Cloud](https://www.hetzner.com/cloud/), or [Sidero Omni](https://omni.siderolabs.com/)
-- **No Lock-In**: Uses native configs (`kind.yaml`, `k3d.yaml`, Talos patches, `vcluster.yaml`) — run clusters with or without KSail
-- **Mirror Registries**: Avoid rate limits and store images once — same mirrors used by different clusters
-- **Everything as Code**: Cluster settings, distribution configs, and workloads in version-controlled files
-- **GitOps Native**: Built-in [Flux](https://fluxcd.io/) or [ArgoCD](https://argo-cd.readthedocs.io/) support with bootstrap, push, and reconcile commands
-- **Customizable Stack**: Select your CNI, CSI, policy engine, cert-manager, and mirror registries
-- **SOPS Built In**: Encrypt, decrypt, and edit secrets with integrated cipher commands
-- **AI Assistant**: Interactive chat powered by [GitHub Copilot](https://github.com/features/copilot) for configuration and troubleshooting
+A tool that bundles common Kubernetes tooling into a single binary, exposed through a **VSCode Extension**, **CLI**, **AI-Enabled Chat TUI**, or **MCP interface**. Use it to create clusters, deploy workloads, and operate GitOps-based cloud-native stacks across a range of distributions and providers.
 
 📖 [Full Documentation](https://ksail.devantler.tech) · 📝 [Read about the journey from .NET to Go](/blog/building-ksail-from-shell-to-dotnet-to-go/)
 

--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -15,7 +15,7 @@ These are the projects I am currently working on and actively maintaining. I'm a
 
 <Image src={ksailImg} alt="KSail CLI" />
 
-A tool that bundles common Kubernetes tooling into a single binary, exposed through a **VSCode Extension**, **CLI**, **AI-Enabled Chat TUI**, or **MCP interface**. Use it to create clusters, deploy workloads, and operate GitOps-based cloud-native stacks across a range of distributions and providers.
+A tool that bundles common Kubernetes tooling into a single binary, exposed through a **VS Code extension**, **CLI**, **AI-enabled chat TUI**, or **MCP interface**. Use it to create clusters, deploy workloads, and operate GitOps-based cloud-native stacks across a range of distributions and providers.
 
 📖 [Full Documentation](https://ksail.devantler.tech) · 📝 [Read about the journey from .NET to Go](/blog/building-ksail-from-shell-to-dotnet-to-go/)
 


### PR DESCRIPTION
> 🤖 Generated by Monorepo AI Assistant

## Summary
Trims the `## KSail` section of the active-projects page to a brief description plus the existing links, per the repo's KSail content rule (*brief description + link to `ksail.devantler.tech` only; never duplicate KSail's detailed docs*).

## What changed
- Removed the nine detailed feature bullets (One Binary, Simple Clusters, No Lock-In, Mirror Registries, Everything as Code, GitOps Native, Customizable Stack, SOPS Built In, AI Assistant) — these duplicate KSail's own documentation.
- Kept the heading (with repo link + tech badges), the screenshot, a two-sentence summary, and the **Full Documentation** + blog links.
- Section word count: **199 → 66 (~67% reduction)**.

## Why
1. **KSail rule compliance** — the portfolio page should point at `ksail.devantler.tech`, not re-host KSail's feature docs.
2. **Resolves a factual staleness** — the removed *Simple Clusters* bullet enumerated distributions/providers (Vanilla, K3s, Talos, VCluster, KWOK across Docker/Hetzner/Sidero Omni) and omitted the newer **EKS distribution** and **AWS provider** now in KSail's README. A brief summary can't drift on details it no longer lists.

## Verification
- `cd docs && npm run build` ✓ — 61 pages built, all internal links valid.

Opened as a draft for review; promote to ready (or merge) to proceed.