### PR TITLE
refactor(ai-assistant): slim hub product skills to pointers

### DIFF
--- a/.claude/skills/products/applications/SKILL.md
+++ b/.claude/skills/products/applications/SKILL.md
@@ -1,29 +1,16 @@
 ---
 name: maintain-applications
-description: Maintenance task menu for the PRIVATE platform-tenant apps — wedding-app (TypeScript) and ascoachingogvaner (Svelte). Conservative: triage, dependency/security hygiene, CI health, small confident fixes. Extra discretion — these are private client/personal repos. Use when the daily maintainer selects applications.
+description: Maintenance task menu for the PRIVATE platform-tenant apps — wedding-app and ascoachingogvaner (both SvelteKit + TS). Conservative: triage, dependency/security hygiene, CI health, small confident fixes. Use when the daily maintainer selects applications.
 ---
 
 # Maintain: Applications (private platform tenants)
 
-| Product | Repo | path | lang | what |
-|---|---|---|---|---|
-| Wedding app | `devantler-tech/wedding-app` | `applications/wedding-app` | SvelteKit + TS | wedding RSVP/booking website (platform tenant) |
-| AS Coaching | `devantler-tech/ascoachingogvaner` | `applications/ascoachingogvaner` | SvelteKit + TS | coaching website (platform tenant) |
+Each app's canonical maintenance task menu lives **in its own (private) repo** — read the
+**`## Maintenance`** section of each `AGENTS.md` (on the submodule's latest `main`):
+- `applications/wedding-app/AGENTS.md` — <https://github.com/devantler-tech/wedding-app/blob/main/AGENTS.md>
+- `applications/ascoachingogvaner/AGENTS.md` — <https://github.com/devantler-tech/ascoachingogvaner/blob/main/AGENTS.md>
 
-Both are near-identical SvelteKit (Svelte 5) + TypeScript apps (TailwindCSS, Drizzle ORM + PostgreSQL, Vitest + Playwright, `adapter-node`), deployed as tenants on the platform cluster.
-
-Both **private**, **Issues enabled**. Shared rules: monorepo
-[`AGENTS.md`](../../../../AGENTS.md). Memory = the [`MAINTENANCE.md`](../../../../MAINTENANCE.md)
-dashboard.
-
-- **Privacy:** never surface these repos' names/contents/links on the **public** devantler.tech site (the monorepo card excludes them from the site map). Extra discretion.
-- **Not checked out by default:** populate at the pinned commit with `git submodule update --init applications/<name>` (never `--remote`) for diff work; otherwise do GitHub-API-only work.
-- First read each repo's `README.md` + `.github/workflows/` + `package.json` for its build/test & release model. **Branch** `claude/daily-ai-assistant-<desc>`; **labels** `automation` + an existing area label.
-- **Validate:** the repo's own checks (both SvelteKit) — `npm ci` then `npm run lint` / `npm run check` (svelte-check) / `npm test` (Vitest) / `npm run test:e2e` (Playwright) / `npm run build`; mirror each repo's `ci.yaml`. Never commit secrets/`.env`.
-
-## Task menu (conservative; ≤1 item per app per run)
-1. **Triage & label** new issues/PRs; one insightful comment on the oldest un-commented item.
-2. **Dependency & security hygiene:** curate Dependabot/Renovate PRs (npm); prioritise security advisories; flag majors.
-3. **CI/workflow health:** keep CI green; red on `main` is top priority — root-cause + draft fix.
-4. **Confident, low-risk fixes** (broken build, obvious bug, broken README link) → draft PR.
-5. **Maintain your own PRs:** fix CI you caused, resolve conflicts.
+These submodules are usually not checked out — populate at the pinned commit with
+`git submodule update --init applications/<name>` (never `--remote`), or do GitHub-API-only work.
+**Private** repos — extra discretion. Shared cross-repo rules are in the monorepo
+[`AGENTS.md`](../../../../AGENTS.md). This card is a pointer by design.

--- a/.claude/skills/products/github-actions/SKILL.md
+++ b/.claude/skills/products/github-actions/SKILL.md
@@ -5,23 +5,11 @@ description: Maintenance task menu for the shared CI/CD building blocks — deva
 
 # Maintain: GitHub Actions + Reusable Workflows
 
-| Product | Repo | path |
-|---|---|---|
-| Composite actions | `devantler-tech/actions` | `github/devantler-tech/github-actions/actions` |
-| Reusable workflows | `devantler-tech/reusable-workflows` | `github/devantler-tech/github-actions/reusable-workflows` |
+Each repo's canonical maintenance task menu lives **in its own repo** — read the **`## Maintenance`**
+section of each `AGENTS.md` (on the submodule's latest `main`):
+- `github/devantler-tech/github-actions/actions/AGENTS.md` — <https://github.com/devantler-tech/actions/blob/main/AGENTS.md>
+- `github/devantler-tech/github-actions/reusable-workflows/AGENTS.md` — <https://github.com/devantler-tech/reusable-workflows/blob/main/AGENTS.md>
 
-Both **Issues enabled**. Shared rules: monorepo [`AGENTS.md`](../../../../AGENTS.md). First read each
-repo's `AGENTS.md`/`README.md` + `.github/workflows/`. Memory = the
-[`MAINTENANCE.md`](../../../../MAINTENANCE.md) dashboard.
-
-- **Branch** `claude/daily-ai-assistant-<desc>`; **labels** `automation` + an existing area label.
-- **Blast radius first:** a change to a composite action / reusable workflow affects **every consumer repo**. Prefer additive, backward-compatible changes; call out any breaking input/output change prominently and treat it as a deliberate decision the maintainer promotes (keep an alias where feasible).
-- **Validate:** `actionlint` on every changed workflow/action (else a thorough YAML parse); confirm `uses:` refs resolve and are pinned/aligned; check `inputs`/`outputs`/`shell:` are declared; for `reusable-workflows`, keep `on: workflow_call` inputs/secrets backward-compatible. No app build here — YAML correctness + pinning is the gate.
-- **Security:** these repos include workflow-vulnerability scanning — keep actions pinned to full-length SHAs where the house style does, avoid `pull_request_target` foot-guns, never weaken a security control to pass a check.
-
-## Task menu (1–2 items/run across both; high care)
-1. **Triage & label** new issues/PRs; one insightful comment on the oldest un-commented item.
-2. **Action/version hygiene:** keep third-party actions pinned & aligned across both repos; bundle Dependabot `github_actions` PRs; flag majors.
-3. **Workflow health & dedup:** consolidate duplicated steps into composite actions, split overgrown jobs, improve caching, remove dead workflows — backward-compatible, one concern per draft PR, `actionlint`-clean.
-4. **Consistency** between the two repos and with how consumer repos call them.
-5. **Maintain your own PRs:** fix CI you caused, resolve conflicts.
+**Blast radius:** changes here ripple to every consumer repo — prefer additive, backward-compatible
+changes. Shared cross-repo rules are in the monorepo [`AGENTS.md`](../../../../AGENTS.md). This card
+is a pointer by design — each menu is maintained once, in the repo's own `AGENTS.md`.

--- a/.claude/skills/products/homebrew-formulas/SKILL.md
+++ b/.claude/skills/products/homebrew-formulas/SKILL.md
@@ -5,20 +5,10 @@ description: Maintenance task menu for the devantler-tech Homebrew tap (repo dev
 
 # Maintain: Homebrew tap
 
-**Repo** `devantler-tech/homebrew-tap` (the `homebrew-formulas` submodule URL redirects here) ·
-**path** `homebrew-formulas` · **Issues** enabled. Shared rules: monorepo
-[`AGENTS.md`](../../../../AGENTS.md). The tap ships **Casks**, not Ruby formulas — `Casks/ksail.rb`
-(CLI) and `Casks/ksail-desktop.rb` (app), both **GoReleaser-generated and marked `# DO NOT EDIT`**.
-First read `README.md`, the casks, and `.github/workflows/ci.yaml` (CI is an aggregate
-required-checks job — it does not run `brew style`/`audit`). Memory = the
-[`MAINTENANCE.md`](../../../../MAINTENANCE.md) dashboard. Usually nothing to do.
+The canonical maintenance task menu lives **in the repo itself** — read the **`## Maintenance`**
+section of `homebrew-formulas/AGENTS.md` (the submodule path; repo `devantler-tech/homebrew-tap`, on
+its latest `main`): <https://github.com/devantler-tech/homebrew-tap/blob/main/AGENTS.md>. The tap
+ships **Casks** (`Casks/*.rb`, GoReleaser-generated `# DO NOT EDIT`) — never chase version/sha bumps.
 
-- **Branch** `claude/daily-ai-assistant-<desc>`; **labels** `automation` + an existing area label.
-- **Releases bump casks automatically.** A tool release (e.g. ksail) opens its own GoReleaser PR to update a cask's `url`/`version`/`sha256`. **Do NOT hand-edit version/sha to chase a release** — you'd race the automation and risk a wrong sha. The generated casks are `# DO NOT EDIT`. Your job is tap *correctness/hygiene*, not version bumps.
-- **Validate:** `brew style ./Casks/<cask>.rb` and `brew audit --strict --online --cask <cask>` if `brew` is available; else `ruby -c Casks/<cask>.rb` + a careful read.
-
-## Task menu (minimal)
-1. **Triage & label** new issues/PRs; one insightful comment on the oldest un-commented item (e.g. an install-failure report → investigate the cask).
-2. **Tap hygiene** (clear, low-risk only): deprecated Homebrew DSL, broken `homepage`/`url`, bad `desc`/license, lint/style failures, README-table drift, dead casks → draft PR (but never the `# DO NOT EDIT` generated fields). **Not** speculative version bumps.
-3. **CI/workflow health:** keep the tap's CI green and tidy.
-4. **Maintain your own PRs:** fix CI you caused, resolve conflicts.
+Shared cross-repo rules are in the monorepo [`AGENTS.md`](../../../../AGENTS.md). This card is a
+pointer by design — the menu is maintained once, in the tap's own `AGENTS.md`.

--- a/.claude/skills/products/ksail/SKILL.md
+++ b/.claude/skills/products/ksail/SKILL.md
@@ -5,30 +5,10 @@ description: Maintenance task menu for devantler-tech/ksail (a Go CLI for local 
 
 # Maintain: KSail
 
-**Repo** `devantler-tech/ksail` · **path** `projects/ksail` · **Issues** enabled.
-Shared rules: monorepo [`AGENTS.md`](../../../../AGENTS.md). First read `projects/ksail/AGENTS.md`
-(+ `.github/instructions/`) for project conventions. Memory = the consolidated
-[`MAINTENANCE.md`](../../../../MAINTENANCE.md) dashboard (no per-repo Activity issue).
+The canonical KSail maintenance task menu lives **in the repo itself** — read the **`## Maintenance`**
+section of `projects/ksail/AGENTS.md` (on the submodule's latest `main`):
+<https://github.com/devantler-tech/ksail/blob/main/AGENTS.md>.
 
-## Repo-specific conventions
-- **Branch** `claude/ksail-ai-assistant-<desc>`; **labels** `automation` + area label.
-- **Validate before any PR:** `golangci-lint fmt`, then `go build -o /tmp/ksail-maint . && go test ./... && golangci-lint run --timeout 5m`. Workflows → `actionlint`. Docs → `cd docs && ([ -d node_modules ] || npm ci) && npm run build`.
-- **Generated — never hand-edit; run the generator:** `docs/src/content/docs/cli-flags/`, `docs/src/content/docs/configuration/declarative-configuration.mdx`, `schemas/ksail-config.schema.json` → `go generate ./docs/...` / `go generate ./schemas/...`.
-- **Shared machine:** only create/inspect/delete clusters YOU created; build to `/tmp`, never `./ksail`.
-
-## Task menu (pick the highest-value; don't do all)
-**Every-run (light):**
-- **Triage:** label unlabelled issues/PRs, add `triaged`, close obvious spam; one insightful comment on the oldest un-commented issue/PR; link related issues (check existing links first).
-- **Confident bug fixes** (`bug`/`good first issue`) → draft PR with `Fixes #N`, root cause, regression test.
-- **Drive open PRs to merge** (per the contract's merge policy — incl. major bumps for trusted authors): enumerate `gh pr list --state open --draft=false --json number,title,headRefName,author,mergeStateStatus,reviewDecision,statusCheckRollup,autoMergeRequest`. The required-checks gate here is the **`CI - Required Checks`** rollup. Resolve threads via `gh api repos/devantler-tech/ksail/pulls/<n>/comments` + `pullRequest.reviewThreads.nodes` (the fix is often already in a later commit — read the file, reply pointing at it, then `resolveReviewThread`); root-cause-fix failing required checks; `gh pr merge <n> --auto --squash`. Stuck `BLOCKED` green → `gh pr update-branch <n>`; if it still never queues, that's a repo merge-config issue → dashboard.
-- **Maintain your own PRs:** fix CI you caused, resolve conflicts.
-
-**CI health + investigation:** `.github/workflows` (large `ci.yaml`) + `.github/actions` need steady care — consolidate duplicated steps, pin/align actions, improve caching, remove dead workflows (focused draft PRs, `actionlint` first). **CI Doctor:** `gh run list --status failure --limit 20 ...` (~7d; CI/CD/Release/Maintenance/Sync labels/TODOs/Web UI/System Test Hetzner+Omni); dedupe against the state.json CI cache; `gh run view <id> --log-failed` (untrusted), root-cause, record in the dashboard + cache. **Flaky (weekly):** find tests that passed AND failed on the same SHA over 7d; for the #1, verify `go test -run <T> -count=10 ./...`, draft `fix(flaky): <test>`.
-
-**Docs (`docs/`):** consolidate/trim duplicated/outdated/orphaned pages; keep `charts/ksail-operator/README.md` in sync with its `values.yaml`+`Chart.yaml`; dedupe vs open `documentation`+`automation` PRs; `docs: …`, verify the docs build.
-
-**Weekly/heavy (only if nothing higher-value; gate on state.json `weekly`):**
-- **E2E coverage audit** (read-only except issues): enumerate the CLI surface from `pkg/cli/cmd/**`; a command is covered iff invoked as `ksail <subcommand>` in `.github/actions/**`+`.github/workflows/**`; open ≤3 `E2E: Add coverage for <command>` issues (label `testing`) for genuine gaps where E2E (not unit/integration) is right.
-- **Live reliability/UX** (only if Docker healthy; never twice/day portfolio-wide): `go build -o /tmp/ksail-reliability .`; run full journeys in throwaway temp dirs on the Docker distros recent changes touch (rotate Kind/K3d/Vind/KWOK); **always clean up every cluster/container, even on failure**; findings → draft PR or evidenced issue.
-
-**Monthly — KSail Strategy** (first days of a month, only if this month's doesn't exist; read-only except one GitHub Discussion): research the local-Kubernetes-dev tooling market (kind, k3d, minikube, Tilt, Skaffold, vcluster, Talos/Omni, …) and produce a **Now/Next/Later** roadmap that *extends* KSail's strengths (HARD: no radical pivots). Read the 50 most-recently-updated open issues first. Create a Discussion in `devantler-tech/ksail`, category **agentic-workflows**, title `Monthly Strategy - <Month Year>` (`gh api graphql createDiscussion`); fall back to an issue if Discussions unavailable. Also turn the latest Strategy discussion into ≤5 deduped backlog issues.
+Shared cross-repo rules are in the monorepo [`AGENTS.md`](../../../../AGENTS.md). This card is a
+pointer by design — the menu is maintained once, in the product's own `AGENTS.md`, so it stays
+correct for every tool (Claude, Copilot, Cursor, …).

--- a/.claude/skills/products/platform/SKILL.md
+++ b/.claude/skills/products/platform/SKILL.md
@@ -5,24 +5,10 @@ description: Maintenance task menu for devantler-tech/platform (a GitOps Kuberne
 
 # Maintain: Platform
 
-**Repo** `devantler-tech/platform` · **path** `platform` · **Issues** enabled.
-Shared rules: monorepo [`AGENTS.md`](../../../../AGENTS.md). First read `platform/AGENTS.md` and skim
-`platform/.github/instructions/` (kustomize-manifests, talos-patches, sops-secrets) before editing
-manifests. Memory = the [`MAINTENANCE.md`](../../../../MAINTENANCE.md) dashboard.
+The canonical Platform maintenance task menu lives **in the repo itself** — read the
+**`## Maintenance`** section of `platform/AGENTS.md` (on the submodule's latest `main`):
+<https://github.com/devantler-tech/platform/blob/main/AGENTS.md>. Static validation only — never run
+a cluster.
 
-## Repo-specific conventions
-- **Branch** `claude/repo-assist-<desc>`; **labels** `automation,repo-assist`.
-- **Validate before any manifest PR** — both overlays MUST build: `kubectl kustomize k8s/clusters/local/` and `kubectl kustomize k8s/clusters/prod/` (standalone `kustomize` isn't installed; `kubectl` has it built in). Per-file: `kubectl apply --dry-run=client -f <file>`. The full Talos+Docker system test runs in CI on the PR (3–5 min, Docker+KSail) — don't run it locally.
-- **Never run a cluster** — static validation only; no `ksail up`/create/switch/delete, no mutating `~/.kube/config`.
-- **Protected — never modify:** `*.enc.yaml` (SOPS), `ksail.prod.yaml` (live prod), `.sops.yaml`. **Bases immutable** — change via Kustomize `patches:` in overlays, never edit `k8s/bases/` from an overlay. Respect Flux order: `variables → infrastructure-controllers → infrastructure → apps`.
-
-## Task menu (pick 2–3; favour the "platform-useful" tasks in AGENTS.md)
-1. **Triage & label** unlabelled issues/PRs; remove misapplied labels; close obvious spam/off-topic.
-2. **Investigate & comment** on open issues lacking an AI comment (oldest first; 1–3/run) — manifest misconfigs, Helm chart issues, Flux sync/dependency-order problems; answer by type, no vague acknowledgements.
-3. **Fix confident, low-risk issues** → branch `claude/repo-assist-fix-issue-<N>-<desc>`, minimal surgical fix, overlays build, draft PR with `Closes #N`, root cause, rationale, build-check result.
-4. **Engineering investments:** Helm chart bumps via HelmRelease `spec.chart.spec.version` (prefer minor/patch; majors only with clear benefit); GitHub Actions/workflow health; bundle compatible Renovate/Dependabot PRs. One concern per draft PR.
-5. **Manifest improvements:** Kustomize cleanup, dead-resource removal, doc gaps — only obviously-beneficial, low-risk, highly selective.
-6. **Maintain your own PRs** (`repo-assist`): fix CI you caused, resolve conflicts; don't push for infra-only failures — comment instead.
-7. **Stale-PR nudges:** ≤3 polite nudges to other contributors' PRs untouched 14+ days waiting on the author.
-
-> Skip performance / test-suite / code-refactoring tasks — per AGENTS.md they're "Less Applicable" to a declarative manifest repo.
+Shared cross-repo rules are in the monorepo [`AGENTS.md`](../../../../AGENTS.md). This card is a
+pointer by design — the menu is maintained once, in the product's own `AGENTS.md`.

--- a/.claude/skills/products/templates/SKILL.md
+++ b/.claude/skills/products/templates/SKILL.md
@@ -5,22 +5,10 @@ description: Maintenance task menu for the devantler-tech project templates — 
 
 # Maintain: Templates (go-template + dotnet-template)
 
-| Product | Repo | path | validate |
-|---|---|---|---|
-| Go template | `devantler-tech/go-template` | `templates/go-template` | `golangci-lint fmt` (if configured), `go build ./... && go test ./...`, `golangci-lint run` (build to /tmp) |
-| .NET template | `devantler-tech/dotnet-template` | `templates/dotnet-template` | `dotnet build` then `dotnet test` (mirror `ci.yaml`/`test.yaml`) |
+Each template's canonical maintenance task menu lives **in its own repo** — read the **`## Maintenance`**
+section of each `AGENTS.md` (on the submodule's latest `main`):
+- `templates/go-template/AGENTS.md` — <https://github.com/devantler-tech/go-template/blob/main/AGENTS.md>
+- `templates/dotnet-template/AGENTS.md` — <https://github.com/devantler-tech/dotnet-template/blob/main/AGENTS.md>
 
-Both have **Issues enabled**. Shared rules: monorepo [`AGENTS.md`](../../../../AGENTS.md). First read
-each repo's `AGENTS.md` + `.github/workflows/*` to confirm its release model (house style:
-Conventional-Commit titles, squash-merge, release automation off the title). Memory = the
-[`MAINTENANCE.md`](../../../../MAINTENANCE.md) dashboard.
-
-- **Branch** `claude/daily-ai-assistant-<desc>`; **labels** `automation` + an existing area label; workflows → `actionlint`.
-- **Bias:** keep the scaffold minimal and idiomatic — don't add product features.
-
-## Task menu (light; ≤1 high-value item per template per run)
-1. **Triage & label** new issues/PRs; one insightful comment on the oldest un-commented item.
-2. **Dependency/toolchain hygiene:** curate Dependabot/Renovate PRs (Go modules / NuGet / Actions); keep Go / .NET SDK version + pinned action versions current and aligned with the house workflows; flag majors.
-3. **CI/workflow health:** keep the template's CI green and tidy (pin/align actions, fix broken/flaky steps, remove dead workflows); red on `main` is top priority.
-4. **Scaffold freshness:** the generated project builds & tests on the current toolchain; README/badges accurate; example code idiomatic — clear low-risk improvement → draft PR.
-5. **Maintain your own PRs:** fix CI you caused, resolve conflicts.
+Shared cross-repo rules are in the monorepo [`AGENTS.md`](../../../../AGENTS.md). This card is a
+pointer by design — each menu is maintained once, in the template's own `AGENTS.md`.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Follow-up cleanup to the Daily AI Assistant rollout (devantler-tech/monorepo#1695 + the per-submodule distribution PRs, now all merged).

**What:** the 6 submodule-backed product skills under `.claude/skills/products/*` carried full maintenance task menus as a *temporary* home during Phase 1. Now that each submodule's `AGENTS.md` carries its own canonical `## Maintenance` section (distributed in the per-repo PRs), those inline copies are redundant. This slims them to **thin pointers** at the canonical menu in each submodule's `AGENTS.md` — single source of truth, no drift, still reusable by Copilot/Cursor/Codex via that `AGENTS.md`.

- Slimmed: `ksail`, `platform`, `templates` (go+dotnet), `github-actions` (actions+reusable), `homebrew-formulas`, `applications`.
- **Unchanged:** `monorepo` — the devantler.tech docs-site menu is not a submodule, so the hub stays its canonical home.

−122/+41 lines; docs/skills only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)