### PR TITLE
refactor: move ksail submodule from projects/ to applications/

### DIFF
--- a/.claude/skills/products/ksail/SKILL.md
+++ b/.claude/skills/products/ksail/SKILL.md
@@ -6,7 +6,7 @@ description: Maintenance task menu for devantler-tech/ksail (a Go CLI for local 
 # Maintain: KSail
 
 The canonical KSail maintenance task menu lives **in the repo itself** — read the **`## Maintenance`**
-section of `projects/ksail/AGENTS.md` (on the submodule's latest `main`):
+section of `applications/ksail/AGENTS.md` (on the submodule's latest `main`):
 <https://github.com/devantler-tech/ksail/blob/main/AGENTS.md>.
 
 Shared cross-repo rules are in the monorepo [`AGENTS.md`](../../../../AGENTS.md). This card is a

--- a/.gitmodules
+++ b/.gitmodules
@@ -38,8 +38,8 @@
 	path = templates/go-template
 	url = git@github.com:devantler-tech/go-template.git
 	branch = main
-[submodule "projects/ksail"]
-	path = projects/ksail
+[submodule "applications/ksail"]
+	path = applications/ksail
 	url = git@github.com:devantler-tech/ksail.git
 	branch = main
 [submodule "github/devantler-tech/maintenance"]

--- a/.vscode/monorepo.code-workspace
+++ b/.vscode/monorepo.code-workspace
@@ -10,7 +10,7 @@
     },
     {
       "name": "🛥️🐳 KSail",
-      "path": "../projects/ksail"
+      "path": "../applications/ksail"
     },
     {
       "name": "😸👨🏻‍💻 GitHub Personal",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ checkout has every product present and a single autonomous maintainer can work a
 
 | Product | Repo | Path | Per-repo AGENTS.md |
 |---|---|---|---|
-| KSail (Go CLI) | `devantler-tech/ksail` | `projects/ksail` | [AGENTS.md](https://github.com/devantler-tech/ksail/blob/main/AGENTS.md) |
+| KSail (Go CLI) | `devantler-tech/ksail` | `applications/ksail` | [AGENTS.md](https://github.com/devantler-tech/ksail/blob/main/AGENTS.md) |
 | Platform (GitOps) | `devantler-tech/platform` | `platform` | [AGENTS.md](https://github.com/devantler-tech/platform/blob/main/AGENTS.md) |
 | devantler.tech site | `devantler-tech/monorepo` | `docs/` + repo root | this file |
 | Go template | `devantler-tech/go-template` | `templates/go-template` | [AGENTS.md](https://github.com/devantler-tech/go-template/blob/main/AGENTS.md) |
@@ -91,7 +91,7 @@ Each run works in **throwaway git worktrees**, never a shared main checkout, so 
 the maintainer's parallel sessions. For each repo touched:
 `git -C <repo_path> worktree add .claude/worktrees/maint-<runid> -b claude/<area>-<desc>`, work there,
 open the PR, then `git -C <repo_path> worktree remove` to clean up (`<repo_path>` is a local
-filesystem path such as `projects/ksail` — `git -C` takes a path, not an `<owner/repo>` slug; use the
+filesystem path such as `applications/ksail` — `git -C` takes a path, not an `<owner/repo>` slug; use the
 slug only for `gh` commands). Worktree isolation is verified working across all submodules. Populate an un-checked-out submodule at its pinned commit with
 `git submodule update --init <path>` (never `--remote`). If a repo's working area is unexpectedly
 dirty or you can't get an isolated tree, do GitHub-API-only work (triage/comment) there.


### PR DESCRIPTION
## What

Moves the **KSail** Git submodule from `projects/ksail` to `applications/ksail` — renaming both the submodule **name** and **path** so they match (consistent with the other `applications/*` entries).

| Change | Detail |
|---|---|
| `.gitmodules` | `[submodule "projects/ksail"]` → `[submodule "applications/ksail"]`, `path` updated; `url`/`branch` unchanged |
| gitlink | `projects/ksail → applications/ksail` (100% rename, same pinned commit `32bc957`) |
| `AGENTS.md` | Portfolio-map path cell + the `git -C <repo_path>` worktree example |
| `.claude/skills/products/ksail/SKILL.md` | Pointer to the canonical maintenance menu → `applications/ksail/AGENTS.md` |
| `.vscode/monorepo.code-workspace` | KSail folder path → `../applications/ksail` |

## Why

KSail is itself an application, and `projects/` was too generic a grouping to keep. Folding it under `applications/` (alongside `wedding-app` and `ascoachingogvaner`) removes the `projects/` tier entirely.

## Reviewer notes

- The submodule **commit pointer is unchanged** — this is purely a relocation, no content/version bump.
- Local-plumbing (`.git/config`, `.git/modules/projects/ksail`) was intentionally **not** rewritten in the working branch, since those are shared across the main checkout and parallel worktrees on this machine. After merge, reconcile any populated checkout with:
  ```
  git submodule sync && git submodule update --init applications/ksail
  rm -rf projects .git/modules/projects/ksail   # remove the orphaned old gitdir
  ```
- The docs-site `docs/src/content/docs/projects/active.mdx` page is the public project-listing content, **not** the submodule path, and is intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)