### PR TITLE
docs: replace Codecov with GitHub Code Quality in template pages

### DIFF
--- a/docs/src/content/docs/templates/dotnet.md
+++ b/docs/src/content/docs/templates/dotnet.md
@@ -11,7 +11,7 @@ A minimal, batteries-included template for new .NET projects and libraries. Skip
 
 - **CI/CD** — GitHub Actions workflows for build, test, lint, and release
 - **Publishing** — Release libraries to [GitHub Container Registry](https://docs.github.com/en/packages) and [NuGet](https://www.nuget.org/) automatically
-- **Testing** — Test projects with coverage reporting via [Codecov](https://about.codecov.io/)
+- **Testing** — Test projects with coverage reporting via [GitHub Code Quality](https://docs.github.com/code-security/code-quality)
 - **Code style** — `.editorconfig` with opinionated .NET code style
 - **Dependency management** — [Renovate](https://docs.renovatebot.com/) keeps NuGet packages and Actions up to date
 - **Release automation** — Semantic versioning and automated GitHub Releases

--- a/docs/src/content/docs/templates/go.md
+++ b/docs/src/content/docs/templates/go.md
@@ -10,7 +10,7 @@ A minimal, batteries-included template for new Go projects. Skip the boilerplate
 ## What's Inside
 
 - **CI/CD** — GitHub Actions workflows for build, test, lint, and release
-- **Testing** — `go test` with coverage reporting via [Codecov](https://about.codecov.io/)
+- **Testing** — `go test` with coverage reporting via [GitHub Code Quality](https://docs.github.com/code-security/code-quality)
 - **Quality** — [Go Report Card](https://goreportcard.com/) integration for continuous code-quality feedback
 - **Dependency management** — [Renovate](https://docs.renovatebot.com/) keeps Go modules and Actions up to date
 - **Release automation** — Semantic versioning and automated GitHub Releases

--- a/docs/src/content/docs/templates/index.mdx
+++ b/docs/src/content/docs/templates/index.mdx
@@ -12,12 +12,12 @@ Starter templates that skip the boilerplate and get you straight to shipping. Ea
 <CardGrid>
   <LinkCard
     title="🐹 Go Template"
-    description="A minimal Go template with CI/CD, test coverage via Codecov, Go Report Card, and Renovate."
+    description="A minimal Go template with CI/CD, test coverage via GitHub Code Quality, Go Report Card, and Renovate."
     href="/templates/go/"
   />
   <LinkCard
     title="📁 .NET Template"
-    description="A minimal .NET template with CI/CD, NuGet/GHCR publishing, Codecov, EditorConfig, and Renovate."
+    description="A minimal .NET template with CI/CD, NuGet/GHCR publishing, GitHub Code Quality coverage, EditorConfig, and Renovate."
     href="/templates/dotnet/"
   />
 </CardGrid>


### PR DESCRIPTION
## What

Updates the devantler.tech template docs (Go + .NET) to describe coverage as reported via **GitHub Code Quality** instead of Codecov, matching the coverage migration (Phase 3 — Codecov retirement).

Files: `docs/src/content/docs/templates/{go.md,dotnet.md,index.mdx}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)