### PR TITLE
docs: make documentation a first-class advance category

### DIFF
--- a/.claude/agents/daily-maintainer.md
+++ b/.claude/agents/daily-maintainer.md
@@ -1,6 +1,6 @@
 ---
 name: daily-maintainer
-description: Autonomous local PRIMARY ENGINEER for ALL devantler-tech products — not just upkeep, but ownership of each product's direction and growth. Surveys the whole portfolio each run, then both OPERATES it (CI triage, draft-PR fixes, dependency/workflow upkeep, docs, driving trusted-author PRs to merge) and ADVANCES it (product strategy & roadmaps, issue triage & implementation, test coverage, benchmarking/performance, refactoring & code quality) across ksail, platform, the devantler.tech site, templates, github-actions, reusable-workflows, homebrew-formulas, and the private apps. Invoked by an hourly scheduled task (paced — most ticks are a light pass, substantive work a few times a day); can also be run interactively with @agent-daily-maintainer.
+description: Autonomous local PRIMARY ENGINEER for ALL devantler-tech products — not just upkeep, but ownership of each product's direction and growth. Surveys the whole portfolio each run, then both OPERATES it (CI triage, draft-PR fixes, dependency/workflow upkeep, docs, driving trusted-author PRs to merge) and ADVANCES it (product strategy & roadmaps, issue triage & implementation, test coverage, benchmarking/performance, refactoring & code quality, documentation) across ksail, platform, the devantler.tech site, templates, github-actions, reusable-workflows, homebrew-formulas, and the private apps. Invoked by an hourly scheduled task (paced — most ticks are a light pass, substantive work a few times a day); can also be run interactively with @agent-daily-maintainer.
 skills:
   - portfolio-maintenance
   - product-engineering
@@ -31,7 +31,8 @@ branch-protection bypass — and you never self-promote your own draft (see the 
    `AGENTS.md`) → update native memory → one consolidated report. **Operate first, then advance.**
 3. **Advance the products.** Once nothing is on fire, use the **`product-engineering`** skill to move a
    product forward: refresh its roadmap, decompose & triage issues, implement a roadmap item, raise
-   coverage, benchmark & optimise, or refactor for quality. Go **deep on 1–2 products** per run; depth
+   coverage, benchmark & optimise, refactor for quality, or keep docs in sync and improve them. Go
+   **deep on 1–2 products** per run; depth
    and substance over artifact count. Most runs should leave at least one product measurably better.
    **~Monthly**, step back for a **holistic review** of the whole suite — extract emergent generic
    patterns into the shared libraries (`devantler-tech/actions`, `reusable-workflows`, `skills`, and

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -122,7 +122,9 @@ For each selected product:
 
   Suggested files (markdown, organise as works best — not a rigid schema):
   - `portfolio-status.md` — `last_run`, `rotation_cursor`, and per product: `last_worked`, `weekly`
-    timestamps, roadmap cursor (last strategy review + current theme), open `needs_attention`.
+    timestamps, roadmap cursor (last strategy review + current theme), `last_docs_pass` (the docs-pass
+    cadence cursor that drives the "oldest first" docs rotation — see *Cadence gates*), open
+    `needs_attention`.
   - `caches.md` — CI-investigation cache (signature/PR/run-ids/dates), `unfixable_links` / `watch_links`
     / `resolved_links`, site QA / content-review cursors.
   - `learnings.md` — self-improvement learnings (`date` / `area` / `observation` / `proposed_change` /

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -78,16 +78,20 @@ and sprawl, not value). Work the ladder top-down — **operate first, then advan
    `Fixes #N`).
 8. **Coverage / Performance / Quality** — add meaningful tests to an under-covered critical path;
    benchmark + optimise a hotspot (before/after numbers); a targeted, behaviour-preserving refactor.
+9. **Documentation** — keep docs in sync with shipped features/fixes (update affected docs in the
+   feature PR; a focused `docs:` PR backfills anything that merged without them) and, on the docs
+   cadence, improve existing docs (accuracy, gaps, clarity, dead links). Spans per-product docs + the
+   site (whose recurring slice — Site QA / Content Sync / Content Review — is the monorepo card).
 
 **Self-improvement** (≈weekly, orthogonal) — distil logged `learnings` into a guard-railed draft PR
 that improves your own definition (the [`self-improvement`](../self-improvement/SKILL.md) skill).
 
 **Fairness:** prefer products with the oldest `last_worked` (and oldest strategy review) when value is
 comparable. Aim over time to advance every product, not just the noisy ones.
-**Cadence gates:** per-product strategy review weekly-to-monthly (oldest first); KSail Monthly Strategy
-at month start; heavy tasks (E2E, live-cluster reliability, content review) ~weekly per the per-product
-`weekly` timestamps; never spin up real clusters more than once/day portfolio-wide. A second run the
-same day → more selective, dedupe vs the earlier run.
+**Cadence gates:** per-product strategy review and docs pass weekly-to-monthly (oldest first); KSail
+Monthly Strategy at month start; heavy tasks (E2E, live-cluster reliability, content review) ~weekly
+per the per-product `weekly` timestamps; never spin up real clusters more than once/day portfolio-wide.
+A second run the same day → more selective, dedupe vs the earlier run.
 
 ## 3. Act (per selected product, via a per-run worktree)
 For each selected product:

--- a/.claude/skills/product-engineering/SKILL.md
+++ b/.claude/skills/product-engineering/SKILL.md
@@ -56,7 +56,9 @@ The roadmap of record is **GitHub Issues** (Issues are enabled on every repo) �
 1. Pick a **ready, well-specified** issue (prefer ones you or the maintainer scoped; for a big design,
    write/extend an ADR or system-design note first and link it).
 2. Isolate a worktree, implement at the **root cause**, and **write tests** that pin the new behaviour
-   and its edge cases (tests are part of the change, not optional).
+   and its edge cases (tests are part of the change, not optional). **Update the docs the change
+   touches in the same PR** (help/generated reference, README, `AGENTS.md`, the relevant site page) —
+   docs are part of the change too; re-run, never hand-edit, any doc generator.
 3. **Validate** (the card's build + test command) — never open a PR that breaks build/validation.
 4. Open a **draft PR**: Conventional-Commit title (`feat:`/`fix:`/`refactor:`/`perf:`/`test:`/`docs:`),
    AI-disclosure line, labels, and **`Fixes #N`** so it closes the issue on merge. Body = what & why,
@@ -89,8 +91,24 @@ Targeted, **behaviour-preserving** improvement, backed by tests.
   (`golangci-lint`, `dotnet format`, `actionlint`, the repo's formatter) and the full test suite before
   the PR; if tests are thin in the area, add them *first* (a separate PR) so the refactor is safe.
 
-## 7. Holistic review & shared-library stewardship
-Sections 1–6 work one product at a time. **~Monthly (on rotation), zoom out and look at the whole suite
+## 7. Documentation
+Treat docs as part of the product — keep them **in sync** with what ships and **improve** what exists.
+- **Sync (definition of done).** A feature/fix that changes behaviour, flags, commands, config, or UX
+  updates the affected docs **in the same PR**: the CLI `--help`/generated reference, README, the
+  repo's `AGENTS.md`, and the relevant devantler.tech `docs/` page. Re-run the doc generator (e.g.
+  KSail's command reference); **never hand-edit generated docs**. If a change already merged without
+  its docs, **backfill** them in a focused `docs:` PR.
+- **Improve (on the docs cadence).** Pick an under-served area and make it genuinely better: fix
+  inaccuracies and stale examples, fill a missing how-to/quickstart/troubleshooting entry, tighten
+  clarity and onboarding flow, repair dead links and broken samples, align terminology. Verify
+  examples actually run; build-verify the site (the monorepo card's `docs` build) before the PR.
+- **Scope.** Spans **every product's own docs** (README, `AGENTS.md`, usage/reference) and the central
+  **devantler.tech site** (`docs/`). The site's recurring slice (Site QA, Content Sync, Content Review)
+  lives in the [monorepo card](../products/monorepo/SKILL.md); this section is the cross-product
+  discipline that also covers per-product docs. `docs:`-titled PRs are first-class advance work.
+
+## 8. Holistic review & shared-library stewardship
+Sections 1–7 work one product at a time. **~Monthly (on rotation), zoom out and look at the whole suite
 at once** — the highest-leverage advance work is often cross-cutting (contract → *Holistic review*).
 - **Spot generic patterns.** When the same approach has independently shown up in **2+ products** (a CI
   step, a release/`.releaserc` setup, a workflow, a lint/test config, an agent skill, a docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,13 @@ Beyond fixing what breaks, proactively improve each product. Choose by what the 
 - **Refactoring & code quality** — targeted, **behaviour-preserving** changes backed by tests: cut
   duplication and complexity, modernise idioms, tighten types/errors, improve names and boundaries.
   Keep diffs reviewable; **never mix a refactor with a behaviour change** in one PR.
+- **Documentation** — keep docs **in sync** with what ships and improve what's already there. Any
+  feature/fix that changes behaviour, flags, commands, config, or UX updates the docs it affects **in
+  the same PR** (definition of done) — re-running, never hand-editing, any doc generator; backfill a
+  focused `docs:` PR when something merged without them. Separately, on the **docs cadence** (see
+  *Cadence & focus*), improve existing docs: accuracy, gaps, clarity, onboarding flow, dead links,
+  stale examples. Spans each product's own docs (README/`AGENTS.md`/usage/reference) and the
+  devantler.tech site; a `docs:`-only change is real advance work, not filler.
 The [`product-engineering`](.claude/skills/product-engineering/SKILL.md) skill is the how-to. All of
 it is **root-cause, validated, draft-PR** work under the guardrails below — advancing a product is
 never licence to skip tests, weaken a safety rule, or hand-edit generated files. Respect each repo's
@@ -225,8 +232,9 @@ don't open shallow filler issues, don't touch more products than you can do just
 don't manufacture work when a product genuinely needs nothing. Later ticks the same day are more
 selective and dedupe against earlier ones (visible in native memory and on GitHub):
 if you already advanced a product today, leave it for tomorrow. Rotate a **per-product strategy
-review** (roadmap refresh) roughly weekly-to-monthly per product; heavy tasks (E2E audits,
-live-cluster reliability, site content review) ~weekly; the KSail Monthly Strategy at month start.
+review** (roadmap refresh) and a **per-product docs pass** (sync docs to what shipped + improve
+existing docs) roughly weekly-to-monthly per product; heavy tasks (E2E audits, live-cluster
+reliability, site content review) ~weekly; the KSail Monthly Strategy at month start.
 Never spin up real clusters more than once a day portfolio-wide. **Quality, validation, and safety are
 never traded for throughput.**
 


### PR DESCRIPTION
## Why

The daily AI assistant rarely updates documentation. Tracing the definition shows why: docs only appeared as **buried upkeep** (operate-ladder item 5, "docs sync/trim") and a **site-specific** content review (the monorepo card's *Content Review*, gated to Mondays). It was **not** a first-class *advance* category like coverage, performance, and refactoring, and **nothing** made "docs stay in sync with shipped features/fixes" an explicit discipline. So docs got starved.

This makes documentation a first-class advance category and gives it a cadence, addressing both halves of the ask:
1. **New features/fixes meriting updates get prioritized** — docs-in-sync becomes a *definition of done* (update affected docs in the same PR; backfill a `docs:` PR otherwise).
2. **We sometimes improve existing docs** — a per-product **docs pass** joins the weekly-to-monthly rotation (alongside the strategy review), so existing docs get periodic attention.

## What changed (4 definition files, additive)

- **`AGENTS.md`**
  - *Enhancement work*: new **Documentation** bullet — docs-in-sync as definition of done (re-run, never hand-edit, generators) + improve-existing on the docs cadence; spans each product's own docs **and** the devantler.tech site.
  - *Cadence & focus*: add a **per-product docs pass** to the weekly-to-monthly rotation (next to the strategy review). The existing site-specific "content review ~weekly" is unchanged.
- **`product-engineering/SKILL.md`**
  - *Plan & implement* step 2: docs added to the definition of done next to tests.
  - New **§7 Documentation** (Sync / Improve / Scope); Holistic review renumbered **§7 → §8** (and its "Sections 1–6" → "1–7").
- **`portfolio-maintenance/SKILL.md`**: advance-ladder **item 9 Documentation**; **docs pass** added to the cadence gates.
- **`daily-maintainer.md`**: advance list and description now include documentation.

## Design choices (worth a look before promoting)

- **Cadence weight.** I matched docs to the *strategy-review* cadence (weekly-to-monthly per product, oldest-first rotation) — deliberately "once in a while", not every run, to match the ask and avoid crowding out code work. Easy to dial up/down.
- **No duplication with the site.** The site's recurring slice (Site QA / Content Sync / Content Review) still lives in the [monorepo card](../products/monorepo/SKILL.md); §7 is the **cross-product** discipline that also covers per-product docs (READMEs, `AGENTS.md`, CLI reference) and links back to the card.
- **Guardrails preserved.** Docs PRs are still root-cause, validated (site `docs` build), draft-first, one-concern; generated docs are regenerated, never hand-edited. No guardrail loosened.

## Validation

`.claude/**` + `AGENTS.md` only — CI is path-filtered to `docs/**`, so no required check runs against this change (aggregate passes on skipped jobs). Verified the new internal link (`../products/monorepo/SKILL.md`) resolves and the §7→§8 renumber + cross-reference are consistent.

---

Draft per the self-improvement contract — **your promotion to "ready for review" is the gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)