### PR TITLE
chore: add gitops-tenant-template submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -62,3 +62,7 @@
 	path = libraries/plugins
 	url = git@github.com:devantler-tech/plugins.git
 	branch = main
+[submodule "templates/gitops-tenant-template"]
+	path = templates/gitops-tenant-template
+	url = git@github.com:devantler-tech/gitops-tenant-template.git
+	branch = main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ keeping them healthy *and* moving them forward.
 | devantler.tech site | `devantler-tech/monorepo` | `docs/` + repo root | this file |
 | Go template | `devantler-tech/go-template` | `templates/go-template` | [AGENTS.md](https://github.com/devantler-tech/go-template/blob/main/AGENTS.md) |
 | .NET template | `devantler-tech/dotnet-template` | `templates/dotnet-template` | [AGENTS.md](https://github.com/devantler-tech/dotnet-template/blob/main/AGENTS.md) |
+| GitOps-tenant template | `devantler-tech/gitops-tenant-template` | `templates/gitops-tenant-template` | [AGENTS.md](https://github.com/devantler-tech/gitops-tenant-template/blob/main/AGENTS.md) |
 | GitHub Actions | `devantler-tech/actions` | `github/devantler-tech/github-actions/actions` | [AGENTS.md](https://github.com/devantler-tech/actions/blob/main/AGENTS.md) |
 | Reusable Workflows | `devantler-tech/reusable-workflows` | `github/devantler-tech/github-actions/reusable-workflows` | [AGENTS.md](https://github.com/devantler-tech/reusable-workflows/blob/main/AGENTS.md) |
 | Homebrew tap | `devantler-tech/homebrew-tap` (renamed from `homebrew-formulas`; the submodule URL redirects) | `homebrew-formulas` | [AGENTS.md](https://github.com/devantler-tech/homebrew-tap/blob/main/AGENTS.md) |


### PR DESCRIPTION
## What

Registers the new [`devantler-tech/gitops-tenant-template`](https://github.com/devantler-tech/gitops-tenant-template) repo as a submodule under `templates/gitops-tenant-template` (pinned at its `main`), and adds it to the portfolio map in `AGENTS.md` alongside `go-template` and `dotnet-template`.

Completes the gitops-tenant template + template-sync effort: the template repo, the `template-sync` reusable workflow (reusable-workflows v5.3.0), the tenant wiring in `ascoachingogvaner`/`wedding-app`, and the platform onboarding doc are all merged.

## Notes

- Staged surgically — only `.gitmodules`, `AGENTS.md`, and the new `templates/gitops-tenant-template` gitlink; no other submodule pointers are bumped.
- `.gitmodules` entry tracks `branch = main`, consistent with the other submodules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
