### PR TITLE
docs: add Templates page for the GitOps Tenant Template

### DIFF
--- a/docs/src/content/docs/templates/gitops-tenant-template.md
+++ b/docs/src/content/docs/templates/gitops-tenant-template.md
@@ -24,11 +24,11 @@ template-sync overwrites the files the template **owns** (the shared `cd.yaml`, 
 
 ```bash
 # Create a new private repo from the template
-gh repo create devantler-tech/<tenant> --template devantler-tech/gitops-tenant-template --private --clone
+gh repo create devantler-tech/my-tenant --template devantler-tech/gitops-tenant-template --private --clone
 
 # Replace the scaffolding with your app (code, Dockerfile, deploy/ manifests, ci.yaml),
 # then validate locally:
-cd <tenant>
+cd my-tenant
 kubectl kustomize deploy/        # manifests build
 actionlint .github/workflows/*   # workflows parse
 ```

--- a/docs/src/content/docs/templates/gitops-tenant-template.md
+++ b/docs/src/content/docs/templates/gitops-tenant-template.md
@@ -1,0 +1,44 @@
+---
+title: 🚀 GitOps Tenant Template
+description: A stack-neutral template for GitOps tenants on the devantler-tech platform, with signed build → publish → release plumbing.
+---
+
+A template for **GitOps tenants** on the [devantler-tech platform](https://github.com/devantler-tech/platform) — an application that runs on the platform from its own repository. Skip the CI/CD boilerplate — bring your own stack and start shipping.
+
+**Repository**: [devantler-tech/gitops-tenant-template](https://github.com/devantler-tech/gitops-tenant-template)
+
+It is intentionally **stack-neutral**: it carries no application code or language-specific tooling. Bring your own language and framework, and fill in the scaffolding.
+
+## What's Inside
+
+- **Signed supply chain** — On a `v*` tag, the image and `deploy/` manifests are built, digest-pinned, pushed as an OCI artifact, and [cosign](https://docs.sigstore.dev/)-signed. The platform's `OCIRepository` verifies that signature, so only artifacts from this trusted workflow are reconciled.
+- **Release automation** — [semantic-release](https://semantic-release.gitbook.io/) turns Conventional-Commit merges to `main` into `vX.Y.Z` tags that drive deployment.
+- **Stays current** — [template-sync](https://github.com/AndreasAugustin/actions-template-sync) opens a weekly PR keeping the shared CI/CD plumbing up to date across every tenant.
+- **Security baseline** — A `zizmor.yml` policy enforces GitHub Actions pinning, scanned in CI.
+
+## What the template owns vs. what you own
+
+template-sync overwrites the files the template **owns** (the shared `cd.yaml`, `release.yaml`, `template-sync.yaml`, `CLAUDE.md`, and `zizmor.yml`) and never touches the files **you own**. Declare the files you own — your app code, `Dockerfile`, `deploy/` manifests, `ci.yaml`, `AGENTS.md`, and `README.md` — in a **`.templatesyncignore`** (same syntax as `.gitignore`).
+
+## Getting Started
+
+```bash
+# Create a new private repo from the template
+gh repo create devantler-tech/<tenant> --template devantler-tech/gitops-tenant-template --private --clone
+
+# Replace the scaffolding with your app (code, Dockerfile, deploy/ manifests, ci.yaml),
+# then validate locally:
+cd <tenant>
+kubectl kustomize deploy/        # manifests build
+actionlint .github/workflows/*   # workflows parse
+```
+
+Then register the tenant on the platform by following [`platform/docs/TENANTS.md`](https://github.com/devantler-tech/platform/blob/main/docs/TENANTS.md).
+
+> **Convention:** the Deployment's container `name` MUST equal the repository name — `publish-app` pins the built image digest into the container with that name.
+
+## Links
+
+- 📦 [Template on GitHub](https://github.com/devantler-tech/gitops-tenant-template)
+- 🛰️ [The devantler-tech platform](https://github.com/devantler-tech/platform)
+- 🔄 [Reusable workflows used by this template](https://github.com/devantler-tech/reusable-workflows)

--- a/docs/src/content/docs/templates/index.mdx
+++ b/docs/src/content/docs/templates/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: Templates
-description: Opinionated Go and .NET starter templates with CI/CD, testing, and code quality baked in.
+description: Opinionated starter templates with CI/CD, testing, and code quality baked in.
 ---
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 [![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/devantler)
 
-Starter templates that skip the boilerplate and get you straight to shipping. Each template comes with GitHub Actions workflows, test coverage, code quality tooling, and Renovate for dependency management.
+Starter templates that skip the boilerplate and get you straight to shipping. Each comes with GitHub Actions workflows, code quality tooling, and automated dependency management.
 
 <CardGrid>
   <LinkCard
@@ -19,5 +19,10 @@ Starter templates that skip the boilerplate and get you straight to shipping. Ea
     title="📁 .NET Template"
     description="A minimal .NET template with CI/CD, NuGet/GHCR publishing, GitHub Code Quality coverage, EditorConfig, and Renovate."
     href="/templates/dotnet/"
+  />
+  <LinkCard
+    title="🚀 GitOps Tenant Template"
+    description="A stack-neutral template for GitOps tenants on the devantler-tech platform, with signed build → publish → release plumbing kept current via template-sync."
+    href="/templates/gitops-tenant-template/"
   />
 </CardGrid>


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What & why

The **gitops-tenant-template** product shipped — its repo is live and it was registered as a monorepo submodule in #1743 — but it had **no presence on the devantler.tech site**. The Templates section listed only the Go and .NET templates, so the third template was undocumented and undiscoverable.

This adds:
- **`templates/gitops-tenant-template.md`** — a dedicated page matching the existing Go/.NET template pages (title, "What's Inside", "Getting Started", "Links").
- **A card** in `templates/index.mdx`, plus a small intro/description tweak so the page no longer claims "Go and .NET" only.

## Accuracy

Content is grounded in the [template's README](https://github.com/devantler-tech/gitops-tenant-template/blob/main/README.md) — not invented: stack-neutral tenant scaffold for the [platform](https://github.com/devantler-tech/platform), signed build → publish → release (cosign-verified `OCIRepository`), semantic-release tags, [template-sync](https://github.com/AndreasAugustin/actions-template-sync) upkeep, the owns-vs-yours `.templatesyncignore` split, and the container-name convention.

## Validation

- The page auto-wires into the **autogenerated** Templates sidebar (`directory: "templates"`).
- `astro build` passes: **61 pages built, "All internal links are valid"** — the new `/templates/gitops-tenant-template/` route and its index card link resolve.

## Trade-offs / notes

- Pure docs/content change — no dependency or config changes.
- Kept the page deliberately concise and consistent with the sibling template pages rather than duplicating the full README.