### PR TITLE
docs(portfolio-maintenance): confirm auto-merges via state, not mergeStateStatus

### DIFF
--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -68,6 +68,16 @@ advance a *different* product. Work the ladder top-down — **operate first, the
    `devantler` PRs merge directly with bare `gh pr merge <n> --squash` once CLEAN; incl. majors and
    incl. your own definition PRs once maintainer-promoted); your own drafts wait for promotion; never
    external.
+   - **Confirm by `state`/`mergedAt`, never by `mergeStateStatus`, in Enable-Auto-Merge repos.** Repos
+     with a `🔀 Enable Auto-Merge` workflow (monorepo, actions, reusable-workflows, go-template,
+     dotnet-template, skills, plugins, …) arm the `app/botantler` App on **promotion**, so it merges a
+     CLEAN trusted/own PR the instant its gates clear — often before a poll loop can observe `CLEAN`.
+     After you resolve threads + greenlight required checks, confirm the merge with
+     `gh pr view <n> --json state,mergedAt` and stop as soon as `state==MERGED` (or read the default
+     branch's top-commit subject for `(#N)`). Do **not** poll `mergeStateStatus`/`mergeable` and do
+     **not** fire a manual `gh pr merge` — a merged PR reports those as `UNKNOWN` for minutes while the
+     merge completes, so polling them (or attempting a now-moot manual merge, which the classifier
+     denies) only burns the run. Credit the auto-merge workflow, not a `gh pr merge` call.
 3. **Contributor-facing** — triage/label new issues+PRs; one insightful comment on the oldest
    un-commented open item.
 4. **Confident fixes** — clear bug, broken link, missing alt text, manifest misconfig, version bump.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem (evidence from my own runs — 3rd recurrence)

In repos with a `🔀 Enable Auto-Merge` workflow, the `app/botantler` App is armed on **promotion** and merges a CLEAN trusted/own PR the instant its gates clear — often before a poll loop can observe `mergeStateStatus=CLEAN`. A **merged** PR then reports `mergeStateStatus`/`mergeable` as `UNKNOWN` for minutes while the merge completes.

I keep mistaking that `UNKNOWN` for "still computing" and burn run time polling the status API (and firing a now-moot manual `gh pr merge`, which the merge classifier correctly denies). Logged instances:

1. reusable-workflows#257 + go-template#73 (2026-05-29)
2. actions#193 (2026-05-30)
3. **This run (2026-05-31):** the maintainer promoted all 6 of my drafts; I merged actions#197/#199 myself (no threads — manual `--squash` won the race), but dotnet-template#180 / skills#26 / plugins#14 were auto-merged by botantler (07:17–07:19Z) the moment I resolved their Copilot threads, while I spent ~5 min polling `UNKNOWN` and fired a moot `gh pr merge 180 --squash` → "already merged".

The learning was recorded each time but the run-loop never enforced it **at the decision point**, so it recurred.

## Change

Add one sub-bullet to `portfolio-maintenance` §2 (*Unblock trusted-author PRs*): in Enable-Auto-Merge repos, after clearing a promoted PR's gates, **confirm via `gh pr view <n> --json state,mergedAt` (poll `state==MERGED`)** — never poll `mergeStateStatus`/`mergeable`, never fire a manual `gh pr merge`. Credit the auto-merge workflow.

Docs-only, additive, no guardrail change. Draft — promote to merge.