### PR TITLE
docs(site): sync Active Projects to the agent-skills rename + add Upload Coverage

### DIFF
--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -42,7 +42,7 @@ A collection of [reusable GitHub Actions workflows](https://docs.github.com/en/a
 
 - **CI Workflows**: [Go](https://go.dev/) testing/linting, [.NET](https://dotnet.microsoft.com/) testing, documentation linting
 - **CD Workflows**: [GitHub Pages](https://pages.github.com/) publish, application/library releases, workflow-run cleanup
-- **Automation**: Auto-merge for trusted bots, [semantic-release](https://semantic-release.gitbook.io/), TODO scanning, [Kyverno](https://kyverno.io/) policy sync, [Zizmor](https://github.com/woodruffw/zizmor) workflow analysis, [Copilot skills](https://docs.github.com/en/copilot/how-tos/copilot-cli) updates
+- **Automation**: Auto-merge for trusted bots, [semantic-release](https://semantic-release.gitbook.io/), TODO scanning, [Kyverno](https://kyverno.io/) policy sync, [Zizmor](https://github.com/woodruffw/zizmor) workflow analysis, [agent skills](https://github.com/devantler-tech/skills) updates
 
 ## [⚡ Actions](https://github.com/devantler-tech/actions) ![GitHub Actions](https://img.shields.io/badge/GitHub%20Actions-2088FF.svg?style=for-the-badge&logo=GitHub-Actions&logoColor=white)
 
@@ -54,12 +54,13 @@ A collection of [composite GitHub Actions](https://docs.github.com/en/actions/tu
 - **Cleanup GHCR**: Clean up old [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) packages
 - **Login to GHCR**: Authenticate with the GitHub Container Registry
 - **.NET Test**: Test [.NET](https://dotnet.microsoft.com/) solutions or projects
-- **Setup Copilot Skills**: Install agent skills via `gh skill`
+- **Setup Agent Skills**: Install agent skills via `gh skill` for one or more agents (e.g. GitHub Copilot, Claude Code)
 - **Setup Go Toolchain**: Set up Go with optional private module support
 - **Setup KSail**: Install [KSail](https://github.com/devantler-tech/ksail) CLI via [Homebrew](https://brew.sh/)
 - **Sync Labels**: Sync GitHub labels across repositories
 - **TODOs**: Create GitHub issues from TODO comments in code
-- **Update Copilot Skills**: Run `gh skill update --all` and report changes
+- **Update Agent Skills**: Run `gh skill update --all` and report changes
+- **Upload Coverage**: Upload a Cobertura XML coverage report to GitHub Code Quality
 - **Upsert Issue**: Create, update, reopen, or close a GitHub issue by title
 
 </div>


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

The **Active Projects** page (`docs/src/content/docs/projects/active.mdx`) lists every `devantler-tech/actions` composite action by name, but the list had drifted from the live repo:

| Page (before) | Live repo | Fix |
|---|---|---|
| **Setup Copilot Skills** | `setup-agent-skills` ("Setup Agent Skills") | renamed → **Setup Agent Skills**, note it targets one or more agents (Copilot, Claude Code) |
| **Update Copilot Skills** | `update-agent-skills` ("Update Agent Skills") | renamed → **Update Agent Skills** |
| *(missing)* | `upload-coverage` ("Upload Coverage") | **added** — GitHub-native Code Quality coverage upload |

The Reusable Workflows automation bullet had the same stale wording ("Copilot skills updates") → **"agent skills updates"**, now linking `devantler-tech/skills`.

## Why

The actions were made **agent-neutral in v5.0.0** (the `setup-agent-skills`/`update-agent-skills` directories), and the GitHub-native coverage action (`upload-coverage`) was added during the Codecov → Code Quality migration but never surfaced on the site. This is docs-sync drift — the definition-of-done is that public docs match what ships.

## Verification

- Each entry checked against the live `action.yaml` `name`/`description` fields.
- Docs-only change; `npm run build` (astro + `starlight-links-validator`) passes locally.

Drafted per the contract — promote to ready when you want it driven to merge.