### PR TITLE
docs(site): sync GitOps Tenant Template ownership list to the template README

### DIFF
--- a/docs/src/content/docs/templates/gitops-tenant-template.md
+++ b/docs/src/content/docs/templates/gitops-tenant-template.md
@@ -18,7 +18,7 @@ It is intentionally **stack-neutral**: it carries no application code or languag
 
 ## What the template owns vs. what you own
 
-template-sync overwrites the files the template **owns** (the shared `cd.yaml`, `release.yaml`, `template-sync.yaml`, `CLAUDE.md`, and `zizmor.yml`) and never touches the files **you own**. Declare the files you own — your app code, `Dockerfile`, `deploy/` manifests, `ci.yaml`, `AGENTS.md`, and `README.md` — in a **`.templatesyncignore`** (same syntax as `.gitignore`).
+template-sync overwrites the files the template **owns** — the shared CI/CD plumbing (`cd.yaml`, `release.yaml`, `template-sync.yaml`, `validate-scaffold.yaml`), the `CLAUDE.md` shim, and the `zizmor.yml` pinning policy — and never touches the files **you own**. Declare the files you own — your app code, `Dockerfile`, `deploy/` manifests, `ci.yaml`, `dependabot.yml`, `AGENTS.md`, `README.md`, and project metadata (`.releaserc`, `.gitignore`, `LICENSE`) — in a **`.templatesyncignore`** (same syntax as `.gitignore`). See the template's [README](https://github.com/devantler-tech/gitops-tenant-template#what-the-template-owns-vs-what-you-own) for the authoritative file-by-file list.
 
 ## Getting Started
 

--- a/docs/src/content/docs/templates/gitops-tenant-template.md
+++ b/docs/src/content/docs/templates/gitops-tenant-template.md
@@ -20,8 +20,8 @@ It is intentionally **stack-neutral**: it carries no application code or languag
 
 | Ownership | Files | Notes |
 | --- | --- | --- |
-| Template-owned | Shared CI/CD plumbing (`cd.yaml`, `release.yaml`, `template-sync.yaml`, `validate-scaffold.yaml`), `CLAUDE.md`, `zizmor.yml` | Overwritten by `template-sync` |
-| You own | App code, `Dockerfile`, `deploy/` manifests, `ci.yaml`, `dependabot.yml`, `AGENTS.md`, `README.md`, `.releaserc`, `.gitignore`, `LICENSE` | Declare in `.templatesyncignore` (same syntax as `.gitignore`) |
+| Template-owned | Shared CI/CD plumbing under `.github/workflows/` (`cd.yaml`, `release.yaml`, `template-sync.yaml`, `validate-scaffold.yaml`), `CLAUDE.md`, `zizmor.yml` | Overwritten by `template-sync` |
+| You own | App code, `Dockerfile`, `deploy/` manifests, `.github/workflows/ci.yaml`, `.github/dependabot.yml`, `AGENTS.md`, `.claude/skills/maintain/SKILL.md`, `README.md`, `.releaserc`, `.gitignore`, `LICENSE`, `.templatesyncignore` | Declare in `.templatesyncignore` (same syntax as `.gitignore`), using these full paths |
 
 See the template's [README](https://github.com/devantler-tech/gitops-tenant-template#what-the-template-owns-vs-what-you-own) for the authoritative file-by-file list.
 

--- a/docs/src/content/docs/templates/gitops-tenant-template.md
+++ b/docs/src/content/docs/templates/gitops-tenant-template.md
@@ -18,7 +18,12 @@ It is intentionally **stack-neutral**: it carries no application code or languag
 
 ## What the template owns vs. what you own
 
-template-sync overwrites the files the template **owns** — the shared CI/CD plumbing (`cd.yaml`, `release.yaml`, `template-sync.yaml`, `validate-scaffold.yaml`), the `CLAUDE.md` shim, and the `zizmor.yml` pinning policy — and never touches the files **you own**. Declare the files you own — your app code, `Dockerfile`, `deploy/` manifests, `ci.yaml`, `dependabot.yml`, `AGENTS.md`, `README.md`, and project metadata (`.releaserc`, `.gitignore`, `LICENSE`) — in a **`.templatesyncignore`** (same syntax as `.gitignore`). See the template's [README](https://github.com/devantler-tech/gitops-tenant-template#what-the-template-owns-vs-what-you-own) for the authoritative file-by-file list.
+| Ownership | Files | Notes |
+| --- | --- | --- |
+| Template-owned | Shared CI/CD plumbing (`cd.yaml`, `release.yaml`, `template-sync.yaml`, `validate-scaffold.yaml`), `CLAUDE.md`, `zizmor.yml` | Overwritten by `template-sync` |
+| You own | App code, `Dockerfile`, `deploy/` manifests, `ci.yaml`, `dependabot.yml`, `AGENTS.md`, `README.md`, `.releaserc`, `.gitignore`, `LICENSE` | Declare in `.templatesyncignore` (same syntax as `.gitignore`) |
+
+See the template's [README](https://github.com/devantler-tech/gitops-tenant-template#what-the-template-owns-vs-what-you-own) for the authoritative file-by-file list.
 
 ## Getting Started
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The devantler.tech [GitOps Tenant Template page](https://github.com/devantler-tech/monorepo/blob/main/docs/src/content/docs/templates/gitops-tenant-template.md)'s **"What the template owns vs. what you own"** section had drifted from the template's own authoritative README ([`gitops-tenant-template#what-the-template-owns-vs-what-you-own`](https://github.com/devantler-tech/gitops-tenant-template#what-the-template-owns-vs-what-you-own)):

- **template-owned list** was missing **`validate-scaffold.yaml`** — a synced, template-owned workflow. A tenant author editing it locally would be surprised when template-sync overwrites it.
- **you-own list** omitted `dependabot.yml`, `.releaserc`, `.gitignore`, and `LICENSE` — all of which the README lists as tenant-owned (must be declared in `.templatesyncignore`).

Verified live against the template repo's tree and README before editing (the README's table is the source of truth).

## Change

- Sync both ownership lists on the public page to match the template README.
- Add a pointer to the README's authoritative file-by-file table so the public page can't silently drift from it again.

Single-file, content-only `docs:` change — no frontmatter, components, or internal links touched.

## Validation

- `npm ci && npm run build` in `docs/` → **build OK**, the `/templates/gitops-tenant-template/` page builds clean; the only build warnings are pre-existing and unrelated (blog-post code-block languages + a chunk-size note).