### PR TITLE
chore(site): replace Google Analytics with self-hosted Umami

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -83,11 +83,14 @@ export default defineConfig({
         // Umami privacy-first web analytics (self-hosted on the platform). The
         // website-id is fixed and managed declaratively — the matching Umami
         // "website" is provisioned from Git on the platform (no UI click-ops).
+        // data-domains restricts the tracker to the trusted host so the public
+        // website-id can't be used to send events from a spoofed site.
         {
           tag: "script",
           attrs: {
             src: "https://analytics.platform.devantler.tech/script.js",
             "data-website-id": "2f8d150e-c6f0-4a90-ab77-431c9ef9dc59",
+            "data-domains": "devantler.tech",
             defer: true,
           },
         },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -80,20 +80,25 @@ export default defineConfig({
           tag: "meta",
           attrs: { name: "author", content: "Nikolai Emil Damm" },
         },
-        {
-          tag: "script",
-          attrs: {
-            src: "https://www.googletagmanager.com/gtag/js?id=G-MK59Q89KYW",
-            async: true,
-          },
-        },
-        {
-          tag: "script",
-          content: `window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', 'G-MK59Q89KYW');`,
-        },
+        // Umami privacy-first web analytics (self-hosted on the platform at
+        // analytics.platform.devantler.tech). The tracking script is injected only
+        // once a website-id is configured, so builds without it stay clean. Create
+        // the site in the Umami dashboard to get its id, then set
+        // PUBLIC_UMAMI_WEBSITE_ID (and optionally PUBLIC_UMAMI_SRC) in the build env.
+        ...(process.env.PUBLIC_UMAMI_WEBSITE_ID
+          ? [
+              {
+                tag: "script",
+                attrs: {
+                  src:
+                    process.env.PUBLIC_UMAMI_SRC ||
+                    "https://analytics.platform.devantler.tech/script.js",
+                  "data-website-id": process.env.PUBLIC_UMAMI_WEBSITE_ID,
+                  defer: true,
+                },
+              },
+            ]
+          : []),
         {
           tag: "script",
           content: `document.addEventListener('DOMContentLoaded',()=>{const sel='main article, .blog-post-list article';function navigate(article){const link=article.querySelector('h2 a');if(link)window.location.href=link.href;}document.addEventListener('click',e=>{if(e.target.closest('a'))return;const article=e.target.closest(sel);if(article)navigate(article);});document.querySelectorAll(sel).forEach(el=>{const link=el.querySelector('h2 a');if(!link)return;el.setAttribute('tabindex','0');el.setAttribute('role','link');el.setAttribute('aria-label',link.textContent.trim());el.addEventListener('keydown',e=>{if(e.target!==el)return;if(e.key==='Enter'||e.code==='Space'||e.key===' '||e.key==='Spacebar'){e.preventDefault();navigate(el);}});});});`,

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -80,25 +80,17 @@ export default defineConfig({
           tag: "meta",
           attrs: { name: "author", content: "Nikolai Emil Damm" },
         },
-        // Umami privacy-first web analytics (self-hosted on the platform at
-        // analytics.platform.devantler.tech). The tracking script is injected only
-        // once a website-id is configured, so builds without it stay clean. Create
-        // the site in the Umami dashboard to get its id, then set
-        // PUBLIC_UMAMI_WEBSITE_ID (and optionally PUBLIC_UMAMI_SRC) in the build env.
-        ...(process.env.PUBLIC_UMAMI_WEBSITE_ID
-          ? [
-              {
-                tag: "script",
-                attrs: {
-                  src:
-                    process.env.PUBLIC_UMAMI_SRC ||
-                    "https://analytics.platform.devantler.tech/script.js",
-                  "data-website-id": process.env.PUBLIC_UMAMI_WEBSITE_ID,
-                  defer: true,
-                },
-              },
-            ]
-          : []),
+        // Umami privacy-first web analytics (self-hosted on the platform). The
+        // website-id is fixed and managed declaratively — the matching Umami
+        // "website" is provisioned from Git on the platform (no UI click-ops).
+        {
+          tag: "script",
+          attrs: {
+            src: "https://analytics.platform.devantler.tech/script.js",
+            "data-website-id": "2f8d150e-c6f0-4a90-ab77-431c9ef9dc59",
+            defer: true,
+          },
+        },
         {
           tag: "script",
           content: `document.addEventListener('DOMContentLoaded',()=>{const sel='main article, .blog-post-list article';function navigate(article){const link=article.querySelector('h2 a');if(link)window.location.href=link.href;}document.addEventListener('click',e=>{if(e.target.closest('a'))return;const article=e.target.closest(sel);if(article)navigate(article);});document.querySelectorAll(sel).forEach(el=>{const link=el.querySelector('h2 a');if(!link)return;el.setAttribute('tabindex','0');el.setAttribute('role','link');el.setAttribute('aria-label',link.textContent.trim());el.addEventListener('keydown',e=>{if(e.target!==el)return;if(e.key==='Enter'||e.code==='Space'||e.key===' '||e.key==='Spacebar'){e.preventDefault();navigate(el);}});});});`,


### PR DESCRIPTION
## What

Removes **Google Analytics** from the devantler.tech docs site and replaces it with the self-hosted **Umami** tracking script.

- Deletes both GA `<script>` blocks from `docs/astro.config.mjs` (the `googletagmanager.com/gtag/js?id=G-MK59Q89KYW` loader and the inline `gtag('config', …)` snippet). No Google Analytics references remain anywhere in `docs/`.
- Adds the Umami tracking script (`analytics.platform.devantler.tech/script.js`) with a **fixed, declaratively-managed `data-website-id`** — the matching Umami "website" is provisioned from Git on the platform (no UI click-ops), so the id is known ahead of time and pinned in config rather than wired through a build-time env var. The script is `defer`red.
- Scoped with **`data-domains="devantler.tech"`** so the public website-id can only record pageviews from the trusted host — it can't be reused to send events from a spoofed site. (Website-ids are not secrets; they appear in page HTML.)

## Why

Switching analytics to self-hosted, privacy-first Umami (deployed on the platform in the companion PR). No further reliance on Google Analytics.

## Validation
- `npm ci && npm run build` — **62 pages built**, no errors (only the pre-existing unrelated `ssh`/`editorconfig` code-block highlight warnings).
- Built HTML contains **no** GA; the Umami `script.js` + `data-website-id` + `data-domains` is injected as expected.

## Sequencing
The Umami collector this script points at is deployed by the companion platform PR — this site change should land **with / after** that deploy so the public site doesn't reference a not-yet-live `analytics.platform.devantler.tech` endpoint. (The script is `defer`red, so a brief gap is harmless, but landing them together is cleanest.)

> Companion PR: devantler-tech/platform#1712 (deploys Umami on the platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
