### PR TITLE
chore: register platform-template submodule and add to portfolio map

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,3 +66,7 @@
 	path = templates/gitops-tenant-template
 	url = git@github.com:devantler-tech/gitops-tenant-template.git
 	branch = main
+[submodule "templates/platform-template"]
+	path = templates/platform-template
+	url = git@github.com:devantler-tech/platform-template.git
+	branch = main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ keeping them healthy *and* moving them forward.
 | Go template | `devantler-tech/go-template` | `templates/go-template` | [AGENTS.md](https://github.com/devantler-tech/go-template/blob/main/AGENTS.md) |
 | .NET template | `devantler-tech/dotnet-template` | `templates/dotnet-template` | [AGENTS.md](https://github.com/devantler-tech/dotnet-template/blob/main/AGENTS.md) |
 | GitOps-tenant template | `devantler-tech/gitops-tenant-template` | `templates/gitops-tenant-template` | [AGENTS.md](https://github.com/devantler-tech/gitops-tenant-template/blob/main/AGENTS.md) |
+| Platform template | `devantler-tech/platform-template` | `templates/platform-template` | [AGENTS.md](https://github.com/devantler-tech/platform-template/blob/main/AGENTS.md) |
 | GitHub Actions | `devantler-tech/actions` | `github/devantler-tech/github-actions/actions` | [AGENTS.md](https://github.com/devantler-tech/actions/blob/main/AGENTS.md) |
 | Reusable Workflows | `devantler-tech/reusable-workflows` | `github/devantler-tech/github-actions/reusable-workflows` | [AGENTS.md](https://github.com/devantler-tech/reusable-workflows/blob/main/AGENTS.md) |
 | Homebrew tap | `devantler-tech/homebrew-tap` (renamed from `homebrew-formulas`; the submodule URL redirects) | `homebrew-formulas` | [AGENTS.md](https://github.com/devantler-tech/homebrew-tap/blob/main/AGENTS.md) |


### PR DESCRIPTION
## What

Registers the new **[devantler-tech/platform-template](https://github.com/devantler-tech/platform-template)** repository as `templates/platform-template`, and adds it to the Portfolio map in `AGENTS.md`.

## Why

First iteration of a reusable, fully-bootstrappable **platform template** — a genericized snapshot of `devantler-tech/platform` (Flux GitOps + KSail + Talos) whose headline `bootstrap.yaml` takes an instance from *Use this template + GitHub Secrets* → a running Hetzner cluster, unattended (generates the Age key, renders config, `sops`-encrypts secrets, `ksail cluster create`, writes `KUBE_CONFIG`/`TALOS_CONFIG`/`SOPS_AGE_KEY` back as `prod` environment secrets, DNS, push+reconcile). Mirrors how `gitops-tenant-template` was registered (monorepo#1743).

## The template repo (already live)

- Genericized: full infrastructure layer kept intact; demo apps `whoami`/`homepage`/`headlamp`; private apps + their vault wiring removed.
- Workflows: `bootstrap` (headline) + ci/cd/release + `template-sync` (v5.3.0) + `validate-scaffold` (`ksail workload validate` gate).
- **Verified**: `ksail workload validate` green for both `ksail.yaml` and `ksail.prod.yaml` (234 files each); whole-tree secret-hygiene sweep clean (no ciphertext / Age keys / real identity values); bootstrap render+encrypt logic dry-run-verified (real ciphertext, round-trip decrypt OK).
- Submodule pinned at the genesis commit `39ac525`; `branch = main`.

## Follow-up (not in this PR)

- The live Hetzner bootstrap run is gated to the maintainer.
- The bootstrap's secret write-back needs a GitHub App (or PAT) with **Contents + Secrets + Environments + Actions: write** — documented in the template's `docs/BOOTSTRAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)