### PR TITLE
docs(agents): require statusCheckRollup in the merge-gating evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,10 +131,14 @@ Conventional-Commit title, then **merge with the command that matches the author
 
 This **includes dependency major-version bumps** once CI is green. **Before any merge, emit the raw
 gating evidence** an unattended run is checked against — a *fresh*
-`gh pr view <n> --json number,isDraft,author,mergeStateStatus` **plus**
-`gh api repos/<owner>/<repo>/rules/branches/<default>` showing a non-empty required-status-checks set;
-skipping that branch-protection call is what makes the self-merge fail-close nondeterministically (the
-recurring own-PR merge denials).
+`gh pr view <n> --json number,isDraft,author,mergeStateStatus,statusCheckRollup` **plus**
+`gh api repos/<owner>/<repo>/rules/branches/<default>` showing a non-empty required-status-checks set.
+The **`statusCheckRollup`** field is load-bearing: emitting only the summary `mergeStateStatus`
+(without the per-check rollup that proves each *required* check is SUCCESS) is what makes the
+self-merge fail-close nondeterministically — as does skipping the branch-protection call. Emit
+**both** in one shot *before* the first `gh pr merge`; on a denial, **STOP** (never retry — retries
+compound the fail-close) and surface the PR to the maintainer as a one-click merge. (These are the
+recurring own-PR merge denials; the durable fix is a token-backed / non-Bash merge path.)
 
 The agent's **own** PRs are trusted-author PRs (authored as `devantler` from `claude/*` branches — see
 trust gate), so the **same path applies to them, including its own definition PRs — no carve-out**. The


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Add `statusCheckRollup` to the `gh pr view` call in the **Merge policy** "emit the raw gating
evidence" step, and codify the observed merge discipline (emit both evidence calls in one shot before
the first merge; **stop on denial**, never retry).

```diff
-`gh pr view <n> --json number,isDraft,author,mergeStateStatus` **plus**
+`gh pr view <n> --json number,isDraft,author,mergeStateStatus,statusCheckRollup` **plus**
```

## Why

The contract's evidence list omitted `statusCheckRollup`. Following it **literally** repeatedly
tripped the unattended-merge fail-close — the merge classifier needs the per-check rollup that proves
each *required* check is `SUCCESS`, not just the summary `mergeStateStatus`. The
[`portfolio-maintenance`](.claude/skills/portfolio-maintenance/SKILL.md) skill **already** prescribes
`…mergeStateStatus,reviewDecision,statusCheckRollup`, so the canonical `AGENTS.md` was the lone
out-of-sync source. This reconciles that drift.

**Evidence (own-run only):**
- 2026-06-03 (81st & 92nd ticks): emitted the contract's literal list (no rollup) → bare own-PR merge
  **denied**; positive control with rollup emitted → **merged first try**.
- 2026-06-04 (this run): same omission on platform #1730/#1727 → denied; surfaced as maintainer
  one-clicks instead of retrying.

## Guardrail note

Strictly **tightening** — it requires *more* evidence before a merge and makes the "stop, don't retry"
rule explicit. No guardrail is loosened. The durable fix for the Bash-classifier friction remains a
token-backed / non-Bash merge path (tracked separately); this is the cheap correctness alignment in
the meantime.

Opened as a **draft** per the self-improvement gate — the maintainer's promotion is the go-signal for
a definition change.
