### PR TITLE
ci: exempt internal devantler-tech deps from Dependabot cooldown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,10 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+      # Internal devantler-tech actions/reusable-workflows are trusted (our own
+      # code) — bump immediately, never hold them in cooldown.
+      exclude:
+        - "devantler-tech/*"
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"


### PR DESCRIPTION
## What

Exempt internal `devantler-tech/*` dependencies from the Dependabot `github-actions` **cooldown** so our own actions/reusable-workflows bump **immediately** instead of waiting 7 days.

```yaml
cooldown:
  default-days: 7
  exclude:
    - "devantler-tech/*"
```

## Why

We trust our own code, so internal bumps shouldn't sit in cooldown like third-party deps. Per Dependabot's [`WildcardMatcher`](https://github.com/dependabot/dependabot-core/blob/main/common/lib/wildcard_matcher.rb), `*` compiles to `.*` (anchored, matches across `/`), so `devantler-tech/*` covers both:
- `devantler-tech/actions`
- `devantler-tech/reusable-workflows/.github/workflows/<file>.yaml`

The `gitsubmodule` ecosystem (all submodules are devantler-tech repos) has no cooldown, so submodule bumps are already immediate. The `npm` `/docs` cooldown is left as-is (no internal npm deps).

Part of a portfolio-wide pass applying this policy to every repo's dependabot/renovate config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)