### PR TITLE
docs: sync site Actions list with live actions repo

### DIFF
--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -50,8 +50,10 @@ A collection of [composite GitHub Actions](https://docs.github.com/en/actions/tu
 
 - **Aggregate Job Checks**: Aggregate multiple job results into a single required check
 - **Approve PR**: Approve a PR using a GitHub App identity
+- **Dependency Review**: Scan a PR's dependency changes for vulnerabilities and disallowed licenses
 - **Enable Auto-Merge**: Enable auto-merge on a pull request
 - **Cleanup GHCR**: Clean up old [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) packages
+- **Free Disk Space**: Reclaim runner disk space by removing large preinstalled toolchains
 - **Login to GHCR**: Authenticate with the GitHub Container Registry
 - **.NET Test**: Test [.NET](https://dotnet.microsoft.com/) solutions or projects
 - **Setup Agent Skills**: Install agent skills via `gh skill` for one or more agents (e.g. GitHub Copilot, Claude Code)


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

The **devantler.tech** projects page (`docs/src/content/docs/projects/active.mdx`) enumerated **14 of the 16** composite actions published in [`devantler-tech/actions`](https://github.com/devantler-tech/actions). This PR adds the two that had drifted out of sync since the page was last updated:

- **Dependency Review** (`dependency-review`) — Scan a PR's dependency changes for vulnerabilities and disallowed licenses.
- **Free Disk Space** (`free-disk-space`) — Reclaim runner disk space by removing large preinstalled toolchains.

## Why

Keeping public docs in sync with what ships is part of the engineering contract's definition of done. The Actions section is an *exhaustive* list (unlike the Reusable Workflows prose summary), so a missing entry is an objective accuracy gap — the page under-represented the Actions product by 2 of 16 (~12.5%).

## Verification

- Cross-checked the full list against the live `devantler-tech/actions` README (16 entries) — the page now lists all of them, with no phantom/stale entries.
- `npm run build` (astro build) passes; the Starlight link validator reports **all internal links valid** (62 pages built).
- Pure additive content change: 2 new bullets matching the existing list style; no new imports, links, or components.

The Reusable Workflows section just above is a representative prose summary rather than an exhaustive enumeration, so it was left as-is (no objective drift).