### PR TITLE
docs: correct site Reusable Workflows list to match live repo

### DIFF
--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -40,9 +40,9 @@ A couple of small apps I build and self-host purely for myself and my family —
 
 A collection of [reusable GitHub Actions workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows) that encapsulate common CI/CD patterns. Used across all DevantlerTech projects to ensure consistency and reduce duplication.
 
-- **CI Workflows**: [Go](https://go.dev/) testing/linting, [.NET](https://dotnet.microsoft.com/) testing, documentation linting
+- **CI Workflows**: [Go](https://go.dev/) testing/linting, [.NET](https://dotnet.microsoft.com/) testing, [dependency review](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review)
 - **CD Workflows**: [GitHub Pages](https://pages.github.com/) publish, application/library releases, workflow-run cleanup
-- **Automation**: Auto-merge for trusted bots, [semantic-release](https://semantic-release.gitbook.io/), TODO scanning, [Kyverno](https://kyverno.io/) policy sync, [Zizmor](https://github.com/woodruffw/zizmor) workflow analysis, [agent skills](https://github.com/devantler-tech/skills) updates
+- **Automation**: Auto-merge for trusted bots, [semantic-release](https://semantic-release.gitbook.io/), TODO scanning, [Kyverno](https://kyverno.io/) policy sync, [Zizmor](https://github.com/woodruffw/zizmor) workflow analysis, [agent skills](https://github.com/devantler-tech/skills) updates, [template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository) sync
 
 ## [⚡ Actions](https://github.com/devantler-tech/actions) ![GitHub Actions](https://img.shields.io/badge/GitHub%20Actions-2088FF.svg?style=for-the-badge&logo=GitHub-Actions&logoColor=white)
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The **Active Projects** page (`docs/src/content/docs/projects/active.mdx`) describes the Reusable Workflows product with a curated CI/CD/Automation list that has drifted from the live [`devantler-tech/reusable-workflows`](https://github.com/devantler-tech/reusable-workflows) repo:

- **CI Workflows** listed **"documentation linting"** — there is **no such reusable workflow** in the repo (the live workflow set has no docs/markdown-lint workflow).
- Two real reusable workflows were **missing** from the summary: `dependency-review.yaml` (🛡️ Dependency Review) and `template-sync.yaml` (🔄 Template Sync).

## Change

Reconcile the list with the live workflows:

- **CI**: replace the non-existent "documentation linting" with **dependency review** (links to GitHub's dependency-review docs).
- **Automation**: add **template repository sync**.

This mirrors the accuracy sweep already done for the sibling **Actions** list in [#1798](https://github.com/devantler-tech/monorepo/pull/1798) — keeping the site's product lists faithful to what actually ships.

## Validation

- `npm run build` (Astro + Starlight) — ✅ green, 63 pages built.
- Starlight links validator — ✅ all internal links valid.

Scope is intentionally minimal: one curated-summary line corrected + one item added; no exhaustive enumeration (the section is a thematic summary by design).