### PR TITLE
docs(site): add Agent Skills and Agent Plugins to Active Projects

### DIFF
--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -65,4 +65,12 @@ A collection of [composite GitHub Actions](https://docs.github.com/en/actions/tu
 - **Upload Coverage**: Upload a Cobertura XML coverage report to GitHub Code Quality
 - **Upsert Issue**: Create, update, reopen, or close a GitHub issue by title
 
+## [🧠 Agent Skills](https://github.com/devantler-tech/skills) ![GitHub Copilot](https://img.shields.io/badge/GitHub%20Copilot-000000.svg?style=for-the-badge&logo=githubcopilot&logoColor=white) ![Claude](https://img.shields.io/badge/Claude-D97757.svg?style=for-the-badge&logo=claude&logoColor=white)
+
+A collection of generic, tool-neutral [agent skills](https://github.com/devantler-tech/skills) that teach AI coding agents how to perform common engineering tasks. Installable via `gh skill` and designed to work across agents such as [GitHub Copilot](https://github.com/features/copilot) and [Claude Code](https://www.anthropic.com/claude-code).
+
+## [🧩 Agent Plugins](https://github.com/devantler-tech/plugins) ![GitHub Copilot](https://img.shields.io/badge/GitHub%20Copilot-000000.svg?style=for-the-badge&logo=githubcopilot&logoColor=white) ![Claude](https://img.shields.io/badge/Claude-D97757.svg?style=for-the-badge&logo=claude&logoColor=white) ![VS Code](https://img.shields.io/badge/VS%20Code-007ACC.svg?style=for-the-badge&logo=visualstudiocode&logoColor=white)
+
+An industry-standard agent-plugin marketplace that bundles curated skills from [Agent Skills](https://github.com/devantler-tech/skills) into category-based plugins. It ships dual manifests so the same plugins work in [VS Code](https://code.visualstudio.com/), the [GitHub Copilot CLI](https://github.com/features/copilot), and [Claude Code](https://www.anthropic.com/claude-code).
+
 </div>


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds **Agent Skills** ([devantler-tech/skills](https://github.com/devantler-tech/skills)) and **Agent Plugins** ([devantler-tech/plugins](https://github.com/devantler-tech/plugins)) to the site's [Active Projects](https://devantler.tech/projects/active/) page.

## Why

The Active Projects page lists KSail, Platform, Reusable Workflows, Actions and the self-hosted apps, but two public, actively-maintained products were missing:

- **skills** — generic, tool-neutral agent skills installable via `gh skill`, working across GitHub Copilot and Claude Code.
- **plugins** — an industry-standard agent-plugin marketplace bundling those curated skills into category-based plugins, shipping dual manifests for VS Code / Copilot CLI / Claude Code.

Both are public and non-archived, and the portfolio treats them as first-class "leverage point" products (the shared agent-extension libraries), yet they had no presence on the public site while templates get a whole section. This closes that gap as part of the docs cadence.

## How

- Two entries appended to `docs/src/content/docs/projects/active.mdx`, mirroring the existing **Actions** / **Reusable Workflows** entry style (heading + shields badges + short description, no screenshot).
- Descriptions are grounded in each repo's own GitHub description — no invented claims.

## Validation

- `npm ci && npm run build` (astro build) in `docs/` — **green**, 63 pages built, *"All internal links are valid."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)