### PR TITLE
ci: reach private submodules via org-level Dependabot registry (keep SSH)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,18 +1,4 @@
 version: 2
-
-# Credential Dependabot's gitsubmodule updater uses to reach our PRIVATE submodules:
-# applications/wedding-app + applications/ascoachingogvaner (org-private) and dotfiles
-# (devantler/dotfiles, a different account). Without it Dependabot cannot clone those
-# three and the whole "submodules in /." job fails with git_dependencies_not_reachable.
-# This only feeds Dependabot's internal HTTPS fetch — .gitmodules keeps its SSH URLs,
-# so local `git submodule` operations are unaffected. PAT lives as a Dependabot secret.
-registries:
-  github-submodules:
-    type: git
-    url: https://github.com
-    username: x-access-token
-    password: ${{secrets.DEPENDABOT_SUBMODULE_PAT}}
-
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -27,6 +13,13 @@ updates:
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"
+    # Opt in to the org-level "Git Source" private registry (https://github.com, a
+    # classic PAT) so Dependabot can reach our PRIVATE submodules — wedding-app and
+    # ascoachingogvaner (org-private) and dotfiles (devantler/dotfiles, another
+    # account). Without access the whole "submodules in /." job fails with
+    # git_dependencies_not_reachable. The credential lives in the org's Dependabot
+    # private-registries UI (not a repo secret); .gitmodules keeps its SSH URLs, so
+    # local `git submodule` operations are unaffected.
     registries: "*"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,18 @@
 version: 2
+
+# Credential Dependabot's gitsubmodule updater uses to reach our PRIVATE submodules:
+# applications/wedding-app + applications/ascoachingogvaner (org-private) and dotfiles
+# (devantler/dotfiles, a different account). Without it Dependabot cannot clone those
+# three and the whole "submodules in /." job fails with git_dependencies_not_reachable.
+# This only feeds Dependabot's internal HTTPS fetch — .gitmodules keeps its SSH URLs,
+# so local `git submodule` operations are unaffected. PAT lives as a Dependabot secret.
+registries:
+  github-submodules:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: ${{secrets.DEPENDABOT_SUBMODULE_PAT}}
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -13,6 +27,7 @@ updates:
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"
+    registries: "*"
     schedule:
       interval: "daily"
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,72 +1,72 @@
 [submodule "templates/dotnet-template"]
 	path = templates/dotnet-template
-	url = git@github.com:devantler-tech/dotnet-template.git
+	url = https://github.com/devantler-tech/dotnet-template.git
 	branch = main
 [submodule "dotfiles"]
 	path = dotfiles
-	url = git@github.com:devantler/dotfiles.git
+	url = https://github.com/devantler/dotfiles.git
 	branch = main
 [submodule "github/devantler-tech/.github-public"]
 	path = github/devantler-tech/.github-public
-	url = git@github.com:devantler-tech/.github.git
+	url = https://github.com/devantler-tech/.github.git
 	branch = main
 [submodule "github/devantler-tech/github-actions/actions"]
 	path = github/devantler-tech/github-actions/actions
-	url = git@github.com:devantler-tech/actions.git
+	url = https://github.com/devantler-tech/actions.git
 	branch = main
 [submodule "github/personal/.github-public"]
 	path = github/personal/.github-public
-	url = git@github.com:devantler/.github.git
+	url = https://github.com/devantler/.github.git
 	branch = main
 [submodule "github/personal/profile"]
 	path = github/personal/profile
-	url = git@github.com:devantler/devantler.git
+	url = https://github.com/devantler/devantler.git
 	branch = main
 [submodule "platform"]
 	path = platform
-	url = git@github.com:devantler-tech/platform.git
+	url = https://github.com/devantler-tech/platform.git
 	branch = main
 [submodule "homebrew-formulas"]
 	path = homebrew-formulas
-	url = git@github.com:devantler-tech/homebrew-formulas.git
+	url = https://github.com/devantler-tech/homebrew-formulas.git
 	branch = main
 [submodule "github/devantler-tech/github-actions/reusable-workflows"]
 	path = github/devantler-tech/github-actions/reusable-workflows
-	url = git@github.com:devantler-tech/reusable-workflows.git
+	url = https://github.com/devantler-tech/reusable-workflows.git
 	branch = main
 [submodule "templates/go-template"]
 	path = templates/go-template
-	url = git@github.com:devantler-tech/go-template.git
+	url = https://github.com/devantler-tech/go-template.git
 	branch = main
 [submodule "applications/ksail"]
 	path = applications/ksail
-	url = git@github.com:devantler-tech/ksail.git
+	url = https://github.com/devantler-tech/ksail.git
 	branch = main
 [submodule "github/devantler-tech/maintenance"]
 	path = github/devantler-tech/maintenance
-	url = git@github.com:devantler-tech/maintenance.git
+	url = https://github.com/devantler-tech/maintenance.git
 	branch = main
 [submodule "applications/wedding-app"]
 	path = applications/wedding-app
-	url = git@github.com:devantler-tech/wedding-app.git
+	url = https://github.com/devantler-tech/wedding-app.git
 	branch = main
 [submodule "applications/ascoachingogvaner"]
 	path = applications/ascoachingogvaner
-	url = git@github.com:devantler-tech/ascoachingogvaner.git
+	url = https://github.com/devantler-tech/ascoachingogvaner.git
 	branch = main
 [submodule "libraries/skills"]
 	path = libraries/skills
-	url = git@github.com:devantler-tech/skills.git
+	url = https://github.com/devantler-tech/skills.git
 	branch = main
 [submodule "libraries/plugins"]
 	path = libraries/plugins
-	url = git@github.com:devantler-tech/plugins.git
+	url = https://github.com/devantler-tech/plugins.git
 	branch = main
 [submodule "templates/gitops-tenant-template"]
 	path = templates/gitops-tenant-template
-	url = git@github.com:devantler-tech/gitops-tenant-template.git
+	url = https://github.com/devantler-tech/gitops-tenant-template.git
 	branch = main
 [submodule "templates/platform-template"]
 	path = templates/platform-template
-	url = git@github.com:devantler-tech/platform-template.git
+	url = https://github.com/devantler-tech/platform-template.git
 	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,72 +1,72 @@
 [submodule "templates/dotnet-template"]
 	path = templates/dotnet-template
-	url = https://github.com/devantler-tech/dotnet-template.git
+	url = git@github.com:devantler-tech/dotnet-template.git
 	branch = main
 [submodule "dotfiles"]
 	path = dotfiles
-	url = https://github.com/devantler/dotfiles.git
+	url = git@github.com:devantler/dotfiles.git
 	branch = main
 [submodule "github/devantler-tech/.github-public"]
 	path = github/devantler-tech/.github-public
-	url = https://github.com/devantler-tech/.github.git
+	url = git@github.com:devantler-tech/.github.git
 	branch = main
 [submodule "github/devantler-tech/github-actions/actions"]
 	path = github/devantler-tech/github-actions/actions
-	url = https://github.com/devantler-tech/actions.git
+	url = git@github.com:devantler-tech/actions.git
 	branch = main
 [submodule "github/personal/.github-public"]
 	path = github/personal/.github-public
-	url = https://github.com/devantler/.github.git
+	url = git@github.com:devantler/.github.git
 	branch = main
 [submodule "github/personal/profile"]
 	path = github/personal/profile
-	url = https://github.com/devantler/devantler.git
+	url = git@github.com:devantler/devantler.git
 	branch = main
 [submodule "platform"]
 	path = platform
-	url = https://github.com/devantler-tech/platform.git
+	url = git@github.com:devantler-tech/platform.git
 	branch = main
 [submodule "homebrew-formulas"]
 	path = homebrew-formulas
-	url = https://github.com/devantler-tech/homebrew-formulas.git
+	url = git@github.com:devantler-tech/homebrew-formulas.git
 	branch = main
 [submodule "github/devantler-tech/github-actions/reusable-workflows"]
 	path = github/devantler-tech/github-actions/reusable-workflows
-	url = https://github.com/devantler-tech/reusable-workflows.git
+	url = git@github.com:devantler-tech/reusable-workflows.git
 	branch = main
 [submodule "templates/go-template"]
 	path = templates/go-template
-	url = https://github.com/devantler-tech/go-template.git
+	url = git@github.com:devantler-tech/go-template.git
 	branch = main
 [submodule "applications/ksail"]
 	path = applications/ksail
-	url = https://github.com/devantler-tech/ksail.git
+	url = git@github.com:devantler-tech/ksail.git
 	branch = main
 [submodule "github/devantler-tech/maintenance"]
 	path = github/devantler-tech/maintenance
-	url = https://github.com/devantler-tech/maintenance.git
+	url = git@github.com:devantler-tech/maintenance.git
 	branch = main
 [submodule "applications/wedding-app"]
 	path = applications/wedding-app
-	url = https://github.com/devantler-tech/wedding-app.git
+	url = git@github.com:devantler-tech/wedding-app.git
 	branch = main
 [submodule "applications/ascoachingogvaner"]
 	path = applications/ascoachingogvaner
-	url = https://github.com/devantler-tech/ascoachingogvaner.git
+	url = git@github.com:devantler-tech/ascoachingogvaner.git
 	branch = main
 [submodule "libraries/skills"]
 	path = libraries/skills
-	url = https://github.com/devantler-tech/skills.git
+	url = git@github.com:devantler-tech/skills.git
 	branch = main
 [submodule "libraries/plugins"]
 	path = libraries/plugins
-	url = https://github.com/devantler-tech/plugins.git
+	url = git@github.com:devantler-tech/plugins.git
 	branch = main
 [submodule "templates/gitops-tenant-template"]
 	path = templates/gitops-tenant-template
-	url = https://github.com/devantler-tech/gitops-tenant-template.git
+	url = git@github.com:devantler-tech/gitops-tenant-template.git
 	branch = main
 [submodule "templates/platform-template"]
 	path = templates/platform-template
-	url = https://github.com/devantler-tech/platform-template.git
+	url = git@github.com:devantler-tech/platform-template.git
 	branch = main


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant — revised interactively at the maintainer's direction (keep SSH; reach private submodules via an **org-level** private registry).

## Problem

The **`submodules in /.` Dependabot job fails on every run** (e.g. [run 27037665644](https://github.com/devantler-tech/monorepo/actions/runs/27037665644)). The summary reports **exactly 3 errors**, all `git_dependencies_not_reachable`:

| Submodule | Repo | Why |
|---|---|---|
| `applications/wedding-app` | `devantler-tech/wedding-app` | **private** — Dependabot has no access |
| `applications/ascoachingogvaner` | `devantler-tech/ascoachingogvaner` | **private** — no access |
| `dotfiles` | `devantler/dotfiles` | **private + different account** — no access |

These are **access** failures, not URL-scheme failures, so the original "switch `.gitmodules` to HTTPS" idea wouldn't have fixed the red (Dependabot's proxy already fetches every submodule over HTTPS internally regardless of the scheme — the log shows `https://…/wedding-app.git → 404`). Confirmed dead ends: `ignore:` does not stop the access attempt ([dependabot-core#8136](https://github.com/dependabot/dependabot-core/issues/8136)); Dependabot fails the whole job on one unreachable dep, by design ([#8433](https://github.com/dependabot/dependabot-core/issues/8433)).

## Fix — org-level private registry, SSH kept

`.gitmodules` is reverted to its original **SSH** URLs (diff vs `main` is empty). Dependabot is given access to the 3 private repos through an **organization-level "Git Source" private registry** (centralized config, [GA 2025-07-22](https://github.blog/changelog/2025-07-22-centralized-private-registry-configuration-for-dependabot-is-now-generally-available/)). The repo only opts in:

```yaml
  - package-ecosystem: "gitsubmodule"
    directory: "/"
    registries: "*"      # uses the org-level Git Source registry
    schedule:
      interval: "daily"
```

No top-level `registries:` block and **no repo secret** — per [GitHub docs](https://docs.github.com/en/code-security/how-tos/secure-at-scale/configure-organization-security/manage-usage-and-access/giving-org-access-private-registries), the org registry stores the credential as an encrypted secret in the UI, and "Dependabot can use any of the org-level private registries." The registry `url` is `https://github.com`, but that only feeds Dependabot's internal fetch — **`.gitmodules` keeps SSH**, so local `git submodule` is unaffected.

## ⚠️ Required before this can go green — maintainer action (org UI)

**Org Settings → Secrets and variables → Dependabot → Private registries → New private registry:**

- **URL** `https://github.com` · **Type** `Git Source`
- **Username and password** → **Username** `devantler`, **Password** = a **classic PAT** owned by `@devantler` with the `repo` scope (one classic PAT spans both the personal account `dotfiles` *and* the two `devantler-tech` org repos; a fine-grained token is locked to one owner and can't).
- **Repository access**: `Selected repositories → monorepo` is enough (or `All repositories`).
- **Leave "Replaces base" unchecked** — additive credential: Dependabot keeps its default github.com token for public repos and uses the PAT only where that fails (the 3 private repos).

## Validation

- `.gitmodules` diff vs `main` is **empty** — SSH URLs unchanged.
- `dependabot.yaml` parses (yq); +8 lines (comment + `registries: "*"`).
- ⚠️ The gitsubmodule job runs **on schedule against the default branch**, not on PRs — so this can only be confirmed green *after* the registry exists + merge, on the next scheduled run.
- Note: org-level private registries are free for **public** consuming repos (the monorepo qualifies); the Code Security SKU note in the changelog applies to *private* consuming repos.

Opened as a **draft** — do not merge until the org-level registry is configured.
