### PR TITLE
docs(site): auto-derive homepage "Latest from the Blog" from the blog collection

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -33,6 +33,12 @@ hero:
 ---
 
 import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
+import { getCollection } from "astro:content";
+
+export const latestPosts = (await getCollection("docs"))
+  .filter((entry) => entry.id.startsWith("blog/"))
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+  .slice(0, 4);
 
 ## What I Do
 
@@ -81,26 +87,15 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 ## Latest from the Blog
 
 <CardGrid>
-  <LinkCard
-    title="I Built an MCP Server into My Kubernetes CLI"
-    description="KSail now ships with a built-in MCP server so Claude, Cursor, and other AI assistants can manage clusters directly."
-    href="/blog/mcp-server-for-kubernetes-cluster-management/"
-  />
-  <LinkCard
-    title="GitOps Without the Git Server"
-    description="Using OCI registries as a Flux source with KSail — a cleaner alternative to local Git servers for tight dev loops."
-    href="/blog/gitops-without-the-git-server-oci-registries-as-a-flux-source-with-ksail/"
-  />
-  <LinkCard
-    title="Storing Secrets in .zshrc with macOS Keychain"
-    description="A quick, practical guide for keeping sensitive environment variables out of plaintext dotfiles."
-    href="/blog/storing-secrets-in-zshrc-with-macos-keychain/"
-  />
-  <LinkCard
-    title="Local Kubernetes Development with KSail and Kind"
-    description="Get a full local Kubernetes cluster running in minutes with KSail and Kind — no cloud account required."
-    href="/blog/local-kubernetes-development-with-ksail-and-kind/"
-  />
+  {
+    latestPosts.map((post) => (
+      <LinkCard
+        title={post.data.title}
+        description={post.data.excerpt}
+        href={`/${post.id}/`}
+      />
+    ))
+  }
 </CardGrid>
 
 [Browse all posts &rarr;](/blog/)


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The devantler.tech homepage's **"Latest from the Blog"** section was a hand-maintained list of four `<LinkCard>`s, and it had drifted out of date. It featured:

- *Local Kubernetes Development with KSail and Kind* (2025-12-15)
- *Storing Secrets in .zshrc with macOS Keychain* (2026-02-12)

…while **omitting the two actual newest posts**:

- *Why I Chose the PolyForm Shield License for KSail* (2026-05-05)
- *How I Run KSail Autonomously with GitHub Agentic Workflows* (2026-04-17)

So the most-visible page on the site was advertising stale "latest" content — and any future post would have the same problem until someone hand-edited the list again.

## Fix (root cause, not just a re-sync)

Replace the four hardcoded cards with a content-collection query that derives the list at build time:

```js
export const latestPosts = (await getCollection("docs"))
  .filter((entry) => entry.id.startsWith("blog/"))
  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
  .slice(0, 4);
```

The `<CardGrid>` then maps over `latestPosts`, using each post's `title`, `excerpt`, and slug. The section now **always** shows the four newest posts and never goes stale again — publishing a post is all it takes to update the homepage.

## Validation

- `npm run build` passes (exit 0); top-level `await` in the splash MDX page compiles fine.
- `starlight-links-validator` (runs in the build) reports **all internal links valid**, including the dynamically-generated `/${post.id}/` hrefs.
- Verified the rendered `dist/index.html` lists, in order: `why-i-chose-the-polyform-shield-license-for-ksail`, `autonomous-oss-with-github-agentic-workflows`, `mcp-server-for-kubernetes-cluster-management`, `gitops-without-the-git-server-...` — the four newest by date.

Net diff: 15 insertions / 20 deletions in a single file (`docs/src/content/docs/index.mdx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)