### PR TITLE
docs(site): correct template dependency tooling + publish target

### DIFF
--- a/docs/src/content/docs/templates/dotnet.md
+++ b/docs/src/content/docs/templates/dotnet.md
@@ -10,10 +10,10 @@ A minimal, batteries-included template for new .NET projects and libraries. Skip
 ## What's Inside
 
 - **CI/CD** — GitHub Actions workflows for build, test, lint, and release
-- **Publishing** — Release libraries to [GitHub Container Registry](https://docs.github.com/en/packages) and [NuGet](https://www.nuget.org/) automatically
+- **Publishing** — Release libraries to [GitHub Packages](https://docs.github.com/en/packages) and [NuGet](https://www.nuget.org/) automatically
 - **Testing** — Test projects with coverage reporting via [GitHub Code Quality](https://docs.github.com/code-security/code-quality)
 - **Code style** — `.editorconfig` with opinionated .NET code style
-- **Dependency management** — [Renovate](https://docs.renovatebot.com/) keeps NuGet packages and Actions up to date
+- **Dependency management** — [Dependabot](https://docs.github.com/code-security/dependabot) keeps NuGet packages and Actions up to date
 - **Release automation** — Semantic versioning and automated GitHub Releases
 
 ## Getting Started

--- a/docs/src/content/docs/templates/go.md
+++ b/docs/src/content/docs/templates/go.md
@@ -12,7 +12,7 @@ A minimal, batteries-included template for new Go projects. Skip the boilerplate
 - **CI/CD** — GitHub Actions workflows for build, test, lint, and release
 - **Testing** — `go test` with coverage reporting via [GitHub Code Quality](https://docs.github.com/code-security/code-quality)
 - **Quality** — [Go Report Card](https://goreportcard.com/) integration for continuous code-quality feedback
-- **Dependency management** — [Renovate](https://docs.renovatebot.com/) keeps Go modules and Actions up to date
+- **Dependency management** — [Dependabot](https://docs.github.com/code-security/dependabot) keeps Go modules and Actions up to date
 - **Release automation** — Semantic versioning and automated GitHub Releases
 
 ## Getting Started


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

A **Technical Rigor** content-review pass over the devantler.tech template pages found two factual claims that don't match the actual templates:

| Page | Claim | Reality |
|---|---|---|
| `templates/go.md` + `templates/dotnet.md` | Dependency management via **Renovate** | Both repos use **Dependabot** (`.github/dependabot.yaml`; both READMEs credit Dependabot). Renovate is not configured in either. |
| `templates/dotnet.md` | Publishes libraries to **GitHub Container Registry** | `publish-dotnet-library` runs `dotnet-releaser`, publishing NuGet packages to **nuget.org** and **GitHub Packages** (the NuGet feed). `ghcr.io` (the container/OCI registry) is not a target. The link already pointed at the GitHub Packages docs — only the visible label was wrong. |

## Verified accurate (left unchanged)
- `go.md` **Go Report Card** — badge is present in the go-template README.
- Both pages' **GitHub Code Quality** coverage claim — consistent with the Codecov→GitHub-native coverage migration; coverlet/`go test` coverage wired via the reusable workflows.

## Validation
- `npm run build` (Astro/Starlight) green; the `starlight-links-validator` integration reports **all internal links valid**.
- The new `https://docs.github.com/code-security/dependabot` link matches the link both template READMEs already use.

Two-file, text-only docs change — no behaviour or schema impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)