### PR TITLE
docs(site): auto-derive the Templates index from the templates collection

### DIFF
--- a/docs/src/content/docs/templates/dotnet.md
+++ b/docs/src/content/docs/templates/dotnet.md
@@ -1,6 +1,6 @@
 ---
 title: 📁 .NET Template
-description: A .NET starter template with CI/CD, testing, publishing, and code quality tooling.
+description: A minimal .NET template with CI/CD, NuGet/GHCR publishing, GitHub Code Quality coverage, EditorConfig, and Renovate.
 ---
 
 A minimal, batteries-included template for new .NET projects and libraries. Skip the boilerplate — start shipping.

--- a/docs/src/content/docs/templates/dotnet.md
+++ b/docs/src/content/docs/templates/dotnet.md
@@ -1,6 +1,6 @@
 ---
 title: 📁 .NET Template
-description: A minimal .NET template with CI/CD, NuGet/GHCR publishing, GitHub Code Quality coverage, EditorConfig, and Renovate.
+description: A minimal .NET template with CI/CD, GitHub Packages/NuGet publishing, GitHub Code Quality coverage, EditorConfig, and Dependabot.
 ---
 
 A minimal, batteries-included template for new .NET projects and libraries. Skip the boilerplate — start shipping.

--- a/docs/src/content/docs/templates/gitops-tenant-template.md
+++ b/docs/src/content/docs/templates/gitops-tenant-template.md
@@ -1,6 +1,6 @@
 ---
 title: 🚀 GitOps Tenant Template
-description: A stack-neutral template for GitOps tenants on the devantler-tech platform, with signed build → publish → release plumbing.
+description: A stack-neutral template for GitOps tenants on the devantler-tech platform, with signed build → publish → release plumbing kept current via template-sync.
 ---
 
 A template for **GitOps tenants** on the [devantler-tech platform](https://github.com/devantler-tech/platform) — an application that runs on the platform from its own repository. Skip the CI/CD boilerplate — bring your own stack and start shipping.

--- a/docs/src/content/docs/templates/go.md
+++ b/docs/src/content/docs/templates/go.md
@@ -1,6 +1,6 @@
 ---
 title: 🐹 Go Template
-description: A minimal Go template with CI/CD, test coverage via GitHub Code Quality, Go Report Card, and Renovate.
+description: A minimal Go template with CI/CD, test coverage via GitHub Code Quality, Go Report Card, and Dependabot.
 ---
 
 A minimal, batteries-included template for new Go projects. Skip the boilerplate — start shipping.

--- a/docs/src/content/docs/templates/go.md
+++ b/docs/src/content/docs/templates/go.md
@@ -1,6 +1,6 @@
 ---
 title: 🐹 Go Template
-description: A Go starter template with CI/CD, testing, and code quality tooling.
+description: A minimal Go template with CI/CD, test coverage via GitHub Code Quality, Go Report Card, and Renovate.
 ---
 
 A minimal, batteries-included template for new Go projects. Skip the boilerplate — start shipping.

--- a/docs/src/content/docs/templates/index.mdx
+++ b/docs/src/content/docs/templates/index.mdx
@@ -4,30 +4,24 @@ description: Opinionated starter templates with CI/CD, testing, and code quality
 ---
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+import { getCollection } from "astro:content";
+
+export const templates = (await getCollection("docs"))
+  .filter((entry) => entry.id.startsWith("templates/") && entry.id !== "templates/index")
+  .sort((a, b) => a.id.localeCompare(b.id));
 
 [![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/devantler)
 
 Starter templates that skip the boilerplate and get you straight to shipping. Each comes with GitHub Actions workflows, code quality tooling, and automated dependency management.
 
 <CardGrid>
-  <LinkCard
-    title="🐹 Go Template"
-    description="A minimal Go template with CI/CD, test coverage via GitHub Code Quality, Go Report Card, and Renovate."
-    href="/templates/go/"
-  />
-  <LinkCard
-    title="📁 .NET Template"
-    description="A minimal .NET template with CI/CD, NuGet/GHCR publishing, GitHub Code Quality coverage, EditorConfig, and Renovate."
-    href="/templates/dotnet/"
-  />
-  <LinkCard
-    title="☸️ Platform Template"
-    description="A batteries-included Kubernetes platform (Flux GitOps + KSail + Talos) you instantiate from a template and bootstrap onto Hetzner Cloud, fully unattended."
-    href="/templates/platform-template/"
-  />
-  <LinkCard
-    title="🚀 GitOps Tenant Template"
-    description="A stack-neutral template for GitOps tenants on the devantler-tech platform, with signed build → publish → release plumbing kept current via template-sync."
-    href="/templates/gitops-tenant-template/"
-  />
+  {
+    templates.map((template) => (
+      <LinkCard
+        title={template.data.title}
+        description={template.data.description}
+        href={`/${template.id}/`}
+      />
+    ))
+  }
 </CardGrid>


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The **Templates** landing page (`docs/src/content/docs/templates/index.mdx`) hand-listed four `<LinkCard>`s whose **titles, descriptions and hrefs duplicated the per-template doc pages**. Adding/renaming a template, or editing its description, silently drifted the index out of sync — the same staleness class already fixed for the homepage "Latest from the Blog" list in #1811.

This is exactly the **site anti-drift** theme of the monorepo strategy roadmap epic #1813 (theme 2: *derive/drift-check hand-maintained lists that duplicate queryable collection data*).

## Change

- Each template page's **frontmatter is now the single source of truth** for its title + description.
- `templates/index.mdx` derives its cards via `getCollection("docs")`, filtering to `templates/*` (excluding the index itself), mirroring the proven blog pattern in `index.mdx`.
- The two terser page descriptions (`go.md`, `dotnet.md`) and the `gitops-tenant-template.md` tail are **enriched up to the previously index-only copy**, so no information is lost (and per-page SEO `<meta description>` improves).

**No information lost.** The cards now single-source from frontmatter; the only visible changes are (a) ordering — now deterministic alphabetical-by-slug (`.NET`, `GitOps Tenant`, `Go`, `Platform`) instead of the prior curated order, chosen so a **new template appears automatically** with zero hand-editing (a hardcoded order array would reintroduce the drift this removes) — and (b) **two factual corrections** to the copy (see *Correction* below), since deriving made the page frontmatter the canonical copy and it was worth fixing the stale facts at the source rather than enshrining them.

## Correction (factual fix while single-sourcing)

The prior hand-written card copy carried two stale facts; corrected at the source so the derived cards are accurate:

- **Renovate → Dependabot** (`go.md` + `dotnet.md`): both templates use Dependabot (`.github/dependabot.yaml`; neither repo has a Renovate config). This already matches the detail-page bodies (#1812 fixed the same drift there); the index/frontmatter just hadn't been updated.
- **NuGet/GHCR → GitHub Packages/NuGet** (`dotnet.md`): the .NET template publishes a *library* to GitHub Packages + the NuGet feed, not the container registry (GHCR). Aligned to the detail-page wording.

Derived `dist/templates/index.html` re-verified after the fix: cards read **Dependabot** (Go + .NET) and **GitHub Packages** (.NET); no `Renovate`/`GHCR` remain.

## Validation

- `astro build` ✓ green — 63 pages, **all internal links valid** (derived `/templates/<slug>/` hrefs resolve).
- Rendered `dist/templates/index.html` confirmed: all 4 cards present with correct titles, full descriptions (Go Report Card / GitHub Packages-NuGet publishing / template-sync / fully-unattended all present) and valid hrefs.

## Notes

Trade-off considered: deriving uses each page's own `description`, so the canonical copy lives once (on the page) and the index follows. If richer index-specific copy is ever wanted, it belongs in the page frontmatter — keeping one source.

Part of the site anti-drift work under #1813. Files changed: `templates/index.mdx` (derive) + `go.md` / `dotnet.md` / `gitops-tenant-template.md` (frontmatter single-source).
