### PR TITLE
docs(site): list sync-labels.yaml + rename-placeholders.sh as template-owned

### DIFF
--- a/docs/src/content/docs/templates/gitops-tenant-template.md
+++ b/docs/src/content/docs/templates/gitops-tenant-template.md
@@ -20,7 +20,7 @@ It is intentionally **stack-neutral**: it carries no application code or languag
 
 | Ownership | Files | Notes |
 | --- | --- | --- |
-| Template-owned | Shared CI/CD plumbing under `.github/workflows/` (`cd.yaml`, `release.yaml`, `template-sync.yaml`, `validate-scaffold.yaml`), `CLAUDE.md`, `zizmor.yml` | Overwritten by `template-sync` |
+| Template-owned | Shared CI/CD plumbing under `.github/workflows/` (`cd.yaml`, `release.yaml`, `template-sync.yaml`, `validate-scaffold.yaml`, `sync-labels.yaml`), `scripts/rename-placeholders.sh`, `CLAUDE.md`, `zizmor.yml` | Overwritten by `template-sync` |
 | You own | App code, `Dockerfile`, `deploy/` manifests, `.github/workflows/ci.yaml`, `.github/dependabot.yml`, `AGENTS.md`, `.claude/skills/maintain/SKILL.md`, `README.md`, `.releaserc`, `.gitignore`, `LICENSE`, `.templatesyncignore` | Declare in `.templatesyncignore` (same syntax as `.gitignore`), using these full paths |
 
 See the template's [README](https://github.com/devantler-tech/gitops-tenant-template#what-the-template-owns-vs-what-you-own) for the authoritative file-by-file list.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

The **GitOps Tenant Template** site page (`docs/src/content/docs/templates/gitops-tenant-template.md`) "What the template owns vs. what you own" table listed only **four** template-owned workflows + `CLAUDE.md`/`zizmor.yml`, but `devantler-tech/gitops-tenant-template` now carries two more template-owned files the page omitted:

- `.github/workflows/sync-labels.yaml`
- `scripts/rename-placeholders.sh`

## Evidence (authoritative ground truth)

The template's [`.templatesyncignore`](https://github.com/devantler-tech/gitops-tenant-template/blob/main/.templatesyncignore) is the source of truth for the ownership boundary — anything **not** listed there is template-owned shared plumbing kept current by `template-sync`. Its header comment enumerates exactly:

> Template-owned files: `.github/workflows/{cd,release,template-sync,validate-scaffold,sync-labels}.yaml`, `CLAUDE.md`, `zizmor.yml`, `scripts/rename-placeholders.sh`.

Neither `sync-labels.yaml` nor `scripts/rename-placeholders.sh` appears in `.templatesyncignore`, confirming both are template-owned. The site's **you-own** list already matches `.templatesyncignore` and is unchanged.

## Validation

- `astro build` green (63 pages, all internal links valid).
- Verified the live repo's `.github/workflows/` contents and `.templatesyncignore` via the GitHub API before editing.

Technical-Rigor content-review pass (Monday cadence). One-line, content-only change.