### PR TITLE
docs(site): list sync-labels.yaml + rename-placeholders.sh as template-owned

### DIFF
--- a/docs/src/content/docs/templates/gitops-tenant-template.md
+++ b/docs/src/content/docs/templates/gitops-tenant-template.md
@@ -20,7 +20,7 @@ It is intentionally **stack-neutral**: it carries no application code or languag
 
 | Ownership | Files | Notes |
 | --- | --- | --- |
-| Template-owned | Shared CI/CD plumbing under `.github/workflows/` (`cd.yaml`, `release.yaml`, `template-sync.yaml`, `validate-scaffold.yaml`), `CLAUDE.md`, `zizmor.yml` | Overwritten by `template-sync` |
+| Template-owned | Shared CI/CD plumbing under `.github/workflows/` (`cd.yaml`, `release.yaml`, `template-sync.yaml`, `validate-scaffold.yaml`, `sync-labels.yaml`), `scripts/rename-placeholders.sh`, `CLAUDE.md`, `zizmor.yml` | Overwritten by `template-sync` |
 | You own | App code, `Dockerfile`, `deploy/` manifests, `.github/workflows/ci.yaml`, `.github/dependabot.yml`, `AGENTS.md`, `.claude/skills/maintain/SKILL.md`, `README.md`, `.releaserc`, `.gitignore`, `LICENSE`, `.templatesyncignore` | Declare in `.templatesyncignore` (same syntax as `.gitignore`), using these full paths |
 
 See the template's [README](https://github.com/devantler-tech/gitops-tenant-template#what-the-template-owns-vs-what-you-own) for the authoritative file-by-file list.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The devantler.tech **GitOps Tenant Template** page (`docs/src/content/docs/templates/gitops-tenant-template.md`) carries a "What the template owns vs. what you own" table. Its **Template-owned** cell had drifted from the template repo: it listed only `cd.yaml`, `release.yaml`, `template-sync.yaml`, `validate-scaffold.yaml`, `CLAUDE.md`, `zizmor.yml` — but the live [`gitops-tenant-template`](https://github.com/devantler-tech/gitops-tenant-template) now also ships two template-owned (synced) files that were missing:

- `.github/workflows/sync-labels.yaml`
- `scripts/rename-placeholders.sh`

Both are confirmed template-owned by the template's **authoritative** sources — its [README ownership table](https://github.com/devantler-tech/gitops-tenant-template#what-the-template-owns-vs-what-you-own) and its [`.templatesyncignore`](https://github.com/devantler-tech/gitops-tenant-template/blob/main/.templatesyncignore) (everything *not* ignored is template-owned plumbing; neither file is ignored). The docs page even links to that README as the authoritative list, so the summary should match it.

## Fix

Add `sync-labels.yaml` and `scripts/rename-placeholders.sh` to the page's **Template-owned** cell. The **You own** cell was already accurate against `.templatesyncignore`, so it is unchanged. One-line content edit.

## Validation

Pure-markdown (`.md`) text addition inside an existing table cell — no MDX/imports/links touched, table stays well-formed (3 columns). The site `astro build` on this PR's CI is the authoritative check; I'll keep it green before promotion.

Verified live (this run): the template's `.github/workflows/` directory, top-level files, README ownership section, and `.templatesyncignore` all confirm both files are template-owned.