### PR TITLE
ci(docs): drift-check the Active Projects lists against their submodules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       docs: ${{ steps.filter.outputs.docs }}
       docs-deps: ${{ steps.filter.outputs.docs-deps }}
+      active-projects: ${{ steps.filter.outputs.active-projects }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -33,6 +34,11 @@ jobs:
             docs-deps:
               - 'docs/package.json'
               - 'docs/package-lock.json'
+            active-projects:
+              - 'docs/src/content/docs/projects/active.mdx'
+              - 'docs/scripts/check-active-projects-drift.sh'
+              - 'github/devantler-tech/github-actions/actions'
+              - 'github/devantler-tech/github-actions/reusable-workflows'
 
   build-docs:
     needs: changes
@@ -82,6 +88,29 @@ jobs:
         working-directory: docs
         run: npm audit --omit=dev
 
+  drift-check-active-projects:
+    needs: changes
+    if: needs.changes.outputs.active-projects == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      # The source-of-truth repos are public submodules; check out only those
+      # two (network-free enumeration, no GitHub API). The SSH→HTTPS rewrite
+      # lets the runner clone them anonymously.
+      - name: Check out source submodules
+        run: |
+          git config url."https://github.com/".insteadOf "git@github.com:"
+          git submodule update --init --depth 1 \
+            github/devantler-tech/github-actions/actions \
+            github/devantler-tech/github-actions/reusable-workflows
+      - name: Check Active Projects lists for drift
+        run: bash docs/scripts/check-active-projects-drift.sh
+
   status:
     name: "CI - Required Checks"
     runs-on: ubuntu-latest
@@ -89,6 +118,7 @@ jobs:
     needs:
       - build-docs
       - audit-docs
+      - drift-check-active-projects
     permissions: {}
     steps:
       - name: Check job results
@@ -97,3 +127,4 @@ jobs:
           job-results: >-
             ${{ needs.build-docs.result }}
             ${{ needs.audit-docs.result }}
+            ${{ needs.drift-check-active-projects.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,11 +100,13 @@ jobs:
         with:
           persist-credentials: false
       # The source-of-truth repos are public submodules; check out only those
-      # two (network-free enumeration, no GitHub API). The SSH→HTTPS rewrite
-      # lets the runner clone them anonymously.
+      # two at their pinned commits (no GitHub API, no other submodules). The
+      # .gitmodules URLs are SSH (git@github.com:), which the runner has no key
+      # for, so point them at public HTTPS first to clone anonymously.
       - name: Check out source submodules
         run: |
-          git config url."https://github.com/".insteadOf "git@github.com:"
+          git submodule set-url github/devantler-tech/github-actions/actions https://github.com/devantler-tech/actions.git
+          git submodule set-url github/devantler-tech/github-actions/reusable-workflows https://github.com/devantler-tech/reusable-workflows.git
           git submodule update --init --depth 1 \
             github/devantler-tech/github-actions/actions \
             github/devantler-tech/github-actions/reusable-workflows

--- a/docs/scripts/check-active-projects-drift.sh
+++ b/docs/scripts/check-active-projects-drift.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# check-active-projects-drift.sh
+#
+# Guards the hand-maintained Actions / Reusable Workflows lists on the Active
+# Projects page (docs/src/content/docs/projects/active.mdx) against silent
+# drift from their source-of-truth sibling repos. Both repos are submodules of
+# this monorepo, so the check is entirely network-free: it reads only the
+# already-checked-out submodules, never the GitHub API.
+#
+#   - Actions list       — one bullet per composite action, so it maps 1:1 to
+#                          the `*/action.yaml` directories. Enforced as a strict
+#                          count equality.
+#   - Reusable Workflows — the site list is *categorical* (CI / CD / Automation
+#                          buckets), not one bullet per workflow, so a bullet
+#                          count cannot map 1:1. Instead we tripwire on the
+#                          number of reusable (`workflow_call`) workflows versus
+#                          an expected count declared inline in active.mdx via a
+#                          `reusable-workflows-count: N` marker. Adding or
+#                          removing a workflow therefore forces a human to
+#                          revisit the category bullets and bump the marker.
+#
+# Run from the repository root (CI sets the working directory there); falls back
+# to a path relative to this script for local runs.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="${GITHUB_WORKSPACE:-$(cd "$script_dir/../.." && pwd)}"
+
+mdx="$repo_root/docs/src/content/docs/projects/active.mdx"
+actions_dir="$repo_root/github/devantler-tech/github-actions/actions"
+rw_workflows_dir="$repo_root/github/devantler-tech/github-actions/reusable-workflows/.github/workflows"
+
+# Anchor each H2 section on the source repo URL it links to — unique and stable.
+actions_anchor="](https://github.com/devantler-tech/actions)"
+
+fail=0
+
+die_missing() {
+  echo "::error::$1 not found at '$2' — is the submodule checked out?" >&2
+  exit 1
+}
+
+[ -f "$mdx" ] || die_missing "active.mdx" "$mdx"
+[ -d "$actions_dir" ] || die_missing "actions submodule" "$actions_dir"
+[ -d "$rw_workflows_dir" ] || die_missing "reusable-workflows submodule" "$rw_workflows_dir"
+
+# Count "- " bullets in the H2 section whose header line contains $1.
+count_section_bullets() {
+  awk -v anchor="$1" '
+    /^## / { insec = (index($0, anchor) > 0) ? 1 : 0; next }
+    insec && /^[[:space:]]*- / { n++ }
+    END { print n + 0 }
+  ' "$mdx"
+}
+
+# --- Actions: strict 1:1 count -------------------------------------------------
+actions_count=$(find "$actions_dir" -mindepth 2 -maxdepth 2 -name action.yaml -type f | wc -l | tr -d ' ')
+actions_bullets=$(count_section_bullets "$actions_anchor")
+
+if [ "$actions_count" -ne "$actions_bullets" ]; then
+  echo "::error file=docs/src/content/docs/projects/active.mdx::Actions list drift: \
+${actions_count} composite action(s) in the actions submodule but ${actions_bullets} bullet(s) under \
+'## ⚡ Actions'. An action was added or removed in devantler-tech/actions but the list was not updated — \
+update the '## ⚡ Actions' section of docs/src/content/docs/projects/active.mdx." >&2
+  fail=1
+else
+  echo "OK: Actions list in sync (${actions_count} actions == ${actions_bullets} bullets)."
+fi
+
+# --- Reusable Workflows: count tripwire vs. inline marker ----------------------
+rw_count=$(grep -lE '^[[:space:]]*workflow_call:' "$rw_workflows_dir"/*.yaml 2>/dev/null | wc -l | tr -d ' ')
+rw_expected=$(grep -oE 'reusable-workflows-count:[[:space:]]*[0-9]+' "$mdx" | grep -oE '[0-9]+' | head -n1 || true)
+
+if [ -z "$rw_expected" ]; then
+  echo "::error file=docs/src/content/docs/projects/active.mdx::Missing 'reusable-workflows-count: N' \
+marker in the '## 🔄 Reusable Workflows' section of docs/src/content/docs/projects/active.mdx." >&2
+  fail=1
+elif [ "$rw_count" -ne "$rw_expected" ]; then
+  echo "::error file=docs/src/content/docs/projects/active.mdx::Reusable Workflows drift: \
+${rw_count} reusable (workflow_call) workflow(s) in the reusable-workflows submodule but the marker \
+declares ${rw_expected}. A workflow was added or removed in devantler-tech/reusable-workflows — review \
+the category bullets under '## 🔄 Reusable Workflows' in docs/src/content/docs/projects/active.mdx and \
+update the 'reusable-workflows-count' marker to ${rw_count}." >&2
+  fail=1
+else
+  echo "OK: Reusable Workflows in sync (${rw_count} workflow_call workflows == marker ${rw_expected})."
+fi
+
+exit "$fail"

--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -44,6 +44,8 @@ A collection of [reusable GitHub Actions workflows](https://docs.github.com/en/a
 - **CD Workflows**: [GitHub Pages](https://pages.github.com/) publish, application/library releases, workflow-run cleanup
 - **Automation**: Auto-merge for trusted bots, [semantic-release](https://semantic-release.gitbook.io/), TODO scanning, [Kyverno](https://kyverno.io/) policy sync, [Zizmor](https://github.com/woodruffw/zizmor) workflow analysis, [agent skills](https://github.com/devantler-tech/skills) updates, [template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository) sync
 
+{/* reusable-workflows-count: 14 — this categorical list covers every reusable (workflow_call) workflow in devantler-tech/reusable-workflows; the docs CI drift-check fails when a workflow is added or removed there. When that happens, review the category bullets above and bump this number to match. */}
+
 ## [⚡ Actions](https://github.com/devantler-tech/actions) ![GitHub Actions](https://img.shields.io/badge/GitHub%20Actions-2088FF.svg?style=for-the-badge&logo=GitHub-Actions&logoColor=white)
 
 A collection of [composite GitHub Actions](https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action) that provide small, reusable components for CI/CD workflows.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Implements #1837 (Theme 2 of the monorepo & site strategy epic #1813 — make site content self-sustaining / anti-drift).

## What

Adds a lightweight, **network-free** CI drift-check that guards the two hand-maintained lists on the Active Projects page (`docs/src/content/docs/projects/active.mdx`) against silent drift from their source-of-truth sibling repos. Both repos are already **submodules** of this monorepo, so the check enumerates the checked-out submodules — no GitHub API calls, no third-party flakiness.

- **`docs/scripts/check-active-projects-drift.sh`** — the check (shellcheck-clean).
- **`.github/workflows/ci.yaml`** — a new dedicated `drift-check-active-projects` job, gated by a new `active-projects` path filter, feeding the existing `CI - Required Checks` aggregator. The `build-docs`/`audit-docs` jobs stay submodule-free (the job is the only place a scoped submodule checkout happens).
- **`active.mdx`** — a single inline `reusable-workflows-count` marker (see below).

## How the two lists differ (the issue's "wrinkle to resolve in implementation")

| List | Structure in `active.mdx` | Check |
|---|---|---|
| **⚡ Actions** | one bullet per composite action (16 bullets) | **strict count equality** vs the 16 `*/action.yaml` dirs in the `actions` submodule |
| **🔄 Reusable Workflows** | **categorical** — 3 bullets (CI / CD / Automation) covering 14 workflows | bullet-count can't map 1:1, so a **count tripwire** vs an inline `reusable-workflows-count: 14` marker, compared to the number of `workflow_call` workflows |

The Actions list is the clean 1:1 case the issue's primary acceptance criterion targets. For the categorical Reusable Workflows list a per-bullet count is meaningless, so I took the issue's suggested escape hatch (an inline mapping marker): adding/removing a workflow changes the actual `workflow_call` count, which forces a human to revisit the category bullets and bump the marker. This honestly catches the add/remove drift mode without faking a 1:1 map.

## Scoped submodule checkout

The job does a plain checkout, then `git submodule update --init --depth 1` for **only** the two source submodules (the docs CI is otherwise pure-npm). The two repos are public, so an SSH→HTTPS `insteadOf` rewrite lets the runner clone them anonymously — no token, no other submodules pulled.

## Validation (local, in a throwaway clone with both submodules initialised)

- ✅ Pass-path on the current in-sync state: `16 actions == 16 bullets`, `14 workflow_call == marker 14`, exit 0.
- ✅ Negative tests all fail with a clear, file-annotated message: (1) an Actions bullet removed, (2) the marker set to a wrong count, (3) the marker missing entirely.
- ✅ `shellcheck` clean; `actionlint` clean on `ci.yaml`; `npm run build` succeeds (the MDX `{/* … */}` marker is valid and non-rendering).

## Acceptance criteria

- [x] CI job fails when the Actions count diverges (and flags reusable-workflow add/remove via the marker).
- [x] Passes on the current in-sync state.
- [x] Runs on `docs/**` changes **and** on `actions`/`reusable-workflows` submodule-pointer bumps.
- [x] No cross-repo network calls — enumeration is from the checked-out submodules only.
- [x] Failure message names which list to update and where.
- [x] `build-docs`/`audit-docs` unchanged (no submodule checkout leaks into them).

Fixes #1837