### PR TITLE
chore: register devantler-tech/unifi as applications/unifi submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,7 @@
 	path = templates/platform-template
 	url = git@github.com:devantler-tech/platform-template.git
 	branch = main
+[submodule "applications/unifi"]
+	path = applications/unifi
+	url = git@github.com:devantler-tech/unifi.git
+	branch = main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ keeping them healthy *and* moving them forward.
 | Agent plugins (shared lib) | `devantler-tech/plugins` (renamed from `copilot-plugins`) | `libraries/plugins` | [repo](https://github.com/devantler-tech/plugins) |
 | Wedding app (private) | `devantler-tech/wedding-app` | `applications/wedding-app` | (private) |
 | AS Coaching (private) | `devantler-tech/ascoachingogvaner` | `applications/ascoachingogvaner` | (private) |
+| UniFi network (private) | `devantler-tech/unifi` | `applications/unifi` | [AGENTS.md](https://github.com/devantler-tech/unifi/blob/main/AGENTS.md) |
 
 > Submodule `AGENTS.md` links use full GitHub URLs because those files live in the submodule repos, not this repo's tree (a relative link would 404 on GitHub).
 


### PR DESCRIPTION
## What

Register the new [`devantler-tech/unifi`](https://github.com/devantler-tech/unifi)
repo — declarative UniFi network management (OpenTofu + `filipowm/unifi`,
reconciled by tofu-controller as a platform tenant) — as the
`applications/unifi` submodule, and add it to the portfolio map in `AGENTS.md`.

## Context

- Repo scaffold: [`devantler-tech/unifi`](https://github.com/devantler-tech/unifi) (private, `Type=Infrastructure`).
- Platform wiring: [platform#2042](https://github.com/devantler-tech/platform/pull/2042) (tofu-controller + `unifi` tenant).
- Steady-state follow-up: #1860 (build `provider-upjet-unifi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)