### PR TITLE
ci: harden Active Projects drift-check with action-name set equality

### DIFF
--- a/docs/scripts/check-active-projects-drift.sh
+++ b/docs/scripts/check-active-projects-drift.sh
@@ -9,8 +9,15 @@
 # already-checked-out submodules, never the GitHub API.
 #
 #   - Actions list       — one bullet per composite action, so it maps 1:1 to
-#                          the `*/action.yaml` directories. Enforced as a strict
-#                          count equality.
+#                          the `*/action.yaml` directories. A bullet *count*
+#                          alone cannot catch a rename (or a net-zero add+remove)
+#                          — the count stays equal while a bullet silently goes
+#                          stale — so we additionally pin the exact directory
+#                          names via an inline `actions-dirs: a,b,c` marker in
+#                          active.mdx and enforce SET equality between that
+#                          marker and the live action directories (plus the
+#                          original bullet-count tripwire, so the marker can't be
+#                          updated without revisiting the prose bullets).
 #   - Reusable Workflows — the site list is *categorical* (CI / CD / Automation
 #                          buckets), not one bullet per workflow, so a bullet
 #                          count cannot map 1:1. Instead we tripwire on the
@@ -54,18 +61,43 @@ count_section_bullets() {
   ' "$mdx"
 }
 
-# --- Actions: strict 1:1 count -------------------------------------------------
-actions_count=$(find "$actions_dir" -mindepth 2 -maxdepth 2 -name action.yaml -type f | wc -l | tr -d ' ')
+# --- Actions: bullet-count tripwire + directory-name set equality --------------
+# Live action directory names (each dir holding an action.yaml), sorted & unique.
+actions_live=$(
+  find "$actions_dir" -mindepth 2 -maxdepth 2 -name action.yaml -type f \
+    | awk -F/ '{ print $(NF - 1) }' | sort -u
+)
+actions_count=$(printf '%s\n' "$actions_live" | grep -c . || true)
 actions_bullets=$(count_section_bullets "$actions_anchor")
 
-if [ "$actions_count" -ne "$actions_bullets" ]; then
+# Declared directory names from the inline `actions-dirs: a,b,c` marker.
+actions_marker=$(
+  grep -oE 'actions-dirs:[[:space:]]*[a-z0-9,_-]+' "$mdx" \
+    | sed -E 's/^actions-dirs:[[:space:]]*//' | head -n1 || true
+)
+actions_declared=$(printf '%s' "$actions_marker" | tr ',' '\n' | sed '/^$/d' | sort -u)
+
+if [ -z "$actions_marker" ]; then
+  echo "::error file=docs/src/content/docs/projects/active.mdx::Missing 'actions-dirs: a,b,c' marker \
+in the '## ⚡ Actions' section of docs/src/content/docs/projects/active.mdx." >&2
+  fail=1
+elif [ "$actions_count" -ne "$actions_bullets" ]; then
   echo "::error file=docs/src/content/docs/projects/active.mdx::Actions list drift: \
 ${actions_count} composite action(s) in the actions submodule but ${actions_bullets} bullet(s) under \
 '## ⚡ Actions'. An action was added or removed in devantler-tech/actions but the list was not updated — \
 update the '## ⚡ Actions' section of docs/src/content/docs/projects/active.mdx." >&2
   fail=1
+elif [ "$actions_declared" != "$actions_live" ]; then
+  only_live=$(comm -23 <(printf '%s\n' "$actions_live") <(printf '%s\n' "$actions_declared") | paste -sd, -)
+  only_marker=$(comm -13 <(printf '%s\n' "$actions_live") <(printf '%s\n' "$actions_declared") | paste -sd, -)
+  echo "::error file=docs/src/content/docs/projects/active.mdx::Actions list drift: the 'actions-dirs' \
+marker does not match the action directories in devantler-tech/actions. \
+Missing from marker: [${only_live:-none}]. Stale in marker (no longer a real action): [${only_marker:-none}]. \
+An action was added, removed, or renamed — update the matching bullet AND the 'actions-dirs' marker in the \
+'## ⚡ Actions' section of docs/src/content/docs/projects/active.mdx." >&2
+  fail=1
 else
-  echo "OK: Actions list in sync (${actions_count} actions == ${actions_bullets} bullets)."
+  echo "OK: Actions list in sync (${actions_count} actions == ${actions_bullets} bullets, marker set matches)."
 fi
 
 # --- Reusable Workflows: count tripwire vs. inline marker ----------------------

--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -67,6 +67,8 @@ A collection of [composite GitHub Actions](https://docs.github.com/en/actions/tu
 - **Upload Coverage**: Upload a Cobertura XML coverage report to GitHub Code Quality
 - **Upsert Issue**: Create, update, reopen, or close a GitHub issue by title
 
+{/* actions-dirs: aggregate-job-checks,approve-pr,dependency-review,enable-auto-merge-on-pr,cleanup-ghcr-packages,free-disk-space,login-to-ghcr,run-dotnet-tests,setup-agent-skills,setup-go-toolchain,setup-ksail-cli,sync-github-labels,create-issues-from-todos,update-agent-skills,upload-coverage,upsert-issue — one entry per composite-action directory in devantler-tech/actions, in bullet order. The docs CI drift-check asserts this set EQUALS the live action directories, so an added, removed, OR renamed action breaks the build. When that happens, update the matching bullet above and this marker together. */}
+
 ## [🧠 Agent Skills](https://github.com/devantler-tech/skills) ![GitHub Copilot](https://img.shields.io/badge/GitHub%20Copilot-000000.svg?style=for-the-badge&logo=githubcopilot&logoColor=white) ![Claude](https://img.shields.io/badge/Claude-D97757.svg?style=for-the-badge&logo=claude&logoColor=white)
 
 A collection of generic, tool-neutral [agent skills](https://github.com/devantler-tech/skills) that teach AI coding agents how to perform common engineering tasks. Installable via `gh skill` and designed to work across agents such as [GitHub Copilot](https://github.com/features/copilot) and [Claude Code](https://www.anthropic.com/claude-code).


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The hand-maintained **Actions** list on the devantler.tech [Active Projects](https://github.com/devantler-tech/monorepo/blob/main/docs/src/content/docs/projects/active.mdx) page was guarded only by a **strict bullet-count equality** (16 prose bullets == 16 `*/action.yaml` directories in `devantler-tech/actions`).

A count alone cannot catch:
- a **renamed** action (e.g. `setup-ksail-cli` → `install-ksail`) — the count stays 16 while the bullet's name/link silently goes stale; or
- a **net-zero add + remove** in the same window.

This is exactly the *"site content cannot silently go stale"* gap that **Theme 2 (anti-drift)** of the monorepo/site roadmap (#1813) targets. The sibling Reusable Workflows list already uses a smarter inline marker; the Actions list lagged behind on count-only.

## Change

- Add an inline `actions-dirs: a,b,c` marker to the `## ⚡ Actions` section of `active.mdx`, listing each composite action's source directory in bullet order (mirrors the existing `reusable-workflows-count` marker convention).
- Upgrade `docs/scripts/check-active-projects-drift.sh` to enforce **set equality** between that marker and the live action directories, **plus** the original bullet-count tripwire (so the marker can't be bumped without revisiting the prose bullets). A rename now fails CI with a precise *"missing from marker / stale in marker"* diff.

No behavior change to the site itself — the marker is an MDX comment (invisible in the rendered page).

## Validation (local)

- ✅ Happy path: `OK: Actions list in sync (16 actions == 16 bullets, marker set matches).`
- ✅ **Rename now caught**: simulated `setup-ksail-cli` → `install-ksail` (count unchanged at 16) → exit 1 with `Missing from marker: [install-ksail]. Stale in marker: [setup-ksail-cli].` (the old count-only check passed this case).
- ✅ `shellcheck` clean.
- ✅ `astro build` green (63 pages; MDX comment renders to nothing).

## Notes

- Drafted per routine discipline; promote to merge when ready. `Refs #1813` (Theme 2 — does not close the epic; one anti-drift increment).
- The CI `drift-check-active-projects` job already triggers on changes to `active.mdx`, the script, and the two source submodules — no workflow change needed.