### PR TITLE
docs: refresh Platform tech stack on devantler.tech (Gateway API, ESO/OpenBao, external-dns)

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -67,7 +67,7 @@ export const latestPosts = (await getCollection("docs"))
   />
   <LinkCard
     title="☸️ Platform"
-    description="A GitOps-driven Kubernetes platform on Talos Linux and Hetzner Cloud — powered by Flux, Cilium, and Traefik."
+    description="A GitOps-driven Kubernetes platform on Talos Linux and Hetzner Cloud — powered by Flux, Cilium, and the Gateway API."
     href="/projects/active/"
   />
   <LinkCard

--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -27,7 +27,7 @@ A [Flux](https://fluxcd.io/) GitOps-based Kubernetes cluster running on [Hetzner
 
 I use this cluster to learn and experiment with new technologies — striving to implement the latest CNCF projects to keep my skills sharp. I also run self-hosted services for entertainment, personal projects, and to own my own data.
 
-**Key Technologies**: [Cilium](https://cilium.io/) (CNI), [Traefik](https://traefik.io/) (Ingress), [cert-manager](https://cert-manager.io/) (TLS), [SOPS](https://getsops.io) (Secrets), [Cloudflare](https://www.cloudflare.com) (DNS & Tunneling)
+**Key Technologies**: [Cilium](https://cilium.io/) (CNI & [Gateway API](https://gateway-api.sigs.k8s.io/) ingress), [cert-manager](https://cert-manager.io/) (TLS), [SOPS](https://getsops.io) & [External Secrets](https://external-secrets.io/) + [OpenBao](https://openbao.org/) (Secrets), [external-dns](https://kubernetes-sigs.github.io/external-dns/) with [Cloudflare](https://www.cloudflare.com) (DNS)
 
 ## 🏠 Self-Hosted Personal Apps
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What & why

The **Home** and **Active Projects** pages on devantler.tech described the Platform's stack with details that have since drifted from what the cluster actually runs. Verified against the live `devantler-tech/platform` manifests:

| Claim on site | Reality in `platform` | Fix |
|---|---|---|
| "powered by Flux, Cilium, and **Traefik**" / "**Traefik** (Ingress)" | No Traefik controller. Ingress is the **Cilium Gateway API** (`Gateway` `platform` in `kube-system`, `gatewayAPI` enabled in Cilium's HelmRelease, apps route via `HTTPRoute`). Traefik survives only as a single-purpose `auth-proxy` *behind* the Cilium Gateway (oauth2-proxy ExternalAuth `HTTPRoute` filter, GEP-1494). | Cilium **+ Gateway API** ingress |
| "**SOPS** (Secrets)" | `external-secrets` **and** `openbao` are live infrastructure controllers (cluster-issuers + external-dns already pull their tokens via `ExternalSecret`); SOPS still coexists. | **SOPS & External Secrets + OpenBao** |
| "Cloudflare (DNS **& Tunneling**)" | No `cloudflared`/`TunnelBinding` anywhere. DNS is automated via **external-dns** with Cloudflare as the provider. | **external-dns with Cloudflare (DNS)** |

This keeps the portfolio's public-facing description of the flagship Platform honest as the stack evolves (Gateway-API ingress, the ESO/OpenBao secrets migration, automated DNS) — part of the docs-currency mandate.

## Changes
- `docs/src/content/docs/index.mdx` — Platform featured-project card description.
- `docs/src/content/docs/projects/active.mdx` — Platform "Key Technologies" line.

Pure copy/link edits; no component or layout change.

## Validation
- `npm run build` (Astro/Starlight) — **green, 63 pages built**.

Opened as a **draft** for maintainer promotion.