### PR TITLE
docs: diagnose & document submodule git-worktree isolation inconsistency

### DIFF
--- a/.claude/worktree-isolation.md
+++ b/.claude/worktree-isolation.md
@@ -1,0 +1,125 @@
+# Submodule git-worktree isolation — diagnosis & repeatable fix
+
+> Reference for the autonomous engineer **and** the maintainer. Resolves monorepo issue
+> [#1838](https://github.com/devantler-tech/monorepo/issues/1838) (Theme 3 of the strategy epic
+> [#1813](https://github.com/devantler-tech/monorepo/issues/1813)).
+
+Per-session `git worktree add` isolation is **inconsistent across the submodules** of this monorepo.
+Some resolve a `git worktree add` into an isolated working tree (correct); most resolve it back into
+the **shared main checkout**, so two sessions' uncommitted changes interleave in one physical directory
+and a commit can silently land on the wrong branch. Routine work then has to fall back to a throwaway
+clone or GitHub-API-only mode, and it risks colliding with the maintainer's parallel interactive
+sessions if that fallback is missed.
+
+This is a **per-machine git-config** condition, not a version-controlled defect in this repo — so the
+shippable output is this documented, verified procedure plus the diagnosis below, applied per submodule
+incrementally as each is verified.
+
+## Root cause
+
+A submodule's git directory lives at `<repo>/.git/modules/<name>/`. The breakage is a stray
+**`core.worktree`** key in that **shared** `.git/modules/<name>/config`:
+
+- `core.worktree` is a **per-worktree** setting — it tells one working tree where its files live.
+- When it sits in the **shared** config, **every** linked worktree created by `git worktree add`
+  **inherits the same value**, which points at the *main* checkout. So the new worktree gets an
+  isolated gitdir (`.git/modules/<name>/worktrees/<id>/`) but its `core.worktree` still resolves to the
+  main checkout — `git rev-parse --show-toplevel` from inside it returns the main tree (or the
+  `.git/modules/<name>` dir), not its own path. That is the collision.
+- The correct layout requires **`extensions.worktreeConfig = true`** *and* `core.worktree` moved **out**
+  of the shared config into each worktree's own `config.worktree` (the main worktree's lives at
+  `.git/modules/<name>/config.worktree`; each linked worktree's at
+  `.git/modules/<name>/worktrees/<id>/config.worktree`). **Setting the `worktreeConfig` flag alone is
+  not enough** — if the stray shared `core.worktree` remains, it is still inherited (see `platform`,
+  `go-template` below: flag on, still broken).
+
+## Diagnosis (captured 2026-06-17 on the scheduled clone `~/git-personal/monorepo`)
+
+`BROKEN` = stray `core.worktree` present in the shared `.git/modules/<name>/config`.
+
+| Submodule | shared `core.worktree` | `extensions.worktreeConfig` | State |
+|---|---|---|---|
+| `applications/ksail` | set | unset | ❌ broken |
+| `applications/ascoachingogvaner` | set | unset | ❌ broken |
+| `github/devantler-tech/github-actions/actions` | set | unset | ❌ broken |
+| `github/devantler-tech/github-actions/reusable-workflows` | set | unset | ❌ broken |
+| `homebrew-formulas` | set | unset | ❌ broken |
+| `libraries/plugins` | set | unset | ❌ broken |
+| `libraries/skills` | set | unset | ❌ broken |
+| `templates/dotnet-template` | set | unset | ❌ broken |
+| `templates/platform-template` | set | unset | ❌ broken |
+| `platform` | set | **true** | ❌ broken (flag set, but stray value still inherited) |
+| `templates/go-template` | set | **true** | ❌ broken (flag set, but stray value still inherited) |
+| `templates/gitops-tenant-template` | ~~set~~ → **unset** | true | ✅ **fixed 2026-06-17** (verified, see below) |
+| `projects/ksail` | unset | true | ✅ correct — but this is the **stale** old ksail module path (pre-rename to `applications/ksail`), not an active submodule |
+
+> **Correction to #1838's hypothesis:** the issue assumed `applications/ksail` was the cleanly-isolated
+> example. It is not — the *live* `applications/ksail` module carries the stray `core.worktree`. The
+> correctly-configured module the maintainer observed is the **orphaned `projects/ksail`** gitdir left
+> from the old layout. In practice **every active portfolio submodule was broken** before this fix.
+
+### Re-generate the table for any submodule
+
+```sh
+cd ~/git-personal/monorepo            # (or the relevant clone)
+for cfg in $(find .git/modules -name config -path '*modules*'); do
+  d=$(dirname "$cfg"); name=${d#.git/modules/}
+  cw=$(git config -f "$cfg" --get core.worktree); [ -z "$cw" ] && cw='(unset)'
+  wt=$(git config -f "$cfg" --get extensions.worktreeConfig); [ -z "$wt" ] && wt='(unset)'
+  printf '%-55s core.worktree=%-8s worktreeConfig=%s\n' "$name" "$cw" "$wt"
+done
+```
+
+> RTK note: this CLI proxy mangles `git worktree add`/`remove`/`list` — prefix those with
+> `rtk proxy git worktree …`. Plain `git config` reads are unaffected.
+
+## Repeatable fix (per submodule, forward-only)
+
+Apply per submodule, in this **additive-first order** so the main worktree is never momentarily without
+a resolvable `core.worktree` (safe even while parallel sessions hold the shared checkout). Let
+`M=.git/modules/<name>` and `ABS` = the absolute path to the submodule's **main** checkout
+(e.g. `~/git-personal/monorepo/templates/gitops-tenant-template`):
+
+```sh
+# 0. (optional) back up, so the change is trivially reversible
+cp "$M/config" /tmp/$(basename "$M")-config.bak
+
+# 1. enable per-worktree config if not already
+git config -f "$M/config" extensions.worktreeConfig true
+
+# 2. ADDITIVE: pin the MAIN worktree's path in its own per-worktree config first
+git config -f "$M/config.worktree" core.worktree "$ABS"
+
+# 3. remove the stray SHARED value (now safe — main resolves via config.worktree)
+git config -f "$M/config" --unset core.worktree
+```
+
+### Verify (acceptance criterion — do this after each fix)
+
+```sh
+P=<submodule-working-path>            # e.g. templates/gitops-tenant-template
+rtk proxy git -C "$P" worktree add .probe-iso -b probe/iso   # add a throwaway worktree
+rtk proxy git -C "$P/.probe-iso" rev-parse --show-toplevel    # MUST print …/$P/.probe-iso, NOT …/.git/modules/…
+rtk proxy git -C "$P" worktree remove --force .probe-iso      # clean up
+rtk proxy git -C "$P" branch -D probe/iso
+rtk proxy git -C "$P" worktree prune
+```
+
+A fixed submodule prints the probe's **own** path; a broken one prints a path under
+`.git/modules/<name>`.
+
+**Verified 2026-06-17 on `templates/gitops-tenant-template`:** before the fix a probe worktree's
+`show-toplevel` resolved to `…/.git/modules/templates/gitops-tenant-template`; after the fix it resolves
+to `…/templates/gitops-tenant-template/.probe-iso` (its own tree), and the main checkout still resolves
+correctly. This submodule is left fixed.
+
+## Rollout status
+
+- ✅ `templates/gitops-tenant-template` — fixed & verified (2026-06-17).
+- ⏳ All other active portfolio submodules in the table above — **apply the procedure incrementally**,
+  one at a time, verifying each. Skip a submodule that currently has a parallel linked worktree (check
+  `rtk proxy git -C <path> worktree list` — a random-slug `.claude/worktrees/<adj>-<name>-<hex>` entry
+  means a live session) until it is quiet, to avoid disrupting an in-flight session.
+- The stray `core.worktree` originates from how these submodules were first initialized; new submodules
+  should be configured with `extensions.worktreeConfig=true` and **no** shared `core.worktree` from the
+  start.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,7 +278,13 @@ the maintainer's parallel sessions. For each repo touched:
 `git -C <repo_path> worktree add .claude/worktrees/maint-<runid> -b claude/<area>-<desc>`, work there,
 open the PR, then `git -C <repo_path> worktree remove` to clean up (`<repo_path>` is a local
 filesystem path such as `applications/ksail` — `git -C` takes a path, not an `<owner/repo>` slug; use the
-slug only for `gh` commands). Worktree isolation is verified working across all submodules. Populate an un-checked-out submodule at its pinned commit with
+slug only for `gh` commands). **Submodule worktree isolation is inconsistent** — most submodules carry
+a stray shared `core.worktree` that makes `git worktree add` resolve back into the main checkout (only
+the stale `projects/ksail` gitdir is correct; `templates/gitops-tenant-template` was fixed 2026-06-17).
+Before relying on an isolated submodule worktree, confirm `git -C <wt> rev-parse --show-toplevel`
+returns the worktree's own path, not a `.git/modules/<name>` path; the diagnosis table and the verified
+per-submodule fix are in [`.claude/worktree-isolation.md`](.claude/worktree-isolation.md). Populate an
+un-checked-out submodule at its pinned commit with
 `git submodule update --init <path>` (never `--remote`). If a repo's working area is unexpectedly
 dirty or you can't get an isolated tree, do GitHub-API-only work (triage/comment) there.
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Resolves **Theme 3** of the monorepo & site strategy epic #1813. **Fixes #1838.**

## Problem
Per-session `git worktree add` isolation is **inconsistent across the submodules**. Most carry a stray shared **`core.worktree`** in `.git/modules/<name>/config`; since that key is per-worktree, every added worktree **inherits the main checkout's value** and resolves back into the shared tree — so two sessions interleave in one physical directory and a commit can land on the wrong branch.

## What this PR does (the deliverable per #1838 is a *documented, verified procedure + diagnosis*, not a config diff — the fix is per-machine git config)
- **New `.claude/worktree-isolation.md`** — root-cause explanation, the **diagnosis table** for every submodule, a one-liner to regenerate it, and the **verified additive-first fix procedure**.
- **AGENTS.md** Execution-model section: corrects the now-false *"isolation is verified working across all submodules"* claim and links the new doc.

## Key finding (corrects #1838's hypothesis)
#1838 assumed `applications/ksail` was the cleanly-isolated example. It is **not** — the live `applications/ksail` module carries the stray `core.worktree`. The only correct module is the **stale `projects/ksail`** gitdir (old pre-rename path), so in practice **every active portfolio submodule was broken**. Also confirmed: setting `extensions.worktreeConfig=true` **alone is insufficient** (`platform` and `go-template` have the flag yet are still broken) — the stray shared `core.worktree` must also be removed.

## Acceptance criteria
- [x] Diagnosis table of `core.worktree` / `worktreeConfig` state per submodule.
- [x] Documented, repeatable fix procedure.
- [x] Isolation **verified working** on a previously-broken submodule — `templates/gitops-tenant-template`: a probe `git worktree add`'s `show-toplevel` resolved into `.git/modules/...` before the fix and into its **own** tree after; that submodule is **left fixed**.
- [x] Procedure captured where future agents/the maintainer will find it (`.claude/worktree-isolation.md`, linked from `AGENTS.md`).

## Rollout
Remaining submodules roll out **incrementally** per the documented procedure (skip any with a live parallel worktree until quiet). No version-controlled change is needed for those — only the per-machine git config.

## Validation
Markdown-only; no `docs/` site files touched, so the path-filtered CI docs build is unaffected. Relative link `.claude/worktree-isolation.md` resolves from repo root.