### PR TITLE
chore: remove non-existent dotfiles submodule

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,11 +15,10 @@ updates:
     directory: "/"
     # Opt in to the org-level "Git Source" private registry (https://github.com, a
     # classic PAT) so Dependabot can reach our PRIVATE submodules — wedding-app and
-    # ascoachingogvaner (org-private) and dotfiles (devantler/dotfiles, another
-    # account). Without access the whole "submodules in /." job fails with
-    # git_dependencies_not_reachable. The credential lives in the org's Dependabot
-    # private-registries UI (not a repo secret); .gitmodules keeps its SSH URLs, so
-    # local `git submodule` operations are unaffected.
+    # ascoachingogvaner (org-private). Without access the whole "submodules in /."
+    # job fails with git_dependencies_not_reachable. The credential lives in the
+    # org's Dependabot private-registries UI (not a repo secret); .gitmodules keeps
+    # its SSH URLs, so local `git submodule` operations are unaffected.
     registries: "*"
     schedule:
       interval: "daily"

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = templates/dotnet-template
 	url = git@github.com:devantler-tech/dotnet-template.git
 	branch = main
-[submodule "dotfiles"]
-	path = dotfiles
-	url = git@github.com:devantler/dotfiles.git
-	branch = main
 [submodule "github/devantler-tech/.github-public"]
 	path = github/devantler-tech/.github-public
 	url = git@github.com:devantler-tech/.github.git

--- a/.vscode/monorepo.code-workspace
+++ b/.vscode/monorepo.code-workspace
@@ -27,10 +27,6 @@
     {
       "name": "🚚🍺 Homebrew Formulas",
       "path": "../homebrew-formulas"
-    },
-    {
-      "name": "🔘 dotfiles",
-      "path": "../dotfiles"
     }
   ],
   "settings": {


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

The `devantler/dotfiles` repository no longer exists, so this removes every trace of it from the monorepo (maintainer-directed):

- **`.gitmodules`** — drop the `[submodule "dotfiles"]` entry and its gitlink (`dotfiles`).
- **`.github/dependabot.yaml`** — remove the `dotfiles` mention from the `gitsubmodule` private-registry comment. The `registries: "*"` opt-in **stays** — it's still needed for the org-private `wedding-app` / `ascoachingogvaner` submodules.
- **`.vscode/monorepo.code-workspace`** — remove the `🔘 dotfiles` workspace folder.

## Why — `Fixes #1894`

The daily Dependabot **"submodules in /."** job was failing with `git_dependencies_not_reachable`: `dotfiles` pointed at `git@github.com:devantler/dotfiles.git`, a cross-account repo unreachable to the org Dependabot registry token, and one unreachable dependency fails the whole run. With the repo gone, option-2 (drop tracking) is the resolution — the job stops failing because the broken submodule is gone.

## Scope note

The blog post `docs/.../macos-as-a-developer-machine.md` references "dotfiles" as a **generic concept** (MackUp, `~/dotfiles`) unrelated to the deleted repo — those are intentionally **left untouched**.

## Validation

- `git rm` cleanly removed the gitlink + `.gitmodules` entry (no orphan refs).
- `.github/dependabot.yaml` parses as valid YAML.
- `.vscode/monorepo.code-workspace` parses as valid JSONC (folders array intact, `dotfiles` removed, no dangling comma).
- `git grep` confirms no remaining `devantler/dotfiles` / `../dotfiles` / `submodule "dotfiles"` references.