### PR TITLE
docs: add live-platform health investigation sources to the daily assistant's platform instructions

### DIFF
--- a/.claude/skills/product-engineering/SKILL.md
+++ b/.claude/skills/product-engineering/SKILL.md
@@ -174,8 +174,12 @@ at once** — the highest-leverage advance work is often cross-cutting (contract
   E2E + reliability and the Monthly Strategy are its heavy cadence (see its card/`AGENTS.md`).
 - **go-template / dotnet-template**: keep the scaffold minimal, idiomatic, current — advance = better
   defaults, toolchain currency, exemplary tests/CI; **don't add product features**.
-- **platform** (GitOps): **static validation only, never run a cluster** — advance = manifest/Helm/Flux
-  structure & quality, policy/security posture, Kustomize hygiene; "tests" are validation, not unit tests.
+- **platform** (GitOps): two surfaces (see the [platform card](../products/platform/SKILL.md)). **Repo** —
+  **static validation, never spin up a cluster to test a diff**; advance = manifest/Helm/Flux structure &
+  quality, policy/security posture, Kustomize hygiene ("tests" are validation, not unit tests). **Live** —
+  **read-only** health investigation of the running prod cluster + observability (Flux Kustomizations/
+  HelmReleases, Coroot, Kubescape, Kyverno, k8s events) feeding reliability/policy/observability/cost
+  enhancements; never spin up real clusters >1×/day.
 - **actions / reusable-workflows**: load-bearing for every repo — advance = new composite actions or
   workflow capabilities, **additive & backward-compatible**, with their own tests; never break consumers.
 - **monorepo + site**: advance = docs/site features, accessibility, performance (bundle/Lighthouse),

--- a/.claude/skills/products/platform/SKILL.md
+++ b/.claude/skills/products/platform/SKILL.md
@@ -1,20 +1,63 @@
 ---
 name: maintain-platform
-description: Maintenance task menu for devantler-tech/platform (a GitOps Kubernetes platform — Kustomize overlays + Flux CD, Cilium/Talos/KSail/SOPS). Triage, manifest/Helm/Flux investigation & fixes, Helm chart + Actions version bumps, manifest cleanup, stale-PR nudges. Static validation only — never runs a cluster. Use when the daily maintainer selects Platform.
+description: Repo + live-platform health/maintenance menu for devantler-tech/platform (GitOps — Kustomize overlays + Flux CD, Cilium/Talos/KSail/SOPS). Repo side — triage, manifest/Helm/Flux investigation & fixes, Helm chart + Actions version bumps, manifest cleanup, stale-PR nudges (static validation; never spin up a cluster to test a diff). Live side — read-only health investigation of the running prod cluster + its observability stack (Flux Kustomizations/HelmReleases, Coroot, Kubescape, Kyverno, Kubernetes events). Use when the daily maintainer selects Platform.
 ---
 
 # Maintain: Platform
 
-The canonical Platform maintenance task menu lives **in the repo itself** — read the
-**`## Maintenance`** section of `platform/AGENTS.md` (on the submodule's latest `main`):
-<https://github.com/devantler-tech/platform/blob/main/AGENTS.md>. Static validation only — never run
-a cluster.
+Platform has **two surfaces to keep healthy *and* advance** — the **repository** (manifests, Helm,
+Flux, policies) and the **live platform** (the running prod cluster it delivers). **Cover both** each
+time you select Platform: the repo can be green while the cluster is unhealthy (and vice-versa).
 
-Shared cross-repo rules are in the monorepo [`AGENTS.md`](../../../../AGENTS.md). This card is a
-pointer by design — the menu is maintained once, in the product's own `AGENTS.md`.
+## Repository menu (canonical, maintained in the product itself)
+The canonical repo maintenance task menu lives **in the repo** — read the **`## Maintenance`** section
+of `platform/AGENTS.md` (on the submodule's latest `main`):
+<https://github.com/devantler-tech/platform/blob/main/AGENTS.md>. For **validating a repo/PR change**,
+use **static validation** (kustomize build + schema/kubeconform, per that menu) — **never spin up a
+cluster just to test a manifest diff**. Shared cross-repo rules are in the monorepo
+[`AGENTS.md`](../../../../AGENTS.md). This part of the card is a pointer by design — the repo menu is
+maintained once, in the product's own `AGENTS.md`.
+
+## Status & live-platform health investigation (read-only)
+Investigating **how the platform itself is doing** is a first-class part of every Platform run — do it
+**read-only** against the running prod cluster + its observability stack, and **dedupe against the
+accepted "known non-issues" baseline in your native memory** so you don't re-chase by-design/transient
+signals. Pin the context — `kubectl --context=admin@prod …` (the shared kubeconfig drifts across
+parallel sessions, and its API endpoint can go stale after a control-plane recreate; the refresh recipe
++ healthy baseline counts live in native memory). Query **at least** the following; the list is
+**non-exhaustive — chase any other anomaly** you see:
+
+- **Flux Kustomizations** — `kubectl --context=admin@prod get kustomization -A` (Ready? suspended?
+  drifting/last-applied revision? health-check timeouts?). For a stuck/failing reconciliation, the
+  `gitops-cluster-debug` skill (Flux MCP server) traces the dependency chain on the live cluster.
+- **Flux HelmReleases** — `kubectl --context=admin@prod get helmrelease -A` (Ready? install/upgrade
+  retries exhausted? stuck/pending-upgrade?).
+- **Coroot** — Incidents, Alerts/SLO burn, Traces, Logs, Risks (deployment & health-check risks), and
+  **cost optimizations** (Node/cost view). Use its **read API** — the access recipe (project id, auth,
+  the SPA-200-masks-404 gotcha, the empty-Hetzner-cost-rollup known limitation) is in native memory.
+- **Kubescape** — its config-scan / vulnerability / compliance / RBAC report objects, for security-
+  posture regressions vs the last run.
+- **Kyverno** — policy **validation & enforcement**: `kubectl --context=admin@prod get cpol,pol`
+  (policies present? mode Audit vs Enforce?) and `polr,cpolr` (PolicyReport / ClusterPolicyReport —
+  failing rules and violating resources).
+- **Kubernetes events & warnings** — `kubectl --context=admin@prod get events -A
+  --field-selector type=Warning`, plus unhealthy / CrashLooping / Pending pods and abnormal restart
+  counts.
+- **Other problems** — node/Talos & etcd-quorum health, Longhorn volume health, cert-manager certs,
+  external-secrets/OpenBao sync, ingress/Envoy reachability — and anything else off the healthy baseline.
+
+**Guardrails.** Investigation is **read-only** — never mutate prod to "test", and never spin up a *new*
+cluster for it (live-cluster reliability E2E is the ~weekly heavy task, and you **never spin up real
+clusters more than once a day** portfolio-wide — contract *Cadence*). Operational recovery follows
+`platform/AGENTS.md` + the DR runbook. Turn a **confirmed, off-baseline** problem into the right
+artifact — a root-cause **draft PR** to the platform repo (manifest/Helm/policy fix) or a triaged issue
+— never a hand-edit of generated files and never a guardrail bypass.
 
 ## Roadmap & enhancement
 Platform's roadmap lives in **GitHub Issues** on `devantler-tech/platform` (`roadmap` epics +
-milestones). **Advance** via [`product-engineering`](../../product-engineering/SKILL.md) — but
-**static validation only, never run a cluster**: here "advance" means manifest/Helm/Flux structure &
-quality, policy & security posture, and Kustomize hygiene, not code unit tests.
+milestones). **Advance** via [`product-engineering`](../../product-engineering/SKILL.md) — on the
+**repo** side: manifest/Helm/Flux structure & quality, policy & security posture, Kustomize hygiene
+(static validation, not unit tests). On the **live** side: the health investigation above is also an
+enhancement engine — gaps it surfaces (a missing alert/SLO, a weak/Audit-only policy that should
+Enforce, an unaddressed Coroot risk or cost optimization, a reliability hotspot) become `roadmap`/
+`enhancement` issues or focused draft PRs.


### PR DESCRIPTION
## What

Teach the **Daily AI Assistant** to investigate the **live platform's** health — not just the repo — whenever it checks the status of `devantler-tech/platform`.

The platform product card ([`.claude/skills/products/platform/SKILL.md`](.claude/skills/products/platform/SKILL.md)) is the assistant's entry point when it selects Platform. It previously described **only** static repo validation and said *"never run a cluster"*, omitting any live-health check — even though the assistant already reads live prod routinely (Coroot, Flux state, control-plane recovery). This closes that gap.

### New "Status & live-platform health investigation (read-only)" section
Enumerates the sources to query (non-exhaustive — explicitly says to chase any other anomaly):

| Source | What to check |
|---|---|
| **Flux Kustomizations** | `get kustomization -A` — Ready / suspended / drift / health-check timeouts; `gitops-cluster-debug` skill for stuck reconciles |
| **Flux HelmReleases** | `get helmrelease -A` — Ready / retries exhausted / pending-upgrade |
| **Coroot** | Incidents, Alerts/SLO, Traces, Logs, Risks, **cost optimizations** (read API; recipe in native memory) |
| **Kubescape** | config-scan / vuln / compliance / RBAC posture reports |
| **Kyverno** | policy **validation & enforcement** — `cpol,pol` (Audit vs Enforce) + `polr,cpolr` violations |
| **Kubernetes events & warnings** | `get events -A --field-selector type=Warning` + unhealthy/CrashLoop/Pending pods |
| **Other problems** | Talos/etcd, Longhorn, cert-manager, ESO/OpenBao, Envoy — anything off-baseline |

## Why

The maintainer wants the assistant to keep **both** the repository contents **and** the live platform healthy and enhanced. The old card only covered the repo surface.

## Key decision — disambiguating the old guardrail

The ambiguous *"never run a cluster"* is split into two precise rules so both goals are served:
- **Validating a repo/PR diff** → static validation (kustomize build + schema); never spin up a cluster for that.
- **Investigating platform status** → **read-only** queries against the live prod cluster + observability (the new section), which also **feeds enhancement** (a missing SLO, an Audit-only policy that should Enforce, an unaddressed Coroot risk/cost, a reliability hotspot → `roadmap`/`enhancement` issues or draft PRs).

All existing safety guardrails are preserved: read-only investigation, never spin up real clusters >1×/day, root-cause draft PRs, no generated-file hand-edits.

## Changes
- [`.claude/skills/products/platform/SKILL.md`](.claude/skills/products/platform/SKILL.md) — rewritten around two surfaces (repo + live platform); adds the health-investigation section + guardrails; updates the frontmatter description.
- [`.claude/skills/product-engineering/SKILL.md`](.claude/skills/product-engineering/SKILL.md) — platform per-product note updated to match (repo = static validation; live = read-only health investigation feeding enhancements).

## Reviewer notes
- **Scope:** edits only the assistant's brain in this repo. The canonical, cross-tool `platform/AGENTS.md ## Maintenance` (a separate repo, not checked out here) is **not** touched. The live-health protocol is intentionally Claude-native here (it references the assistant's native memory, the `gitops-cluster-debug` skill, and run cadence). A tool-neutral mirror into `platform/AGENTS.md` can follow as a separate PR if wanted.
- Opened as a **draft** per the repo's agent-definition convention — promote to ready when you're happy with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)