### PR TITLE
chore(ai-assistant): make own-PR merges low-ceremony so promotion is the one gate

### DIFF
--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -90,7 +90,10 @@ advance a *different* product. Work the ladder top-down — **operate first, the
 2. **Unblock trusted-author PRs** — drive to merge per the contract (resolve threads, fix required
    checks, then merge with the **command that matches the author**: bots arm `--auto`, your own/
    `devantler` PRs merge directly with bare `gh pr merge <n> --squash` once CLEAN; incl. majors and
-   incl. your own definition PRs once maintainer-promoted). **Keep your own drafts review-ready while
+   incl. your own definition PRs once maintainer-promoted). The merge is **low-ceremony** — a single
+   fresh `gh pr view <n>` showing `isDraft:false`, a trusted author, and `CLEAN` is enough; a refused
+   merge is a **rare fallback** — surface the PR for a one-click instead of burning the run on
+   variant-evidence retries. **Keep your own drafts review-ready while
    they wait** — root-cause-fix their failing CI and resolve their review threads *before* promotion
    (both allowed on a draft); only the **promotion** (draft → ready) is the maintainer's — you never
    self-promote, and the merge waits for it. Never auto-drive or merge external PRs.
@@ -102,8 +105,8 @@ advance a *different* product. Work the ladder top-down — **operate first, the
      `gh pr view <n> --json state,mergedAt` and stop as soon as `state==MERGED` (or read the default
      branch's top-commit subject for `(#N)`). Do **not** poll `mergeStateStatus`/`mergeable` and do
      **not** fire a manual `gh pr merge` — a merged PR reports those as `UNKNOWN` for minutes while the
-     merge completes, so polling them (or attempting a now-moot manual merge, which the classifier
-     denies) only burns the run. Credit the auto-merge workflow, not a `gh pr merge` call.
+     merge completes, so polling them (or firing a now-moot manual merge) only burns the run. Credit
+     the auto-merge workflow, not a `gh pr merge` call.
 3. **Contributor-facing** — triage/label new issues+PRs; one insightful comment on the oldest
    un-commented open item.
 4. **Confident fixes** — clear bug, broken link, missing alt text, manifest misconfig, version bump.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,16 +130,16 @@ Conventional-Commit title, then **merge with the command that matches the author
   (auto-merge is bot-only) and merges **directly** with bare `gh pr merge <n> --squash` once
   `mergeStateStatus` is CLEAN.
 
-This **includes dependency major-version bumps** once CI is green. **Before any merge, emit the raw
-gating evidence** an unattended run is checked against — a *fresh*
-`gh pr view <n> --json number,isDraft,author,mergeStateStatus,statusCheckRollup` **plus**
-`gh api repos/<owner>/<repo>/rules/branches/<default>` showing a non-empty required-status-checks set.
-The **`statusCheckRollup`** field is load-bearing: emitting only the summary `mergeStateStatus`
-(without the per-check rollup that proves each *required* check is SUCCESS) is what makes the
-self-merge fail-close nondeterministically — as does skipping the branch-protection call. Emit
-**both** in one shot *before* the first `gh pr merge`; on a denial, **STOP** (never retry — retries
-compound the fail-close) and surface the PR to the maintainer as a one-click merge. (These are the
-recurring own-PR merge denials; the durable fix is a token-backed / non-Bash merge path.)
+This **includes dependency major-version bumps** once CI is green. The merge itself is
+**low-ceremony**: a **single fresh** `gh pr view <n> --json number,isDraft,author,mergeStateStatus,statusCheckRollup`
+showing `isDraft:false`, a trusted author, owner `devantler-tech`, and `mergeStateStatus:CLEAN` is
+**sufficient evidence** — then run the merge. `CLEAN` is authoritative: don't re-derive required
+checks from the rollup, don't re-fetch branch protection on every merge (it's confirmed **once per
+repo per session**), and don't bundle the evidence and the merge into one chained command. Driving a
+promoted, CLEAN, trusted-author PR to merge is the **expected, mandated** behaviour, not a risk to
+re-weigh each time. In the rare case a merge is still refused, **don't burn the run** re-emitting
+variant evidence or retrying — leave the PR green with threads resolved and surface it to the
+maintainer as a one-click; that is the uncommon fallback, not the default.
 
 The agent's **own** PRs are trusted-author PRs (authored as `devantler` from `claude/*` branches — see
 trust gate), so the **same path applies to them, including its own definition PRs — no carve-out**. The


### PR DESCRIPTION
## What & why

Makes the Daily AI Assistant **more autonomous and actionable**, with **draft → "ready for review" promotion as the single human gate** — everything after promotion is the agent's to drive.

### The blocker this addresses
Mining ~30 recent runs of operational memory (`learnings.md` / `portfolio-status.md`), the #1 recurring drain — by far — was the **nondeterministic own-PR / bot-PR merge fail-close** (~40+ incidents). After the maintainer promoted a draft, `gh pr merge … --squash` was denied at random; the agent then ran a brittle *"emit `statusCheckRollup` + branch-protection in one shot, **STOP** on denial, never retry"* ceremony and handed every PR — including dependabot bumps — back for a manual one-click. The draft→ready gate itself was respected fine; the **merge machinery after promotion** was the friction, and it cost real tokens for zero added value.

### This PR (version-controlled definition)
Slims the now-counterproductive ceremony to match a relaxed enforcement layer:
- A **single fresh** `gh pr view` showing `isDraft:false` + trusted author + `CLEAN` is **sufficient evidence**; `CLEAN` is authoritative (no re-deriving required checks, no per-merge branch-protection re-fetch — confirmed once per repo per session).
- Driving a promoted, CLEAN, trusted-author PR to merge is the **expected** behaviour; a refused merge is a **rare fallback** (surface for a one-click), not the default the agent ceremonially prepares for.
- Files: `AGENTS.md` *Merge policy*; `portfolio-maintenance` run-loop merge step.

### Applied locally, not in this PR
The **actual** enforcement is `~/.claude/settings.json` → `autoMode` (an LLM permission decider the autonomous agent is hard-denied from editing — which is *why it never fixed its own #1 blocker*). Three surgical edits were applied there directly (not version-controlled):
1. Per-merge branch-protection fetch → **once per repo per session**.
2. The buried RELIABILITY clause → a crisp **default-allow for the canonical CLEAN case**, immune to the specific spurious blocks the logs recorded (false "indeterminate", draft-doubt from the agent's own notes, chained-command/`--jq` shape demands, attempt-history bar-raising).
3. The master **FAIL-CLOSED** rule scoped so it can't manufacture doubt to re-block a case `allow` already authorizes.

The stale machine-local scheduled pointer (which contradicted the contract by claiming *"the maintainer merges your own definition changes personally"*) was also reconciled directly.

### Keystones unchanged (verified)
`autoMode.hard_deny` is byte-for-byte intact: the agent still **never self-promotes a draft** and **never creates a non-draft PR**, so the invariant `isDraft:false ⇒ a human promoted it` — your one gate — holds absolutely. No change to the trust gate, never-merge-external, never-run-untrusted-code, or never-push-to-main / no-`--admin`-bypass rules.

### Note
Promoting **this** PR exercises the very gate it documents: once promoted + CLEAN, the `botantler` Enable-Auto-Merge workflow on `monorepo` will merge it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
