### PR TITLE
ci(docs): drift-check the Active Projects submodule set against .gitmodules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
             active-projects:
               - 'docs/src/content/docs/projects/active.mdx'
               - 'docs/scripts/check-active-projects-drift.sh'
+              - '.gitmodules'
               - 'github/devantler-tech/github-actions/actions'
               - 'github/devantler-tech/github-actions/reusable-workflows'
 

--- a/docs/scripts/check-active-projects-drift.sh
+++ b/docs/scripts/check-active-projects-drift.sh
@@ -26,6 +26,23 @@
 #                          `reusable-workflows-count: N` marker. Adding or
 #                          removing a workflow therefore forces a human to
 #                          revisit the category bullets and bump the marker.
+#   - Submodules         — the page is a *curated* view of the monorepo's
+#                          submodule set (the source-of-truth is .gitmodules):
+#                          some submodules are their own H2 product section,
+#                          some are grouped under "Self-Hosted Personal Apps",
+#                          some are listed on the Templates page instead, and
+#                          several are infra/config repos not surfaced as
+#                          projects at all. A count or section scan can't model
+#                          that curation, so we pin the FULL submodule set via a
+#                          `projects-submodules: path=disposition,...` marker and
+#                          enforce SET equality between the marker's paths and
+#                          the live .gitmodules paths. Adding or removing a
+#                          submodule therefore forces a human to record it and
+#                          decide whether/how it appears — a brand-new product
+#                          can no longer land in the monorepo while silently
+#                          going unrepresented on the site. (This check reads
+#                          only the tracked .gitmodules file, so it needs no
+#                          submodule checkout and stays network-free.)
 #
 # Run from the repository root (CI sets the working directory there); falls back
 # to a path relative to this script for local runs.
@@ -37,6 +54,7 @@ repo_root="${GITHUB_WORKSPACE:-$(cd "$script_dir/../.." && pwd)}"
 mdx="$repo_root/docs/src/content/docs/projects/active.mdx"
 actions_dir="$repo_root/github/devantler-tech/github-actions/actions"
 rw_workflows_dir="$repo_root/github/devantler-tech/github-actions/reusable-workflows/.github/workflows"
+gitmodules="$repo_root/.gitmodules"
 
 # Anchor each H2 section on the source repo URL it links to — unique and stable.
 actions_anchor="](https://github.com/devantler-tech/actions)"
@@ -51,6 +69,7 @@ die_missing() {
 [ -f "$mdx" ] || die_missing "active.mdx" "$mdx"
 [ -d "$actions_dir" ] || die_missing "actions submodule" "$actions_dir"
 [ -d "$rw_workflows_dir" ] || die_missing "reusable-workflows submodule" "$rw_workflows_dir"
+[ -f "$gitmodules" ] || die_missing ".gitmodules" "$gitmodules"
 
 # Count "- " bullets in the H2 section whose header line contains $1.
 count_section_bullets() {
@@ -117,6 +136,43 @@ update the 'reusable-workflows-count' marker to ${rw_count}." >&2
   fail=1
 else
   echo "OK: Reusable Workflows in sync (${rw_count} workflow_call workflows == marker ${rw_expected})."
+fi
+
+# --- Submodules: every submodule is consciously represented (or excluded) ------
+# Live submodule paths from .gitmodules (a tracked file at the repo root, so no
+# submodule contents are needed here), sorted & unique.
+submodules_live=$(
+  grep -E '^[[:space:]]*path[[:space:]]*=' "$gitmodules" \
+    | awk -F'=' '{ gsub(/[[:space:]]/, "", $2); print $2 }' | sort -u
+)
+
+# Declared paths from the inline `projects-submodules: path=disposition,...`
+# marker — take the path (left of '=') from each comma-separated entry.
+submodules_marker=$(
+  grep -oE 'projects-submodules:[[:space:]]*[a-z0-9/=,._-]+' "$mdx" \
+    | sed -E 's/^projects-submodules:[[:space:]]*//' | head -n1 || true
+)
+submodules_declared=$(
+  printf '%s' "$submodules_marker" | tr ',' '\n' | sed -E 's/=.*$//; /^[[:space:]]*$/d' | sort -u
+)
+
+if [ -z "$submodules_marker" ]; then
+  echo "::error file=docs/src/content/docs/projects/active.mdx::Missing \
+'projects-submodules: path=disposition,...' marker in \
+docs/src/content/docs/projects/active.mdx." >&2
+  fail=1
+elif [ "$submodules_declared" != "$submodules_live" ]; then
+  only_live=$(comm -23 <(printf '%s\n' "$submodules_live") <(printf '%s\n' "$submodules_declared") | paste -sd, -)
+  only_marker=$(comm -13 <(printf '%s\n' "$submodules_live") <(printf '%s\n' "$submodules_declared") | paste -sd, -)
+  echo "::error file=docs/src/content/docs/projects/active.mdx::Submodule drift: the \
+'projects-submodules' marker does not match the submodules in .gitmodules. \
+Missing from marker: [${only_live:-none}]. Stale in marker (no longer a submodule): [${only_marker:-none}]. \
+A submodule was added or removed — record it in the 'projects-submodules' marker with its disposition \
+(section / grouped / templates-page / infra / omitted) and, if it should appear as a project, update the page." >&2
+  fail=1
+else
+  sub_n=$(printf '%s\n' "$submodules_live" | grep -c .)
+  echo "OK: Submodule representation in sync (${sub_n} submodules all accounted for in the marker)."
 fi
 
 exit "$fail"

--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -11,6 +11,16 @@ import platformImg from "../../../assets/platform.webp";
 
 These are the projects I am currently working on and actively maintaining. I'm always looking for contributors and feedback — feel free to visit each project's GitHub page and follow the contribution guidelines.
 
+{/* projects-submodules: applications/ascoachingogvaner=grouped,applications/fleet-gitops=infra,applications/ksail=section,applications/unifi=omitted,applications/wedding-app=grouped,github/devantler-tech/.github-public=infra,github/devantler-tech/github-actions/actions=section,github/devantler-tech/github-actions/reusable-workflows=section,github/devantler-tech/maintenance=infra,github/personal/.github-public=infra,github/personal/profile=infra,homebrew-tap=omitted,libraries/agent-plugins=section,libraries/agent-skills=section,platform=section,templates/dotnet-template=templates-page,templates/gitops-tenant-template=templates-page,templates/go-template=templates-page,templates/platform-template=templates-page
+
+  This marker pins EVERY submodule this monorepo tracks (the source-of-truth is .gitmodules) to how it is represented on the site, so a newly-added product can't silently go unlisted. The docs CI drift-check asserts this path set EQUALS the live .gitmodules paths; when a submodule is added or removed, record it here with one disposition and update the page if needed:
+    • section        — has its own H2 product section on this page (KSail, Platform, Reusable Workflows, Actions, Agent Skills, Agent Plugins).
+    • grouped        — a private self-hosted app folded into the "🏠 Self-Hosted Personal Apps" section (wedding-app, ascoachingogvaner).
+    • templates-page — a starter template listed on the Templates page (/templates/) instead of here.
+    • infra          — an internal config/automation/GitOps-state repo, not surfaced as a project (the .github-public/profile/maintenance/fleet-gitops repos).
+    • omitted        — a product that is deliberately not surfaced on this page (homebrew-tap distribution tap; the private applications/unifi network config). Promote to section/grouped if it should appear.
+*/}
+
 ## [🛥️ KSail](https://github.com/devantler-tech/ksail) ![Go](https://img.shields.io/badge/Go-00ADD8.svg?style=for-the-badge&logo=Go&logoColor=white) ![Docker](https://img.shields.io/badge/Docker-2496ED.svg?style=for-the-badge&logo=Docker&logoColor=white) ![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5.svg?style=for-the-badge&logo=Kubernetes&logoColor=white)
 
 <Image src={ksailImg} alt="KSail CLI" />


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The Active Projects page (`docs/src/content/docs/projects/active.mdx`) already guards its **Actions** and **Reusable Workflows** sub-lists against silent drift (via the existing `actions-dirs` / `reusable-workflows-count` markers + `docs/scripts/check-active-projects-drift.sh`). But nothing guarded the **top-level set of product sections**. A brand-new product could be added to the monorepo as a submodule and silently go unrepresented on the site between maintenance runs — exactly the recurring "site content drifted from reality" friction captured by **monorepo #1813 Theme 2** (*make site content self-sustaining / anti-drift*).

There is already one latent instance: `applications/unifi` is a product (per the portfolio map) but appears nowhere on the page.

## Change

Extend the existing **network-free** drift-check with a third tripwire — submodule-set completeness:

- **`projects-submodules: path=disposition,...` marker** added to `active.mdx`, pinning **every** submodule in `.gitmodules` to how it is represented. The check enforces **SET equality** between the marker's paths and the live `.gitmodules` paths (the same proven pattern as `actions-dirs`). The source-of-truth is the tracked `.gitmodules` file, so no submodule checkout is needed and the check stays offline.
- Dispositions (documentation; the check validates the path set, not the values):
  - `section` — own H2 product section (KSail, Platform, Reusable Workflows, Actions, Agent Skills, Agent Plugins)
  - `grouped` — folded into 🏠 Self-Hosted Personal Apps (wedding-app, ascoachingogvaner)
  - `templates-page` — listed on the Templates page instead
  - `infra` — internal config/automation/GitOps-state repo, not a project
  - `omitted` — a product deliberately not surfaced on this page
- **CI wiring:** added `.gitmodules` to the `active-projects` paths filter so the check runs on a submodule **add/remove**. A routine submodule **pointer bump** (e.g. dependabot bumping a pinned commit) does *not* touch `.gitmodules`, so this adds **no** extra CI runs for routine dependency work.

Adding/removing a submodule now fails the build with an actionable message until the marker is updated and a disposition chosen — a new product can no longer land while silently going unlisted.

## Maintainer call surfaced (not decided here)

The marker documents the **current** curation, which makes one gap explicit: **`applications/unifi` is currently `omitted`**. It is a product per the portfolio map and, like wedding-app/ascoaching, runs as a private tenant on the platform — so it arguably belongs under 🏠 Self-Hosted Personal Apps (`grouped`). I left the status quo intact rather than make the content/curation call unilaterally; promote it to `grouped` (and add a bullet to that section) if it should be listed.

## Validation

- `bash docs/scripts/check-active-projects-drift.sh` → all three checks green (16 actions, 15 reusable workflows, **19 submodules accounted for**).
- **Negative test:** removing one entry from the marker fails with `exit=1` and `Missing from marker: [applications/unifi]` — the tripwire trips.
- `npm run build` (the docs CI gate) → **63 pages built**; the JSX marker parses and is **not** rendered into the page HTML.

Opened as a **draft** per routine; promote to mark it review-ready.