### PR TITLE
ci(docs): set-equality drift check for reusable-workflow names

### DIFF
--- a/docs/scripts/check-active-projects-drift.sh
+++ b/docs/scripts/check-active-projects-drift.sh
@@ -20,12 +20,21 @@
 #                          updated without revisiting the prose bullets).
 #   - Reusable Workflows — the site list is *categorical* (CI / CD / Automation
 #                          buckets), not one bullet per workflow, so a bullet
-#                          count cannot map 1:1. Instead we tripwire on the
-#                          number of reusable (`workflow_call`) workflows versus
-#                          an expected count declared inline in active.mdx via a
-#                          `reusable-workflows-count: N` marker. Adding or
-#                          removing a workflow therefore forces a human to
-#                          revisit the category bullets and bump the marker.
+#                          count cannot map 1:1. We tripwire on the number of
+#                          reusable (`workflow_call`) workflows versus an expected
+#                          count declared inline in active.mdx via a
+#                          `reusable-workflows-count: N` marker — but a count
+#                          alone, exactly like the Actions bullet count, cannot
+#                          catch a rename or a net-zero add+remove (the count
+#                          stays equal while a category bullet silently goes
+#                          stale), so we additionally pin the exact workflow names
+#                          via a `reusable-workflows-names: a,b,c` marker and
+#                          enforce SET equality between it and the live
+#                          `workflow_call` workflows (keeping the count tripwire so
+#                          the names marker can't be updated without revisiting the
+#                          category bullets). Adding, removing, OR renaming a
+#                          workflow therefore forces a human to revisit the
+#                          category bullets and update both markers.
 #   - Submodules         — the page is a *curated* view of the monorepo's
 #                          submodule set (the source-of-truth is .gitmodules):
 #                          some submodules are their own H2 product section,
@@ -119,12 +128,28 @@ else
   echo "OK: Actions list in sync (${actions_count} actions == ${actions_bullets} bullets, marker set matches)."
 fi
 
-# --- Reusable Workflows: count tripwire vs. inline marker ----------------------
-rw_count=$(grep -lE '^[[:space:]]*workflow_call:' "$rw_workflows_dir"/*.yaml 2>/dev/null | wc -l | tr -d ' ')
+# --- Reusable Workflows: count tripwire + workflow-name set equality -----------
+# Live reusable (workflow_call) workflow names (basename minus .yaml), sorted & unique.
+rw_live=$(
+  grep -lE '^[[:space:]]*workflow_call:' "$rw_workflows_dir"/*.yaml 2>/dev/null \
+    | awk -F/ '{ name = $NF; sub(/\.yaml$/, "", name); print name }' | sort -u
+)
+rw_count=$(printf '%s\n' "$rw_live" | grep -c . || true)
 rw_expected=$(grep -oE 'reusable-workflows-count:[[:space:]]*[0-9]+' "$mdx" | grep -oE '[0-9]+' | head -n1 || true)
+
+# Declared workflow names from the inline `reusable-workflows-names: a,b,c` marker.
+rw_marker=$(
+  grep -oE 'reusable-workflows-names:[[:space:]]*[a-z0-9,_-]+' "$mdx" \
+    | sed -E 's/^reusable-workflows-names:[[:space:]]*//' | head -n1 || true
+)
+rw_declared=$(printf '%s' "$rw_marker" | tr ',' '\n' | sed '/^$/d' | sort -u)
 
 if [ -z "$rw_expected" ]; then
   echo "::error file=docs/src/content/docs/projects/active.mdx::Missing 'reusable-workflows-count: N' \
+marker in the '## 🔄 Reusable Workflows' section of docs/src/content/docs/projects/active.mdx." >&2
+  fail=1
+elif [ -z "$rw_marker" ]; then
+  echo "::error file=docs/src/content/docs/projects/active.mdx::Missing 'reusable-workflows-names: a,b,c' \
 marker in the '## 🔄 Reusable Workflows' section of docs/src/content/docs/projects/active.mdx." >&2
   fail=1
 elif [ "$rw_count" -ne "$rw_expected" ]; then
@@ -134,8 +159,18 @@ declares ${rw_expected}. A workflow was added or removed in devantler-tech/reusa
 the category bullets under '## 🔄 Reusable Workflows' in docs/src/content/docs/projects/active.mdx and \
 update the 'reusable-workflows-count' marker to ${rw_count}." >&2
   fail=1
+elif [ "$rw_declared" != "$rw_live" ]; then
+  only_live=$(comm -23 <(printf '%s\n' "$rw_live") <(printf '%s\n' "$rw_declared") | paste -sd, -)
+  only_marker=$(comm -13 <(printf '%s\n' "$rw_live") <(printf '%s\n' "$rw_declared") | paste -sd, -)
+  echo "::error file=docs/src/content/docs/projects/active.mdx::Reusable Workflows drift: the \
+'reusable-workflows-names' marker does not match the workflow_call workflows in \
+devantler-tech/reusable-workflows. Missing from marker: [${only_live:-none}]. \
+Stale in marker (no longer a workflow_call workflow): [${only_marker:-none}]. A workflow was added, \
+removed, or renamed — review the category bullets under '## 🔄 Reusable Workflows' AND update the \
+'reusable-workflows-names' marker in docs/src/content/docs/projects/active.mdx." >&2
+  fail=1
 else
-  echo "OK: Reusable Workflows in sync (${rw_count} workflow_call workflows == marker ${rw_expected})."
+  echo "OK: Reusable Workflows in sync (${rw_count} workflow_call workflows == marker ${rw_expected}, name set matches)."
 fi
 
 # --- Submodules: every submodule is consciously represented (or excluded) ------

--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -56,6 +56,8 @@ A collection of [reusable GitHub Actions workflows](https://docs.github.com/en/a
 
 {/* reusable-workflows-count: 15 — this categorical list covers every reusable (workflow_call) workflow in devantler-tech/reusable-workflows; the docs CI drift-check fails when a workflow is added or removed there. When that happens, review the category bullets above and bump this number to match. */}
 
+{/* reusable-workflows-names: create-release,delete-workflow-runs,dependency-review,deploy-github-pages,enable-auto-merge,publish-app,publish-dotnet-library,publish-manifests,run-dotnet-tests,scan-for-todo-comments,scan-for-workflow-vulnerabilities,sync-cluster-policies,template-sync,update-agent-skills,validate-go-project — the exact set of reusable (workflow_call) workflow filenames (minus .yaml) in devantler-tech/reusable-workflows. The docs CI drift-check asserts this set EQUALS the live workflow_call workflows, so an added, removed, OR renamed workflow breaks the build even when the count is unchanged (a count alone misses renames and net-zero swaps). When that happens, review the category bullets above and update this marker together with the count. */}
+
 ## [⚡ Actions](https://github.com/devantler-tech/actions) ![GitHub Actions](https://img.shields.io/badge/GitHub%20Actions-2088FF.svg?style=for-the-badge&logo=GitHub-Actions&logoColor=white)
 
 A collection of [composite GitHub Actions](https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action) that provide small, reusable components for CI/CD workflows.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The Active Projects drift guard (`docs/scripts/check-active-projects-drift.sh`) protects three hand-maintained site lists against silent drift from their source-of-truth sibling repos. Two of the three were hardened with **set-equality** markers precisely because a bare count can't catch a rename or a net-zero add+remove (the count stays equal while a list entry silently goes stale):

- **Actions** → `actions-dirs: a,b,c` set-equality (catches add/remove/**rename**).
- **Submodules** → `projects-submodules: path=disp,...` set-equality (added in #1925).
- **Reusable Workflows** → still **count-only** (`reusable-workflows-count: N`).

So the reusable-workflows check carried the exact blind spot the other two were fixed for: rename `template-sync` → `template-syncer`, or swap one workflow for another, and the count stays `15` while the categorical CI/CD/Automation bullets silently go stale.

## Change

Add a `reusable-workflows-names: …` marker pinning the exact set of `workflow_call` workflow filenames (minus `.yaml`) and enforce **set equality** against the live submodule, mirroring the proven `actions-dirs` pattern. The count tripwire is kept, so the names marker can't be updated without revisiting the category bullets. Header doc-comment updated to match. No behaviour change to the green path — only a previously-undetectable drift class is now caught.

## Validation (local, network-free — same inputs as CI)

- **Positive:** `bash docs/scripts/check-active-projects-drift.sh` → `OK: Reusable Workflows in sync (15 workflow_call workflows == marker 15, name set matches).`
- **Negative — net-zero rename** (the blind spot): mutate the marker `template-sync` → `template-syncer` (count unchanged at 15) → fails with `Missing from marker: [template-sync]. Stale in marker: [template-syncer]`. The old count-only check passed this.
- **Negative — drop a name** → fails with `Missing from marker: [validate-go-project]`.
- `shellcheck docs/scripts/check-active-projects-drift.sh` → clean.
- `npm run build` → 63 pages, all internal links valid; the `{/* … */}` marker is a JSX comment and does **not** render (confirmed absent from `dist/`).

Advances **#1813** theme 2 (*site content cannot silently go stale*) — the same incremental anti-drift hardening as #1925, now applied to the last count-only list.