### PR TITLE
test: cover the active-projects drift guard with a self-test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
               - 'docs/src/content/docs/projects/active.mdx'
               - 'docs/src/content/docs/templates/**'
               - 'docs/scripts/check-active-projects-drift.sh'
+              - 'docs/scripts/check-active-projects-drift.test.sh'
               - '.gitmodules'
               - 'github/devantler-tech/github-actions/actions'
               - 'github/devantler-tech/github-actions/reusable-workflows'
@@ -101,6 +102,10 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      # Verify the drift checker itself first — self-contained fixtures, no
+      # submodule checkout needed, so it fails fast if a refactor broke a check.
+      - name: Self-test the drift checker
+        run: bash docs/scripts/check-active-projects-drift.test.sh
       # The source-of-truth repos are public submodules; check out only those
       # two at their pinned commits (no GitHub API, no other submodules). The
       # .gitmodules URLs are SSH (git@github.com:), which the runner has no key

--- a/docs/scripts/check-active-projects-drift.test.sh
+++ b/docs/scripts/check-active-projects-drift.test.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# Self-test for check-active-projects-drift.sh — proves the drift guard PASSES a
+# fully-consistent fixture and FAILS each individual drift scenario (a missing
+# marker, a count tripwire, and a set-equality mismatch for every one of the
+# four checks: Actions, Reusable Workflows, Submodules, Templates page). Run in
+# CI so the guard's correctness is continuously verified — a refactor that
+# silently weakens any check is caught here, not in production drift.
+#
+# The guard reads its repo root from $GITHUB_WORKSPACE (falling back to the
+# checkout when unset), so every case points it at a self-contained fixture tree
+# under a tempdir — the test needs no submodule checkout and never touches the
+# real repo.
+set -Eeuo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+guard="$here/check-active-projects-drift.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail=0
+
+pass_case() { # name root
+  if GITHUB_WORKSPACE="$2" bash "$guard" >/dev/null 2>&1; then
+    printf '  ✅ %s — passed as expected\n' "$1"
+  else
+    printf '  ❌ %s — expected PASS but the guard FAILED\n' "$1"; fail=1
+  fi
+}
+
+fail_case() { # name root
+  if GITHUB_WORKSPACE="$2" bash "$guard" >/dev/null 2>&1; then
+    printf '  ❌ %s — expected FAIL but the guard PASSED\n' "$1"; fail=1
+  else
+    printf '  ✅ %s — failed as expected\n' "$1"
+  fi
+}
+
+# Build a fully-consistent fixture repo root at $1: two composite actions, two
+# reusable (workflow_call) workflows, four submodules (two infra-section, one
+# grouped, one templates-page), and one matching template doc page — all four
+# markers in active.mdx agreeing with the live sources.
+build_fixture() {
+  local root="$1"
+  rm -rf "$root"
+  local mdx_dir="$root/docs/src/content/docs/projects"
+  local tpl_dir="$root/docs/src/content/docs/templates"
+  local actions_dir="$root/github/devantler-tech/github-actions/actions"
+  local rw_dir="$root/github/devantler-tech/github-actions/reusable-workflows/.github/workflows"
+  mkdir -p "$mdx_dir" "$tpl_dir" "$actions_dir/alpha" "$actions_dir/beta" "$rw_dir"
+
+  printf 'name: alpha\n' > "$actions_dir/alpha/action.yaml"
+  printf 'name: beta\n'  > "$actions_dir/beta/action.yaml"
+
+  printf 'on:\n  workflow_call:\n' > "$rw_dir/ci-one.yaml"
+  printf 'on:\n  workflow_call:\n' > "$rw_dir/cd-two.yaml"
+
+  cat > "$root/.gitmodules" <<'EOF'
+[submodule "actions"]
+	path = github/devantler-tech/github-actions/actions
+	url = https://github.com/devantler-tech/actions.git
+[submodule "reusable-workflows"]
+	path = github/devantler-tech/github-actions/reusable-workflows
+	url = https://github.com/devantler-tech/reusable-workflows.git
+[submodule "bar"]
+	path = applications/bar
+	url = https://github.com/devantler-tech/bar.git
+[submodule "foo-template"]
+	path = templates/foo-template
+	url = https://github.com/devantler-tech/foo-template.git
+EOF
+
+  cat > "$tpl_dir/foo.md" <<'EOF'
+---
+title: Foo Template
+---
+**Repository**: [devantler-tech/foo-template](https://github.com/devantler-tech/foo-template)
+EOF
+
+  cat > "$mdx_dir/active.mdx" <<'EOF'
+---
+title: Active Projects
+---
+
+{/* projects-submodules: applications/bar=grouped,github/devantler-tech/github-actions/actions=section,github/devantler-tech/github-actions/reusable-workflows=section,templates/foo-template=templates-page */}
+
+## [⚡ Actions](https://github.com/devantler-tech/actions)
+
+- alpha — first action
+- beta — second action
+
+{/* actions-dirs: alpha,beta */}
+
+## 🔄 Reusable Workflows
+
+- CI bucket
+- CD bucket
+
+{/* reusable-workflows-count: 2 */}
+{/* reusable-workflows-names: cd-two,ci-one */}
+EOF
+}
+
+# 0. fully-consistent fixture → pass (the happy path; guards against a guard
+#    that fails-closed on a correct page).
+good="$tmp/good"; build_fixture "$good"
+pass_case "fully-consistent fixture" "$good"
+
+# 1. Actions: marker absent → fail (missing-marker branch).
+c="$tmp/actions-missing-marker"; build_fixture "$c"
+sed -i.bak '/actions-dirs:/d' "$c/docs/src/content/docs/projects/active.mdx"
+fail_case "Actions: missing actions-dirs marker" "$c"
+
+# 2. Actions: a third action dir but the bullets/marker still list two →
+#    bullet-count tripwire fires.
+c="$tmp/actions-count"; build_fixture "$c"
+mkdir -p "$c/github/devantler-tech/github-actions/actions/gamma"
+printf 'name: gamma\n' > "$c/github/devantler-tech/github-actions/actions/gamma/action.yaml"
+fail_case "Actions: count tripwire (3 dirs, 2 bullets)" "$c"
+
+# 3. Actions: count matches but a marker name is renamed → set-equality fires.
+c="$tmp/actions-set"; build_fixture "$c"
+sed -i.bak 's/actions-dirs: alpha,beta/actions-dirs: alpha,gamma/' \
+  "$c/docs/src/content/docs/projects/active.mdx"
+fail_case "Actions: set mismatch (marker renames beta→gamma)" "$c"
+
+# 4. Reusable Workflows: count marker disagrees with the live workflow count.
+c="$tmp/rw-count"; build_fixture "$c"
+sed -i.bak 's/reusable-workflows-count: 2/reusable-workflows-count: 3/' \
+  "$c/docs/src/content/docs/projects/active.mdx"
+fail_case "Reusable Workflows: count tripwire (marker 3, live 2)" "$c"
+
+# 5. Reusable Workflows: count matches but a name is renamed → set-equality fires.
+c="$tmp/rw-set"; build_fixture "$c"
+sed -i.bak 's/reusable-workflows-names: cd-two,ci-one/reusable-workflows-names: cd-three,ci-one/' \
+  "$c/docs/src/content/docs/projects/active.mdx"
+fail_case "Reusable Workflows: set mismatch (marker renames cd-two→cd-three)" "$c"
+
+# 6. Submodules: a new submodule in .gitmodules not recorded in the marker →
+#    submodule set-equality fires.
+c="$tmp/submodule-set"; build_fixture "$c"
+cat >> "$c/.gitmodules" <<'EOF'
+[submodule "newthing"]
+	path = applications/newthing
+	url = https://github.com/devantler-tech/newthing.git
+EOF
+fail_case "Submodules: unrecorded new submodule" "$c"
+
+# 7. Templates page: a templates-page submodule (recorded in .gitmodules so the
+#    submodule check still passes) has no matching template doc page → templates
+#    set-equality fires in isolation.
+c="$tmp/templates-set"; build_fixture "$c"
+sed -i.bak 's#templates/foo-template=templates-page#templates/foo-template=templates-page,templates/baz-template=templates-page#' \
+  "$c/docs/src/content/docs/projects/active.mdx"
+cat >> "$c/.gitmodules" <<'EOF'
+[submodule "baz-template"]
+	path = templates/baz-template
+	url = https://github.com/devantler-tech/baz-template.git
+EOF
+fail_case "Templates: templates-page submodule with no doc page" "$c"
+
+if [ "$fail" -ne 0 ]; then
+  printf '❌ active-projects drift-guard self-test FAILED\n' >&2
+  exit 1
+fi
+printf '✅ active-projects drift-guard self-test passed (8 cases)\n'


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What & why

`docs/scripts/check-active-projects-drift.sh` is ~270 lines of critical guard logic — it keeps the [Active Projects page](https://github.com/devantler-tech/monorepo/blob/main/docs/src/content/docs/projects/active.mdx) from silently drifting out of sync with its source-of-truth repos via **four independent checks** (Actions list, Reusable Workflows list, submodule representation, Templates page), each with a count tripwire **and** a set-equality assertion. It had **no tests**, so a refactor could silently weaken any one check and nothing would catch it — and a weakened guard fails open (drift lands unnoticed).

This adds a fixture-based self-test, **purely additive** (the production guard is unchanged).

## How

Mirrors the proven precedent in [`applications/unifi/scripts/check-import-first.test.sh`](https://github.com/devantler-tech/monorepo/blob/main/applications/unifi/scripts/check-import-first.test.sh) (the unifi T2 CI guard): plain bash, no new dependencies.

- Builds a fully self-contained fixture repo root (two composite actions, two `workflow_call` workflows, four submodules with mixed dispositions, one matching template doc page) and points the guard at it via **`GITHUB_WORKSPACE`** — which the guard already honors as its repo root — so it needs no submodule checkout and never touches the real repo.
- Asserts the guard **PASSES** the consistent fixture (guards against a fail-closed regression) and **FAILS** each drift scenario in isolation (8 cases): a missing marker, the bullet/count tripwires, and set-equality mismatches for all four checks.
- Wires it into the `drift-check-active-projects` CI job as a **fail-fast step before** the submodule checkout, and registers the test file in the `active-projects` path filter so editing it re-runs the job.

## Validation

- `bash docs/scripts/check-active-projects-drift.test.sh` → ✅ all 8 cases pass (exit 0)
- `bash -n` syntax check ✅ · `shellcheck` clean ✅ · `ci.yaml` parses, steps ordered Checkout → Self-test → submodule checkout → drift check ✅

Advances the monorepo anti-drift/agent-file-freshness theme (#1813) by pinning the behaviour of the guard that enforces it.