### PR TITLE
perf(docs): lazy-load below-the-fold images on the about page

### DIFF
--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -27,7 +27,7 @@ I am a Developer Experience Engineer based in Denmark with an MSc in Software En
 
 <div style="text-align: center;">
   <a href="https://youtu.be/Q-Hfn_-B7p8?si=2Uec_kld--fNw3gm" target="_blank">
-    <img src="/images/talks/kcd-denmark-2024-ksail.jpeg" alt="KSail talk at KCD Denmark 2024" width="400" />
+    <img src="/images/talks/kcd-denmark-2024-ksail.jpeg" alt="KSail talk at KCD Denmark 2024" width="400" loading="lazy" decoding="async" />
     <br />
     🎥 Watch the talk! 🎥
   </a>
@@ -220,18 +220,20 @@ Member of the VS Code and GitHub Copilot backstage group, where I get early acce
 ### Certificates
 
 <div style="text-align: center;">
-  <img src="/images/certificates/github-actions-certification.png" alt="GitHub Actions Certification" width="420" />
+  <img src="/images/certificates/github-actions-certification.png" alt="GitHub Actions Certification" width="420" loading="lazy" decoding="async" />
 </div>
 
 ### [Credly Badges](https://www.credly.com/users/nikolai-emil-damm/badges)
 
 <div style="text-align: left;">
-  <img src="/images/badges/speaker-kcd-denmark-2024.png" alt="KCD 2024 Speaker" width="172" height="172" />
+  <img src="/images/badges/speaker-kcd-denmark-2024.png" alt="KCD 2024 Speaker" width="172" height="172" loading="lazy" decoding="async" />
   <img
     src="/images/badges/cilium-discovery-platform-engineer.png"
     alt="Cilium: Discovery Platform Engineer"
     width="172"
     height="172"
+    loading="lazy"
+    decoding="async"
   />
 </div>
 
@@ -242,11 +244,15 @@ Member of the VS Code and GitHub Copilot backstage group, where I get early acce
     src="/images/courses/kodecloud-kubernetes-for-the-absolute-beginners-course-completion-certificate.png"
     alt="KodeKloud: Kubernetes for the Absolute Beginners"
     width="420"
+    loading="lazy"
+    decoding="async"
   />
   <img
     src="/images/courses/kodecloud-kcna-course-completion-certificate.png"
     alt="KodeKloud: Kubernetes and Cloud-Native Associate (KCNA)"
     width="420"
+    loading="lazy"
+    decoding="async"
   />
 </div>
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What
Add `loading="lazy"` + `decoding="async"` to the six raw `<img>` tags on the **About** page (talk thumbnail, certificate, two Credly badges, two course certificates).

## Why
All six images sit well below the fold (Talks section at the top of a long page, then Achievements/Courses near the bottom), yet they rendered as plain `<img>` with no loading hints — so the browser fetched and decoded every one eagerly on first paint. The page's LCP image is the top profile photo, which already uses Astro's `<Image>` (optimized + lazy by default), so deferring the remaining offscreen images is pure upside:

- **Network:** offscreen images no longer compete with above-the-fold content for initial bandwidth.
- **Decode:** `decoding="async"` keeps image decode off the main thread.
- No risk to LCP — the lazy images are all below the fold; the LCP `<Image>` is untouched.

## Scope / safety
- Standard-HTML attribute additions only — no asset moves, no component changes, no new imports.
- Verified the attributes pass through MDX into the rendered output (`dist/about/index.html` shows all six `<img>` with `loading="lazy"`).

## Validation
- `npm ci && npm run build` — ✅ 63 pages built, all internal links valid, no warnings introduced.

This is a small, isolated docs **performance** improvement; the larger consistency question (migrating these raw `<img>` to Astro's `<Image>` for full optimization, which would require moving the assets from `public/` into `src/assets/`) is intentionally left out of scope.