### PR TITLE
docs(blog): add per-post meta descriptions for SEO

### DIFF
--- a/docs/src/content/docs/blog/ai-powered-github-issues-with-copilot-and-claude-opus.md
+++ b/docs/src/content/docs/blog/ai-powered-github-issues-with-copilot-and-claude-opus.md
@@ -9,6 +9,7 @@ tags:
   - copilot
   - productivity
   - developer-experience
+description: How I leverage GitHub Copilot with Claude Opus 4.5 to analyze codebases, investigate context, and create well-structured GitHub issues that save time for myself and my team.
 excerpt: How I leverage GitHub Copilot with Claude Opus 4.5 to analyze codebases, investigate context, and create well-structured GitHub issues that save time for myself and my team.
 cover:
   alt: AI-powered GitHub Issues

--- a/docs/src/content/docs/blog/autonomous-oss-with-github-agentic-workflows.md
+++ b/docs/src/content/docs/blog/autonomous-oss-with-github-agentic-workflows.md
@@ -11,6 +11,7 @@ tags:
   - automation
   - ksail
   - developer-experience
+description: A Mac Mini runs 24/7 at home, firing scheduled prompts that open PRs against KSail. Here's how I've set it up and what I've learned running it.
 excerpt: A Mac Mini runs 24/7 at home, firing scheduled prompts that open PRs against KSail. Here's how I've set it up and what I've learned running it.
 cover:
   alt: Autonomous OSS development with GitHub Agentic Workflows

--- a/docs/src/content/docs/blog/building-an-ai-assistant-for-kubernetes-with-github-copilot-sdk.md
+++ b/docs/src/content/docs/blog/building-an-ai-assistant-for-kubernetes-with-github-copilot-sdk.md
@@ -9,6 +9,7 @@ tags:
   - go
   - copilot
   - tui
+description: How I built KSail's interactive AI chat assistant using Go, GitHub Copilot SDK, and Bubbletea TUI framework.
 excerpt: How I built KSail's interactive AI chat assistant using Go, GitHub Copilot SDK, and Bubbletea TUI framework.
 cover:
   alt: KSail Copilot Chat in action

--- a/docs/src/content/docs/blog/building-ksail-from-shell-to-dotnet-to-go.md
+++ b/docs/src/content/docs/blog/building-ksail-from-shell-to-dotnet-to-go.md
@@ -9,6 +9,7 @@ tags:
   - dotnet
   - architecture
   - open-source
+description: The journey of building KSail through three major rewrites and what I learned along the way.
 excerpt: The journey of building KSail through three major rewrites and what I learned along the way.
 cover:
   alt: KSail logo

--- a/docs/src/content/docs/blog/creating-development-kubernetes-clusters-on-hetzner-with-ksail-and-talos.md
+++ b/docs/src/content/docs/blog/creating-development-kubernetes-clusters-on-hetzner-with-ksail-and-talos.md
@@ -9,6 +9,7 @@ tags:
   - talos
   - hetzner
   - cloud
+description: A step-by-step guide to creating Talos Linux Kubernetes clusters on Hetzner Cloud using KSail.
 excerpt: A step-by-step guide to creating Talos Linux Kubernetes clusters on Hetzner Cloud using KSail.
 cover:
   alt: Talos Linux on Hetzner Cloud

--- a/docs/src/content/docs/blog/gitops-without-the-git-server-oci-registries-as-a-flux-source-with-ksail.md
+++ b/docs/src/content/docs/blog/gitops-without-the-git-server-oci-registries-as-a-flux-source-with-ksail.md
@@ -9,6 +9,7 @@ tags:
   - flux
   - oci
   - ksail
+description: Most local Flux setups point at a Git repo. OCI registries are cleaner — here's a full walkthrough using KSail's local registry and workload push command, plus how to extend the same workflow to GHCR for CI.
 excerpt: Most local Flux setups point at a Git repo. OCI registries are cleaner — here's a full walkthrough using KSail's local registry and workload push command, plus how to extend the same workflow to GHCR for CI.
 cover:
   alt: OCI artifacts as a Flux source with KSail

--- a/docs/src/content/docs/blog/local-kubernetes-development-with-ksail-and-k3d.md
+++ b/docs/src/content/docs/blog/local-kubernetes-development-with-ksail-and-k3d.md
@@ -9,6 +9,7 @@ tags:
   - k3s
   - k3d
   - local-development
+description: A guide to creating local Kubernetes development clusters using KSail with K3d (K3s in Docker).
 excerpt: A guide to creating local Kubernetes development clusters using KSail with K3d (K3s in Docker).
 cover:
   alt: KSail with K3d

--- a/docs/src/content/docs/blog/local-kubernetes-development-with-ksail-and-kind.md
+++ b/docs/src/content/docs/blog/local-kubernetes-development-with-ksail-and-kind.md
@@ -8,6 +8,7 @@ tags:
   - ksail
   - kind
   - local-development
+description: A guide to creating local Kubernetes development clusters using KSail with Kind (vanilla Kubernetes) in Docker.
 excerpt: A guide to creating local Kubernetes development clusters using KSail with Kind (vanilla Kubernetes) in Docker.
 cover:
   alt: KSail with Kind

--- a/docs/src/content/docs/blog/local-kubernetes-development-with-ksail-and-talos.md
+++ b/docs/src/content/docs/blog/local-kubernetes-development-with-ksail-and-talos.md
@@ -8,6 +8,7 @@ tags:
   - ksail
   - talos
   - local-development
+description: A guide to creating local Kubernetes development clusters using KSail with Talos Linux in Docker.
 excerpt: A guide to creating local Kubernetes development clusters using KSail with Talos Linux in Docker.
 cover:
   alt: KSail with Talos

--- a/docs/src/content/docs/blog/macos-as-a-developer-machine.md
+++ b/docs/src/content/docs/blog/macos-as-a-developer-machine.md
@@ -7,6 +7,7 @@ tags:
   - macos
   - developer-experience
   - tooling
+description: Setting up MacOS as a developer machine can be a daunting task. In this post, I will share my learnings and experiences to help you get started.
 excerpt: Setting up MacOS as a developer machine can be a daunting task. In this post, I will share my learnings and experiences to help you get started.
 cover:
   alt: MacBook developer setup

--- a/docs/src/content/docs/blog/mcp-server-for-kubernetes-cluster-management.md
+++ b/docs/src/content/docs/blog/mcp-server-for-kubernetes-cluster-management.md
@@ -9,6 +9,7 @@ tags:
   - mcp
   - devtools
   - golang
+description: KSail now ships with a built-in MCP server that lets Claude, Cursor, and other AI assistants manage Kubernetes clusters directly. Here's how it works and what you can do with it.
 excerpt: KSail now ships with a built-in MCP server that lets Claude, Cursor, and other AI assistants manage Kubernetes clusters directly. Here's how it works and what you can do with it.
 cover:
   alt: KSail MCP Server connecting AI assistants to Kubernetes clusters

--- a/docs/src/content/docs/blog/storing-secrets-in-zshrc-with-macos-keychain.md
+++ b/docs/src/content/docs/blog/storing-secrets-in-zshrc-with-macos-keychain.md
@@ -8,6 +8,7 @@ tags:
   - security
   - zsh
   - developer-experience
+description: A quick guide on using macOS Keychain to avoid storing secrets in plaintext in your .zshrc.
 excerpt: A quick guide on using macOS Keychain to avoid storing secrets in plaintext in your .zshrc.
 cover:
   alt: macOS Keychain security

--- a/docs/src/content/docs/blog/welcome.md
+++ b/docs/src/content/docs/blog/welcome.md
@@ -5,6 +5,7 @@ authors:
   - devantler
 tags:
   - personal
+description: A welcome post to introduce myself and the site.
 excerpt: A welcome post to introduce myself and the site.
 cover:
   alt: Welcome to devantler.tech

--- a/docs/src/content/docs/blog/why-i-chose-the-polyform-shield-license-for-ksail.md
+++ b/docs/src/content/docs/blog/why-i-chose-the-polyform-shield-license-for-ksail.md
@@ -8,6 +8,7 @@ tags:
   - licensing
   - open-source
   - polyform
+description: KSail's license changed three times in 18 months. Here's why it went from Apache-2.0 to GPL-3.0 to PolyForm Shield 1.0.0, and why I think more dev tools should consider it.
 excerpt: KSail's license changed three times in 18 months. Here's why it went from Apache-2.0 to GPL-3.0 to PolyForm Shield 1.0.0, and why I think more dev tools should consider it.
 cover:
   alt: PolyForm Shield License — use it for anything, just don't compete with it


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

All 14 docs blog posts carried a starlight-blog \`excerpt:\` (used only in the blog **listing** preview) but **no Starlight \`description:\`** frontmatter. Starlight derives \`<meta name="description">\` and \`og:description\` from the \`description\` field — not from \`excerpt\` — so **every blog post fell back to the identical site-wide default** description:

\`\`\`
<meta name="description" content="Personal site of Nikolai Emil Damm — software engineer, open-source advocate, and Kubernetes enthusiast."/>
\`\`\`

That means search engines and social-share cards saw all 14 posts as indistinguishable. This is a natural follow-up to the just-merged sitemap/robots work (#1958): crawlers now *discover* the posts, but each had no unique snippet.

## Fix

Add a \`description:\` to each post **mirroring its existing \`excerpt:\`** (the excerpts are already concise, accurate summaries authored for the listing). Purely additive frontmatter — no content rewrites, no schema or agent-file changes.

## Validation

- \`npm run build\` ✅ (includes the links-validator plugin — PASS)
- Verified each of the 14 built blog pages now emits a **unique** \`<meta name="description">\` + \`<meta property="og:description">\` matching its excerpt (previously all 14 = the site default).
- The only pages still using the site default are \`blog/2\` and \`blog/3\` — the paginated blog **index** pages, which correctly have no per-post description.

## Notes

- Trade-off considered: a config-level \`excerpt → description\` mapping would be DRY-er, but Starlight has no built-in hook for it and a custom remark/integration would be fragile; per-post \`description\` is the idiomatic, reviewable Starlight approach.