### PR TITLE
docs(agents): make bot PRs first-priority — drive them green, don't dismiss

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,26 @@ Conventional-Commit title, then **merge with the command that matches the author
   (auto-merge is bot-only) and merges **directly** with bare `gh pr merge <n> --squash` once
   `mergeStateStatus` is CLEAN.
 
+**Bot PRs are first-priority work, not background noise — a red `dependabot`/`renovate` PR is driven
+green, never dismissed as "self-managing".** Sweep **every** open `dependabot[bot]`/`renovate[bot]` PR
+across the portfolio each run (`gh search prs --owner devantler-tech --author app/dependabot --state
+open`; likewise `--author app/renovate`) and **drive each toward green** exactly like any trusted PR —
+do not generalise "bots rebase themselves" into "leave their failing CI alone":
+- **CLEAN** → merge it (bot path above; if `--auto` arming is denied, fall back to a direct `gh pr merge
+  <n> --squash`, then surface-as-one-click only if *that* is refused). Never end a run with a CLEAN
+  trusted bot PR unmerged.
+- **stale / behind main / DIRTY** → `@dependabot rebase` (or `@dependabot recreate`).
+- **transient CI flake** (disk-full `no space left on device`, runner OOM, network) → re-run the failed
+  jobs / rebase to retrigger — don't label it "flaky" and walk away.
+- **real adaptation needed** (an API change in the bumped dep, a lint/vuln finding, a toolchain-floor
+  bump) → **fix it by pushing a commit to the bot branch** (bots are trusted, so building/running/pushing
+  their branch inside `devantler-tech` is allowed). The bump *is* the issue; the fix unblocks it.
+- **genuine maintainer-decision block** (e.g. an unlicensed transitive dependency → license/compliance
+  call) → triage + surface. This and an **archived** repo (read-only — stale bot PRs can't be merged;
+  verify `gh repo view --json isArchived`) are the *only* "leave it" cases.
+Letting bot PRs sit red is a failure mode — they are part of the first-priority PR sweep that runs
+**before** issue/advance work.
+
 This **includes dependency major-version bumps** once CI is green. The merge itself is
 **low-ceremony**: a **single fresh** `gh pr view <n> --json number,isDraft,author,mergeStateStatus,statusCheckRollup`
 showing `isDraft:false`, a trusted author, owner `devantler-tech`, and `mergeStateStatus:CLEAN` is


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

*"Trusted author PRs also include dependabot and renovate bot PRs, and there is a lot of these needing your attention. Please update your instructions to ensure you do not overlook these again."*

The contract already lists dependabot/renovate/github-actions/ksail-bot as trusted authors and already mandates driving trusted-author PRs to merge — but it was silent on the **failing** bot-PR case, which let the run-loop drift into treating red bot PRs as "self-managing background noise" and skipping them. This run, all 5 open ksail dependabot PRs were dismissed that way; they should have been triaged and driven toward green.

## What

Adds a focused paragraph to the **Merge policy** section of `AGENTS.md` making explicit that a red `dependabot`/`renovate` PR is **first-priority work, driven green — never dismissed as "self-managing"**, with the per-state playbook:

- **CLEAN** → merge (bot path; direct-`--squash` fallback if `--auto` arming is denied).
- **stale/DIRTY** → `@dependabot rebase`/`recreate`.
- **transient CI flake** (disk-full, OOM, network) → re-run failed jobs / rebase to retrigger.
- **real adaptation** (dep API change, lint/vuln finding, toolchain-floor bump) → fix by pushing a commit to the bot branch (bots are trusted).
- **leave + surface** only for a genuine maintainer-decision block (e.g. unlicensed transitive dep) or an **archived** repo (read-only — verify `isArchived`).

## Validation

Markdown-only contract change. cspell introduces no new flagged words (the edit reuses vocabulary already in the contract: `dependabot`, `renovate`, `rebase`, `toolchain`). No generated files touched.

Drafted per the self-improvement discipline (definition changes ship as a draft PR; promotion is the maintainer's gate). My native memory was updated in lockstep (`feedback_drive_bot_prs`).
