### PR TITLE
fix(docs): add height to about-page images to prevent layout shift

### DIFF
--- a/docs/src/content/docs/about.mdx
+++ b/docs/src/content/docs/about.mdx
@@ -27,7 +27,7 @@ I am a Developer Experience Engineer based in Denmark with an MSc in Software En
 
 <div style="text-align: center;">
   <a href="https://youtu.be/Q-Hfn_-B7p8?si=2Uec_kld--fNw3gm" target="_blank">
-    <img src="/images/talks/kcd-denmark-2024-ksail.jpeg" alt="KSail talk at KCD Denmark 2024" width="400" loading="lazy" decoding="async" />
+    <img src="/images/talks/kcd-denmark-2024-ksail.jpeg" alt="KSail talk at KCD Denmark 2024" width="400" height="400" loading="lazy" decoding="async" />
     <br />
     🎥 Watch the talk! 🎥
   </a>
@@ -220,7 +220,7 @@ Member of the VS Code and GitHub Copilot backstage group, where I get early acce
 ### Certificates
 
 <div style="text-align: center;">
-  <img src="/images/certificates/github-actions-certification.png" alt="GitHub Actions Certification" width="420" loading="lazy" decoding="async" />
+  <img src="/images/certificates/github-actions-certification.png" alt="GitHub Actions Certification" width="420" height="321" loading="lazy" decoding="async" />
 </div>
 
 ### [Credly Badges](https://www.credly.com/users/nikolai-emil-damm/badges)
@@ -244,6 +244,7 @@ Member of the VS Code and GitHub Copilot backstage group, where I get early acce
     src="/images/courses/kodecloud-kubernetes-for-the-absolute-beginners-course-completion-certificate.png"
     alt="KodeKloud: Kubernetes for the Absolute Beginners"
     width="420"
+    height="297"
     loading="lazy"
     decoding="async"
   />
@@ -251,6 +252,7 @@ Member of the VS Code and GitHub Copilot backstage group, where I get early acce
     src="/images/courses/kodecloud-kcna-course-completion-certificate.png"
     alt="KodeKloud: Kubernetes and Cloud-Native Associate (KCNA)"
     width="420"
+    height="297"
     loading="lazy"
     decoding="async"
   />


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds the missing `height` attribute to the four `<img>` tags on the About page (`docs/src/content/docs/about.mdx`) that already declared `width` but no `height`:

| Image | width | added height | intrinsic px |
|---|---|---|---|
| `kcd-denmark-2024-ksail.jpeg` (talk) | 400 | **400** | 1200×1200 |
| `github-actions-certification.png` | 420 | **321** | 1716×1312 |
| `kodecloud-kubernetes-for-the-absolute-beginners-…png` | 420 | **297** | 1754×1241 |
| `kodecloud-kcna-course-completion-certificate.png` | 420 | **297** | 1754×1241 |

Each `height` is the intrinsic aspect ratio applied to the declared `width`, rounded to the nearest pixel.

## Why

A `width`-only `<img>` lets the browser reserve **zero vertical space** until the image loads, so surrounding content reflows downward when it arrives — **Cumulative Layout Shift (CLS)**, one of the Core Web Vitals. Declaring both dimensions lets the browser reserve the correct box up front and eliminates the shift. These four were the only `width`-only images on the page; the Credly badges right beside them already declare both `width` and `height`, so this just brings the rest in line with the existing convention.

Continues the docs-site performance thread (lazy-loaded About images #1956, favicon shrink #1960, sitemap/robots #1958).

## Validation

- `cd docs && npm ci && npm run build` — **green** (Astro build + `starlight-links-validator` pass; no link/content drift).
- Purely additive attributes; no content, layout, or styling changes. Computed heights preserve each image's true aspect ratio, so rendered size is unchanged.
