### PR TITLE
docs: list required bootstrap App credentials + missing platform-template inputs

### DIFF
--- a/docs/src/content/docs/templates/platform-template.md
+++ b/docs/src/content/docs/templates/platform-template.md
@@ -38,8 +38,8 @@ gh repo create my-platform --template devantler-tech/platform-template --private
 
 Then, in your new repository:
 
-1. **Install a GitHub App** (or fine-grained PAT) granted **Contents: write, Secrets: write, Environments: write, Actions: write** — the bootstrap writes cluster-derived credentials back as `prod` environment secrets, which the default `GITHUB_TOKEN` cannot do.
-2. **Set the Variables + Secrets** (`DOMAIN`, `CLOUDFLARE_ZONE`, `ADMIN_EMAIL`, `HETZNER_LOCATION`, `HCLOUD_TOKEN`, `CLOUDFLARE_API_TOKEN`, …). A few cluster secrets (`SOPS_AGE_KEY`, `KUBE_CONFIG`, `TALOS_CONFIG`) are auto-generated — you never set those.
+1. **Install a GitHub App** (or fine-grained PAT) granted **Contents: write, Secrets: write, Environments: write, Actions: write** — the bootstrap writes cluster-derived credentials back as `prod` environment secrets, which the default `GITHUB_TOKEN` cannot do. Then expose its credentials to the workflow as the `APP_ID` variable and the `APP_PRIVATE_KEY` secret.
+2. **Set the Variables + Secrets** (variables `DOMAIN`, `CLOUDFLARE_ZONE`, `CLOUDFLARE_ACCOUNT_ID`, `ADMIN_EMAIL`, `HETZNER_LOCATION`; secrets `HCLOUD_TOKEN`, `GHCR_TOKEN`, `CLOUDFLARE_API_TOKEN`, …). A few cluster secrets (`SOPS_AGE_KEY`, `KUBE_CONFIG`, `TALOS_CONFIG`) are auto-generated — you never set those.
 3. **Run the Bootstrap workflow** (Actions → 🌱 Bootstrap → *Run workflow*, choose `prod`, type `yes`). It provisions the Talos cluster via `ksail cluster create`, persists credentials back as `prod` secrets, points Cloudflare DNS at the new load balancer, and commits the rendered + encrypted tree back to your repo.
 
 The authoritative, step-by-step guide — prerequisites, configuration tables, verification, teardown, and troubleshooting — lives in the template's [`docs/BOOTSTRAP.md`](https://github.com/devantler-tech/platform-template/blob/main/docs/BOOTSTRAP.md).


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The docs-site **Platform Template** getting-started summary
([`templates/platform-template.md`](https://github.com/devantler-tech/monorepo/blob/main/docs/src/content/docs/templates/platform-template.md))
omitted **required** onboarding inputs that the template's authoritative
[`docs/BOOTSTRAP.md`](https://github.com/devantler-tech/platform-template/blob/main/docs/BOOTSTRAP.md)
mandates. A user following only the docs-site page would hit a failed Bootstrap run:

- **Step 1** told you to install the bootstrap GitHub App but never to expose its
  credentials to the workflow as the **`APP_ID` variable** + **`APP_PRIVATE_KEY` secret**
  (BOOTSTRAP.md §1). Without those, the workflow cannot authenticate as the App at all.
- **Step 2's** representative list omitted the required **`GHCR_TOKEN`** secret (publishes the
  OCI manifest artifact) and **`CLOUDFLARE_ACCOUNT_ID`** variable, and grouped variables and
  secrets together ambiguously.

## Change

- Step 1: add the `APP_ID` variable + `APP_PRIVATE_KEY` secret you must set after installing the App.
- Step 2: split the list into explicit **variables** vs. **secrets** and add the missing required
  `GHCR_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`.

The trailing `…` and the `BOOTSTRAP.md` pointer are kept, so the page stays a **summary** that
defers to the authoritative table — not an exhaustive duplicate that would drift.

## Validation

`npm run build` (Astro) — **63 pages built, Complete!**; only pre-existing `ssh`/`editorconfig`
code-highlight WARNs in an unrelated blog post, none on the edited page. Net **+2/-2 lines**, content-only.

Maps to docs-site roadmap [#1813](https://github.com/devantler-tech/monorepo/issues/1813) (accurate, current docs).