### PR TITLE
docs: add the rename-placeholders step to the template getting-started guides

### DIFF
--- a/docs/src/content/docs/templates/dotnet.md
+++ b/docs/src/content/docs/templates/dotnet.md
@@ -21,9 +21,15 @@ A minimal, batteries-included template for new .NET projects and libraries. Skip
 ```bash
 # Create a new repo from the template
 gh repo create my-project --template devantler-tech/dotnet-template --public --clone
+cd my-project
+
+# Repoint the `Example` scaffold (.slnx, src/, tests/, README) to your project
+# name in one shot — run this first. With no argument it derives a PascalCase
+# name from your origin GitHub remote. Review the result with `git diff`.
+./scripts/rename-placeholders.sh Widget   # e.g. your project name
 
 # Restore packages
-cd my-project && dotnet restore
+dotnet restore
 
 # Run tests
 dotnet test

--- a/docs/src/content/docs/templates/gitops-tenant-template.md
+++ b/docs/src/content/docs/templates/gitops-tenant-template.md
@@ -30,12 +30,18 @@ See the template's [README](https://github.com/devantler-tech/gitops-tenant-temp
 ```bash
 # Create a new private repo from the template
 gh repo create devantler-tech/my-tenant --template devantler-tech/gitops-tenant-template --private --clone
-
-# Replace the scaffolding with your app (code, Dockerfile, deploy/ manifests, ci.yaml),
-# then validate locally:
 cd my-tenant
-kubectl kustomize deploy/        # manifests build
-actionlint .github/workflows/*   # workflows parse
+
+# Rename the placeholders in deploy/ to your tenant name (defaults to the repo
+# directory name, or pass one). Run this FIRST — it rewrites the `app` and
+# `REPLACE_ME` placeholders consistently. Doing it by hand is easy to get
+# half-wrong; delete the one-shot helper once adopted.
+scripts/rename-placeholders.sh        # or: scripts/rename-placeholders.sh my-tenant
+
+# Replace the rest of the scaffolding with your app (code, Dockerfile, ci.yaml),
+# then validate locally:
+kubectl kustomize deploy/             # manifests build
+actionlint .github/workflows/*        # workflows parse
 ```
 
 Then register the tenant on the platform by following [`platform/docs/TENANTS.md`](https://github.com/devantler-tech/platform/blob/main/docs/TENANTS.md).

--- a/docs/src/content/docs/templates/go.md
+++ b/docs/src/content/docs/templates/go.md
@@ -20,9 +20,12 @@ A minimal, batteries-included template for new Go projects. Skip the boilerplate
 ```bash
 # Create a new repo from the template
 gh repo create my-project --template devantler-tech/go-template --public --clone
+cd my-project
 
-# Install dependencies
-cd my-project && go mod tidy
+# Repoint the module path (go.mod, imports, README badges) in one shot — run this
+# first. With no argument it derives the path from your origin GitHub remote.
+# The script also runs `go mod tidy`; review the result with `git diff`.
+scripts/rename-placeholders.sh github.com/<you>/my-project
 
 # Run tests
 go test ./...


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Across the template docs pages, the **Getting Started** snippet jumps straight from `gh repo create` to "install/restore + test" — silently skipping `scripts/rename-placeholders.sh`, which each template's own README makes a **first** step right after creating the repo. A reader following only the docs site would never personalise the scaffold:

| Docs page | What the omitted rename does |
|---|---|
| `gitops-tenant-template.md` | Rewrites `app`/`REPLACE_ME` across `deploy/*.yaml` — incl. the container name that **must** equal the repo name — without corrupting `app.kubernetes.io/name` label *keys*, CloudNativePG's `-app` secret suffix, or the `openbao` SecretStore name. Skipping it ships broken manifests. |
| `go.md` | Repoints the module path (`go.mod`, imports, README badges) and runs `go mod tidy`. Skipping it leaves the scaffold on the template's module path. |
| `dotnet.md` | Repoints the `Example` scaffold across the `.slnx`, `src/`, `tests/`, and README. Skipping it leaves `Example` everywhere. |

(`platform-template.md` was handled separately in #1976.)

## Change

Docs-only. Adds the `scripts/rename-placeholders.sh` step to all three Getting Started code blocks, mirroring each template README's canonical flow (run it first; no-arg derives the name from the `origin` remote; review with `git diff`), and moves `cd <repo>` up so the steps run in order.

## Validation

- `npm run build` (Astro) after each edit — 63 pages built, **all internal links valid**.
- Wording cross-checked against each template's authoritative `README` *Use this template* section ([gitops-tenant](https://github.com/devantler-tech/gitops-tenant-template#use-this-template), [go](https://github.com/devantler-tech/go-template#-use-this-template), [dotnet](https://github.com/devantler-tech/dotnet-template#-use-this-template)).

Behaviour-preserving for the site (Markdown content edits inside fenced code blocks; no components, links, or other pages touched).