### PR TITLE
docs: link shared-library rows in the portfolio map to their AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ keeping them healthy *and* moving them forward.
 | GitHub Actions | `devantler-tech/actions` | `github/devantler-tech/github-actions/actions` | [AGENTS.md](https://github.com/devantler-tech/actions/blob/main/AGENTS.md) |
 | Reusable Workflows | `devantler-tech/reusable-workflows` | `github/devantler-tech/github-actions/reusable-workflows` | [AGENTS.md](https://github.com/devantler-tech/reusable-workflows/blob/main/AGENTS.md) |
 | Homebrew tap | `devantler-tech/homebrew-tap` (repo renamed from `homebrew-formulas`) | `homebrew-tap` | [AGENTS.md](https://github.com/devantler-tech/homebrew-tap/blob/main/AGENTS.md) |
-| Agent skills (shared lib) | `devantler-tech/agent-skills` | `libraries/agent-skills` | [repo](https://github.com/devantler-tech/agent-skills) |
-| Agent plugins (shared lib) | `devantler-tech/agent-plugins` (renamed from `copilot-plugins`) | `libraries/agent-plugins` | [repo](https://github.com/devantler-tech/agent-plugins) |
+| Agent skills (shared lib) | `devantler-tech/agent-skills` | `libraries/agent-skills` | [AGENTS.md](https://github.com/devantler-tech/agent-skills/blob/main/AGENTS.md) |
+| Agent plugins (shared lib) | `devantler-tech/agent-plugins` (renamed from `copilot-plugins`) | `libraries/agent-plugins` | [AGENTS.md](https://github.com/devantler-tech/agent-plugins/blob/main/AGENTS.md) |
 | Wedding app (private) | `devantler-tech/wedding-app` | `applications/wedding-app` | (private) |
 | AS Coaching (private) | `devantler-tech/ascoachingogvaner` | `applications/ascoachingogvaner` | (private) |
 | UniFi network (private) | `devantler-tech/unifi` | `applications/unifi` | [AGENTS.md](https://github.com/devantler-tech/unifi/blob/main/AGENTS.md) |


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

The root `AGENTS.md` **portfolio map** links every non-private product row's *"Per-repo AGENTS.md"* column to that repo's `AGENTS.md` — KSail, Platform, all four templates, Actions, Reusable Workflows, Homebrew tap, and even the private UniFi row. Two rows were the outliers, still linking to `[repo]`:

- **Agent skills** (`devantler-tech/agent-skills`)
- **Agent plugins** (`devantler-tech/agent-plugins`)

This PR repoints both to their `blob/main/AGENTS.md`, matching the column's purpose and every other row.

## Why

Both shared libraries now carry a **substantive canonical `AGENTS.md`** on `main` — each opens with *"This file is the single canonical instructions file for the repository"* and documents repository structure + conventions. Linking those rows to `[repo]` under-points a reader looking for the libraries' repo-specific conventions; the column header literally promises a per-repo `AGENTS.md`, and the note under the table already explains these links use full GitHub URLs because the files live in the submodule repos.

Keeping agent/instruction files accurate and in sync is part of the engineering contract (a stale pointer silently misleads every future agent and reviewer) — this closes a small freshness-drift in the canonical instructions file itself.

## Change

Two table cells in `AGENTS.md` (lines 30–31): `[repo](…/agent-skills)` → `[AGENTS.md](…/agent-skills/blob/main/AGENTS.md)`, same for agent-plugins. Pure docs, behaviour-preserving, no code or generated files touched.

## Verification

- Both targets exist on live `main`: `gh api repos/devantler-tech/agent-skills/contents/AGENTS.md` and `…/agent-plugins/contents/AGENTS.md` resolve, and both are full canonical instruction files (not stubs).
- New URLs follow the identical `blob/main/AGENTS.md` pattern as the 11 other rows that already pass CI link-checking.