### PR TITLE
docs: add KubeVirt + CDI virtualization to the platform-template inventory

### DIFF
--- a/docs/src/content/docs/templates/platform-template.md
+++ b/docs/src/content/docs/templates/platform-template.md
@@ -23,6 +23,7 @@ A high-level inventory of what Flux reconciles onto the cluster. The exact set i
 - **Autoscaling** — Cluster Autoscaler, Vertical Pod Autoscaler, KEDA + KEDA HTTP add-on
 - **Observability** — kube-prometheus-stack (Prometheus, Grafana, Alertmanager), Loki (logs), Grafana Alloy (collection), OpenCost (cost)
 - **Backup / DR** — Velero with CloudNativePG backups to S3-compatible storage (Cloudflare R2 in prod)
+- **Virtualization** — KubeVirt + CDI (Containerized Data Importer), so VM workloads run alongside containers (local/CI only; opted out of the Hetzner/prod overlay)
 - **Demo apps** — Homepage (dashboard), Headlamp (Kubernetes web UI), and whoami, so the platform stands up with something to look at
 
 To run **your own** application on the platform, add it as a GitOps tenant from its own repository — see the [GitOps Tenant Template](/templates/gitops-tenant-template/).


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds a **Virtualization** row to the platform-template "What's Inside" inventory on the docs site:

> - **Virtualization** — KubeVirt + CDI (Containerized Data Importer), so VM workloads run alongside containers (local/CI only; opted out of the Hetzner/prod overlay)

## Why

The docs-site inventory had drifted from the template's actual deployed component set. `cdi/` and `kubevirt/` are wired into the base infrastructure controllers kustomization (`k8s/bases/infrastructure/controllers/kustomization.yaml`) — deployed on the Docker/local+CI overlay and deliberately opted out of the Hetzner/prod overlay (the prod overlay references the base controller dirs individually and omits cdi/kubevirt to save resources, exactly as the inventory's intro describes for "a few controllers").

The platform-template repo's **own README** already documents this as the authoritative inventory (`- **Virtualization** — KubeVirt + CDI _(local/CI only; disabled on the Hetzner/prod overlay)_`), so this syncs the public docs to it. VM-workload support is otherwise undiscoverable from the docs site.

## Scope notes

- Matched the authoritative README: did **not** add `metrics-server` (the README intentionally omits it as a foundational dependency, not a headline capability) or `Testkube` (its dir/helm-release exist but **no kustomization references it** — it isn't actually deployed; the README's Testkube line appears to be stale drift in the template repo, flagged separately).
- The `Cluster Autoscaler` row is correct as-is (node-level on Hetzner; confirmed by the template README + `docs/node-autoscaling.md`).

## Validation

`npm run build` in `docs/` passes — 63 pages built, `starlight-links-validator` reports all internal links valid.