### PR TITLE
docs: list .github/CODEOWNERS as tenant-owned on the GitOps Tenant Template page

### DIFF
--- a/docs/src/content/docs/templates/gitops-tenant-template.md
+++ b/docs/src/content/docs/templates/gitops-tenant-template.md
@@ -21,7 +21,7 @@ It is intentionally **stack-neutral**: it carries no application code or languag
 | Ownership | Files | Notes |
 | --- | --- | --- |
 | Template-owned | Shared CI/CD plumbing under `.github/workflows/` (`cd.yaml`, `release.yaml`, `template-sync.yaml`, `validate-scaffold.yaml`, `sync-labels.yaml`), `scripts/rename-placeholders.sh`, `CLAUDE.md`, `zizmor.yml` | Overwritten by `template-sync` |
-| You own | App code, `Dockerfile`, `deploy/` manifests, `.github/workflows/ci.yaml`, `.github/dependabot.yml`, `AGENTS.md`, `.claude/skills/maintain/SKILL.md`, `README.md`, `.releaserc`, `.gitignore`, `LICENSE`, `.templatesyncignore` | Declare in `.templatesyncignore` (same syntax as `.gitignore`), using these full paths |
+| You own | App code, `Dockerfile`, `deploy/` manifests, `.github/CODEOWNERS`, `.github/workflows/ci.yaml`, `.github/dependabot.yml`, `AGENTS.md`, `.claude/skills/maintain/SKILL.md`, `README.md`, `.releaserc`, `.gitignore`, `LICENSE`, `.templatesyncignore` | Declare in `.templatesyncignore` (same syntax as `.gitignore`), using these full paths |
 
 See the template's [README](https://github.com/devantler-tech/gitops-tenant-template#what-the-template-owns-vs-what-you-own) for the authoritative file-by-file list.
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The devantler.tech **GitOps Tenant Template** page (`docs/src/content/docs/templates/gitops-tenant-template.md`) lists a file-by-file **"What the template owns vs. what you own"** table, but its **"You own"** row omits `.github/CODEOWNERS`. The template's authoritative `.templatesyncignore` already lists `.github/CODEOWNERS` as a **tenant-owned** file (template-sync skips it), so the table was incomplete.

## Fix

Add `.github/CODEOWNERS` to the **"You own"** row, next to the other `.github/` tenant files. CODEOWNERS is tenant-owned because each tenant names its *own* code owners.

Brings the public docs table back in sync with the authoritative `.templatesyncignore`. Docs-only; no behaviour change.

## Validation

`npm run build` (Astro/Starlight) — **green, 63 pages built, no errors**. Single table-cell text edit; no new links or MDX.

## Related

Companion to the authoritative README fix [devantler-tech/gitops-tenant-template#47](https://github.com/devantler-tech/gitops-tenant-template/pull/47), which adds the same missing entry to the template's own README "Yours" block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the template guidance for items you manage, including that entries should be added to `.templatesyncignore` using full paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->