### PR TITLE
docs: reflect agent-plugins' multi-upstream skill sourcing on Active Projects

### DIFF
--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -87,6 +87,6 @@ A collection of generic, tool-neutral [agent skills](https://github.com/devantle
 
 ## [🧩 Agent Plugins](https://github.com/devantler-tech/agent-plugins) ![GitHub Copilot](https://img.shields.io/badge/GitHub%20Copilot-000000.svg?style=for-the-badge&logo=githubcopilot&logoColor=white) ![Claude](https://img.shields.io/badge/Claude-D97757.svg?style=for-the-badge&logo=claude&logoColor=white) ![VS Code](https://img.shields.io/badge/VS%20Code-007ACC.svg?style=for-the-badge&logo=visualstudiocode&logoColor=white)
 
-An industry-standard agent-plugin marketplace that bundles curated skills from [Agent Skills](https://github.com/devantler-tech/agent-skills) into category-based plugins. It ships dual manifests so the same plugins work in [VS Code](https://code.visualstudio.com/), the [GitHub Copilot CLI](https://github.com/features/copilot), and [Claude Code](https://www.anthropic.com/claude-code).
+An industry-standard agent-plugin marketplace that bundles curated agent skills — sourced from across the agent-skill ecosystem — into category-based plugins. Each bundled skill is pulled from its own upstream, spanning many sources including the in-house sibling library [Agent Skills](https://github.com/devantler-tech/agent-skills). It ships dual manifests so the same plugins work in [VS Code](https://code.visualstudio.com/), the [GitHub Copilot CLI](https://github.com/features/copilot), and [Claude Code](https://www.anthropic.com/claude-code).
 
 </div>


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

The **Active Projects** page (`docs/src/content/docs/projects/active.mdx`) described **Agent Plugins** as a marketplace that *"bundles curated skills from [Agent Skills](https://github.com/devantler-tech/agent-skills) into category-based plugins"* — framing `devantler-tech/agent-skills` as **the** source.

That is stale. The marketplace bundles curated agent skills **sourced from across the agent-skill ecosystem** — each skill is pulled from **its own upstream** (recorded in its `SKILL.md` `metadata.github-*` frontmatter), spanning many sources (`github/awesome-copilot`, `fluxcd/agent-skills`, `astrolicious/agent-skills`, `anthropics/skills`, our in-house sibling `devantler-tech/agent-skills`, …). None of the **currently** bundled skills come from agent-skills; it is one in-house source among many.

## Change

Reword the blurb to the accurate multi-upstream model. The `Agent Skills` link is kept, now correctly framed as the **in-house sibling source** rather than *the* source. The wording stays accurate after the maintainer's planned bundling of the in-house skills.

This is the **docs-site mirror** of the maintainer-endorsed correction to the agent-plugins `README.md`/`AGENTS.md` in [agent-plugins#34](https://github.com/devantler-tech/agent-plugins/pull/34) (per the [#33](https://github.com/devantler-tech/agent-plugins/issues/33) "go with 1a" direction) — keeping the portfolio's public description in sync with the repo's own.

## Validation

- Docs-only prose change; touches **no** drift-guard marker (submodule paths / reusable-workflows names+count / actions dirs all unchanged).
- `astro build` green (only pre-existing unrelated highlighting warnings).

Refs devantler-tech/agent-plugins#33, devantler-tech/agent-plugins#34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Agent Plugins” description to better explain where bundled agent skills come from.
  * Clarified that bundled skills are sourced from across the agent-skill ecosystem and pulled from their own upstream sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->