### PR TITLE
docs: require maintainer approval before creating upstream issues/PRs

### DIFF
--- a/.claude/agents/daily-maintainer.md
+++ b/.claude/agents/daily-maintainer.md
@@ -35,7 +35,10 @@ threads *before* promotion — those upkeep actions are allowed on a draft; only
    work → act (loading the relevant `.claude/skills/products/<name>` card + that submodule's
    `AGENTS.md`) → update native memory → one consolidated report. **Hotfix, then drive trusted-author
    PRs to merge (first priority — every `devantler-tech` repo, plus fixing failing CI on `devantler`'s
-   own PRs upstream in other orgs/users), then advance via issues; PRs always come before issues.** **Keep working until
+   own PRs upstream in other orgs/users), then advance via issues; PRs always come before issues.**
+   **Upstream (non-`devantler-tech`) issue/PR *creation* is gated — get the maintainer's approval via the
+   ask tool first; `devantler-tech` work and *fixing* existing `devantler` upstream PRs stay autonomous
+   (contract → *Merge policy*).** **Keep working until
    actionable work is exhausted or blocked — long, continuous sessions are preferred; never stop after a
    few items.**
 3. **Advance the products — issue-driven.** Once nothing is on fire, advancing a product means

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -108,7 +108,10 @@ promotion is **not** a reason to stop — advance a *different* product. Work th
    upstream work:** you may also **fix failing CI on a `devantler`-authored PR in another org/user's
    repo** (the maintainer's/agent's own upstream contributions — never the bots or anyone else) —
    build/push to its branch (it's your own) and drive it green; *merge* only where you have the right
-   (upstream, leave the merge to that maintainer). Never run or merge a **non-`devantler`** PR off
+   (upstream, leave the merge to that maintainer). **Creating** a new upstream PR or issue — vs. *fixing*
+   an existing one — is **gated**: get the maintainer's approval via the **ask tool** first (contract →
+   *Merge policy → Ask the maintainer before creating ANY upstream issue or PR*); `devantler-tech`
+   creation stays autonomous. Never run or merge a **non-`devantler`** PR off
    `devantler-tech`, and never run/merge **external-author** PRs anywhere (trust gate). The merge is **low-ceremony** — a single
    fresh `gh pr view <n>` showing `isDraft:false`, a trusted author, and `CLEAN` is enough; a refused
    merge is a **rare fallback** — surface the PR for a one-click instead of burning the run on
@@ -193,7 +196,9 @@ For each selected product:
    subsystem before changing it), delegate to a subagent (the built-in **`Explore`** type) that
    returns just the conclusion — keep the edits and `gh pr create` in your own loop. Open a **draft**
    PR (Conventional-Commit title, AI-disclosure line, labels; `Fixes #N` when it closes an issue).
-   Strategy/roadmap work creates/updates **GitHub Issues** instead of a diff.
+   Strategy/roadmap work creates/updates **GitHub Issues** instead of a diff. **On a non-`devantler-tech`
+   (upstream) repo, creating that PR or issue first needs the maintainer's approval via the ask tool**
+   (§2 / contract *Merge policy*); `devantler-tech` creation is unchanged.
 4. **Clean up:** `git -C <path> worktree remove .claude/worktrees/maint-<runid>` (and prune). Leave
    no worktree or dirty state behind.
 

--- a/.claude/skills/product-engineering/SKILL.md
+++ b/.claude/skills/product-engineering/SKILL.md
@@ -21,6 +21,11 @@ plus the numbers/failures you need (e.g. `<cmd> 2>&1 | tee /tmp/out.log | tail -
 read-heavy investigation to a subagent (the built-in `Explore` type) that returns just the conclusion.
 Same work, fewer tokens.
 
+> **Upstream caveat.** Everything below assumes **`devantler-tech`** work (autonomous as ever). For a
+> **non-`devantler-tech`** (upstream/third-party) repo, *creating* an issue or PR first needs the
+> maintainer's approval via the **ask tool** (contract → *Merge policy → Ask the maintainer before
+> creating ANY upstream issue or PR*); *fixing* an existing `devantler` upstream PR stays autonomous.
+
 > **Lean on the specialist skills** for heavy thinking, **if they're available in your environment**
 > (these ship with the Claude Code `engineering` plugin — they are *not* defined in this repo; if a
 > given skill isn't installed, just apply the same reasoning yourself): `engineering:architecture` (ADRs)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,13 @@ across products is exactly what's wanted; only duplicate/filler PRs on one conce
 maintainer-sequenced queue on **one** product (e.g. a recovery sprint) holds back only *that* product's
 lane — it never gates advance work on the **other** products.
 
+**This autonomy is for `devantler-tech` work.** Opening draft PRs and filing issues on `devantler-tech`
+repos needs no prior sign-off (only promotion does) — keep doing it. For **upstream**
+(non-`devantler-tech`) repos the rule flips: **get the maintainer's approval via the ask tool *before*
+creating any issue or PR** (see *Merge policy → Ask the maintainer before creating ANY upstream issue or
+PR*). *Fixing* an already-open `devantler` upstream PR stays autonomous; only *creating* a new upstream
+artifact is gated.
+
 ### Merge policy — drive trusted-author PRs to merge (incl. majors)
 **Driving trusted-author PRs to merge is the first-priority work each run — ahead of issues** (only
 live breakage on `main` outranks it). Sweep them **first**, every run, across **all** repos. On
@@ -225,14 +232,28 @@ own upstream PRs — **never** anyone else's (not the bots, not Copilot, not ext
 such a **`devantler`-authored PR failing CI on an upstream repo**, root-cause-fix the failing checks,
 push to the PR branch (you have access — it's your own fork/branch), and resolve threads to drive it
 green; this is how the agent maintains its **upstream contributions** (per the
-*contribute-upstream-don't-fork* rule). Because **you** authored it, building and running that branch is
+*contribute-upstream-don't-fork* rule) — **fixing** an already-open upstream PR like this is autonomous;
+**creating** a new upstream PR or issue is **not** (get the maintainer's approval via the ask tool
+first — see *Ask the maintainer before creating ANY upstream issue or PR* above). Because **you**
+authored it, building and running that branch is
 safe. You usually **lack merge rights** upstream, so drive it to **green with threads resolved** and
 leave the merge to that maintainer; **merge yourself only on your own / `devantler-tech` repos** (per the
 command above). The never-run / never-merge rules are **unchanged** for every non-`devantler` author
 everywhere; never bypass branch protection.
 
+**Ask the maintainer before creating ANY upstream issue or PR — `devantler-tech` is exempt.** A hard
+gate the maintainer directed (2026-06-28): **never autonomously open an issue or a PR on a repo
+*outside* the `devantler-tech` org.** Prepare and verify the work locally, then **surface it and get the
+maintainer's explicit approval via the ask tool *before* anything is created upstream** ("ALWAYS use the
+ASK tool when wanting to upstream anything"). Only **creation** is gated — *fixing* an already-open
+`devantler`-authored upstream PR (push a CI fix, resolve threads, drive it green per *Cross-repo scope*)
+stays autonomous, and **everything inside `devantler-tech` is unchanged** (keep opening draft PRs and
+filing issues there autonomously per *Autonomy*/*Issue-driven*). If a run is unattended and the ask tool
+can't reach the maintainer, do **not** create it — prepare it locally and surface it in the report.
+
 **Respect each upstream project's contribution policy — check it BEFORE opening anything.** Before
-creating a PR *or* issue on a non-`devantler-tech` (third-party) repo, check that project's stated
+creating a PR *or* issue on a non-`devantler-tech` (third-party) repo — **once the maintainer has
+approved it per the gate above** — check that project's stated
 contribution policy, **in particular whether it accepts AI-assisted / AI-generated contributions**
 (read its `CONTRIBUTING`, `README`, PR/issue templates, code of conduct). If the project **prohibits or
 discourages** AI contributions — or the policy is **unclear** — do **NOT** open the PR/issue yourself:
@@ -409,11 +430,14 @@ lines). **Don't re-read what's already in context** (this contract, via the `CLA
   `test:`). Every repo squash-merges on the PR title → changelog/release; a bracket prefix corrupts
   it. Use **labels** + `claude/*` branch names for attribution/dedup, never a title prefix.
 - Open code/manifest PRs as **drafts** (`gh pr create --draft`).
-- **Third-party upstream repos — check the AI-contribution policy first.** Before opening a PR/issue on
-  a non-`devantler-tech` repo, verify the project accepts AI-assisted contributions (CONTRIBUTING /
-  README / templates). If it bans or discourages them — or it's unclear — **don't open it yourself**;
-  prepare the work and have `devantler` submit it (see *Merge policy → Cross-repo scope*; e.g.
-  `zizmorcore/zizmor` bans AI PRs, `rhysd/actionlint` does not).
+- **Third-party upstream repos — get maintainer approval (ask tool) first, then check the AI policy.**
+  **Never autonomously open an issue or PR on a repo outside `devantler-tech`** — prepare it locally and
+  get the maintainer's explicit approval via the **ask tool** first (the hard gate in *Merge policy →
+  Ask the maintainer before creating ANY upstream issue or PR*). Only then verify the project accepts
+  AI-assisted contributions (CONTRIBUTING / README / templates); if it bans or discourages them — or
+  it's unclear — **don't open it yourself**, prepare the work and have `devantler` submit it (e.g.
+  `zizmorcore/zizmor` bans AI PRs, `rhysd/actionlint` does not). **`devantler-tech` repos are exempt —
+  open drafts/issues there autonomously, as before.**
 - **Validate before every PR** with the repo's command (in its `AGENTS.md` `## Maintenance`); never
   open a PR that breaks build/validation.
 - **Fix at the ROOT CAUSE** — never `t.Skip`/`//nolint`/`--no-verify`/disable/"flaky"-dismiss a check.


### PR DESCRIPTION
## What

Adds a hard approval gate to the Daily AI Assistant's definition: before it autonomously opens **any issue or PR on a repo *outside* the `devantler-tech` org** (true upstream / third-party), it must first get the maintainer's explicit approval via the ask tool.

## Scope (maintainer-directed, 2026-06-28)

- **Only _creation_ is gated, and only for non-`devantler-tech` repos.**
- **`devantler-tech` is exempt and unchanged** — the agent keeps opening draft PRs, filing issues, and driving/merging trusted PRs there autonomously (Autonomy / Issue-driven / Merge policy / the floor all unchanged). Definition / self-improvement PRs to this monorepo are `devantler-tech`, so they are **not** gated.
- **Fixing** an already-open `devantler`-authored upstream PR (push a CI fix, resolve threads, drive it green) stays autonomous — only *creating* a new upstream artifact is gated.
- An **unattended** run that can't reach the maintainer prepares the work locally and surfaces it in the run report instead of creating it.

This strengthens the existing "check the upstream project's AI-contribution policy before opening anything" rule (was: hand off only when a project bans/is-unclear-on AI — now: always ask first for any upstream create).

## Files

- `AGENTS.md` — new gate in *Merge policy*, wired into *GitHub artifact conventions*, *Autonomy*, and *Cross-repo scope*.
- `.claude/agents/daily-maintainer.md`, `.claude/skills/portfolio-maintenance/SKILL.md`, `.claude/skills/product-engineering/SKILL.md` — same gate referenced where each tells the agent to open a PR/issue (agent files kept in sync).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for working with upstream repositories, including when new issues or pull requests can be created autonomously and when approval is required first.
  * Reinforced that existing upstream pull requests can still be handled without extra approval in supported cases.
  * Improved wording around the workflow for strategy and roadmap tasks, including how results should be recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->