### PR TITLE
ci(dependabot): pin docs npm registry to public via .npmrc

### DIFF
--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,0 +1,9 @@
+# Pin the default registry to public npm.
+#
+# Dependabot's `automatic-github-packages-auth` rollout auto-injects an
+# npm.pkg.github.com registry credential into npm jobs. Without a .npmrc (or an
+# explicit scope/replaces-base in dependabot.yaml) it aborts every npm update
+# run with `private_registry_config_not_found`, silently halting npm updates.
+# This site consumes only public packages, so declaring the public registry
+# resolves the ambiguity. See devantler-tech/.github#77.
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Implements **option 1** from devantler-tech/.github#77 (maintainer-chosen) for this repo's `docs/` npm directory.

## Problem

Since **2026-06-26**, the `npm_and_yarn in /docs` Dependabot job aborts before producing any PR:

```
Error during file fetching; aborting: Private npm registries require either a .npmrc
file in your repository, or explicit `scope`/`replaces-base` configuration in dependabot.yml.
Registry: npm.pkg.github.com
   → private_registry_config_not_found  { "source": "npm.pkg.github.com" }
```

Dependabot's `automatic-github-packages-auth` rollout auto-injects an `npm.pkg.github.com` registry credential (not declared in `dependabot.yaml`). With no `.npmrc` present, the job hard-fails — silently halting all npm updates (security advisories included) for the public docs site. Root cause + org-wide scope are in devantler-tech/.github#77.

## Fix

Add `docs/.npmrc` pinning the default registry to public npm:

```
registry=https://registry.npmjs.org/
```

This is GitHub's first documented remedy ("a `.npmrc` file in your repository") and resolves the registry ambiguity. It is **inert for resolution** — every `resolved:` in `docs/package-lock.json` already points at `registry.npmjs.org` (the npm default), so installs/builds are unchanged. Verified locally: `npm config get registry` → `https://registry.npmjs.org/`.

## Validation

- `.npmrc` parsed by npm; registry resolves to public npm (unchanged default).
- Server-side confirmation can only come from the next scheduled Dependabot run (post-merge): the `npm_and_yarn in /docs` job should complete without `private_registry_config_not_found` and resume opening PRs.

Companion PR for `ksail/vsce` (+ `ksail/docs`) tracked under the same issue. `devantler-tech/.github#77` will be closed once all affected directories are covered and a live Dependabot run confirms recovery.
