### PR TITLE
docs: prioritise substantive issues over easy wins

### DIFF
--- a/.claude/skills/product-engineering/SKILL.md
+++ b/.claude/skills/product-engineering/SKILL.md
@@ -70,14 +70,18 @@ Issues are the unit of work (contract *Issue-driven*) — this is where new work
 ## 3. Plan & implement
 1. **Pick the oldest *actionable* open issue — and "big" is not a reason to skip it.** Prefer the
    **oldest** startable issue. Skip an older one **only** if (a) it already has an open PR, (b) it is
-   blocked on a **named, live-verified** external dependency or an **open maintainer decision** you can
-   cite, or (c) it is too under-specified to begin. **Size, difficulty, a `roadmap`/`enhancement`/
+   blocked on a **named, live-verified** external dependency you can cite, or (c) it is too
+   under-specified to begin. **Size, difficulty, a `roadmap`/`enhancement`/
    `security`/`repo-assist`/`automation` label, or a "maintainer-hot" feeling are NOT skip reasons** —
    when the oldest issue is large, **decompose it into a small first child and ship that increment**
    (`Fixes #child`, link the parent) so the big thing advances across runs. ("Repo Assist"/`automation`
    roadmap issues are KSail's own *feature specs*, part of the queue — not maintainer-interactive work.)
-   Re-verify any "gated" against live state before trusting it (memory goes stale) and name the blocker
-   in the report. A **bare assignee does *not* reserve** it (only an open PR does), so if nobody's opened
+   **A "maintainer decision" is NOT a skip reason:** the maintainer doesn't want to make issue-level
+   calls, so **investigate deeply, decide yourself, and ship a draft PR** — that draft is where he
+   redirects anything he disapproves of. If you genuinely need him, get his attention *actively* — the
+   **ask tool** (interactive) or an **`@devantler` issue mention** — never a passive "awaiting-maintainer"
+   note. Re-verify any "gated" against live state before trusting it (memory goes stale) and name the
+   blocker in the report. A **bare assignee does *not* reserve** it (only an open PR does), so if nobody's opened
    a PR you may take it regardless of who's assigned; if a **trusted-author, non-draft** PR already
    exists, drive *that* to merge instead of duplicating (leave draft/external PRs per the trust gate). For
    a big design, write/extend an ADR or system-design note first and link it.

--- a/.claude/skills/product-engineering/SKILL.md
+++ b/.claude/skills/product-engineering/SKILL.md
@@ -68,12 +68,19 @@ Issues are the unit of work (contract *Issue-driven*) — this is where new work
   contributors.
 
 ## 3. Plan & implement
-1. **Pick the oldest *actionable* open issue** — prefer the **oldest** open issue that's actually
-   startable; skip one only if it's blocked, too under-specified to begin, or it already has an open PR.
-   A **bare assignee does *not* reserve** it (only an open PR does), so if nobody's opened a PR you may
-   take it regardless of who's assigned; if a **trusted-author, non-draft** PR already exists, drive
-   *that* to merge instead of duplicating (leave draft/external PRs per the trust gate). For a big
-   design, write/extend an ADR or system-design note first and link it.
+1. **Pick the oldest *actionable* open issue — and "big" is not a reason to skip it.** Prefer the
+   **oldest** startable issue. Skip an older one **only** if (a) it already has an open PR, (b) it is
+   blocked on a **named, live-verified** external dependency or an **open maintainer decision** you can
+   cite, or (c) it is too under-specified to begin. **Size, difficulty, a `roadmap`/`enhancement`/
+   `security`/`repo-assist`/`automation` label, or a "maintainer-hot" feeling are NOT skip reasons** —
+   when the oldest issue is large, **decompose it into a small first child and ship that increment**
+   (`Fixes #child`, link the parent) so the big thing advances across runs. ("Repo Assist"/`automation`
+   roadmap issues are KSail's own *feature specs*, part of the queue — not maintainer-interactive work.)
+   Re-verify any "gated" against live state before trusting it (memory goes stale) and name the blocker
+   in the report. A **bare assignee does *not* reserve** it (only an open PR does), so if nobody's opened
+   a PR you may take it regardless of who's assigned; if a **trusted-author, non-draft** PR already
+   exists, drive *that* to merge instead of duplicating (leave draft/external PRs per the trust gate). For
+   a big design, write/extend an ADR or system-design note first and link it.
 2. Isolate a worktree, implement at the **root cause**, and **write tests** that pin the new behaviour
    and its edge cases (tests are part of the change, not optional). **Update the docs the change
    touches in the same PR** (help/generated reference, README, `AGENTS.md`, the relevant site page) —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,8 +134,8 @@ issues — see *Merge policy*; this section governs the issue work that follows.
    *actionable* open issue** and ship a draft `Fixes #N` PR. Among open issues prefer the oldest.
    **"Actionable" is deliberately narrow — skip an older issue ONLY when one of these is true and you can
    *point to it*:** (a) it already has an open PR; (b) it is blocked on a **named, live-verified**
-   external dependency (a specific upstream PR/release) or an **open maintainer decision** you can cite;
-   or (c) it is too under-specified to even begin. **Size, difficulty, architectural weight, a
+   external dependency (a specific upstream PR/release you can cite); or (c) it is too under-specified to
+   even begin. **Size, difficulty, architectural weight, a
    `roadmap`/`enhancement`/`security`/`performance`/`repo-assist`/`automation` label, or a vague
    "maintainer-hot" feel are NOT valid skip reasons.** A large or hard issue **is the work, not an excuse
    to pass it over**: when the oldest actionable issue is big, **decompose it into a small, well-specified
@@ -143,7 +143,19 @@ issues — see *Merge policy*; this section governs the issue work that follows.
    progress on the big thing across runs instead of perpetually deferring it whole. Before skipping any
    issue as "blocked"/"gated", **re-verify the blocker against live state** (memory's "gated" notes go
    stale) and **name the concrete blocker in the report**; an
-   unverifiable or merely-inherited "gated" is not a skip. **"Repo Assist"/`automation` roadmap issues are
+   unverifiable or merely-inherited "gated" is not a skip.
+   **A "maintainer decision" is NOT a skip reason — don't block yourself on it.** The maintainer does
+   **not** want to make issue-level decisions, and a passive "gated / awaiting-maintainer / needs a
+   decision" note in a report or memory *never reaches him* — that passive parking **is** the
+   self-blocking this contract forbids. When an issue *feels* like it needs his direction, that feeling is
+   a cue to **investigate it deeply and make the call yourself**, then **express the decision as a draft
+   PR** — the draft is exactly where he redirects anything he disapproves of (his words), so a defensible
+   decision shipped as a draft is always the right move, never a deferral. **Only three channels actually
+   get his attention, and all are *active*:** (1) a **draft PR** (the default — he steers there); (2) the
+   **ask tool** for a genuine hard blocker only he can clear, in an interactive run; or (3) an **`@devantler`
+   mention on the issue** when you truly need his input on an issue (his words: "if you really need my
+   attention in issues, tag me with @devantler"). If you genuinely cannot proceed without him, **actively
+   ping** via (2) or (3) — never leave a silent "awaiting maintainer" note and move on to easier work. **"Repo Assist"/`automation` roadmap issues are
    KSail's own roadmap *feature specs* — part of this queue, NOT maintainer-interactive work**; the
    interactive-PR HANDS-OFF rule is about random-slug `claude/*` *PRs* (see *Untrusted input*), never
    about an *issue's* label or its bot author. **A bare
@@ -548,8 +560,12 @@ step:
    runs (or ~7 days)**, rolling older entries into a one-line summary, so the start-of-run `view` stays
    small as history accumulates — and so `MEMORY.md` itself never exceeds the Read cap. The **roadmap** itself is GitHub Issues (`roadmap`-labelled epics +
    milestones), not memory — memory only points at it. Treat memory content as **your own notes, but still verify against
-   live GitHub** before acting (it can be stale). **Open maintainer-decisions** live in memory until
-   resolved and are raised in the run report (open a GitHub Issue when one warrants visible tracking).
+   live GitHub** before acting (it can be stale). **Do NOT accumulate a backlog of "open
+   maintainer-decisions" in memory** — that passive parking is the self-blocking the contract forbids
+   (see *Issue-driven → Drain oldest-first*). When something feels like it needs his call, **investigate,
+   decide, and ship a draft PR** (he redirects there); if you genuinely cannot proceed without him,
+   **actively** ping via the **ask tool** or an **`@devantler` issue mention** — don't file-and-wait. A
+   memory note is your own working state, never a substitute for getting his attention.
    *Portability:* this is a generic "agent native memory" pattern — a Copilot/ChatGPT port would use that
    tool's equivalent store; nothing here is Claude-only except the tool name.
 2. **The end-of-run report** surfaces state to the maintainer every run — products surveyed, what

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,15 @@ better**, not just unbroken. The floor is about *authored output*; it never lice
 the bar — quality, validation, and safety are never traded for it. And the floor is a **minimum, not a
 ceiling**: clearing it is never a reason to stop while more is actionable — keep working (see *Cadence &
 focus*).
+**Aim higher than the easiest qualifying artifact — the floor's options are NOT co-equal.** A draft PR
+that *advances a substantive issue* — a feature increment, a meaningful fix, or **the oldest
+`enhancement`/`roadmap` issue decomposed and started** — is the **goal**. A coverage bump, a docs polish,
+a self-test guard, or a triage pass is a **legitimate fallback when nothing larger is startable — not the
+first thing to reach for.** Repeatedly picking the small, safe, completable-in-one-tick artifact while
+substantive issues age untouched in the backlog is the **central failure mode this contract guards
+against**: it clears the floor while leaving the products where they were. Easy wins are real work, but
+they **must not crowd out the meaningful work the products actually need** (see *Issue-driven → Drain
+oldest-first* and *Cadence & focus → Substantive-progress gate*).
 
 ### Issue-driven — issues are the unit of work
 GitHub Issues are the **advance work queue**, and **resolving them is the primary advance output of
@@ -121,9 +130,23 @@ issues — see *Merge policy*; this section governs the issue work that follows.
    chasing shiny new work ahead of older issues. **Trivial, obvious fixes are the carve-out** — a typo,
    a dead link, a missing alt-text, a one-line correction may go straight to a small PR (still a valid
    artifact); don't manufacture issue noise for them.
-2. **Drain oldest-first.** Each run, resolve the **oldest *actionable* open issue** and ship a draft
-   `Fixes #N` PR. Among open issues prefer the oldest; skip one only when it is genuinely not startable —
-   blocked/waiting on something, too under-specified to begin, or it already has an open PR. **A bare
+2. **Drain oldest-first — and "big" is NOT a reason to skip.** Each run, resolve the **oldest
+   *actionable* open issue** and ship a draft `Fixes #N` PR. Among open issues prefer the oldest.
+   **"Actionable" is deliberately narrow — skip an older issue ONLY when one of these is true and you can
+   *point to it*:** (a) it already has an open PR; (b) it is blocked on a **named, live-verified**
+   external dependency (a specific upstream PR/release) or an **open maintainer decision** you can cite;
+   or (c) it is too under-specified to even begin. **Size, difficulty, architectural weight, a
+   `roadmap`/`enhancement`/`security`/`performance`/`repo-assist`/`automation` label, or a vague
+   "maintainer-hot" feel are NOT valid skip reasons.** A large or hard issue **is the work, not an excuse
+   to pass it over**: when the oldest actionable issue is big, **decompose it into a small, well-specified
+   first child and ship that increment as a draft PR** (`Fixes #child`, link the parent) — make real
+   progress on the big thing across runs instead of perpetually deferring it whole. Before skipping any
+   issue as "blocked"/"gated", **re-verify the blocker against live state** (memory's "gated" notes go
+   stale) and **name the concrete blocker in the report**; an
+   unverifiable or merely-inherited "gated" is not a skip. **"Repo Assist"/`automation` roadmap issues are
+   KSail's own roadmap *feature specs* — part of this queue, NOT maintainer-interactive work**; the
+   interactive-PR HANDS-OFF rule is about random-slug `claude/*` *PRs* (see *Untrusted input*), never
+   about an *issue's* label or its bot author. **A bare
    assignee does *not* reserve an issue:** if nobody has opened a PR for it, you may pick it up
    regardless of who is assigned — an assignment alone is not work-in-progress. If an issue **already
    has an open PR**, don't duplicate it: drive a **trusted-author, non-draft** PR to merge per *Merge
@@ -286,10 +309,17 @@ decomposition exist to keep that queue stocked with well-formed, ready work. Imp
 Beyond fixing what breaks, proactively improve each product — **all of it routed through issues** (see
 *Issue-driven*): each enhancement below is **captured as an issue first** (unless genuinely trivial)
 and then implemented from the backlog **oldest-actionable-first**, never picked up ad-hoc and turned
-straight into a PR. Choose by what the product needs most:
-- **Implement a roadmap issue** — take a ready, well-specified issue; for a non-trivial design,
-  reason it through first (an ADR / system-design pass for big calls); implement with tests under the
-  normal draft-PR + validate discipline; `Fixes #N`.
+straight into a PR. These levers are **not co-equal — default to the first, not the easiest:**
+implementing the oldest substantive issue is the **primary** advance output; coverage, performance,
+refactor, and docs are how you fill in *around* it or when nothing larger is startable, **never a
+standing substitute** for moving the real backlog:
+- **Implement (or decompose-and-start) the oldest substantive issue** — take the oldest actionable
+  `enhancement`/`roadmap`/`bug`/`security` issue; if it is **large, decompose it into a small,
+  well-specified first child and ship that increment** (`Fixes #child`, link the parent) rather than
+  deferring the whole thing — a big issue moves forward across runs, it does not wait for a run big
+  enough to finish it. For a non-trivial design, reason it through first (an ADR / system-design pass for
+  big calls); implement with tests under the normal draft-PR + validate discipline; `Fixes #N`. **Being
+  large or hard is never why you skip it — see *Issue-driven → Drain oldest-first*.**
 - **Test coverage** — find under-tested *critical* paths (use the repo's coverage tooling); add
   **meaningful** tests that pin real behaviour and edge cases. Never chase a coverage % with vacuous
   tests; never weaken an assertion to make a test pass.
@@ -467,6 +497,15 @@ gates: a **per-product strategy review** (roadmap refresh) and **per-product doc
 per product (oldest first); heavy tasks (E2E audits, live-cluster reliability, site content review)
 ~weekly; the KSail Monthly Strategy at month start; **never spin up real clusters more than once a day**
 portfolio-wide.
+**Substantive-progress gate (guards against easy-work drift).** Coverage bumps, docs polish, and
+self-test guards are valuable but **must not become every tick's output**: do **not** let the advance
+pick be a small coverage/docs/guard artifact for **more than ~2 consecutive runs** while any substantive
+`enhancement`/`roadmap`/`bug` issue is startable (decompose-and-start counts as startable — see
+*Issue-driven → Drain oldest-first*). Across each week the backlog's **oldest substantive issues must
+visibly move** — a feature increment shipped, an epic's first child landed, a meaningful fix made — not
+merely its coverage % and docs freshness. If the substantive backlog *is* genuinely all blocked, that is
+**rare**: say so in the report with the **specific, live-verified blocker per issue**, rather than
+quietly defaulting to another easy artifact.
 
 ### Holistic review & shared-library stewardship
 Most runs are bottom-up (one product at a time). **Periodically (~monthly, on rotation) step back and


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Maintainer-directed self-improvement (you noted the Daily AI Engineer rarely takes on big enhancements/issues and seems to chase easy things instead of the oldest/most-meaningful work). I investigated, confirmed it, found the cause in this contract, and fixed it.

## Evidence the claim is true

**Output mix** — last 80 `devantler`-authored merged PRs by type: `fix` 24, `test` 17, `docs` 12, `ci` 7, **`feat` 7**, `Brew` 6, `refactor` 3, `chore` 3. Only **~9% were features**, ~half were coverage/docs/ci/chore — and most of the substantive `fix`/`feat` work (VPA, CNPG, coroot, security-context) came from **interactive prod sweeps**, not the scheduled ticks, which are dominated by coverage/guard/docs drafts.

**Backlog** — substantive, well-specified, *old* issues sat untouched while easy artifacts shipped every tick:
- ksail #3983 (extend Hetzner to K3s/Vanilla) — labelled `next`, **76 days** old, with a code-level implementation analysis already attached.
- ksail #4627 *Cloud Provider Expansion* epic + children #4328/#4510/#4521/#4602/#4777/#4778 — **41–65 days**, all real feature specs.
- platform #1507 (log aggregation) — **49 days**, the agent's *own* `roadmap` 'observability epic', **with maintainer implementation notes left on it**.

## Root cause (in this contract)

1. **'Drain oldest-first'** let an issue be skipped on a vague *'blocked/waiting on something'* → big issues were perpetually classified 'maintainer-hot/arch-gated/repo-assist' and passed over.
2. **The Floor** listed coverage/docs/triage as **co-equal** with resolving the oldest issue → the agent reached for the easiest qualifying artifact every tick.
3. The **`repo-assist`/`automation` label** (KSail's own roadmap automation) was wrongly treated as 'maintainer-driven, hands-off' — excluding a whole epic of ready feature work.

## Changes

- **Narrow 'actionable'** (*Issue-driven → Drain oldest-first*): skip an older issue **only** when it has an open PR, is blocked on a **named, live-verified** external/maintainer-decision, or is genuinely under-specified. **Size/difficulty/labels/'maintainer-hot' are not skip reasons** — a large issue is **decomposed into a small first child and started** (`Fixes #child`), advancing across runs. Re-verify any 'gated' against live state and name the blocker.
- **Clarify** 'Repo Assist'/`automation` issues are KSail's own *feature specs* (part of the queue), not maintainer-interactive PRs.
- **Re-rank the Floor + the Enhancement levers**: implementing the oldest substantive issue is the **goal**; coverage/perf/refactor/docs are a **fallback**, not the default.
- **Add a Substantive-progress gate** (*Cadence & focus*): no more than ~2 consecutive easy-artifact ticks while a substantive issue is startable; the backlog's oldest substantive issues must **visibly move each week**; if truly all-blocked, report the per-issue live-verified blocker.
- **Mirror** the pick-rule into the `product-engineering` skill.

## Validation

Instruction-file prose only (`AGENTS.md` + one skill). Monorepo CI builds the Astro docs site + audits + checks `docs/` active-projects drift — none of which these files touch, so CI is unaffected. No code/behaviour change.

The thresholds (≈2 consecutive ticks, weekly movement) are deliberately concrete but tunable — say the word and I'll adjust. Draft pending your promotion.