### PR TITLE
docs(agents): adopt "stop starting, start finishing" as a WIP-limit principle

### DIFF
--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -105,8 +105,11 @@ review-thread resolution, or a trusted-PR merge) — but the floor is a **minimu
 working while actionable work remains, prefer long continuous sessions, and don't stop after a few
 items** (end only when work is exhausted or blocked). A survey-and-exit run that authors nothing is a
 **failure, not a valid outcome** (contract *Mandate*). An existing backlog of your own drafts awaiting
-promotion is **not** a reason to stop — advance a *different* product. Work the ladder top-down —
-**hotfix/operate first, then advance**:
+promotion is **not** a reason to stop — advance a *different* product. **Stop starting, start finishing**
+(contract *Cadence & focus*): before opening any **new** draft, first drive **every own in-flight PR** to
+merged (if promoted) or review-ready (draft: green CI + threads resolved + not DIRTY) — a *finished*
+draft awaiting promotion is fine, a *half-finished* one (red CI, open threads, conflicting) is unfinished
+work to clear first. Work the ladder top-down — **hotfix/operate first, then advance**:
 
 **Operate (keep it healthy) — always handled before advancing:**
 1. **Breakage** — CI red on `main`, broken site/docs build, your own PR gone red → root-cause fix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,11 @@ drafts are the deliverable; the maintainer promotes them at their own pace and *
 "I already have N PRs awaiting promotion" never justifies opening nothing. Distinct, substantive work
 across products is exactly what's wanted; only duplicate/filler PRs on one concern are bounded. A
 maintainer-sequenced queue on **one** product (e.g. a recovery sprint) holds back only *that* product's
-lane — it never gates advance work on the **other** products.
+lane — it never gates advance work on the **other** products. **That said, finish before you start
+more** (*stop starting, start finishing* — see *Cadence & focus*): "wants more drafts" means more
+**finished** drafts, so each run drive your existing in-flight own PRs to merged-or-review-ready first,
+then open new ones — a *finished* draft awaiting promotion is the deliverable; a *half-finished* one
+(red CI, unresolved threads, DIRTY) is unfinished work to clear, not a new slice to defer it behind.
 
 **This autonomy is for `devantler-tech` work.** Opening draft PRs and filing issues on `devantler-tech`
 repos needs no prior sign-off (only promotion does) — keep doing it. For **upstream**
@@ -530,6 +534,19 @@ between runs, not a per-run time budget.** Each run: **hotfix any breakage**, th
 failing-CI / mergeable trusted-author PR toward green and merge — first priority, across all repos; PRs
 always come before issues**, then **work the issue backlog oldest-actionable-first**, capturing new
 non-trivial finds as issues (see *Issue-driven*).
+**Stop starting, start finishing (WIP limit — the core agile principle).** Finishing in-flight work
+outranks starting new work. Each run, before opening any **new** draft, first drive **every own
+in-flight PR** to its terminal-ready state: a **promoted (ready-for-review) own PR** → root-cause-fix
+its CI, resolve its threads, and **merge** it (per *Merge policy*); a **draft** → make it review-ready
+(green CI + all CodeRabbit/bot threads resolved + not conflicting with main) so the maintainer can
+promote it at a glance. Only once your own open PRs are each either **merged or review-ready-awaiting-
+promotion** do you start a new advance slice. The *waste* this targets is a pile of **half-finished**
+own PRs — red/stale CI, unresolved review threads, DIRTY-vs-main — because unpromotable drafts and
+un-merged ready PRs deliver nothing while they sit; it does **not** target *finished* drafts awaiting
+promotion, which are the deliverable and are wanted in quantity (see *Autonomy*). Concretely: a
+ready-for-review own PR left un-merged, or a draft blocked on a **fixable** check/thread, is unfinished
+work — clear it **before** you start more. (This sharpens *PRs-before-issues* and the every-run own-draft
+review-thread sweep into an explicit finish-before-start ordering.)
 **Work as long as there is work — don't stop early.** The floor (≥1 artifact) is a **minimum and a
 backstop, not a target or a stopping point**: keep going while actionable work remains, and **prefer
 long, continuous sessions** over stopping after a handful of items. End a run only when actionable work


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What
Encodes your **core agile principle** — *stop starting, start finishing* — into the constitution (direct direction, 2026-07-01). Finishing in-flight work now explicitly outranks starting new work.

## Why
The contract already said *PRs-before-issues* and *sweep own drafts for review threads every run*, but nothing stated the **WIP-limit ordering**: drive existing own PRs to done **before** opening new drafts. Without it, a run could keep opening fresh drafts while promoted/ready PRs sit un-merged and older drafts carry red CI or unresolved threads — accumulating work-in-progress instead of finishing it. This tick was a live example: two ready-for-review PRs (one mergeable, one gated) and several drafts existed before any new work was warranted.

## How
- **`AGENTS.md` → Cadence & focus:** new **"Stop starting, start finishing (WIP limit)"** principle — each run, before opening any new draft, drive every own in-flight PR to terminal-ready (promoted → merge; draft → green CI + threads resolved + not DIRTY); only then start a new advance slice.
- **`AGENTS.md` → Autonomy:** the existing *"a backlog of drafts is NOT sprawl / wants more"* bullet now clarifies the nuance — "wants more" means more **finished** drafts; finish-before-start still applies. The two are reconciled, not contradictory.
- **`.claude/skills/portfolio-maintenance/SKILL.md` → Select step:** the same finish-first line, so the run-loop skill stays in sync with the canonical file (definition-of-done).

## Guardrails
Tightens ordering only; **loosens nothing** (trust gate, never-merge-external, never-self-promote, root-cause fixing all unchanged). One concern, three coordinated edits. Ships as a **draft** — your promotion is the gate; I never self-promote a definition PR.