### PR TITLE
docs(agents): make submodule worktree-isolation repair proactive in the run loop

### DIFF
--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -226,6 +226,16 @@ For each selected product:
 1. **Isolate:** `cd /Users/homelab-mac-mini/git-personal/monorepo`;
    `git -C <path> worktree add .claude/worktrees/maint-<runid> -b claude/<area>-<desc>` (populate an
    empty submodule first with `git submodule update --init <path>`). Work **in that worktree**.
+   **`git submodule update --init` re-sets the shared `core.worktree`** (observed 8× across runs:
+   ksail ×4, go-template, homebrew-tap, `.github-public`, agent-plugins), which makes the worktree
+   resolve back into `.git/modules/<name>` — so after **every** init-then-worktree-add on a
+   submodule, **probe and repair proactively** rather than discovering the collision mid-edit:
+   `git -C <wt> rev-parse --show-toplevel` must print the worktree's own path; if it prints a
+   `.git/modules/<name>` path, apply the 3-step repair from
+   [`worktree-isolation.md`](../../worktree-isolation.md) (enable `extensions.worktreeConfig`; pin
+   the main checkout's and each live worktree's own `core.worktree` in their `config.worktree`;
+   then unset the shared value — **guard every pin against empty vars and stop the sequence on a
+   failed `worktree add`**, per the 445th-run corruption lesson), and re-probe before editing.
    If the tree is unexpectedly dirty / not isolable, do GitHub-API-only work and skip diff work.
 2. **Load the product card** (`products/<name>`) + that submodule's `AGENTS.md` `## Maintenance`.
    Follow them; they carry validate commands, protected/generated files, label set, task menu, and the


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

My automated runs keep tripping over the same git-setup fault in the monorepo's submodules — eight times now. Each time it silently breaks the isolation between parallel work sessions and costs a mid-task detour to diagnose and repair before real work can continue.

## What

Updates my own run procedure to check for and repair the fault up front, every time, instead of discovering it after it bites. Self-improvement change to my instructions only — no product code touched.