### PR TITLE
feat(agent): make the daily engineer drive Kubescape security to 100% and hold it

### DIFF
--- a/.claude/skills/products/platform/SKILL.md
+++ b/.claude/skills/products/platform/SKILL.md
@@ -35,8 +35,11 @@ parallel sessions, and its API endpoint can go stale after a control-plane recre
 - **Coroot** — Incidents, Alerts/SLO burn, Traces, Logs, Risks (deployment & health-check risks), and
   **cost optimizations** (Node/cost view). Use its **read API** — the access recipe (project id, auth,
   the SPA-200-masks-404 gotcha, the empty-Hetzner-cost-rollup known limitation) is in native memory.
-- **Kubescape** — its config-scan / vulnerability / compliance / RBAC report objects, for security-
-  posture regressions vs the last run.
+- **Kubescape** — the three finding surfaces (posture / CVE / runtime), for security-posture regressions
+  vs the last run. **A `0`/empty reading is NOT automatically "clean" — verify the scanner is actually
+  producing data first** (a broken scanner reads identically to a compliant cluster). See the dedicated
+  **Security posture** section below for the object names, the broken-vs-clean checks, and the
+  fix-vs-except ladder.
 - **Kyverno** — policy **validation & enforcement**: `kubectl --context=admin@prod get cpol,pol`
   (policies present? mode Audit vs Enforce?) and `polr,cpolr` (PolicyReport / ClusterPolicyReport —
   failing rules and violating resources).
@@ -52,6 +55,47 @@ clusters more than once a day** portfolio-wide — contract *Cadence*). Operatio
 `platform/AGENTS.md` + the DR runbook. Turn a **confirmed, off-baseline** problem into the right
 artifact — a root-cause **draft PR** to the platform repo (manifest/Helm/policy fix) or a triaged issue
 — never a hand-edit of generated files and never a guardrail bypass.
+
+## Security posture (Kubescape) — drive to 100% and hold
+Kubescape runs **three finding surfaces**; **driving all three to 100% and holding them is a standing
+objective, not a floor** (epic + children: [devantler-tech/platform#2447](https://github.com/devantler-tech/platform/issues/2447)).
+The recurring trap, learned the hard way (2026-07-04, all three surfaces were silently dead): **an
+empty/zero reading almost always means the scanner is broken, not that the cluster is clean** — a broken
+scanner and a compliant cluster look identical, so **check liveness first, every time**:
+
+- **Posture** (config scan) — `configurationscansummaries` / `workloadconfigurationscansummaries`
+  (per-namespace scores + failed controls). **Broken if** scores are `0.00` across frameworks,
+  `controls: null` en masse, or objects are days stale — check the `kubescape` scanner pod logs for scan
+  aborts. Note: the CI gate (`ksail workload scan --framework nsa --compliance-threshold N`) is a
+  **separate** static scan in a healthy CLI context — **a green CI gate does NOT prove the in-cluster
+  scan works.**
+- **CVE** (kubevuln) — `vulnerabilitymanifestsummaries` / `vulnerabilitymanifests`. **Broken if**
+  manifests carry no grype `matches` / no `tool.name` and summaries are empty (both `.all` and
+  `.relevant`) — check kubevuln logs for `ScanCP … partial` (the relevancy path aborting on partial
+  ApplicationProfiles). Prioritise by relevancy × severity × fixability; emit VEX to suppress
+  non-reachable CVEs.
+- **Runtime** (node-agent) — `applicationprofiles`, `networkneighborhoods`, and the
+  `node_agent_alert_counter` metric. **Invisible if** the exporters are stdout-only
+  (`alertManagerExporterUrls: []`, `prometheusExporterEnabled: false`). Route **natively to Coroot**
+  (minimal-custom, all declarative): node-agent Prometheus exporter → `coroot.com/scrape-metrics`
+  annotation → a custom PromQL `alertingRules[]` in the Coroot CR → the existing Slack `notificationIntegrations`
+  webhook — **no new infra** (Coroot CE supports custom-PromQL alerts natively; it has no standard
+  Alertmanager, so don't add one).
+
+**Fix-vs-except ladder — the definition of done for a finding.** An exception is the audited last resort,
+never the first move:
+1. **Fix the manifest/root cause** — the real remediation (securityContext, RBAC scope, probes, labels).
+2. **Runtime-enforce** — if it's mutated/enforced at admission (Kyverno) or by the network layer
+   (Cilium), it's covered even where the static scan can't see it; **graduate a fixed control into Kyverno
+   `Enforce`** so it can't regress.
+3. **Except only when genuinely irreducible** (e.g. C-0002, the KubeVirt operator's `pods/exec` RBAC) — a
+   narrow, justified `ClusterSecurityException` in `k8s/bases/infrastructure/cluster-security-exceptions/`
+   with a written *why*, reviewed via PR, and periodically pruned. A growing exceptions dir is a smell,
+   not progress.
+
+A confirmed off-baseline finding on any surface — **including a scanner that has silently stopped
+producing data** — becomes a `security` issue under the epic (capture step), or a hotfix if it's active
+breakage. Ratchet the CI `--compliance-threshold` up as gaps close; never lower it.
 
 ## Roadmap & enhancement
 Platform's roadmap lives in **GitHub Issues** on `devantler-tech/platform` (`roadmap` epics +

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,6 +410,18 @@ standing substitute** for moving the real backlog:
   enough to finish it. For a non-trivial design, reason it through first (an ADR / system-design pass for
   big calls); implement with tests under the normal draft-PR + validate discipline; `Fixes #N`. **Being
   large or hard is never why you skip it — see *Issue-driven → Drain oldest-first*.**
+- **Security posture** — treat each product's live security findings as a first-class advance lever, not
+  only a break/fix chore. **Ingest** them (the survey looks at live scanner state, not just GitHub) and
+  beware the trap that **a `0`/empty reading is usually a *broken* scanner, not a clean cluster** — a
+  broken scanner and a compliant one read identically, so verify the scanner is actually producing data.
+  **Drive the numbers to 100% and hold them** — for the platform: Kubescape posture/compliance, the
+  reachable-CVE count, and routed runtime detections; equivalent scanners elsewhere. Resolve findings by
+  the **fix-vs-except ladder**: fix at the manifest/code root cause first; runtime-enforce (Kyverno /
+  admission / network policy) what a static scan can't see, graduating a fixed control to `Enforce` so it
+  can't regress; reserve a **scoped, justified** exception (e.g. a `ClusterSecurityException`) for
+  genuinely irreducible controls, reviewed via PR and periodically pruned (a growing exceptions set is a
+  smell, not progress). Ratchet the CI gate up as gaps close, never down. The per-product how-to lives in
+  each product's card (for the platform, its *Security posture (Kubescape)* section).
 - **Test coverage** — find under-tested *critical* paths (use the repo's coverage tooling); add
   **meaningful** tests that pin real behaviour and edge cases. Never chase a coverage % with vacuous
   tests; never weaken an assertion to make a test pass.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

A live investigation found the platform's entire Kubescape stack had silently broken — posture scoring `0.00`, zero CVE data on 197 images, runtime alerts going only to stdout — and the daily engineer **never noticed**. Its survey looks only at GitHub, so live cluster findings never enter the backlog, and there's no rule for *when to fix vs. when to except*. Left alone, security can rot invisibly (a broken scanner reads identically to a compliant cluster).

## What

Instruction-only change that makes security a continuously-driven objective, not a break/fix afterthought:
- **Root contract** — adds **Security posture** as a first-class advance lever: ingest live findings, treat a `0`/empty reading as *probably a broken scanner, not a clean cluster*, drive posture/CVE/runtime to 100% and hold it, and resolve findings by a **fix → runtime-enforce → scoped-exception** ladder.
- **Platform card** — a dedicated *Security posture (Kubescape)* section: the object names to query, the broken-vs-clean check per surface, the Coroot-native (no-new-infra) runtime-alert routing, and the fix-vs-except definition of done.

Part of devantler-tech/monorepo#2051; drives the platform recovery epic devantler-tech/platform#2447. The concrete cluster fixes are tracked separately (platform #2448–#2451).
