### PR TITLE
feat(docs): adopt build-time feature flags (astro:env)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,71 @@
+# devantler.tech
+
+The [devantler.tech](https://devantler.tech) site — an [Astro](https://astro.build) +
+[Starlight](https://starlight.astro.build) static site. It lives in this monorepo (`docs/` + repo
+root) and deploys to GitHub Pages via `.github/workflows/publish-pages.yaml`.
+
+## Develop
+
+```sh
+cd docs
+npm install
+npm run dev      # local dev server
+npm run build    # production build (this is what CI validates)
+```
+
+## Feature flags (build-time)
+
+Part of the portfolio-wide **feature-flag-first delivery** program
+([monorepo#2059](https://github.com/devantler-tech/monorepo/issues/2059)): unreleased content or UI
+lands **behind a default-off flag** so it can ship latent and be previewed before it goes live.
+
+The site is a **pure static build**, so flags are **baked at build time** — there is no runtime,
+per-user, or percentage evaluation. Flipping a flag means a **rebuild + redeploy**. (Live/per-user
+rollout would require an SSR/hybrid adapter or a client-side [OpenFeature](https://openfeature.dev/)
+web island — explicitly out of scope for the static site today.)
+
+### The convention — `astro:env`
+
+Flags are declared in the Zod-validated [`astro:env`](https://docs.astro.build/en/guides/environment-variables/)
+`env.schema` in [`astro.config.mjs`](astro.config.mjs) — type-safe over raw `import.meta.env`:
+
+```js
+env: {
+  schema: {
+    FEATURE_PREVIEW_BANNER: envField.boolean({
+      context: "server",   // read at build time in .astro components (SSG)
+      access: "public",
+      default: false,      // OFF by default — production omits the gated output
+    }),
+  },
+},
+```
+
+Gate rendering on the flag by importing it from `astro:env/server` (or `astro:env/client` for a
+`PUBLIC_`-prefixed client flag) — see [`src/components/PreviewBanner.astro`](src/components/PreviewBanner.astro),
+the worked example wired into the home page. When the flag is off, the component emits nothing.
+
+Flags can also gate **content-collection inclusion** (filter entries out of `getCollection(...)`
+when a flag is off) to hold back whole docs sections.
+
+### Preview builds
+
+To review flagged content before production enables it, run a **preview build** with the flag on:
+
+```sh
+FEATURE_PREVIEW_BANNER=true npm run build
+```
+
+The production build (CI / `publish-pages.yaml`) leaves the flag unset, so it stays off.
+
+### Lifecycle — remove the gate once shipped
+
+A *release* flag is **short-lived**. Once the content/UI is live for good:
+
+1. Delete the flag from the `env.schema` in `astro.config.mjs`.
+2. Inline the gated markup (drop the `{ FLAG && (...) }` wrapper) or delete the example component.
+3. Remove the flag from any preview-build invocations.
+
+A growing set of stale flags is debt, not progress — retire each one as soon as its content ships.
+Only a genuine kill-switch or a permanent setting is long-lived (and a permanent setting belongs in
+plain config, not a flag).

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,13 +1,32 @@
 import sitemap from "@astrojs/sitemap";
 import starlight from "@astrojs/starlight";
 import mermaid from "astro-mermaid";
-import { defineConfig } from "astro/config";
+import { defineConfig, envField } from "astro/config";
 import starlightBlog from "starlight-blog";
 import starlightGithubAlerts from "starlight-github-alerts";
 import starlightLinksValidator from "starlight-links-validator";
 
 export default defineConfig({
   site: "https://devantler.tech",
+  // Build-time feature flags (feature-flag-first delivery, monorepo#2059).
+  // The site is a pure static build, so flags are baked at build time: flipping
+  // one means a rebuild + redeploy, there is no runtime/per-user evaluation. Use
+  // `astro:env` with a Zod-validated schema — type-safe over raw import.meta.env.
+  // Convention + lifecycle (remove the gate once shipped) live in docs/README.md.
+  env: {
+    schema: {
+      // Example gated section: an unreleased-preview banner on the home page.
+      // Default-off, so production builds omit it; a preview build enables it
+      // with `FEATURE_PREVIEW_BANNER=true npm run build`. Server context = the
+      // flag is read while the .astro component renders at build time (SSG), so
+      // the banner's HTML is simply not emitted when off — no client JS needed.
+      FEATURE_PREVIEW_BANNER: envField.boolean({
+        context: "server",
+        access: "public",
+        default: false,
+      }),
+    },
+  },
   integrations: [
     mermaid(),
     starlight({

--- a/docs/src/components/PreviewBanner.astro
+++ b/docs/src/components/PreviewBanner.astro
@@ -1,0 +1,35 @@
+---
+// Example feature-flagged section (feature-flag-first delivery, monorepo#2059).
+//
+// Reads the build-time `FEATURE_PREVIEW_BANNER` flag from `astro:env/server`
+// (type-safe, Zod-validated in astro.config.mjs, default: false). Because this
+// runs while the page renders at build time, the banner is only emitted when
+// the flag is on — production builds (flag off) ship nothing at all: no markup
+// and no styles (the styles are inlined on the element, so nothing is hoisted
+// into the page CSS when the gate is closed).
+//
+// This is the pattern to copy for any unreleased content/UI: declare a
+// default-off flag in the schema, gate rendering on it here, and enable it in a
+// preview build (`FEATURE_PREVIEW_BANNER=true npm run build`) to review before
+// the production build flips it on. Remove the flag + gate once shipped.
+import { FEATURE_PREVIEW_BANNER } from "astro:env/server";
+
+const style = [
+  "margin:0 0 1.5rem",
+  "padding:0.75rem 1rem",
+  "border:1px solid var(--sl-color-orange)",
+  "border-radius:0.5rem",
+  "background:var(--sl-color-orange-low)",
+  "color:var(--sl-color-white)",
+  "font-size:var(--sl-text-sm)",
+].join(";");
+---
+
+{
+  FEATURE_PREVIEW_BANNER && (
+    <aside role="note" aria-label="Preview build notice" style={style}>
+      🚧 <strong>Preview build</strong> — this page includes unreleased content
+      gated behind the <code>FEATURE_PREVIEW_BANNER</code> feature flag.
+    </aside>
+  )
+}

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -34,11 +34,14 @@ hero:
 
 import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 import { getCollection } from "astro:content";
+import PreviewBanner from "../../components/PreviewBanner.astro";
 
 export const latestPosts = (await getCollection("docs"))
   .filter((entry) => entry.id.startsWith("blog/"))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
   .slice(0, 4);
+
+<PreviewBanner />
 
 ## What I Do
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Why** — The devantler.tech site had no way to hold back unreleased content or UI: anything merged went live immediately. It was also the one product not following the portfolio's own feature-flag-first delivery convention (#2059).

**What** — Adds a build-time feature-flag convention for the static site using `astro:env`: a default-off flag, one worked example gated section (a preview banner on the home page), and a documented preview-build + remove-once-shipped lifecycle in a new `docs/README.md`. Default-off means production is unchanged until a flag is deliberately flipped.

Validated by building in both flag states. Fixes #2060 · Part of #2059