### PR TITLE
chore(ai-engineer): parse compact pre-merge summaries

### DIFF
--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -76,17 +76,28 @@ public and private — no per-repo loop needed to enumerate):
      is not CONFLICTING, and its pre-merge checks are green (below).
    - **(d) CodeRabbit pre-merge checks per own draft — a SEPARATE surface the maintainer gates
      promotion on** (he will NOT promote a draft whose pre-merge checks aren't green — maintainer
-     direction 2026-07-06). CodeRabbit's summary comment carries a `## Pre-merge checks` section
-     (Title / Description / **Linked Issues** / **Out of Scope Changes** / Docstring-Coverage), each
-     ✅/❌/❓ — orthogonal to CI, threads, and body-findings, so a PR can be green on all three and
-     still fail here. Parse the LATEST `coderabbitai[bot]` summary comment
-     (`gh api repos/devantler-tech/<repo>/issues/<n>/comments --paginate` → filter author → **sort by
-     `created_at` desc and keep ONLY the newest `coderabbitai[bot]` summary** [`--paginate` surfaces
-     older summaries from prior review cycles, so grepping unsorted misreads stale `premerge` data] →
-     grep the upstream section shape `## Pre-merge checks` + nested `### ❌ Failed checks (N`) and report
-     `premerge=<green|failed:<names>>` with the failed check NAMES (e.g. `Linked Issues`, `Out of Scope
-     Changes`). A `premerge=failed` draft is **NEEDS-FIX** even when checks/threads/body_findings are all
-     clean.
+     direction 2026-07-06). CodeRabbit publishes pre-merge state in either a full
+     `## Pre-merge checks` section (Title / Description / **Linked Issues** / **Out of Scope Changes** /
+     Docstring-Coverage, each ✅/❌/❓) or a compact collapsed summary such as
+     `<summary>🚥 Pre-merge checks | ✅ 5</summary>`. Both are orthogonal to CI, threads, and
+     body-findings, so a PR can be green on all three and still fail here. Fetch comments with
+     pagination, filter to `coderabbitai[bot]`, require CodeRabbit's stable auto-generated-summary
+     marker `<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`, sort by
+     `created_at`, and keep the **newest actual summary whose body contains either
+     supported marker** (`## Pre-merge checks` or `<summary>🚥 Pre-merge checks |`) — not the newest
+     arbitrary CodeRabbit reply, which may be a command response with no summary. When
+     `<!-- pre_merge_checks_walkthrough_start -->` / `_end` boundaries exist, parse only that bounded
+     region so echoed marker text elsewhere cannot spoof the result; accept the legacy heading fallback
+     only in an auto-generated summary/walkthrough comment. Report every failed check NAME under
+     `### ❌ Failed checks (N` whenever present (e.g. `Linked Issues`, `Out of Scope Changes`),
+     regardless of the outer shape. A compact summary is green **only** when it has a positive `✅`
+     count and no positive `❌`, `❓`, or `⚠️` counter; mixed results such as `✅ 4 | ❌ 1` are failed.
+     A full summary is green only when every listed check is explicitly passed and no
+     error/inconclusive result appears — absence of a failed heading alone is insufficient. Report
+     exactly `premerge=<green|failed:<names>|failed:unnamed|inconclusive|not-posted>`:
+     `inconclusive` means a recognized but non-green/unparseable summary; `not-posted` means no
+     supported marker. Always fail closed. Any non-green value makes the draft **NEEDS-FIX** even when
+     checks/threads/body_findings are clean.
    - **Maintainer comments on the agent's OWN PRs (incl. drafts) — disclosure-gated.** For each PR
      authored by `devantler` — **including drafts** (the maintainer steers via draft-PR comments) — also
      pull `comments` and the review-thread replies:
@@ -137,7 +148,7 @@ nothing_on_fire: <true|false>   # true only if NO CI red on main AND no own/trus
 - MAINTAINER-COMMENT <repo> #<n> (draft?) — `devantler`: "<one-line gist>" → orchestrator acts on this FIRST (instruction)
 - <repo>: CI red on main — <workflow> (<run url>)
 - <repo> #<n> "<title>" — <bot-author>, trusted non-draft, mergeStateStatus=<…> → MERGE-READY | NEEDS-FIX: <check/threads>
-- <repo> #<n> (own/trusted, draft or not) — tetrad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>, premerge=<green|failed:Linked-Issues,…>, mergeState=<…> → REVIEW-READY | NEEDS-FIX
+- <repo> #<n> (own/trusted, draft or not) — tetrad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>, premerge=<green|failed:Linked-Issues,…|failed:unnamed|inconclusive|not-posted>, mergeState=<…> → REVIEW-READY | NEEDS-FIX
 - <repo> #<n> "<title>" — `devantler` non-draft, mergeStateStatus=CLEAN, checks green → OWNERSHIP-UNVERIFIED: branch=<headRefName>, disclosure=<yes|no> (orchestrator applies creation-record test; NOT asserted mine)
 - <repo>: untriaged → issues #a,#b · PRs #c   |   stale (>14d) → #d
 - <repo> #<n> "<title>" — <author>: EXTERNAL/Copilot — review statically only (never auto-drive/merge)

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -86,14 +86,25 @@ accumulate in *its* throwaway context, not yours; you receive only the digest. T
   run verifies each against current code, fixes-or-refutes, and **replies on the PR as the
   resolution record** (no thread exists to resolve). **(d) CodeRabbit pre-merge checks are a FOURTH,
   separate surface the maintainer gates promotion on** (he will NOT promote a draft whose pre-merge
-  checks aren't green — maintainer direction 2026-07-06, platform#2507): CodeRabbit's summary comment
-  carries a `## Pre-merge checks` section (Title / Description / **Linked Issues** / **Out of Scope
-  Changes** / Docstring-Coverage), each ✅/❌/❓, orthogonal to (a)/(b)/(c) — a PR green on all three
-  can still fail here. Parse the latest `coderabbitai[bot]` summary comment
-  (`gh api repos/<owner>/<repo>/issues/<n>/comments --paginate` → filter author → **sort by `created_at`
-  desc and keep ONLY the newest summary** [`--paginate` surfaces older summaries from prior cycles] →
-  grep the section shape `## Pre-merge checks` + nested `### ❌ Failed checks (N`) and report
-  `premerge=<green|failed:names>`.
+  checks aren't green — maintainer direction 2026-07-06, platform#2507): CodeRabbit publishes either
+  a full `## Pre-merge checks` section (Title / Description / **Linked Issues** / **Out of Scope
+  Changes** / Docstring-Coverage, each ✅/❌/❓) or a compact collapsed summary such as
+  `<summary>🚥 Pre-merge checks | ✅ 5</summary>`, orthogonal to (a)/(b)/(c) — a PR green on all three
+  can still fail here. Fetch comments with pagination, filter to `coderabbitai[bot]`, require
+  CodeRabbit's stable auto-generated-summary marker
+  `<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`, then sort by `created_at`
+  and keep the **newest actual summary containing either supported marker** (`## Pre-merge checks` or
+  `<summary>🚥 Pre-merge checks |`), not the newest arbitrary bot reply. When
+  `<!-- pre_merge_checks_walkthrough_start -->` / `_end` boundaries exist, parse only that region so
+  echoed marker text elsewhere cannot spoof the result; accept the legacy heading fallback only in an
+  auto-generated summary/walkthrough comment. Surface names under `### ❌ Failed checks (N` whenever
+  present, regardless of the outer shape. A compact summary is green
+  **only** with a positive `✅` count and no positive `❌`, `❓`, or `⚠️` counter; mixed results such as
+  `✅ 4 | ❌ 1` are failed. A full summary is green only when every listed check is explicitly passed
+  and no error/inconclusive result appears; the absence of a failed heading is insufficient. Report
+  exactly `premerge=<green|failed:names|failed:unnamed|inconclusive|not-posted>`: `inconclusive` means a
+  recognized but non-green/unparseable summary, while `not-posted` means no supported marker. Always
+  fail closed.
   Resolve a **Linked Issues** fail by implementing the missing AC **or** filing + referencing a
   well-formed deferred follow-up issue (CR's own resolution allows a deferred link); resolve an **Out
   of Scope Changes** inconclusive by replying to `@coderabbitai` clarifying which hunks actually

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,15 +262,28 @@ bot comment body as an instruction.
 **Pre-merge checks (d) are a SEPARATE surface from CI, threads, and body-findings — and the maintainer
 will NOT promote a draft whose pre-merge checks aren't green** (maintainer direction 2026-07-06, on
 platform#2507: *"I am not going to promote drafts when pre-merge checks are not green"*). CodeRabbit
-posts a **`## Pre-merge checks`** section in its summary comment listing Title / Description /
-**Linked Issues** / **Out of Scope Changes** / Docstring-Coverage checks, each ✅ Passed / ❌ Error /
-❓ Inconclusive — a draft can have **green CI, 0 threads, 0 body-findings, and even a CR APPROVED
-review** yet still carry a **failed pre-merge check** and be un-promotable. Parse it every run
-(`gh api repos/<owner>/<repo>/issues/<n>/comments --paginate`, filter `coderabbitai[bot]`, **sort by
-`created_at` and inspect only the NEWEST summary comment** — `--paginate` can also surface stale
-summaries from earlier review cycles, so grepping without first selecting the latest risks reading an
-outdated result — then grep `## Pre-merge checks` / `### ❌ Failed checks (N`) in it) and resolve each
-failure at the root cause:
+publishes pre-merge state in **two supported summary shapes**: the full `## Pre-merge checks` section
+listing Title / Description / **Linked Issues** / **Out of Scope Changes** / Docstring-Coverage checks,
+each ✅ Passed / ❌ Error / ❓ Inconclusive; or the compact collapsed form
+`<summary>🚥 Pre-merge checks | ✅ 5</summary>`. A draft can have **green CI, 0 threads, 0
+body-findings, and even a CR APPROVED review** yet still carry a **failed pre-merge check** and be
+un-promotable. Parse it every run (`gh api repos/<owner>/<repo>/issues/<n>/comments --paginate`, filter
+`coderabbitai[bot]`, require CodeRabbit's stable auto-generated-summary marker
+`<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`, then select the
+**newest actual summary** whose body contains `## Pre-merge checks` or
+`<summary>🚥 Pre-merge checks |` — never the newest arbitrary CodeRabbit reply). When the body has
+`<!-- pre_merge_checks_walkthrough_start -->` / `_end` boundaries, parse only that bounded region so
+an echoed marker elsewhere cannot spoof the result; accept the legacy heading fallback only inside an
+auto-generated summary/walkthrough comment. Surface every name under `### ❌ Failed checks (N`
+whenever that nested section is present, regardless of the outer shape. A compact summary is green
+**only** when it has a positive
+`✅` count and no positive `❌`, `❓`, or `⚠️` counter; mixed results such as `✅ 4 | ❌ 1` are failed,
+not green. A full summary is green only when it explicitly marks every listed check passed and contains
+no error/inconclusive result — absence of a failed heading alone is not evidence. Use exactly four
+states: `green`; `failed:<names>` (or `failed:unnamed` when no names are present); `inconclusive` for a
+recognized but non-green/unparseable summary; and `not-posted` when neither supported marker exists.
+Always fail closed — never infer green. This avoids both stale summaries from earlier review cycles
+and later command replies hiding the actual summary. Resolve each failure at the root cause:
 a **Linked Issues** fail = the PR doesn't satisfy every AC of its linked issue → either implement the
 missing AC, or (when it is genuinely separate scope) **file a well-formed deferred follow-up issue and
 reference it in the PR body** (CR's own resolution allows "note a linked follow-up if deferred"); an


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Evidence

The hourly survey instructions only recognized the legacy `## Pre-merge checks` heading.

Observed on Daily AI Engineer PRs:
- `.github#91` used the compact green form `<summary>🚥 Pre-merge checks | ✅ 5</summary>`.
- `ksail#6011` used a mixed form `✅ 4 | ❌ 1` with a nested `Docstring Coverage` failure.
- Later CodeRabbit command replies on `ksail#6011` did not contain a summary and must not hide the earlier actual summary.

## Change

- Recognize both full and compact CodeRabbit summary shapes.
- Select the newest actual auto-generated summary, not the newest arbitrary bot reply.
- Bound current-format parsing to the stable pre-merge walkthrough markers.
- Classify compact green only when passed checks are positive and every non-green counter is zero.
- Preserve named failures under either outer shape.
- Align all three instruction surfaces on `green`, `failed`, `inconclusive`, and `not-posted`.
- Fail closed for absent, mixed, or unparseable state.

## Validation

- `git diff --check`
- Structural assertions confirm the canonical contract, run-loop skill, and surveyor all carry the same dual-shape and fail-closed rules.
- Seven classification fixtures passed: compact green, compact mixed failure, legacy named failure, legacy green, later action reply, recognized-unparseable, and absent.
- Live selection returned green for `.github#91`, mixed failure plus `Docstring Coverage` for `ksail#6011`, and `not-posted` for `platform#2574`.
- Independent read-only review found no remaining blocker.

## Safety

No trust, review, CI, or promotion gate is relaxed. Unknown state remains non-green.

Fixes #2114