### PR TITLE
feat(agents): enforced safe-clone primitive for temp-clone credentials

### DIFF
--- a/.claude/scripts/safe-clone.sh
+++ b/.claude/scripts/safe-clone.sh
@@ -31,16 +31,18 @@ fail() {
   exit 1
 }
 
-# list_remote_urls <dir> — emit "remote.<name>.url<TAB><value>" lines to
-# stdout for iteration. Callers must never print the value field.
+# list_remote_urls <dir> — emit "remote.<name>.url|pushurl<TAB><value>" lines
+# to stdout for iteration (pushurl leaks through `git remote -v` exactly like
+# url). Callers must never print the value field.
 list_remote_urls() {
-  git -C "$1" config --get-regexp '^remote\..*\.url$' | sed 's/ /\t/' || true
+  git -C "$1" config --get-regexp '^remote\..*\.(url|pushurl)$' | sed 's/ /\t/' || true
 }
 
 # has_userinfo <url> — 0 when an http(s) URL carries userinfo (anything
-# before an @ in the authority part).
+# before an @ in the authority part). Scheme match is case-insensitive —
+# git accepts HTTPS:// remotes and they display the same way.
 has_userinfo() {
-  [[ "$1" =~ ^https?://[^/@]*@ ]]
+  [[ "$1" =~ ^[Hh][Tt][Tt][Pp][Ss]?://[^/@]*@ ]]
 }
 
 # env_guard [dir] — fail closed when the EFFECTIVE git config (system,
@@ -54,9 +56,17 @@ env_guard() {
   local dir="${1:-}"
   local -a cmd=(git)
   [[ -n "$dir" ]] && cmd=(git -C "$dir")
-  if "${cmd[@]}" config --list --name-only 2>/dev/null |
-    grep -Eiq '^url\.https?://[^/@]*@.*\.insteadof$'; then
-    echo "safe-clone: UNSAFE — a git insteadOf URL rewrite in the effective config embeds credentials (key redacted); remove it from host config, use the credential helper instead, and rotate the credential" >&2
+  # One pass over key=value lines catches the classes that leak through the
+  # guarded diagnostics even when stored remote URLs are clean:
+  #   1. a credential in an insteadOf/pushInsteadOf rewrite KEY,
+  #   2. a credential in an insteadOf/pushInsteadOf rewrite VALUE,
+  #   3. any http.*.extraHeader (its practical use is auth headers, and
+  #      `git config --list` would print it) — fail closed on presence.
+  if "${cmd[@]}" config --list 2>/dev/null | grep -Eiq \
+    -e '^url\.https?://[^/@]*@[^=]*\.(insteadof|pushinsteadof)=' \
+    -e '^url\.[^=]*\.(insteadof|pushinsteadof)=https?://[^/@]*@' \
+    -e '^http\.[^=]*extraheader='; then
+    echo "safe-clone: UNSAFE — the effective git config carries a credential-bearing URL rewrite (insteadOf/pushInsteadOf) or an http extraHeader (details redacted); remove it from host config, use the credential helper instead, and rotate the credential" >&2
     return 1
   fi
   return 0
@@ -79,17 +89,16 @@ guard() {
 # sanitize <dir> — rewrite every credential-bearing http(s) remote URL to its
 # userinfo-free form in place.
 sanitize() {
-  local dir="$1" key value name stripped
+  local dir="$1" key value stripped
   while IFS=$'\t' read -r key value; do
     [[ -n "${value:-}" ]] || continue
     if has_userinfo "$value"; then
-      name="${key#remote.}"
-      name="${name%.url}"
       # https://user:secret@host/path -> https://host/path (pure bash — the
-      # secret never passes through another process's argv).
+      # secret never passes through another process's argv). Setting the full
+      # config key covers url and pushurl alike.
       stripped="${value%%://*}://${value#*@}"
-      git -C "$dir" remote set-url "$name" "$stripped"
-      echo "safe-clone: sanitized remote ${name} (userinfo stripped)" >&2
+      git -C "$dir" config "$key" "$stripped"
+      echo "safe-clone: sanitized ${key} (userinfo stripped)" >&2
     fi
   done < <(list_remote_urls "$dir")
 }
@@ -120,7 +129,9 @@ case "${1:-}" in
     slug="$1"
     dest="$2"
     shift 2
-    [[ "$slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || fail "invalid repo slug (want owner/repo): $slug"
+    # Never echo the rejected value — a caller may mistakenly pass the very
+    # credential-bearing URL this helper exists to replace.
+    [[ "$slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || fail "invalid repo slug (want owner/repo; value redacted)"
     [[ -e "$dest" ]] && fail "destination already exists: $dest"
 
     # Refuse to clone at all in a credential-leaking environment — nothing
@@ -141,9 +152,12 @@ case "${1:-}" in
     git -C "$dest" remote set-url origin "$url"
     git -C "$dest" config credential.helper '!gh auth git-credential'
 
-    if ! guard "$dest"; then
+    # Re-run BOTH guards against the finished clone: pass-through git-clone
+    # options (e.g. `-c url.<...>.insteadOf=...`) can write config into the
+    # new repository that the pre-clone environment check never saw.
+    if ! guard "$dest" || ! env_guard "$dest"; then
       rm -rf "$dest"
-      fail "clone of ${slug} had a credential-bearing remote; clone removed — rotate the credential before retrying"
+      fail "clone of ${slug} failed the credential guard; clone removed — rotate the credential before retrying"
     fi
 
     echo "safe-clone: ${slug} -> ${dest} (remotes credential-free)"

--- a/.claude/scripts/safe-clone.sh
+++ b/.claude/scripts/safe-clone.sh
@@ -62,11 +62,20 @@ env_guard() {
   #   2. a credential in an insteadOf/pushInsteadOf rewrite VALUE,
   #   3. any http.*.extraHeader (its practical use is auth headers, and
   #      `git config --list` would print it) — fail closed on presence.
-  if "${cmd[@]}" config --list 2>/dev/null | grep -Eiq \
+  # Capture the listing first: with a bare pipe, a failed config read leaves
+  # grep matching empty input, so the UNSAFE branch is silently skipped — an
+  # unreadable config must fail closed, not open.
+  local config_listing
+  if ! config_listing="$("${cmd[@]}" config --list 2>/dev/null)"; then
+    echo "safe-clone: UNSAFE — could not read the effective git config to verify it is credential-free; fix the config read error and retry" >&2
+    return 1
+  fi
+  if grep -Eiq \
     -e '^url\.https?://[^/@]*@[^=]*\.(insteadof|pushinsteadof)=' \
     -e '^url\.[^=]*\.(insteadof|pushinsteadof)=https?://[^/@]*@' \
     -e '^http\.[^=]*extraheader=' \
-    -e '^(http\.([^=]*\.)?proxy|remote\.[^=]*\.proxy|core\.gitproxy)=[a-z][a-z0-9+.-]*://[^/@]*@'; then
+    -e '^(http\.([^=]*\.)?proxy|remote\.[^=]*\.proxy|core\.gitproxy)=[a-z][a-z0-9+.-]*://[^/@]*@' \
+    <<<"$config_listing"; then
     echo "safe-clone: UNSAFE — the effective git config carries a credential-bearing URL rewrite (insteadOf/pushInsteadOf), an http extraHeader, or a credentialed proxy (details redacted); remove it from host config, use the credential helper instead, and rotate the credential" >&2
     return 1
   fi
@@ -111,8 +120,11 @@ sanitize() {
     while IFS= read -r value; do
       if has_userinfo "$value"; then
         # https://user:secret@host/path -> https://host/path (pure bash — the
-        # secret never passes through another process's argv).
-        stripped="${value%%://*}://${value#*@}"
+        # secret never passes through another process's argv). Split at the
+        # LAST @: RFC 3986 forbids an unescaped @ in the host, so any earlier
+        # @ belongs to the userinfo (e.g. an email-address username) and must
+        # be stripped with it.
+        stripped="${value%%://*}://${value##*@}"
         values+=("$stripped")
       else
         values+=("$value")

--- a/.claude/scripts/safe-clone.sh
+++ b/.claude/scripts/safe-clone.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# safe-clone.sh — the shared safe-clone primitive for autonomous agent work
+# (monorepo#2132). Guarantees a temporary clone's HTTP(S) remotes never carry
+# URL userinfo (an embedded credential), so a later output-producing
+# diagnostic (`git remote -v`, `GIT_TRACE`, `git config --list`) cannot leak
+# a token into durable task output. Authenticated fetch/push flows through
+# `gh auth git-credential` instead of the remote URL.
+#
+# Modes:
+#   safe-clone.sh <owner>/<repo> <dest-dir> [git-clone-options...]
+#       Clone with a scrubbed environment, force the canonical
+#       credential-free origin URL, wire the gh credential helper, then run
+#       the fail-closed guard. An unsafe result is DELETED before returning.
+#   safe-clone.sh --check <dir>
+#       Verify an existing clone: exit 1 with a redacted message if any
+#       HTTP(S) remote URL carries userinfo, or if the effective git config
+#       carries a credential-bearing insteadOf rewrite (which would leak
+#       through `git remote -v` even on a clean clone). Never prints a URL
+#       value or config key.
+#   safe-clone.sh --sanitize <dir>
+#       Strip userinfo from every HTTP(S) remote URL in place, then re-run
+#       the guard. Never prints a URL value.
+#
+# Every failure path prints only redacted messages — no remote URL value is
+# ever echoed, traced, or embedded in an error.
+set -Eeuo pipefail
+
+fail() {
+  echo "safe-clone: $*" >&2
+  exit 1
+}
+
+# list_remote_urls <dir> — emit "remote.<name>.url<TAB><value>" lines to
+# stdout for iteration. Callers must never print the value field.
+list_remote_urls() {
+  git -C "$1" config --get-regexp '^remote\..*\.url$' | sed 's/ /\t/' || true
+}
+
+# has_userinfo <url> — 0 when an http(s) URL carries userinfo (anything
+# before an @ in the authority part).
+has_userinfo() {
+  [[ "$1" =~ ^https?://[^/@]*@ ]]
+}
+
+# env_guard [dir] — fail closed when the EFFECTIVE git config (system,
+# global, and — when dir is given — the clone's local scope) carries a
+# `url.<...>.insteadOf` rewrite whose URL embeds credentials. Such a rewrite
+# leaks the secret through every `git remote -v`/`get-url` even when the
+# stored remote URL is clean (the 2026-07-12 incident mechanism), and the
+# secret sits in the config KEY itself, so nothing matched here is ever
+# echoed — only a redacted message.
+env_guard() {
+  local dir="${1:-}"
+  local -a cmd=(git)
+  [[ -n "$dir" ]] && cmd=(git -C "$dir")
+  if "${cmd[@]}" config --list --name-only 2>/dev/null |
+    grep -Eiq '^url\.https?://[^/@]*@.*\.insteadof$'; then
+    echo "safe-clone: UNSAFE — a git insteadOf URL rewrite in the effective config embeds credentials (key redacted); remove it from host config, use the credential helper instead, and rotate the credential" >&2
+    return 1
+  fi
+  return 0
+}
+
+# guard <dir> — fail-closed verification. Exits 1 (redacted) on the first
+# credential-bearing remote; prints nothing sensitive.
+guard() {
+  local dir="$1" key value
+  while IFS=$'\t' read -r key value; do
+    [[ -n "${value:-}" ]] || continue
+    if has_userinfo "$value"; then
+      echo "safe-clone: UNSAFE — ${key} carries URL userinfo (value redacted)" >&2
+      return 1
+    fi
+  done < <(list_remote_urls "$dir")
+  return 0
+}
+
+# sanitize <dir> — rewrite every credential-bearing http(s) remote URL to its
+# userinfo-free form in place.
+sanitize() {
+  local dir="$1" key value name stripped
+  while IFS=$'\t' read -r key value; do
+    [[ -n "${value:-}" ]] || continue
+    if has_userinfo "$value"; then
+      name="${key#remote.}"
+      name="${name%.url}"
+      # https://user:secret@host/path -> https://host/path (pure bash — the
+      # secret never passes through another process's argv).
+      stripped="${value%%://*}://${value#*@}"
+      git -C "$dir" remote set-url "$name" "$stripped"
+      echo "safe-clone: sanitized remote ${name} (userinfo stripped)" >&2
+    fi
+  done < <(list_remote_urls "$dir")
+}
+
+case "${1:-}" in
+  --check)
+    dir="${2:-}"
+    [[ $# -eq 2 && ( -d "${dir}/.git" || -f "${dir}/.git" ) ]] ||
+      fail "usage: safe-clone.sh --check <clone-dir>"
+    env_guard "$dir" || fail "environment guard failed — fix host git config before running remote/trace diagnostics"
+    guard "$dir" || fail "guard failed for ${dir} — sanitize or delete the clone and rotate the credential"
+    echo "safe-clone: ${dir} remotes are credential-free"
+    ;;
+  --sanitize)
+    dir="${2:-}"
+    [[ $# -eq 2 && ( -d "${dir}/.git" || -f "${dir}/.git" ) ]] ||
+      fail "usage: safe-clone.sh --sanitize <clone-dir>"
+    sanitize "$dir"
+    guard "$dir" || fail "guard still failing for ${dir} after sanitize — delete the clone and rotate the credential"
+    env_guard "$dir" || fail "stored remotes are clean but the environment guard failed — fix host git config before running remote/trace diagnostics"
+    echo "safe-clone: ${dir} remotes are credential-free"
+    ;;
+  --*)
+    fail "unknown mode ${1}"
+    ;;
+  *)
+    [[ $# -ge 2 ]] || fail "usage: safe-clone.sh <owner>/<repo> <dest-dir> [git-clone-options...]"
+    slug="$1"
+    dest="$2"
+    shift 2
+    [[ "$slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || fail "invalid repo slug (want owner/repo): $slug"
+    [[ -e "$dest" ]] && fail "destination already exists: $dest"
+
+    # Refuse to clone at all in a credential-leaking environment — nothing
+    # is created, so there is nothing to quarantine.
+    env_guard || fail "environment guard failed — fix host git config before cloning"
+
+    url="https://github.com/${slug}.git"
+
+    # Scrub inherited token env vars so no tool on this path can embed one
+    # into the persisted remote; auth flows through the credential helper.
+    env -u GITHUB_TOKEN -u GH_TOKEN \
+      git -c credential.helper='!gh auth git-credential' \
+      clone --quiet "$@" "$url" "$dest" ||
+      fail "clone failed for ${slug}"
+
+    # Belt-and-braces: force the canonical credential-free URL and wire the
+    # helper for future authenticated fetch/push from this clone.
+    git -C "$dest" remote set-url origin "$url"
+    git -C "$dest" config credential.helper '!gh auth git-credential'
+
+    if ! guard "$dest"; then
+      rm -rf "$dest"
+      fail "clone of ${slug} had a credential-bearing remote; clone removed — rotate the credential before retrying"
+    fi
+
+    echo "safe-clone: ${slug} -> ${dest} (remotes credential-free)"
+    ;;
+esac

--- a/.claude/scripts/safe-clone.sh
+++ b/.claude/scripts/safe-clone.sh
@@ -9,9 +9,9 @@
 #
 # Modes:
 #   safe-clone.sh <owner>/<repo> <dest-dir> [git-clone-options...]
-#       Clone with a scrubbed environment, force the canonical
+#       Clone (options restricted to a safe allowlist), force the canonical
 #       credential-free origin URL, wire the gh credential helper, then run
-#       the fail-closed guard. An unsafe result is DELETED before returning.
+#       the fail-closed guards. An unsafe result is DELETED before returning.
 #   safe-clone.sh --check <dir>
 #       Verify an existing clone: exit 1 with a redacted message if any
 #       HTTP(S) remote URL carries userinfo, or if the effective git config
@@ -65,8 +65,9 @@ env_guard() {
   if "${cmd[@]}" config --list 2>/dev/null | grep -Eiq \
     -e '^url\.https?://[^/@]*@[^=]*\.(insteadof|pushinsteadof)=' \
     -e '^url\.[^=]*\.(insteadof|pushinsteadof)=https?://[^/@]*@' \
-    -e '^http\.[^=]*extraheader='; then
-    echo "safe-clone: UNSAFE — the effective git config carries a credential-bearing URL rewrite (insteadOf/pushInsteadOf) or an http extraHeader (details redacted); remove it from host config, use the credential helper instead, and rotate the credential" >&2
+    -e '^http\.[^=]*extraheader=' \
+    -e '^(http\.([^=]*\.)?proxy|remote\.[^=]*\.proxy|core\.gitproxy)=[a-z][a-z0-9+.-]*://[^/@]*@'; then
+    echo "safe-clone: UNSAFE — the effective git config carries a credential-bearing URL rewrite (insteadOf/pushInsteadOf), an http extraHeader, or a credentialed proxy (details redacted); remove it from host config, use the credential helper instead, and rotate the credential" >&2
     return 1
   fi
   return 0
@@ -87,20 +88,43 @@ guard() {
 }
 
 # sanitize <dir> — rewrite every credential-bearing http(s) remote URL to its
-# userinfo-free form in place.
+# userinfo-free form in place. Keys are rewritten wholesale (unset-all, then
+# re-add each stripped value) because pushurl is multi-valued and a plain
+# `git config <key> <value>` aborts on multiple values.
 sanitize() {
   local dir="$1" key value stripped
+  local -a keys=() values=()
   while IFS=$'\t' read -r key value; do
     [[ -n "${value:-}" ]] || continue
     if has_userinfo "$value"; then
-      # https://user:secret@host/path -> https://host/path (pure bash — the
-      # secret never passes through another process's argv). Setting the full
-      # config key covers url and pushurl alike.
-      stripped="${value%%://*}://${value#*@}"
-      git -C "$dir" config "$key" "$stripped"
-      echo "safe-clone: sanitized ${key} (userinfo stripped)" >&2
+      keys+=("$key")
     fi
   done < <(list_remote_urls "$dir")
+
+  [[ ${#keys[@]} -gt 0 ]] || return 0
+
+  local uniq_keys
+  uniq_keys="$(printf '%s\n' "${keys[@]:-}" | sort -u)"
+  while IFS= read -r key; do
+    [[ -n "$key" ]] || continue
+    values=()
+    while IFS= read -r value; do
+      if has_userinfo "$value"; then
+        # https://user:secret@host/path -> https://host/path (pure bash — the
+        # secret never passes through another process's argv).
+        stripped="${value%%://*}://${value#*@}"
+        values+=("$stripped")
+      else
+        values+=("$value")
+      fi
+    done < <(git -C "$dir" config --get-all "$key")
+
+    git -C "$dir" config --unset-all "$key"
+    for value in "${values[@]}"; do
+      git -C "$dir" config --add "$key" "$value"
+    done
+    echo "safe-clone: sanitized ${key} (userinfo stripped)" >&2
+  done <<<"$uniq_keys"
 }
 
 case "${1:-}" in
@@ -134,16 +158,39 @@ case "${1:-}" in
     [[ "$slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || fail "invalid repo slug (want owner/repo; value redacted)"
     [[ -e "$dest" ]] && fail "destination already exists: $dest"
 
+    # Pass-through options are ALLOWLISTED: open-ended forwarding lets a
+    # caller break the safety invariants (`-c` writes repo config the
+    # pre-clone check never saw, `--origin` renames origin so the canonical
+    # set-url fails, `--separate-git-dir` moves the git dir outside the
+    # delete-on-failure path). Only shape/history options are permitted.
+    expect_value=""
+    for opt in "$@"; do
+      if [[ -n "$expect_value" ]]; then
+        expect_value=""
+        continue
+      fi
+      case "$opt" in
+        --depth=*|--branch=*|--filter=*|--shallow-since=*|--shallow-exclude=*) ;;
+        --depth|--branch|-b|--filter|--shallow-since|--shallow-exclude) expect_value=1 ;;
+        --single-branch|--no-single-branch|--sparse|--no-tags|--quiet) ;;
+        *)
+          fail "clone option not in the safe allowlist (value redacted); allowed: --depth --branch --single-branch --filter --sparse --no-tags --shallow-since --shallow-exclude --quiet"
+          ;;
+      esac
+    done
+    [[ -z "$expect_value" ]] || fail "clone option expects a value but none was given"
+
     # Refuse to clone at all in a credential-leaking environment — nothing
     # is created, so there is nothing to quarantine.
     env_guard || fail "environment guard failed — fix host git config before cloning"
 
     url="https://github.com/${slug}.git"
 
-    # Scrub inherited token env vars so no tool on this path can embed one
-    # into the persisted remote; auth flows through the credential helper.
-    env -u GITHUB_TOKEN -u GH_TOKEN \
-      git -c credential.helper='!gh auth git-credential' \
+    # No env scrubbing here: plain `git clone` never reads GITHUB_TOKEN /
+    # GH_TOKEN, and the `gh auth git-credential` helper NEEDS them on hosts
+    # where gh is authenticated only via environment token. The guard below
+    # verifies nothing token-shaped was persisted regardless.
+    git -c credential.helper='!gh auth git-credential' \
       clone --quiet "$@" "$url" "$dest" ||
       fail "clone failed for ${slug}"
 

--- a/.claude/scripts/safe-clone.test.sh
+++ b/.claude/scripts/safe-clone.test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Self-test for safe-clone.sh — proves the credential guard DETECTS a remote
+# URL carrying userinfo without ever printing the secret, that --sanitize
+# strips the userinfo in place, that a clean clone passes, and that the
+# argument guards fail closed. Fixtures are local `git init` repos with
+# hand-set remote URLs — no network, no real credentials (the fixture secret
+# is a synthetic marker string). Run in CI so a refactor that weakens the
+# guard or starts echoing URL values is caught here, not by a leaked token.
+set -Eeuo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper="$here/safe-clone.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Hermetic git environment: the host's real system/global config (which may
+# itself carry the very rewrites the guard hunts) must not affect fixtures.
+touch "$tmp/gitconfig-clean"
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL="$tmp/gitconfig-clean"
+
+secret="SYNTHETIC-FIXTURE-SECRET-0000"
+fail=0
+
+report() {
+  local name="$1" ok="$2" detail="${3:-}"
+  if [[ "$ok" == "yes" ]]; then
+    echo "PASS: $name"
+  else
+    echo "FAIL: $name${detail:+ — $detail}"
+    fail=1
+  fi
+}
+
+mk_fixture() {
+  local dir="$1" url="$2"
+  git init --quiet "$dir"
+  git -C "$dir" remote add origin "$url"
+}
+
+# 1. --check fails on a userinfo remote and never prints the secret.
+unsafe="$tmp/unsafe"
+mk_fixture "$unsafe" "https://x-access-token:${secret}@github.com/example/repo.git"
+out="$("$helper" --check "$unsafe" 2>&1)" && rc=0 || rc=$?
+report "check detects userinfo remote (exit != 0)" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+report "check output names the unsafe remote" \
+  "$(grep -q "remote.origin.url" <<<"$out" && echo yes || echo no)"
+report "check output does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+
+# 2. --sanitize strips the userinfo, passes the guard, leaks nothing.
+# Assert on the RAW stored config value — `remote get-url` applies insteadOf
+# rewrites at read time, which is display state, not what is on disk.
+out="$("$helper" --sanitize "$unsafe" 2>&1)" && rc=0 || rc=$?
+sanitized_url="$(git -C "$unsafe" config remote.origin.url)"
+report "sanitize exits 0" "$([[ $rc -eq 0 ]] && echo yes || echo no)"
+report "sanitize leaves a credential-free URL" \
+  "$([[ "$sanitized_url" == "https://github.com/example/repo.git" ]] && echo yes || echo no)" \
+  "got a rewritten URL that still differs from the canonical form"
+report "sanitize output does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+
+# 3. --check passes a clean clone.
+clean="$tmp/clean"
+mk_fixture "$clean" "https://github.com/example/repo.git"
+out="$("$helper" --check "$clean" 2>&1)" && rc=0 || rc=$?
+report "check passes a credential-free clone" "$([[ $rc -eq 0 ]] && echo yes || echo no)"
+
+# 4. Guard covers every remote, not just origin.
+multi="$tmp/multi"
+mk_fixture "$multi" "https://github.com/example/repo.git"
+git -C "$multi" remote add upstream "https://user:${secret}@github.com/example/upstream.git"
+out="$("$helper" --check "$multi" 2>&1)" && rc=0 || rc=$?
+report "check detects userinfo on a non-origin remote" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+report "multi-remote check does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+
+# 5. SSH-style remotes (no userinfo semantics to leak a token) pass untouched.
+ssh="$tmp/ssh"
+mk_fixture "$ssh" "git@github.com:example/repo.git"
+out="$("$helper" --check "$ssh" 2>&1)" && rc=0 || rc=$?
+report "check passes an ssh remote" "$([[ $rc -eq 0 ]] && echo yes || echo no)"
+
+# 6. Environment guard: a credential-bearing insteadOf rewrite in the
+# effective config fails --check on an otherwise-clean clone, with the
+# secret (which sits in the config KEY) never printed. This pins the actual
+# 2026-07-12 incident mechanism.
+unsafe_global="$tmp/gitconfig-unsafe"
+git config --file "$unsafe_global" \
+  "url.https://x-access-token:${secret}@github.com/.insteadOf" \
+  "https://github.com/"
+out="$(GIT_CONFIG_GLOBAL="$unsafe_global" "$helper" --check "$clean" 2>&1)" && rc=0 || rc=$?
+report "env guard fails a clean clone under an unsafe insteadOf rewrite" \
+  "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+report "env guard output mentions insteadOf" \
+  "$(grep -qi "insteadof" <<<"$out" && echo yes || echo no)"
+report "env guard output does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+
+# 7. Environment guard refuses clone mode up front (nothing gets created).
+out="$(GIT_CONFIG_GLOBAL="$unsafe_global" "$helper" example/repo "$tmp/refused" 2>&1)" && rc=0 || rc=$?
+report "env guard refuses clone mode" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+report "refused clone creates nothing" \
+  "$([[ ! -e "$tmp/refused" ]] && echo yes || echo no)"
+report "refused clone output does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+
+# 8. A credential-free insteadOf rewrite (legitimate mirror redirect) passes.
+benign_global="$tmp/gitconfig-benign"
+git config --file "$benign_global" \
+  "url.https://mirror.example.com/.insteadOf" "https://github.com/"
+out="$(GIT_CONFIG_GLOBAL="$benign_global" "$helper" --check "$clean" 2>&1)" && rc=0 || rc=$?
+report "credential-free insteadOf rewrite passes" "$([[ $rc -eq 0 ]] && echo yes || echo no)"
+
+# 9. Argument guards fail closed.
+out="$("$helper" not-a-slug "$tmp/never" 2>&1)" && rc=0 || rc=$?
+report "invalid slug is rejected" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+out="$("$helper" --check "$tmp/missing" 2>&1)" && rc=0 || rc=$?
+report "check on a non-clone is rejected" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+mkdir -p "$tmp/exists"
+out="$("$helper" example/repo "$tmp/exists" 2>&1)" && rc=0 || rc=$?
+report "existing destination is rejected" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+
+if [[ $fail -ne 0 ]]; then
+  echo "safe-clone self-test: FAILURES above" >&2
+  exit 1
+fi
+echo "safe-clone self-test: all cases passed"

--- a/.claude/scripts/safe-clone.test.sh
+++ b/.claude/scripts/safe-clone.test.sh
@@ -204,6 +204,27 @@ mkdir -p "$tmp/exists"
 out="$("$helper" example/repo "$tmp/exists" 2>&1)" && rc=0 || rc=$?
 report "existing destination is rejected" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
 
+# 16. Userinfo containing a raw @ (email-address username) is stripped to the
+# LAST @ — no credential remnant may survive in the "sanitized" URL.
+at_user="$tmp/at-user"
+mk_fixture "$at_user" "https://user@example.com:${secret}@github.com/example/repo.git"
+out="$("$helper" --sanitize "$at_user" 2>&1)" && rc=0 || rc=$?
+at_url="$(git -C "$at_user" config remote.origin.url)"
+report "sanitize strips userinfo containing a raw @ to the last @" \
+  "$([[ $rc -eq 0 && "$at_url" == "https://github.com/example/repo.git" ]] && echo yes || echo no)" \
+  "sanitized URL still carries a credential remnant"
+report "at-userinfo sanitize output does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+
+# 17. env_guard fails CLOSED when the config itself is unreadable — a corrupt
+# config must not read as "no rewrites found".
+corrupt="$tmp/corrupt"
+mk_fixture "$corrupt" "https://github.com/example/repo.git"
+printf '[section\n' >>"$corrupt/.git/config"
+out="$("$helper" --check "$corrupt" 2>&1)" && rc=0 || rc=$?
+report "check fails closed on an unreadable git config" \
+  "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+
 if [[ $fail -ne 0 ]]; then
   echo "safe-clone self-test: FAILURES above" >&2
   exit 1

--- a/.claude/scripts/safe-clone.test.sh
+++ b/.claude/scripts/safe-clone.test.sh
@@ -113,7 +113,57 @@ git config --file "$benign_global" \
 out="$(GIT_CONFIG_GLOBAL="$benign_global" "$helper" --check "$clean" 2>&1)" && rc=0 || rc=$?
 report "credential-free insteadOf rewrite passes" "$([[ $rc -eq 0 ]] && echo yes || echo no)"
 
-# 9. Argument guards fail closed.
+# 9. pushurl is covered like url: detection, sanitize, no leak.
+pushu="$tmp/pushurl"
+mk_fixture "$pushu" "https://github.com/example/repo.git"
+git -C "$pushu" config remote.origin.pushurl "https://x:${secret}@github.com/example/repo.git"
+out="$("$helper" --check "$pushu" 2>&1)" && rc=0 || rc=$?
+report "check detects userinfo pushurl" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+out="$("$helper" --sanitize "$pushu" 2>&1)" && rc=0 || rc=$?
+report "sanitize strips pushurl userinfo" \
+  "$([[ $rc -eq 0 && "$(git -C "$pushu" config remote.origin.pushurl)" == "https://github.com/example/repo.git" ]] && echo yes || echo no)"
+report "pushurl handling does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+
+# 10. Uppercase scheme cannot bypass the userinfo check.
+upper="$tmp/upper"
+mk_fixture "$upper" "HTTPS://x:${secret}@github.com/example/repo.git"
+out="$("$helper" --check "$upper" 2>&1)" && rc=0 || rc=$?
+report "check detects uppercase-scheme userinfo remote" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+
+# 11. pushInsteadOf rewrites are guarded like insteadOf (key side).
+pio_global="$tmp/gitconfig-pushinsteadof"
+git config --file "$pio_global" \
+  "url.https://x:${secret}@github.com/.pushInsteadOf" "https://github.com/"
+out="$(GIT_CONFIG_GLOBAL="$pio_global" "$helper" --check "$clean" 2>&1)" && rc=0 || rc=$?
+report "env guard fails on credential-bearing pushInsteadOf" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+report "pushInsteadOf output does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+
+# 12. A credential in a rewrite VALUE (clean key) is caught too.
+vio_global="$tmp/gitconfig-value-rewrite"
+git config --file "$vio_global" \
+  "url.https://github.com/.insteadOf" "https://x:${secret}@github.com/"
+out="$(GIT_CONFIG_GLOBAL="$vio_global" "$helper" --check "$clean" 2>&1)" && rc=0 || rc=$?
+report "env guard fails on credential in rewrite value" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+report "value-rewrite output does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+
+# 13. http extraHeader (auth-header carrier) fails closed before config diagnostics.
+xh_global="$tmp/gitconfig-extraheader"
+git config --file "$xh_global" \
+  "http.https://github.com/.extraHeader" "AUTHORIZATION: bearer ${secret}"
+out="$(GIT_CONFIG_GLOBAL="$xh_global" "$helper" --check "$clean" 2>&1)" && rc=0 || rc=$?
+report "env guard fails on http extraHeader" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+report "extraHeader output does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+
+# 14. A rejected slug value is never echoed (it may itself be a secret URL).
+out="$("$helper" "https://x:${secret}@github.com/o/r.git" "$tmp/never2" 2>&1)" && rc=0 || rc=$?
+report "invalid slug is rejected without echoing it" \
+  "$([[ $rc -ne 0 ]] && ! grep -q "$secret" <<<"$out" && echo yes || echo no)"
+
+# 15. Argument guards fail closed.
 out="$("$helper" not-a-slug "$tmp/never" 2>&1)" && rc=0 || rc=$?
 report "invalid slug is rejected" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
 out="$("$helper" --check "$tmp/missing" 2>&1)" && rc=0 || rc=$?

--- a/.claude/scripts/safe-clone.test.sh
+++ b/.claude/scripts/safe-clone.test.sh
@@ -158,6 +158,38 @@ report "env guard fails on http extraHeader" "$([[ $rc -ne 0 ]] && echo yes || e
 report "extraHeader output does not leak the secret" \
   "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
 
+# 13b. Credentialed proxy values fail closed before config diagnostics.
+px_global="$tmp/gitconfig-proxy"
+git config --file "$px_global" http.proxy "https://user:${secret}@proxy.example.com:8080"
+out="$(GIT_CONFIG_GLOBAL="$px_global" "$helper" --check "$clean" 2>&1)" && rc=0 || rc=$?
+report "env guard fails on credentialed http.proxy" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+report "proxy output does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+
+# 13c. Multi-valued pushurl keys sanitize every value without aborting.
+multi_push="$tmp/multi-pushurl"
+mk_fixture "$multi_push" "https://github.com/example/repo.git"
+git -C "$multi_push" config --add remote.origin.pushurl "https://x:${secret}@github.com/example/a.git"
+git -C "$multi_push" config --add remote.origin.pushurl "https://github.com/example/b.git"
+out="$("$helper" --sanitize "$multi_push" 2>&1)" && rc=0 || rc=$?
+report "multi-valued pushurl sanitize exits 0" "$([[ $rc -eq 0 ]] && echo yes || echo no)"
+report "multi-valued pushurl keeps both values credential-free" \
+  "$([[ "$(git -C "$multi_push" config --get-all remote.origin.pushurl | tr '\n' ' ')" == "https://github.com/example/a.git https://github.com/example/b.git " ]] && echo yes || echo no)"
+report "multi-valued pushurl output does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+
+# 13d. Clone options outside the safe allowlist are rejected up front.
+out="$("$helper" example/repo "$tmp/never3" -c "url.https://x:${secret}@github.com/.insteadOf=https://github.com/" 2>&1)" && rc=0 || rc=$?
+report "-c clone option is rejected" \
+  "$([[ $rc -ne 0 && ! -e "$tmp/never3" ]] && echo yes || echo no)"
+report "rejected -c option does not leak the secret" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
+out="$("$helper" example/repo "$tmp/never4" --origin upstream 2>&1)" && rc=0 || rc=$?
+report "--origin clone option is rejected" "$([[ $rc -ne 0 && ! -e "$tmp/never4" ]] && echo yes || echo no)"
+out="$("$helper" example/repo "$tmp/never5" --separate-git-dir "$tmp/gitdir" 2>&1)" && rc=0 || rc=$?
+report "--separate-git-dir clone option is rejected" \
+  "$([[ $rc -ne 0 && ! -e "$tmp/never5" && ! -e "$tmp/gitdir" ]] && echo yes || echo no)"
+
 # 14. A rejected slug value is never echoed (it may itself be a secret URL).
 out="$("$helper" "https://x:${secret}@github.com/o/r.git" "$tmp/never2" 2>&1)" && rc=0 || rc=$?
 report "invalid slug is rejected without echoing it" \

--- a/.claude/scripts/safe-clone.test.sh
+++ b/.claude/scripts/safe-clone.test.sh
@@ -217,13 +217,17 @@ report "at-userinfo sanitize output does not leak the secret" \
   "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
 
 # 17. env_guard fails CLOSED when the config itself is unreadable — a corrupt
-# config must not read as "no rewrites found".
+# config must not read as "no rewrites found". The secret sits in the VALID
+# prefix before the corrupt line: `git config --list` can emit partial stdout
+# before failing, so the failure path must not echo config contents either.
 corrupt="$tmp/corrupt"
 mk_fixture "$corrupt" "https://github.com/example/repo.git"
-printf '[section\n' >>"$corrupt/.git/config"
+printf '[safeclone]\n\tfixturesecret = %s\n[section\n' "$secret" >>"$corrupt/.git/config"
 out="$("$helper" --check "$corrupt" 2>&1)" && rc=0 || rc=$?
 report "check fails closed on an unreadable git config" \
   "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+report "corrupt-config failure output does not leak config contents" \
+  "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
 
 if [[ $fail -ne 0 ]]; then
   echo "safe-clone self-test: FAILURES above" >&2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       docs-deps: ${{ steps.filter.outputs.docs-deps }}
       active-projects: ${{ steps.filter.outputs.active-projects }}
+      safe-clone: ${{ steps.filter.outputs.safe-clone }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -41,6 +42,9 @@ jobs:
               - 'docs/scripts/check-active-projects-drift.test.sh'
               - '.gitmodules'
               - 'github/devantler-tech/github-actions/actions'
+            safe-clone:
+              - '.claude/scripts/safe-clone.sh'
+              - '.claude/scripts/safe-clone.test.sh'
 
   build-docs:
     needs: changes
@@ -117,6 +121,22 @@ jobs:
       - name: Check Active Projects lists for drift
         run: bash docs/scripts/check-active-projects-drift.sh
 
+  test-safe-clone:
+    needs: changes
+    if: needs.changes.outputs.safe-clone == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      # Self-contained local fixtures (hermetic git config, synthetic secret
+      # marker) — no network, no real credentials involved.
+      - name: Self-test the safe-clone guard
+        run: bash .claude/scripts/safe-clone.test.sh
+
   status:
     name: "CI - Required Checks"
     runs-on: ubuntu-latest
@@ -125,6 +145,7 @@ jobs:
       - build-docs
       - audit-docs
       - drift-check-active-projects
+      - test-safe-clone
     permissions: {}
     steps:
       - name: Check job results
@@ -134,3 +155,4 @@ jobs:
             ${{ needs.build-docs.result }}
             ${{ needs.audit-docs.result }}
             ${{ needs.drift-check-active-projects.result }}
+            ${{ needs.test-safe-clone.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -744,6 +744,20 @@ Never `git reset --hard`, `git stash`, force-push, or discard changes you did no
 `git add -A` / `git add .` — stage only files you edited. Never stage submodule-pointer bumps unless
 a task explicitly calls for it. Leave every checkout/worktree clean when done.
 
+**Temporary clones go through the safe-clone primitive — credentials never live in remote URLs.**
+Every autonomous temporary clone uses [`safe-clone.sh`](.claude/scripts/safe-clone.sh)
+(`.claude/scripts/safe-clone.sh <owner>/<repo> <dest>`): it clones with a scrubbed environment,
+forces the canonical credential-free `origin` URL, routes auth through `gh auth git-credential`,
+and fail-closed-verifies that no HTTP(S) remote carries URL userinfo and no effective-config
+`insteadOf` rewrite embeds a credential — deleting (clone mode) or flagging (`--check`) anything
+unsafe with **redacted** output only. On any clone the helper did not create, run
+`safe-clone.sh --check <dir>` **before** any output-producing remote or trace diagnostic
+(`git remote -v`, `GIT_TRACE*`, `git config --list`, `git remote get-url`); if the guard fails,
+sanitize (`--sanitize <dir>`) or delete the clone — and treat the credential as leaked (surface
+rotation to the maintainer) — **never** print a remote URL or config listing first. (Born of the
+2026-07-10/12 incidents where a token embedded in clone remotes and in a global `insteadOf` key
+reached durable task output — monorepo#2132.)
+
 ### Context & token discipline
 Your context window is finite and **re-processed every turn** — spend it deliberately. **Delegate
 read-heavy / verbose work to subagents** (the survey → the read-only `portfolio-surveyor`, which

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -746,7 +746,10 @@ a task explicitly calls for it. Leave every checkout/worktree clean when done.
 
 **Temporary clones go through the safe-clone primitive — credentials never live in remote URLs.**
 Every autonomous temporary clone uses [`safe-clone.sh`](.claude/scripts/safe-clone.sh)
-(`.claude/scripts/safe-clone.sh <owner>/<repo> <dest>`): it clones with a scrubbed environment,
+(`.claude/scripts/safe-clone.sh <owner>/<repo> <dest>`): it guards the effective git config against
+credential-bearing rewrites (`insteadOf`/`pushInsteadOf`), auth `extraHeader`s, and credentialed
+proxies before cloning (the environment is deliberately NOT scrubbed — `gh auth git-credential`
+needs `GITHUB_TOKEN`/`GH_TOKEN`),
 forces the canonical credential-free `origin` URL, routes auth through `gh auth git-credential`,
 and fail-closed-verifies that no HTTP(S) remote carries URL userinfo and no effective-config
 `insteadOf` rewrite embeds a credential — deleting (clone mode) or flagging (`--check`) anything


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
Agent temporary clones have twice leaked a GitHub credential into durable task output (2026-07-10 and 2026-07-12) — once via a remote URL carrying userinfo and once via a token embedded in a host-level git `insteadOf` rewrite that surfaces through `git remote -v` even on clean clones. Warnings in memory did not prevent recurrence; the workflow needs an enforced, tested guard.

## What
Adds one shared safe-clone primitive that produces credential-free clones, fails closed (redacted output only) on both leak mechanisms, and is self-tested in CI; the engineering contract now requires it before any output-producing remote/trace diagnostic.

Fixes #2132