### PR TITLE
fix(ai-engineer): clean interrupted safe clones

### DIFF
--- a/.claude/scripts/safe-clone.sh
+++ b/.claude/scripts/safe-clone.sh
@@ -96,6 +96,24 @@ guard() {
   return 0
 }
 
+# path_identity <path> — emit a stable device:inode pair without printing the
+# path. BSD/macOS and GNU stat use different format flags, so try both and
+# accept only the numeric shape expected from either implementation.
+path_identity() {
+  local identity
+  identity="$(stat -f '%d:%i' "$1" 2>/dev/null)" || true
+  if [[ "$identity" =~ ^[0-9]+:[0-9]+$ ]]; then
+    printf '%s\n' "$identity"
+    return 0
+  fi
+  identity="$(stat -c '%d:%i' "$1" 2>/dev/null)" || true
+  if [[ "$identity" =~ ^[0-9]+:[0-9]+$ ]]; then
+    printf '%s\n' "$identity"
+    return 0
+  fi
+  return 1
+}
+
 # sanitize <dir> — rewrite every credential-bearing http(s) remote URL to its
 # userinfo-free form in place. Keys are rewritten wholesale (unset-all, then
 # re-add each stripped value) because pushurl is multi-valued and a plain
@@ -198,13 +216,74 @@ case "${1:-}" in
 
     url="https://github.com/${slug}.git"
 
+    # Claim the destination atomically and record its identity. If identity
+    # capture itself fails, rmdir is deliberately used instead of recursive
+    # removal: it can clean our still-empty claim without risking user data.
+    mkdir "$dest" || fail "could not claim destination for ${slug}"
+    if ! clone_dest_identity="$(path_identity "$dest")"; then
+      rmdir "$dest" >/dev/null 2>&1 || true
+      fail "could not verify ownership of the claimed destination for ${slug}"
+    fi
+
+    # The claimed destination belongs to this invocation until the clone,
+    # canonical remote rewrite, credential-helper setup, and both guards have
+    # all succeeded. Clean it on ordinary failures and catchable interruptions
+    # so a partial pack / refs/heads/.invalid checkout cannot survive as if it
+    # were a valid isolated worktree.
+    clone_committed=0
+    cleanup_partial_clone() {
+      local rc=$? cleanup_failed=0 quarantine_root="" quarantine_path=""
+      local quarantined_identity="" dest_parent=""
+      trap - EXIT HUP INT TERM
+      if [[ $clone_committed -eq 0 && -e "$dest" ]]; then
+        # Never check an identity and then recursively delete that same path:
+        # another process could replace it between those two lookups. Move the
+        # current path atomically into a private, same-parent quarantine first,
+        # then verify the moved directory. A raced replacement remains in
+        # quarantine and is never passed to rm or moved onto another path.
+        dest_parent="$(dirname -- "$dest")"
+        if quarantine_root="$(mktemp -d "${dest_parent}/.safe-clone-cleanup.XXXXXX" 2>/dev/null)"; then
+          quarantine_path="${quarantine_root}/clone"
+          if mv -- "$dest" "$quarantine_path" >/dev/null 2>&1; then
+            quarantined_identity="$(path_identity "$quarantine_path")" || true
+            if [[ -n "$quarantined_identity" && "$quarantined_identity" == "$clone_dest_identity" ]]; then
+              if ! rm -rf -- "$quarantine_root" >/dev/null 2>&1; then
+                cleanup_failed=1
+              fi
+            else
+              echo "safe-clone: partial destination ownership changed; refusing to delete it" >&2
+              # The replacement remains preserved under the private
+              # quarantine root. Never try to restore it: portable mv treats
+              # a concurrently recreated destination as a directory and can
+              # silently nest the quarantined data inside it.
+              cleanup_failed=1
+            fi
+          else
+            rmdir "$quarantine_root" >/dev/null 2>&1 || true
+            cleanup_failed=1
+          fi
+        else
+          cleanup_failed=1
+        fi
+      fi
+      if [[ $cleanup_failed -ne 0 ]]; then
+        echo "safe-clone: partial destination cleanup failed (details redacted)" >&2
+      fi
+      exit "$rc"
+    }
+    trap cleanup_partial_clone EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+
     # No env scrubbing here: plain `git clone` never reads GITHUB_TOKEN /
     # GH_TOKEN, and the `gh auth git-credential` helper NEEDS them on hosts
     # where gh is authenticated only via environment token. The guard below
     # verifies nothing token-shaped was persisted regardless.
-    git -c credential.helper='!gh auth git-credential' \
-      clone --quiet "$@" "$url" "$dest" ||
+    if ! git -c credential.helper='!gh auth git-credential' \
+      clone --quiet "$@" "$url" "$dest" >/dev/null 2>&1; then
       fail "clone failed for ${slug}"
+    fi
 
     # Belt-and-braces: force the canonical credential-free URL and wire the
     # helper for future authenticated fetch/push from this clone.
@@ -215,10 +294,11 @@ case "${1:-}" in
     # options (e.g. `-c url.<...>.insteadOf=...`) can write config into the
     # new repository that the pre-clone environment check never saw.
     if ! guard "$dest" || ! env_guard "$dest"; then
-      rm -rf "$dest"
-      fail "clone of ${slug} failed the credential guard; clone removed — rotate the credential before retrying"
+      fail "clone of ${slug} failed the credential guard; clone refused — rotate the credential before retrying"
     fi
 
+    clone_committed=1
+    trap - EXIT HUP INT TERM
     echo "safe-clone: ${slug} -> ${dest} (remotes credential-free)"
     ;;
 esac

--- a/.claude/scripts/safe-clone.test.sh
+++ b/.claude/scripts/safe-clone.test.sh
@@ -248,6 +248,9 @@ printf '%s\n' \
   '  if [[ "${FAKE_GIT_MODE:-failure}" == "success" ]]; then' \
   '    "${REAL_GIT:?}" init --quiet "$dest"' \
   '    "${REAL_GIT:?}" -C "$dest" remote add origin https://github.com/example/repo.git' \
+  '    if [[ -n "${FAKE_GIT_REMOTE_URL:-}" ]]; then' \
+  '      "${REAL_GIT:?}" -C "$dest" remote add upstream "$FAKE_GIT_REMOTE_URL"' \
+  '    fi' \
   '    exit 0' \
   '  fi' \
   '  mkdir -p "$dest/.git/objects/pack"' \
@@ -278,6 +281,17 @@ out="$(FAKE_GIT_MODE=success REAL_GIT="$real_git" PATH="$fake_bin:$PATH" "$helpe
 report "successful clone mode exits 0" "$([[ $rc -eq 0 ]] && echo yes || echo no)"
 report "successful clone mode keeps a valid checkout" \
   "$([[ -d "$successful/.git" ]] && "$helper" --check "$successful" >/dev/null 2>&1 && echo yes || echo no)"
+
+guard_failed="$tmp/post-clone-guard-failure"
+unsafe_remote="https://x-access-token:${secret}@github.com/example/repo.git"
+out="$(FAKE_GIT_MODE=success FAKE_GIT_REMOTE_URL="$unsafe_remote" REAL_GIT="$real_git" \
+  PATH="$fake_bin:$PATH" "$helper" example/repo "$guard_failed" 2>&1)" && rc=0 || rc=$?
+report "post-clone credential guard fails clone mode" \
+  "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+report "post-clone credential guard removes its destination" \
+  "$([[ ! -e "$guard_failed" ]] && echo yes || echo no)"
+report "post-clone credential guard output remains redacted" \
+  "$(! grep -Eq "https?://|${secret}" <<<"$out" && echo yes || echo no)"
 
 partial="$tmp/partial-clone"
 out="$(FAKE_GIT_SECRET="$secret" REAL_GIT="$real_git" PATH="$fake_bin:$PATH" "$helper" example/repo "$partial" 2>&1)" && rc=0 || rc=$?

--- a/.claude/scripts/safe-clone.test.sh
+++ b/.claude/scripts/safe-clone.test.sh
@@ -229,6 +229,149 @@ report "check fails closed on an unreadable git config" \
 report "corrupt-config failure output does not leak config contents" \
   "$(grep -q "$secret" <<<"$out" && echo no || echo yes)"
 
+# 18. A clone failure that has already created a partial destination must not
+# leave that unusable checkout behind. Use a fake git binary so the fixture is
+# local, deterministic, and exercises the helper's failure path without a
+# network request.
+fake_bin="$tmp/fake-bin"
+mkdir -p "$fake_bin"
+# The quoted fixture lines must expand only when the generated fake git runs.
+# shellcheck disable=SC2016
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -Eeuo pipefail' \
+  'if [[ "$1" == "config" && "$2" == "--list" ]]; then' \
+  '  exit 0' \
+  'fi' \
+  'if [[ "$1" == "-c" ]]; then' \
+  '  dest="${!#}"' \
+  '  if [[ "${FAKE_GIT_MODE:-failure}" == "success" ]]; then' \
+  '    "${REAL_GIT:?}" init --quiet "$dest"' \
+  '    "${REAL_GIT:?}" -C "$dest" remote add origin https://github.com/example/repo.git' \
+  '    exit 0' \
+  '  fi' \
+  '  mkdir -p "$dest/.git/objects/pack"' \
+  '  printf "ref: refs/heads/.invalid\\n" >"$dest/.git/HEAD"' \
+  '  printf partial >"$dest/.git/objects/pack/tmp_pack_fixture"' \
+  '  if [[ -n "${FAKE_GIT_SECRET:-}" ]]; then' \
+  '    printf "clone diagnostic: %s\\n" "$FAKE_GIT_SECRET" >&2' \
+  '  fi' \
+  '  if [[ "${FAKE_GIT_MODE:-failure}" == "replace" ]]; then' \
+  '    mv "$dest" "${dest}.owned"' \
+  '    mkdir -p "$dest"' \
+  '    printf unrelated >"$dest/sentinel"' \
+  '    exit 42' \
+  '  fi' \
+  '  if [[ "${FAKE_GIT_MODE:-failure}" == "interrupt" ]]; then' \
+  '    kill -s "${FAKE_SIGNAL:-TERM}" "$PPID"' \
+  '    sleep 0.1' \
+  '    exit 143' \
+  '  fi' \
+  '  exit 42' \
+  'fi' \
+  'exec "${REAL_GIT:?}" "$@"' >"$fake_bin/git"
+chmod +x "$fake_bin/git"
+real_git="$(command -v git)"
+
+successful="$tmp/successful-clone"
+out="$(FAKE_GIT_MODE=success REAL_GIT="$real_git" PATH="$fake_bin:$PATH" "$helper" example/repo "$successful" 2>&1)" && rc=0 || rc=$?
+report "successful clone mode exits 0" "$([[ $rc -eq 0 ]] && echo yes || echo no)"
+report "successful clone mode keeps a valid checkout" \
+  "$([[ -d "$successful/.git" ]] && "$helper" --check "$successful" >/dev/null 2>&1 && echo yes || echo no)"
+
+partial="$tmp/partial-clone"
+out="$(FAKE_GIT_SECRET="$secret" REAL_GIT="$real_git" PATH="$fake_bin:$PATH" "$helper" example/repo "$partial" 2>&1)" && rc=0 || rc=$?
+report "failed clone exits non-zero" "$([[ $rc -ne 0 ]] && echo yes || echo no)"
+report "failed clone removes its partial destination" \
+  "$([[ ! -e "$partial" ]] && echo yes || echo no)"
+report "failed clone output remains redacted" \
+  "$(! grep -Eq "https?://|${secret}" <<<"$out" && echo yes || echo no)"
+
+replacement="$tmp/replaced-clone"
+out="$(FAKE_GIT_MODE=replace PATH="$fake_bin:$PATH" "$helper" example/repo "$replacement" 2>&1)" && rc=0 || rc=$?
+replacement_quarantine="$(find "$tmp" -path '*/.safe-clone-cleanup.*/clone/sentinel' -type f -print -quit)"
+report "failed clone quarantines a replaced destination without deleting or restoring it" \
+  "$([[ $rc -ne 0 && ! -e "$replacement" && -n "$replacement_quarantine" ]] && echo yes || echo no)"
+
+# Replace the destination after cleanup's identity read, then return the old
+# identity. This deterministically catches a check-then-rm implementation:
+# only moving the path aside and verifying it after that atomic rename can
+# prove a replacement will not be recursively deleted.
+fake_stat_bin="$tmp/fake-stat-bin"
+mkdir -p "$fake_stat_bin"
+stat_state="$tmp/stat-state"
+printf '0\n' >"$stat_state"
+# The quoted fixture variables must expand only in the generated fake stat.
+# shellcheck disable=SC2016
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -Eeuo pipefail' \
+  'value="$("${REAL_STAT:?}" "$@" 2>/dev/null)" || exit $?' \
+  'if [[ "$value" =~ ^[0-9]+:[0-9]+$ ]]; then' \
+  '  count="$(<"${FAKE_STAT_STATE:?}")"' \
+  '  if [[ "$count" == "0" ]]; then' \
+  '    printf "1\\n" >"$FAKE_STAT_STATE"' \
+  '  else' \
+  '    if [[ -e "${FAKE_STAT_DEST:?}" ]]; then' \
+  '      mv "$FAKE_STAT_DEST" "${FAKE_STAT_DEST}.owned-late"' \
+  '    fi' \
+  '    mkdir -p "$FAKE_STAT_DEST"' \
+  '    printf unrelated >"$FAKE_STAT_DEST/sentinel"' \
+  '  fi' \
+  'fi' \
+  'printf "%s\\n" "$value"' >"$fake_stat_bin/stat"
+chmod +x "$fake_stat_bin/stat"
+late_replacement="$tmp/late-replaced-clone"
+out="$(REAL_STAT="$(command -v stat)" FAKE_STAT_STATE="$stat_state" \
+  FAKE_STAT_DEST="$late_replacement" PATH="$fake_stat_bin:$fake_bin:$PATH" \
+  "$helper" example/repo "$late_replacement" 2>&1)" && rc=0 || rc=$?
+report "cleanup cannot delete a destination replaced after its identity read" \
+  "$([[ $rc -ne 0 && -f "$late_replacement/sentinel" ]] && echo yes || echo no)"
+
+# Identity capture itself can fail on a constrained host. The newly-created,
+# still-empty claim must be removed before failing so retrying is possible.
+fake_stat_failure_bin="$tmp/fake-stat-failure-bin"
+mkdir -p "$fake_stat_failure_bin"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$fake_stat_failure_bin/stat"
+chmod +x "$fake_stat_failure_bin/stat"
+identity_failure="$tmp/identity-failure"
+out="$(PATH="$fake_stat_failure_bin:$fake_bin:$PATH" \
+  "$helper" example/repo "$identity_failure" 2>&1)" && rc=0 || rc=$?
+report "identity-capture failure removes the empty destination claim" \
+  "$([[ $rc -ne 0 && ! -e "$identity_failure" ]] && echo yes || echo no)"
+
+fake_rm_bin="$tmp/fake-rm-bin"
+mkdir -p "$fake_rm_bin"
+# The quoted fixture variable must expand only in the generated fake rm.
+# shellcheck disable=SC2016
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "cleanup diagnostic: %s\\n" "${FAKE_RM_SECRET:-}" >&2' \
+  'exit 77' >"$fake_rm_bin/rm"
+chmod +x "$fake_rm_bin/rm"
+cleanup_failure="$tmp/cleanup-failure"
+out="$(FAKE_RM_SECRET="$secret" PATH="$fake_rm_bin:$fake_bin:$PATH" "$helper" example/repo "$cleanup_failure" 2>&1)" && rc=0 || rc=$?
+report "cleanup failure preserves the clone failure status" \
+  "$([[ $rc -eq 1 ]] && echo yes || echo no)" "got exit $rc instead of 1"
+report "cleanup failure output remains redacted" \
+  "$(! grep -Eq "https?://|${secret}" <<<"$out" && echo yes || echo no)"
+report "clone failure does not claim cleanup succeeded before the EXIT trap" \
+  "$(! grep -q "partial destination removed" <<<"$out" && echo yes || echo no)"
+"$(command -v rm)" -rf "$cleanup_failure"
+
+for signal_spec in HUP:129 INT:130 TERM:143; do
+  signal="${signal_spec%%:*}"
+  expected="${signal_spec##*:}"
+  interrupted="$tmp/interrupted-clone-${signal}"
+  out="$(FAKE_GIT_MODE=interrupt FAKE_SIGNAL="$signal" FAKE_GIT_SECRET="$secret" PATH="$fake_bin:$PATH" "$helper" example/repo "$interrupted" 2>&1)" && rc=0 || rc=$?
+  report "$signal interruption preserves exit status $expected" \
+    "$([[ $rc -eq $expected ]] && echo yes || echo no)" "got exit $rc"
+  report "$signal interruption removes its partial destination" \
+    "$([[ ! -e "$interrupted" ]] && echo yes || echo no)"
+  report "$signal interruption output remains redacted" \
+    "$(! grep -Eq "https?://|${secret}" <<<"$out" && echo yes || echo no)"
+done
+
 if [[ $fail -ne 0 ]]; then
   echo "safe-clone self-test: FAILURES above" >&2
   exit 1

--- a/.claude/scripts/safe-clone.test.sh
+++ b/.claude/scripts/safe-clone.test.sh
@@ -288,8 +288,9 @@ out="$(FAKE_GIT_MODE=success FAKE_GIT_REMOTE_URL="$unsafe_remote" REAL_GIT="$rea
   PATH="$fake_bin:$PATH" "$helper" example/repo "$guard_failed" 2>&1)" && rc=0 || rc=$?
 report "post-clone credential guard fails clone mode" \
   "$([[ $rc -ne 0 ]] && echo yes || echo no)"
-report "post-clone credential guard removes its destination" \
-  "$([[ ! -e "$guard_failed" ]] && echo yes || echo no)"
+guard_quarantine="$(find "$tmp" -maxdepth 1 -type d -name '.safe-clone-cleanup.*' -print)"
+report "post-clone credential guard removes its destination and quarantine" \
+  "$([[ ! -e "$guard_failed" && -z "$guard_quarantine" ]] && echo yes || echo no)"
 report "post-clone credential guard output remains redacted" \
   "$(! grep -Eq "https?://|${secret}" <<<"$out" && echo yes || echo no)"
 

--- a/.claude/scripts/safe-clone.test.sh
+++ b/.claude/scripts/safe-clone.test.sh
@@ -288,7 +288,13 @@ out="$(FAKE_GIT_MODE=success FAKE_GIT_REMOTE_URL="$unsafe_remote" REAL_GIT="$rea
   PATH="$fake_bin:$PATH" "$helper" example/repo "$guard_failed" 2>&1)" && rc=0 || rc=$?
 report "post-clone credential guard fails clone mode" \
   "$([[ $rc -ne 0 ]] && echo yes || echo no)"
-guard_quarantine="$(find "$tmp" -maxdepth 1 -type d -name '.safe-clone-cleanup.*' -print)"
+guard_quarantine=
+for candidate in "$tmp"/.safe-clone-cleanup.*; do
+  if [[ -d "$candidate" ]]; then
+    guard_quarantine="$candidate"
+    break
+  fi
+done
 report "post-clone credential guard removes its destination and quarantine" \
   "$([[ ! -e "$guard_failed" && -z "$guard_quarantine" ]] && echo yes || echo no)"
 report "post-clone credential guard output remains redacted" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,11 @@ jobs:
   test-safe-clone:
     needs: changes
     if: needs.changes.outputs.safe-clone == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The first live scheduled-run use of the new safe-clone primitive exposed an abnormal-exit gap: an interrupted `git clone` could leave a large partial destination whose `HEAD` pointed at `refs/heads/.invalid`. The credential guard correctly found no URL userinfo, but the unusable directory could then be mistaken for a valid isolated checkout.

Fixes #2136.

## What changed

- Atomically claim the destination and retain its device/inode identity until clone setup and both credential guards complete.
- On failure or catchable `HUP`, `INT`, and `TERM`, atomically move the path into a private same-parent quarantine before checking ownership; only the directory created by this invocation is recursively removed.
- Preserve a raced replacement in quarantine without deleting or restoring it, avoiding both check-then-delete and portable `mv` nesting races.
- Preserve the original failure/signal exit status, keep diagnostics redacted, and disarm cleanup only after successful verification.
- Add hermetic fake-git/stat/rm regressions for ordinary failure, all three signals, cleanup failure, ownership replacement before and after identity reads, identity-capture failure, and the successful path.

## Validation

- TDD red/green: ordinary failure and `HUP`/`INT`/`TERM` interruption cleanup.
- TDD red/green: a destination replaced before cleanup and after its identity read is never recursively deleted.
- TDD red/green: identity-capture failure removes only the empty claim; cleanup failure preserves the original status and never leaks diagnostics.
- TDD red/green: cleanup does not restore mismatched data with a portable `mv` or claim success before the EXIT trap runs.
- All safe-clone self-tests pass, including the unchanged successful-clone and credential-guard cases.
- `bash -n .claude/scripts/safe-clone.sh .claude/scripts/safe-clone.test.sh`
- `shellcheck .claude/scripts/safe-clone.sh .claude/scripts/safe-clone.test.sh`
- `git diff --check`

No credential/trust guard is relaxed; the change only tightens failure cleanup.
