### PR TITLE
fix(ai-engineer): verify live auth before blocking

### DIFF
--- a/.claude/scripts/maintainer-preflight.test.sh
+++ b/.claude/scripts/maintainer-preflight.test.sh
@@ -14,8 +14,11 @@ fail() {
 grep -Fq 'sandboxed' "${run_loop}" ||
   fail "missing the sandboxed saved-login failure case"
 
-grep -Fq 'env -u GH_TOKEN -u GITHUB_TOKEN gh auth status' "${run_loop}" ||
+grep -Fq 'env -u GH_TOKEN -u GITHUB_TOKEN gh auth status --active --hostname github.com' "${run_loop}" ||
   fail "saved-login probe does not clear both injected-token variables"
+
+grep -Fq "If the saved login is selected, prefix every subsequent \`gh\` command with \`env -u GH_TOKEN -u GITHUB_TOKEN\`" "${run_loop}" ||
+  fail "saved-login fallback does not neutralize env tokens for later gh commands"
 
 grep -Fq 'approved host-level execution path' "${run_loop}" ||
   fail "missing the required host-level keychain retry"

--- a/.claude/scripts/maintainer-preflight.test.sh
+++ b/.claude/scripts/maintainer-preflight.test.sh
@@ -3,7 +3,8 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-run_loop="${repo_root}/.claude/skills/portfolio-maintenance/SKILL.md"
+run_loop="${1:-${repo_root}/.claude/skills/portfolio-maintenance/SKILL.md}"
+routine_prompt="${2:-}"
 
 fail() {
   echo "maintainer preflight contract: FAIL — $*" >&2
@@ -21,5 +22,26 @@ grep -Fq 'approved host-level execution path' "${run_loop}" ||
 
 grep -Fq 'A sandbox-only failure is not evidence that the saved login is invalid.' "${run_loop}" ||
   fail "missing the fail-closed sandbox false-negative rule"
+
+grep -Fq 'classify the saved login as indeterminate' "${run_loop}" ||
+  fail "missing the indeterminate sandbox classification"
+
+grep -Fq 'authentication verification unavailable' "${run_loop}" ||
+  fail "missing the unavailable host-verification classification"
+
+grep -Fq 'Only an explicit credential rejection from that host-level check proves the saved login invalid.' "${run_loop}" ||
+  fail "missing the host-confirmed invalid classification"
+
+grep -Fq 'record only these gate classifications in durable memory' "${run_loop}" ||
+  fail "missing the credential-safe memory rule"
+
+if [[ -n "${routine_prompt}" ]]; then
+  grep -Fq '.claude/agents/daily-maintainer.md' "${routine_prompt}" ||
+    fail "routine prompt does not hand off to the versioned definition"
+
+  if grep -Fq 'gh auth status' "${routine_prompt}"; then
+    fail "routine prompt duplicates the versioned authentication preflight"
+  fi
+fi
 
 echo "maintainer preflight contract: all assertions passed"

--- a/.claude/scripts/maintainer-preflight.test.sh
+++ b/.claude/scripts/maintainer-preflight.test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+run_loop="${repo_root}/.claude/skills/portfolio-maintenance/SKILL.md"
+
+fail() {
+  echo "maintainer preflight contract: FAIL — $*" >&2
+  exit 1
+}
+
+grep -Fq 'sandboxed' "${run_loop}" ||
+  fail "missing the sandboxed saved-login failure case"
+
+grep -Fq 'env -u GITHUB_TOKEN gh auth status' "${run_loop}" ||
+  fail "missing the injected-token fallback command"
+
+grep -Fq 'approved host-level execution path' "${run_loop}" ||
+  fail "missing the required host-level keychain retry"
+
+grep -Fq 'A sandbox-only failure is not evidence that the saved login is invalid.' "${run_loop}" ||
+  fail "missing the fail-closed sandbox false-negative rule"
+
+echo "maintainer preflight contract: all assertions passed"

--- a/.claude/scripts/maintainer-preflight.test.sh
+++ b/.claude/scripts/maintainer-preflight.test.sh
@@ -14,8 +14,8 @@ fail() {
 grep -Fq 'sandboxed' "${run_loop}" ||
   fail "missing the sandboxed saved-login failure case"
 
-grep -Fq 'env -u GITHUB_TOKEN gh auth status' "${run_loop}" ||
-  fail "missing the injected-token fallback command"
+grep -Fq 'env -u GH_TOKEN -u GITHUB_TOKEN gh auth status' "${run_loop}" ||
+  fail "saved-login probe does not clear both injected-token variables"
 
 grep -Fq 'approved host-level execution path' "${run_loop}" ||
   fail "missing the required host-level keychain retry"

--- a/.claude/scripts/maintainer-preflight.test.sh
+++ b/.claude/scripts/maintainer-preflight.test.sh
@@ -17,8 +17,14 @@ grep -Fq 'sandboxed' "${run_loop}" ||
 grep -Fq 'env -u GH_TOKEN -u GITHUB_TOKEN gh auth status --active --hostname github.com' "${run_loop}" ||
   fail "saved-login probe does not clear both injected-token variables"
 
+grep -Fq "active account other than \`devantler\`" "${run_loop}" ||
+  fail "saved-login fallback does not cover a valid token for the wrong account"
+
 grep -Fq "If the saved login is selected, prefix every subsequent \`gh\` command with \`env -u GH_TOKEN -u GITHUB_TOKEN\`" "${run_loop}" ||
   fail "saved-login fallback does not neutralize env tokens for later gh commands"
+
+grep -Fq "If only the host-level saved-login check succeeds, run every subsequent \`gh\` command through that" "${run_loop}" ||
+  fail "host-only keychain access is not preserved for later gh commands"
 
 grep -Fq 'approved host-level execution path' "${run_loop}" ||
   fail "missing the required host-level keychain retry"

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -27,6 +27,14 @@ card.
    `main` is behind `origin/main` and the only dirt is submodule pointers, fast-forward with
    `git fetch origin main && git merge --ff-only origin/main` (it never checks out submodule contents;
    `--ff-only` refuses anything that isn't a clean fast-forward).
+   When `gh auth status` reports an invalid credential, retry once as
+   `env -u GITHUB_TOKEN gh auth status` to separate an injected-token failure from the saved login.
+   In a runtime that sandboxes macOS keychain access, if the sandboxed `env -u GITHUB_TOKEN gh auth status`
+   also fails, repeat that exact check once through the approved host-level execution path before
+   declaring the saved login broken. A sandbox-only failure is not evidence that the saved login is invalid.
+   Continue when the host-level check authenticates
+   `devantler`; hard-block only when that live check also fails. Keep this identity gate separate from
+   `git fetch`, because repository reachability cannot prove GitHub API identity (and vice versa).
 3. **Load durable memory:** **`view` your native memory** (Claude: the memory tool / the project
    `memory/` dir + `MEMORY.md`) — the single source of truth for cross-run orchestration (rotation
    cursor, per-product `last_worked`/`weekly`/roadmap cursor/`needs_attention`, CI & link caches, recent

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -28,10 +28,11 @@ card.
    `git fetch origin main && git merge --ff-only origin/main` (it never checks out submodule contents;
    `--ff-only` refuses anything that isn't a clean fast-forward).
    When `gh auth status` reports an invalid credential, retry once as
-   `env -u GITHUB_TOKEN gh auth status` to separate an injected-token failure from the saved login.
-   In a runtime that sandboxes macOS keychain access, if the sandboxed `env -u GITHUB_TOKEN gh auth status`
-   also fails, classify the saved login as indeterminate and repeat that exact check once through the
-   approved host-level execution path. A sandbox-only failure is not evidence that the saved login is invalid.
+   `env -u GH_TOKEN -u GITHUB_TOKEN gh auth status` to clear both environment-token sources and test the
+   saved login. In a runtime that sandboxes macOS keychain access, if that sandboxed saved-login check also
+   fails, classify the saved login as indeterminate.
+   Repeat the exact command once through the approved host-level execution path.
+   A sandbox-only failure is not evidence that the saved login is invalid.
    Continue when the host-level check authenticates `devantler`.
    Only an explicit credential rejection from that host-level check proves the saved login invalid.
    If the host-level check cannot run or fails

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -28,17 +28,24 @@ card.
    `main` is behind `origin/main` and the only dirt is submodule pointers, fast-forward with
    `git fetch origin main && git merge --ff-only origin/main` (it never checks out submodule contents;
    `--ff-only` refuses anything that isn't a clean fast-forward).
-   When `gh auth status --active --hostname github.com` reports an invalid credential, retry once as
+   When `gh auth status --active --hostname github.com` reports an invalid credential or authenticates
+   an active account other than `devantler`, retry once as
    `env -u GH_TOKEN -u GITHUB_TOKEN gh auth status --active --hostname github.com` to clear both
-   environment-token sources and test the active saved login for the host this portfolio uses. In a runtime
-   that sandboxes macOS keychain access, if that sandboxed saved-login check also fails:
+   environment-token sources and test the active saved login for the host this portfolio uses. Accept either
+   probe only when it authenticates `devantler`. In a runtime that sandboxes macOS keychain access, if that
+   sandboxed saved-login check also fails to authenticate `devantler`:
    classify the saved login as indeterminate.
    Repeat the exact command once through the approved host-level execution path.
    A sandbox-only failure is not evidence that the saved login is invalid.
    Continue when the host-level check authenticates `devantler`.
    If the saved login is selected, prefix every subsequent `gh` command with `env -u GH_TOKEN -u GITHUB_TOKEN`.
    This prevents a rejected injected token from overriding the verified login again.
+   If only the host-level saved-login check succeeds, run every subsequent `gh` command through that
+   approved host-level execution path.
+   Clearing the injected tokens does not make a sandboxed macOS Keychain readable.
    Only an explicit credential rejection from that host-level check proves the saved login invalid.
+   If the host-level check instead authenticates a different account, hard-block as `wrong GitHub identity`
+   without describing the credential as invalid.
    If the host-level check cannot run or fails
    for a transport reason, hard-block as `authentication verification unavailable` instead of instructing
    the maintainer to replace a credential that was never tested. Keep the injected-token result, saved-login

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -30,11 +30,15 @@ card.
    When `gh auth status` reports an invalid credential, retry once as
    `env -u GITHUB_TOKEN gh auth status` to separate an injected-token failure from the saved login.
    In a runtime that sandboxes macOS keychain access, if the sandboxed `env -u GITHUB_TOKEN gh auth status`
-   also fails, repeat that exact check once through the approved host-level execution path before
-   declaring the saved login broken. A sandbox-only failure is not evidence that the saved login is invalid.
-   Continue when the host-level check authenticates
-   `devantler`; hard-block only when that live check also fails. Keep this identity gate separate from
-   `git fetch`, because repository reachability cannot prove GitHub API identity (and vice versa).
+   also fails, classify the saved login as indeterminate and repeat that exact check once through the
+   approved host-level execution path. A sandbox-only failure is not evidence that the saved login is invalid.
+   Continue when the host-level check authenticates `devantler`.
+   Only an explicit credential rejection from that host-level check proves the saved login invalid.
+   If the host-level check cannot run or fails
+   for a transport reason, hard-block as `authentication verification unavailable` instead of instructing
+   the maintainer to replace a credential that was never tested. Keep the injected-token result, saved-login
+   result, and `git fetch` result as separate gates, because repository reachability cannot prove GitHub API
+   identity (and vice versa); record only these gate classifications in durable memory, never credential output.
 3. **Load durable memory:** **`view` your native memory** (Claude: the memory tool / the project
    `memory/` dir + `MEMORY.md`) — the single source of truth for cross-run orchestration (rotation
    cursor, per-product `last_worked`/`weekly`/roadmap cursor/`needs_attention`, CI & link caches, recent

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -22,18 +22,22 @@ card.
    Only if it is somehow *not* already in your context should you read it once.
 2. **Working checkout:** `cd /Users/homelab-mac-mini/git-personal/monorepo` (this deployment's primary
    checkout — the scheduled task runs on a fixed machine; adjust the path if relocated); confirm
-   (`test -d docs && test -f .gitmodules`); `gh auth status` shows `devantler`. **Sync the definition:**
+   (`test -d docs && test -f .gitmodules`); `gh auth status --active --hostname github.com` shows
+   `devantler`. **Sync the definition:**
    this checkout carries permanent submodule-pointer drift, so don't gate on a fully clean tree — if
    `main` is behind `origin/main` and the only dirt is submodule pointers, fast-forward with
    `git fetch origin main && git merge --ff-only origin/main` (it never checks out submodule contents;
    `--ff-only` refuses anything that isn't a clean fast-forward).
-   When `gh auth status` reports an invalid credential, retry once as
-   `env -u GH_TOKEN -u GITHUB_TOKEN gh auth status` to clear both environment-token sources and test the
-   saved login. In a runtime that sandboxes macOS keychain access, if that sandboxed saved-login check also
-   fails, classify the saved login as indeterminate.
+   When `gh auth status --active --hostname github.com` reports an invalid credential, retry once as
+   `env -u GH_TOKEN -u GITHUB_TOKEN gh auth status --active --hostname github.com` to clear both
+   environment-token sources and test the active saved login for the host this portfolio uses. In a runtime
+   that sandboxes macOS keychain access, if that sandboxed saved-login check also fails:
+   classify the saved login as indeterminate.
    Repeat the exact command once through the approved host-level execution path.
    A sandbox-only failure is not evidence that the saved login is invalid.
    Continue when the host-level check authenticates `devantler`.
+   If the saved login is selected, prefix every subsequent `gh` command with `env -u GH_TOKEN -u GITHUB_TOKEN`.
+   This prevents a rejected injected token from overriding the verified login again.
    Only an explicit credential rejection from that host-level check proves the saved login invalid.
    If the host-level check cannot run or fails
    for a transport reason, hard-block as `authentication verification unavailable` instead of instructing

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,6 +156,7 @@ jobs:
         run: bash .claude/scripts/safe-clone.test.sh
 
   test-maintainer-preflight:
+    name: Test maintainer preflight contract
     needs: changes
     if: needs.changes.outputs.maintainer-preflight == 'true'
     runs-on: ubuntu-latest
@@ -170,6 +171,7 @@ jobs:
         run: bash .claude/scripts/maintainer-preflight.test.sh
 
   test-product-value-contract:
+    name: Test product value contract
     needs: changes
     if: needs.changes.outputs.product-value == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
       docs-deps: ${{ steps.filter.outputs.docs-deps }}
       active-projects: ${{ steps.filter.outputs.active-projects }}
       safe-clone: ${{ steps.filter.outputs.safe-clone }}
+      maintainer-preflight: ${{ steps.filter.outputs.maintainer-preflight }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -45,6 +46,9 @@ jobs:
             safe-clone:
               - '.claude/scripts/safe-clone.sh'
               - '.claude/scripts/safe-clone.test.sh'
+            maintainer-preflight:
+              - '.claude/skills/portfolio-maintenance/SKILL.md'
+              - '.claude/scripts/maintainer-preflight.test.sh'
 
   build-docs:
     needs: changes
@@ -141,6 +145,20 @@ jobs:
       - name: Self-test the safe-clone guard
         run: bash .claude/scripts/safe-clone.test.sh
 
+  test-maintainer-preflight:
+    needs: changes
+    if: needs.changes.outputs.maintainer-preflight == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Verify the maintainer preflight contract
+        run: bash .claude/scripts/maintainer-preflight.test.sh
+
   status:
     name: "CI - Required Checks"
     runs-on: ubuntu-latest
@@ -150,6 +168,7 @@ jobs:
       - audit-docs
       - drift-check-active-projects
       - test-safe-clone
+      - test-maintainer-preflight
     permissions: {}
     steps:
       - name: Check job results
@@ -160,3 +179,4 @@ jobs:
             ${{ needs.audit-docs.result }}
             ${{ needs.drift-check-active-projects.result }}
             ${{ needs.test-safe-clone.result }}
+            ${{ needs.test-maintainer-preflight.result }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer (Codex instance)

## Why

The scheduled preflight treated a sandbox-only macOS Keychain denial as proof that the saved login was invalid, even though the identical approved host-level probe authenticated successfully. The machine-local scheduler duplicated that ambiguous check before loading the versioned definition.

## What

The versioned preflight now scopes authentication to the active `github.com` account and requires the `devantler` identity. It clears both injected token variables when testing the saved login, handles valid-but-wrong injected identities, and preserves both the verified token environment and—when Keychain is host-only—the approved host execution context for every later `gh` call.

It classifies sandbox failure as indeterminate, distinguishes host-confirmed invalid credentials, wrong identity, and unavailable verification, keeps injected-token/auth/fetch gates separate, and records no credential output. The live scheduler delegates auth and sync to that contract; automation memory records the corrected classification, and CI asserts the contract.

## Validation

The regression assertions failed against the old behavior and now pass. Bash syntax, ShellCheck, actionlint, the focused contract checks (including the live scheduler), and `git diff --check` pass.

Fixes #2159
