### PR TITLE
fix(worktrees): submodule init re-breaks isolation — make init+repair one operation

### DIFF
--- a/.claude/scripts/submodule-init.sh
+++ b/.claude/scripts/submodule-init.sh
@@ -62,6 +62,39 @@ resolves_to_itself() {
   [ "$top" = "$abs" ]
 }
 
+# Verify every EXISTING linked worktree of this submodule resolves to its OWN physical path. The main
+# checkout and a freshly-created probe worktree passing does NOT prove a live session's worktree isn't
+# colliding: an interrupted repair or a worktree created against a stray shared `core.worktree` can
+# leave one `$gitdir/worktrees/*` entry pinned at the shared checkout, and that session keeps colliding
+# while a fresh probe stays clean. `--check` is the trust gate for exactly this parallel-session case,
+# so it must enumerate the live worktrees too. Read-only: it only rev-parses other sessions' trees.
+check_existing_worktrees() {
+  local path=$1 rc=0 mdir wtadmin wt got want
+  # Iterate the LINKED-worktree admin dirs under the submodule gitdir directly, rather than
+  # `git worktree list`: the submodule's MAIN checkout legitimately resolves to itself, and so does a
+  # colliding linked worktree whose stray `core.worktree` points at the shared checkout — so
+  # show-toplevel alone cannot tell them apart. Only linked worktrees live under `$mdir/worktrees/*`;
+  # the main checkout is never listed there, so it is excluded without a fragile self-comparison.
+  mdir=$(module_dir "$path") || return 0
+  [ -d "$mdir/worktrees" ] || return 0
+  for wtadmin in "$mdir"/worktrees/*/; do
+    [ -f "$wtadmin/gitdir" ] || continue
+    # The `gitdir` admin file points at the worktree's own `.git` file; its parent is the worktree.
+    wt=$(dirname "$(cat "$wtadmin/gitdir" 2>/dev/null)")
+    case "$wt" in *"/probe-iso-"*) continue ;; esac
+    # A pruned/missing worktree dir cannot host a live colliding session — skip it.
+    [ -d "$wt" ] || continue
+    got=$(git -C "$wt" rev-parse --show-toplevel 2>/dev/null) || got=''
+    [ -n "$got" ] && got=$(cd "$got" 2>/dev/null && pwd -P)
+    want=$(cd "$wt" && pwd -P)
+    if [ "$got" != "$want" ]; then
+      warn "$path — ISOLATION BROKEN: existing linked worktree '$wt' resolves to '${got:-<unresolvable>}', not its own path. A parallel session there is colliding — do not edit it."
+      rc=1
+    fi
+  done
+  return "$rc"
+}
+
 # Move the stray shared core.worktree into each worktree's own per-worktree config. Idempotent.
 repair() {
   local path=$1
@@ -133,6 +166,9 @@ probe() {
   git -C "$path" worktree remove --force "$name" >/dev/null 2>&1 || true
   git -C "$path" worktree prune >/dev/null 2>&1 || true
   rm -rf "$probe_dir"
+
+  # A fresh probe passing does not clear existing live worktrees — enumerate and verify those too.
+  check_existing_worktrees "$path" || rc=1
 
   [ "$rc" -eq 0 ] && printf 'submodule-init: %s — isolated ✓\n' "$path"
   return "$rc"

--- a/.claude/scripts/submodule-init.sh
+++ b/.claude/scripts/submodule-init.sh
@@ -13,7 +13,12 @@
 # Usage:
 #   .claude/scripts/submodule-init.sh <submodule-path> [<submodule-path>...]
 #   .claude/scripts/submodule-init.sh --all      # init + repair + probe every submodule (first clone)
-#   .claude/scripts/submodule-init.sh --check    # read-only: probe every initialised submodule
+#   .claude/scripts/submodule-init.sh --check    # non-destructive probe of every initialised submodule
+#
+# `--check` never modifies submodule content, tracked files, or other sessions' worktrees, but it is
+# NOT strictly read-only: to prove isolation empirically it adds and then removes a throwaway,
+# uniquely-named probe worktree (and prunes its own admin entry). That empirical add/remove is the
+# whole point — it catches a dangling `core.worktree` a config read alone would miss.
 set -euo pipefail
 
 die() {
@@ -145,6 +150,17 @@ initialised_paths() {
 
 init_repair_probe() {
   local path=${1%/}
+  # If the submodule is ALREADY populated, a stray shared `core.worktree` may point at ANOTHER
+  # checkout — the exact collision this script exists to catch. `git submodule update` honours that
+  # value, so running it first would operate through the wrong worktree: aborting on another
+  # session's local changes, or checking the pinned commit out into THEIR tree. Repair the stale
+  # config FIRST so the update always acts on this tree; the post-update repair then relocates the
+  # `core.worktree` the update itself re-adds. A fresh (unpopulated) submodule has no gitdir to
+  # repair yet — skip straight to the update, which populates it, and let the post-update repair
+  # handle the freshly-written key.
+  if is_populated "$path"; then
+    repair "$path"
+  fi
   git submodule update --init "$path"
   repair "$path"
   probe "$path" || die "repair did not restore isolation for '$path' — do not edit it"
@@ -153,7 +169,9 @@ init_repair_probe() {
 [ $# -gt 0 ] || die 'usage: submodule-init.sh <submodule-path>... | --all | --check'
 
 case "$1" in
-  # READ-ONLY. It must NOT repair first: a check that fixes what it is checking can never fail.
+  # NON-DESTRUCTIVE probe (see the header note): never touches content or other sessions' trees, but
+  # not strictly read-only — `probe` adds/removes its own throwaway worktree. It must NOT repair
+  # first: a check that fixes what it is checking can never fail.
   --check)
     broken=0
     while read -r path; do probe "$path" || broken=1; done < <(initialised_paths)

--- a/.claude/scripts/submodule-init.sh
+++ b/.claude/scripts/submodule-init.sh
@@ -23,16 +23,16 @@ die() {
 
 warn() { printf 'submodule-init: %s\n' "$1" >&2; }
 
-# Resolve paths from git rather than assuming `<root>/.git/...`. When this runs from a linked
-# superproject worktree — which is the documented execution model for agent runs — `.git` is a gitdir
-# FILE and `.git/modules` does not exist relative to the worktree, so a hard-coded path would break
-# exactly where it matters most.
-super_common=$(git rev-parse --path-format=absolute --git-common-dir) ||
-  die 'not inside a git repository'
-super_main=$(dirname "$super_common") # the superproject's MAIN checkout, from any worktree
+# NEVER compute a submodule's gitdir — ask git. Run from a linked superproject worktree (the documented
+# execution model for agent runs), git puts each submodule's gitdir under
+# `.git/worktrees/<super-wt>/modules/<path>`, NOT under `.git/modules/<path>` — and that is where the
+# stray `core.worktree` lands too. Any assumed path is wrong exactly where this script matters most.
+super_root=$(git rev-parse --show-toplevel) || die 'not inside a git repository'
+cd "$super_root"
 
-# The shared gitdir of a submodule, valid from any superproject worktree.
-module_dir() { printf '%s/modules/%s\n' "$super_common" "$1"; }
+# The gitdir git is ACTUALLY using for this submodule, and the tree it is checked out in.
+module_dir() { git -C "$1" rev-parse --path-format=absolute --git-common-dir 2>/dev/null; }
+module_tree() { git -C "$1" rev-parse --show-toplevel 2>/dev/null; }
 
 # A submodule is only its own repository if git, run inside it, reports IT as the toplevel. If the
 # submodule is deinitialised (empty dir) git walks UP to the superproject and every check below would
@@ -49,13 +49,15 @@ assert_is_submodule_root() {
 # Move the stray shared core.worktree into each worktree's own per-worktree config. Idempotent.
 repair() {
   local path=$1
-  local mdir
+  local mdir tree
   mdir=$(module_dir "$path")
-  [ -d "$mdir" ] || die "no gitdir for '$path' (is it a submodule?)"
+  tree=$(module_tree "$path")
+  { [ -n "$mdir" ] && [ -d "$mdir" ] && [ -n "$tree" ]; } ||
+    die "git does not report a gitdir for '$path' (not an initialised submodule?)"
 
   git config -f "$mdir/config" extensions.worktreeConfig true
-  # The submodule's MAIN checkout always lives under the superproject's MAIN checkout.
-  git config -f "$mdir/config.worktree" core.worktree "$super_main/$path"
+  # Pin the tree this gitdir is actually checked out in — not a path we guessed.
+  git config -f "$mdir/config.worktree" core.worktree "$tree"
   git config -f "$mdir/config" --unset-all core.worktree 2>/dev/null || true
 
   # Existing linked worktrees inherited the stray value — pin each to the path it actually lives at.
@@ -95,7 +97,10 @@ probe() {
   [ -n "$got" ] && got=$(cd "$got" 2>/dev/null && pwd -P)
   want=$(cd "$probe_dir" && pwd -P)
 
-  if [ "$got" != "$want" ]; then
+  if [ -z "$got" ]; then
+    warn "$path — ISOLATION BROKEN: git cannot resolve a worktree created there (dangling core.worktree). Do not edit it."
+    rc=1
+  elif [ "$got" != "$want" ]; then
     warn "$path — ISOLATION BROKEN: a worktree there resolves to '$got', not its own path ('$want'). Do not edit it — parallel sessions would collide."
     rc=1
   fi
@@ -108,10 +113,11 @@ probe() {
   return "$rc"
 }
 
-all_paths() { git config -f "$super_main/.gitmodules" --get-regexp '^submodule\..*\.path$' | awk '{print $2}'; }
+all_paths() { git config -f .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}'; }
+# "Initialised" means git actually treats it as its own repository here — again, asked, not assumed.
 initialised_paths() {
   local p
-  while read -r p; do [ -d "$(module_dir "$p")" ] && printf '%s\n' "$p"; done < <(all_paths)
+  while read -r p; do assert_is_submodule_root "$p" && printf '%s\n' "$p"; done < <(all_paths)
 }
 
 init_repair_probe() {

--- a/.claude/scripts/submodule-init.sh
+++ b/.claude/scripts/submodule-init.sh
@@ -30,17 +30,28 @@ warn() { printf 'submodule-init: %s\n' "$1" >&2; }
 super_root=$(git rev-parse --show-toplevel) || die 'not inside a git repository'
 cd "$super_root"
 
-# The gitdir git is ACTUALLY using for this submodule, and the tree it is checked out in.
+# The gitdir git is ACTUALLY using for this submodule.
 module_dir() { git -C "$1" rev-parse --path-format=absolute --git-common-dir 2>/dev/null; }
-module_tree() { git -C "$1" rev-parse --show-toplevel 2>/dev/null; }
 
-# A submodule is only its own repository if git, run inside it, reports IT as the toplevel. If the
-# submodule is deinitialised (empty dir) git walks UP to the superproject and every check below would
-# silently pass against the wrong repo — a fail-open. Refuse instead.
-assert_is_submodule_root() {
+# The tree this submodule is checked out in is simply its own absolute path. Do NOT derive it from
+# `rev-parse --show-toplevel`: that is computed FROM `core.worktree`, so in the broken case it returns
+# the checkout the stray value points at — and repair would then pin the collision back in.
+module_tree() { (cd "$1" 2>/dev/null && pwd -P); }
+
+# An UNINITIALISED submodule is an empty directory. Distinguish that (legitimately skip) from a
+# populated one (must be checked) — see `probe`, where conflating the two was a fail-open.
+is_populated() {
+  local path=$1
+  [ -d "$path" ] && [ -n "$(ls -A "$path" 2>/dev/null)" ]
+}
+
+# Does git, run inside the submodule, agree that the submodule IS this directory? If a stray
+# `core.worktree` points at another valid checkout — the exact collision this script exists to catch —
+# git reports THAT checkout instead. Returning "not a submodule" there would silently drop it from
+# `--check`; it must be reported as BROKEN.
+resolves_to_itself() {
   local path=$1 abs top
-  [ -d "$path" ] || return 1
-  abs=$(cd "$path" && pwd -P)
+  abs=$(module_tree "$path") || return 1
   top=$(git -C "$path" rev-parse --show-toplevel 2>/dev/null) || return 1
   top=$(cd "$top" 2>/dev/null && pwd -P) || return 1
   [ "$top" = "$abs" ]
@@ -76,8 +87,17 @@ repair() {
 probe() {
   local path=$1
 
-  if ! assert_is_submodule_root "$path"; then
-    warn "$path — NOT a populated submodule root (deinitialised, or git resolves it to the parent repo); refusing to probe"
+  if ! is_populated "$path"; then
+    warn "$path — not checked out here; nothing to probe"
+    return 1
+  fi
+
+  # THE collision, detected directly: the submodule is populated, but git resolves it to a DIFFERENT
+  # checkout because a stray `core.worktree` points there. Report it — treating this as "not a
+  # submodule" and skipping it (as an earlier version did) silently dropped the one case this whole
+  # script exists to catch, and `--check` then exited 0 on a colliding tree.
+  if ! resolves_to_itself "$path"; then
+    warn "$path — ISOLATION BROKEN: git resolves it to '$(git -C "$path" rev-parse --show-toplevel 2>/dev/null)', not '$(module_tree "$path")'. Another checkout is sharing this working tree — do not edit it."
     return 1
   fi
 
@@ -115,9 +135,12 @@ probe() {
 
 all_paths() { git config -f .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}'; }
 # "Initialised" means git actually treats it as its own repository here — again, asked, not assumed.
+# Select every submodule that is CHECKED OUT here. Deliberately NOT "every submodule git resolves
+# correctly": a colliding submodule resolves elsewhere, and filtering on that would drop it from the
+# sweep — the fail-open this script must never have.
 initialised_paths() {
   local p
-  while read -r p; do assert_is_submodule_root "$p" && printf '%s\n' "$p"; done < <(all_paths)
+  while read -r p; do is_populated "$p" && printf '%s\n' "$p"; done < <(all_paths)
 }
 
 init_repair_probe() {

--- a/.claude/scripts/submodule-init.sh
+++ b/.claude/scripts/submodule-init.sh
@@ -148,21 +148,35 @@ initialised_paths() {
   while read -r p; do is_populated "$p" && printf '%s\n' "$p"; done < <(all_paths)
 }
 
+# Is $1 one of the paths declared in .gitmodules? Only these may have their config rewritten.
+is_registered_submodule() {
+  local p=$1 x
+  while read -r x; do [ "$x" = "$p" ] && return 0; done < <(all_paths)
+  return 1
+}
+
 init_repair_probe() {
   local path=${1%/}
-  # If the submodule is ALREADY populated, a stray shared `core.worktree` may point at ANOTHER
-  # checkout — the exact collision this script exists to catch. `git submodule update` honours that
-  # value, so running it first would operate through the wrong worktree: aborting on another
-  # session's local changes, or checking the pinned commit out into THEIR tree. Repair the stale
-  # config FIRST so the update always acts on this tree; the post-update repair then relocates the
-  # `core.worktree` the update itself re-adds. A fresh (unpopulated) submodule has no gitdir to
-  # repair yet — skip straight to the update, which populates it, and let the post-update repair
-  # handle the freshly-written key.
+  # Only ever mutate config for a path git actually registers as a submodule. Handed a linked
+  # worktree path (or any other populated directory) by mistake, `repair` would rewrite the shared
+  # submodule gitdir's `core.worktree` to point THERE — recreating the exact cross-session collision
+  # this script exists to prevent. Validate against .gitmodules first and fail closed.
+  is_registered_submodule "$path" ||
+    die "'$path' is not a registered submodule (see .gitmodules) — refusing to repair"
+
   if is_populated "$path"; then
+    # Already checked out here: only its isolation can be stale, so repair the stray `core.worktree`
+    # IN PLACE and stop. Do NOT run `git submodule update` — its checkout update strategy would
+    # detach/move this tree back to the pinned gitlink commit, silently discarding a local branch or
+    # ahead-of-pin work. Populating is the only thing update is for, and this tree is already
+    # populated.
+    repair "$path"
+  else
+    # Fresh (empty) submodule: populate it at its pinned commit, then relocate the `core.worktree`
+    # that `git submodule update` writes into the shared config.
+    git submodule update --init "$path"
     repair "$path"
   fi
-  git submodule update --init "$path"
-  repair "$path"
   probe "$path" || die "repair did not restore isolation for '$path' — do not edit it"
 }
 

--- a/.claude/scripts/submodule-init.sh
+++ b/.claude/scripts/submodule-init.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Initialise a submodule at its pinned commit AND keep per-session worktree isolation intact.
+#
+# Why this exists: `git submodule update --init <path>` writes a `core.worktree` key into the
+# submodule's SHARED config (.git/modules/<name>/config). `core.worktree` is a per-worktree setting,
+# so every worktree later created with `git worktree add` inherits it and resolves back into the main
+# checkout — silently collapsing all parallel agent sessions into one physical tree. That is why the
+# isolation fix never stays fixed: the init command re-breaks it.
+#
+# This script makes init + repair a single operation, then PROBES that isolation actually holds and
+# fails closed if it does not.
+#
+# Usage:  .claude/scripts/submodule-init.sh <submodule-path> [<submodule-path>...]
+#         .claude/scripts/submodule-init.sh --check              # probe every initialised submodule
+set -euo pipefail
+
+die() {
+  printf 'submodule-init: %s\n' "$1" >&2
+  exit 1
+}
+
+repo_root=$(git rev-parse --show-toplevel) || die 'not inside a git repository'
+cd "$repo_root"
+
+# Move the stray shared core.worktree into the main worktree's own per-worktree config, and pin each
+# existing linked worktree to its real path. Idempotent.
+repair() {
+  local path=$1
+  local module_dir=".git/modules/$path"
+  [ -d "$module_dir" ] || die "no gitdir for '$path' (is it a submodule?)"
+
+  git config -f "$module_dir/config" extensions.worktreeConfig true
+  git config -f "$module_dir/config.worktree" core.worktree "$repo_root/$path"
+  git config -f "$module_dir/config" --unset-all core.worktree 2>/dev/null || true
+
+  # Existing linked worktrees inherited the stray value — pin each to the path it actually lives at.
+  local wt gitdir tree
+  for wt in "$module_dir"/worktrees/*/; do
+    [ -d "$wt" ] || continue
+    [ -f "$wt/gitdir" ] || continue
+    gitdir=$(cat "$wt/gitdir")
+    tree=$(dirname "$gitdir")
+    git config -f "$wt/config.worktree" core.worktree "$tree"
+  done
+}
+
+# Fail closed: a submodule is only isolated if a throwaway worktree reports its OWN path as the
+# toplevel. Compare resolved absolute paths — never match on a symptom substring.
+# Returns non-zero (rather than exiting) so callers can probe every submodule before deciding.
+probe() {
+  local path=$1
+  local probe_dir="$path/.probe-iso"
+
+  rm -rf "$probe_dir"
+  if ! git -C "$path" worktree add --detach "$(basename "$probe_dir")" >/dev/null 2>&1; then
+    printf 'submodule-init: %s — could not create probe worktree\n' "$path" >&2
+    return 1
+  fi
+
+  # Resolve both sides to physical paths (/tmp vs /private/tmp, symlinked checkouts) before comparing.
+  local got want
+  got=$(git -C "$probe_dir" rev-parse --show-toplevel) || got=''
+  [ -n "$got" ] && got=$(cd "$got" && pwd -P)
+  want=$(cd "$probe_dir" && pwd -P)
+
+  git -C "$path" worktree remove --force "$(basename "$probe_dir")" >/dev/null 2>&1 || true
+  git -C "$path" worktree prune >/dev/null 2>&1 || true
+
+  if [ "$got" != "$want" ]; then
+    printf "submodule-init: %s — ISOLATION BROKEN: a worktree there resolves to '%s', not its own path ('%s'). Do not edit it — parallel sessions would collide.\n" \
+      "$path" "$got" "$want" >&2
+    return 1
+  fi
+
+  printf 'submodule-init: %s — isolated ✓\n' "$path"
+}
+
+initialised_paths() {
+  git config -f .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}' | while read -r p; do
+    [ -d ".git/modules/$p" ] && printf '%s\n' "$p"
+  done
+}
+
+[ $# -gt 0 ] || die 'usage: submodule-init.sh <submodule-path>... | --check'
+
+# --check is READ-ONLY: it reports isolation as it stands, so it can actually fail. Repairing first
+# would make the check vacuous (it could never detect a broken submodule).
+if [ "$1" = '--check' ]; then
+  broken=0
+  while read -r path; do
+    if probe "$path"; then :; else broken=1; fi
+  done < <(initialised_paths)
+  [ "$broken" -eq 0 ] || die 'one or more submodules are NOT isolated — run submodule-init.sh <path> to repair before editing them'
+  exit 0
+fi
+
+for path in "$@"; do
+  path=${path%/}
+  git submodule update --init "$path"
+  repair "$path"
+  probe "$path" || die "repair did not restore isolation for '$path' — do not edit it"
+done

--- a/.claude/scripts/submodule-init.sh
+++ b/.claude/scripts/submodule-init.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
-# Initialise a submodule at its pinned commit AND keep per-session worktree isolation intact.
+# Initialise submodules at their pinned commit AND keep per-session worktree isolation intact.
 #
 # Why this exists: `git submodule update --init <path>` writes a `core.worktree` key into the
-# submodule's SHARED config (.git/modules/<name>/config). `core.worktree` is a per-worktree setting,
-# so every worktree later created with `git worktree add` inherits it and resolves back into the main
-# checkout — silently collapsing all parallel agent sessions into one physical tree. That is why the
-# isolation fix never stays fixed: the init command re-breaks it.
+# submodule's SHARED config. `core.worktree` is a per-worktree setting, so every worktree later
+# created with `git worktree add` inherits it and resolves back into the main checkout — silently
+# collapsing all parallel agent sessions into one physical tree. That is why the isolation fix never
+# stays fixed: the init command re-breaks it.
 #
 # This script makes init + repair a single operation, then PROBES that isolation actually holds and
 # fails closed if it does not.
 #
-# Usage:  .claude/scripts/submodule-init.sh <submodule-path> [<submodule-path>...]
-#         .claude/scripts/submodule-init.sh --check              # probe every initialised submodule
+# Usage:
+#   .claude/scripts/submodule-init.sh <submodule-path> [<submodule-path>...]
+#   .claude/scripts/submodule-init.sh --all      # init + repair + probe every submodule (first clone)
+#   .claude/scripts/submodule-init.sh --check    # read-only: probe every initialised submodule
 set -euo pipefail
 
 die() {
@@ -19,23 +21,46 @@ die() {
   exit 1
 }
 
-repo_root=$(git rev-parse --show-toplevel) || die 'not inside a git repository'
-cd "$repo_root"
+warn() { printf 'submodule-init: %s\n' "$1" >&2; }
 
-# Move the stray shared core.worktree into the main worktree's own per-worktree config, and pin each
-# existing linked worktree to its real path. Idempotent.
+# Resolve paths from git rather than assuming `<root>/.git/...`. When this runs from a linked
+# superproject worktree — which is the documented execution model for agent runs — `.git` is a gitdir
+# FILE and `.git/modules` does not exist relative to the worktree, so a hard-coded path would break
+# exactly where it matters most.
+super_common=$(git rev-parse --path-format=absolute --git-common-dir) ||
+  die 'not inside a git repository'
+super_main=$(dirname "$super_common") # the superproject's MAIN checkout, from any worktree
+
+# The shared gitdir of a submodule, valid from any superproject worktree.
+module_dir() { printf '%s/modules/%s\n' "$super_common" "$1"; }
+
+# A submodule is only its own repository if git, run inside it, reports IT as the toplevel. If the
+# submodule is deinitialised (empty dir) git walks UP to the superproject and every check below would
+# silently pass against the wrong repo — a fail-open. Refuse instead.
+assert_is_submodule_root() {
+  local path=$1 abs top
+  [ -d "$path" ] || return 1
+  abs=$(cd "$path" && pwd -P)
+  top=$(git -C "$path" rev-parse --show-toplevel 2>/dev/null) || return 1
+  top=$(cd "$top" 2>/dev/null && pwd -P) || return 1
+  [ "$top" = "$abs" ]
+}
+
+# Move the stray shared core.worktree into each worktree's own per-worktree config. Idempotent.
 repair() {
   local path=$1
-  local module_dir=".git/modules/$path"
-  [ -d "$module_dir" ] || die "no gitdir for '$path' (is it a submodule?)"
+  local mdir
+  mdir=$(module_dir "$path")
+  [ -d "$mdir" ] || die "no gitdir for '$path' (is it a submodule?)"
 
-  git config -f "$module_dir/config" extensions.worktreeConfig true
-  git config -f "$module_dir/config.worktree" core.worktree "$repo_root/$path"
-  git config -f "$module_dir/config" --unset-all core.worktree 2>/dev/null || true
+  git config -f "$mdir/config" extensions.worktreeConfig true
+  # The submodule's MAIN checkout always lives under the superproject's MAIN checkout.
+  git config -f "$mdir/config.worktree" core.worktree "$super_main/$path"
+  git config -f "$mdir/config" --unset-all core.worktree 2>/dev/null || true
 
   # Existing linked worktrees inherited the stray value — pin each to the path it actually lives at.
   local wt gitdir tree
-  for wt in "$module_dir"/worktrees/*/; do
+  for wt in "$mdir"/worktrees/*/; do
     [ -d "$wt" ] || continue
     [ -f "$wt/gitdir" ] || continue
     gitdir=$(cat "$wt/gitdir")
@@ -44,59 +69,72 @@ repair() {
   done
 }
 
-# Fail closed: a submodule is only isolated if a throwaway worktree reports its OWN path as the
-# toplevel. Compare resolved absolute paths — never match on a symptom substring.
-# Returns non-zero (rather than exiting) so callers can probe every submodule before deciding.
+# Fail closed: a submodule is isolated only if a throwaway worktree reports its OWN path as the
+# toplevel. Returns non-zero (never exits) so callers can probe everything before deciding.
 probe() {
   local path=$1
-  local probe_dir="$path/.probe-iso"
 
-  rm -rf "$probe_dir"
-  if ! git -C "$path" worktree add --detach "$(basename "$probe_dir")" >/dev/null 2>&1; then
-    printf 'submodule-init: %s — could not create probe worktree\n' "$path" >&2
+  if ! assert_is_submodule_root "$path"; then
+    warn "$path — NOT a populated submodule root (deinitialised, or git resolves it to the parent repo); refusing to probe"
+    return 1
+  fi
+
+  # A unique probe dir per invocation: a fixed `.probe-iso` could collide with — and `rm -rf` — a
+  # concurrent session's probe or a user's scratch dir. This script exists FOR overlapping sessions.
+  local name="probe-iso-$$-${RANDOM}"
+  local probe_dir="$path/$name"
+
+  if ! git -C "$path" worktree add --detach "$name" >/dev/null 2>&1; then
+    warn "$path — could not create probe worktree"
     return 1
   fi
 
   # Resolve both sides to physical paths (/tmp vs /private/tmp, symlinked checkouts) before comparing.
-  local got want
-  got=$(git -C "$probe_dir" rev-parse --show-toplevel) || got=''
-  [ -n "$got" ] && got=$(cd "$got" && pwd -P)
+  local got want rc=0
+  got=$(git -C "$probe_dir" rev-parse --show-toplevel 2>/dev/null) || got=''
+  [ -n "$got" ] && got=$(cd "$got" 2>/dev/null && pwd -P)
   want=$(cd "$probe_dir" && pwd -P)
 
-  git -C "$path" worktree remove --force "$(basename "$probe_dir")" >/dev/null 2>&1 || true
-  git -C "$path" worktree prune >/dev/null 2>&1 || true
-
   if [ "$got" != "$want" ]; then
-    printf "submodule-init: %s — ISOLATION BROKEN: a worktree there resolves to '%s', not its own path ('%s'). Do not edit it — parallel sessions would collide.\n" \
-      "$path" "$got" "$want" >&2
-    return 1
+    warn "$path — ISOLATION BROKEN: a worktree there resolves to '$got', not its own path ('$want'). Do not edit it — parallel sessions would collide."
+    rc=1
   fi
 
-  printf 'submodule-init: %s — isolated ✓\n' "$path"
+  git -C "$path" worktree remove --force "$name" >/dev/null 2>&1 || true
+  git -C "$path" worktree prune >/dev/null 2>&1 || true
+  rm -rf "$probe_dir"
+
+  [ "$rc" -eq 0 ] && printf 'submodule-init: %s — isolated ✓\n' "$path"
+  return "$rc"
 }
 
+all_paths() { git config -f "$super_main/.gitmodules" --get-regexp '^submodule\..*\.path$' | awk '{print $2}'; }
 initialised_paths() {
-  git config -f .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}' | while read -r p; do
-    [ -d ".git/modules/$p" ] && printf '%s\n' "$p"
-  done
+  local p
+  while read -r p; do [ -d "$(module_dir "$p")" ] && printf '%s\n' "$p"; done < <(all_paths)
 }
 
-[ $# -gt 0 ] || die 'usage: submodule-init.sh <submodule-path>... | --check'
-
-# --check is READ-ONLY: it reports isolation as it stands, so it can actually fail. Repairing first
-# would make the check vacuous (it could never detect a broken submodule).
-if [ "$1" = '--check' ]; then
-  broken=0
-  while read -r path; do
-    if probe "$path"; then :; else broken=1; fi
-  done < <(initialised_paths)
-  [ "$broken" -eq 0 ] || die 'one or more submodules are NOT isolated — run submodule-init.sh <path> to repair before editing them'
-  exit 0
-fi
-
-for path in "$@"; do
-  path=${path%/}
+init_repair_probe() {
+  local path=${1%/}
   git submodule update --init "$path"
   repair "$path"
   probe "$path" || die "repair did not restore isolation for '$path' — do not edit it"
-done
+}
+
+[ $# -gt 0 ] || die 'usage: submodule-init.sh <submodule-path>... | --all | --check'
+
+case "$1" in
+  # READ-ONLY. It must NOT repair first: a check that fixes what it is checking can never fail.
+  --check)
+    broken=0
+    while read -r path; do probe "$path" || broken=1; done < <(initialised_paths)
+    [ "$broken" -eq 0 ] ||
+      die 'one or more submodules are NOT isolated — run submodule-init.sh <path> to repair before editing them'
+    ;;
+  --all)
+    while read -r path; do init_repair_probe "$path"; done < <(all_paths)
+    ;;
+  *)
+    for path in "$@"; do init_repair_probe "$path"; done
+    ;;
+esac

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -346,19 +346,25 @@ A second run the same day → more selective, dedupe vs the earlier run.
 
 ## 3. Act (per selected product, via a per-run worktree)
 For each selected product:
-1. **Isolate:** `cd /Users/homelab-mac-mini/git-personal/monorepo`;
-   `git -C <path> worktree add .claude/worktrees/maint-<runid> -b claude/<area>-<desc>` (populate an
-   empty submodule first with `git submodule update --init <path>`). Work **in that worktree**.
-   **`git submodule update --init` re-sets the shared `core.worktree`** (observed 8× across runs:
-   ksail ×4, go-template, homebrew-tap, `.github-public`, agent-plugins), which makes the worktree
-   resolve back into `.git/modules/<name>` — so after **every** init-then-worktree-add on a
-   submodule, **probe and repair proactively** rather than discovering the collision mid-edit:
-   `git -C <wt> rev-parse --show-toplevel` must print the worktree's own path; if it prints a
-   `.git/modules/<name>` path, apply the 3-step repair from
-   [`worktree-isolation.md`](../../worktree-isolation.md) (enable `extensions.worktreeConfig`; pin
-   the main checkout's and each live worktree's own `core.worktree` in their `config.worktree`;
-   then unset the shared value — **guard every pin against empty vars and stop the sequence on a
-   failed `worktree add`**, per the 445th-run corruption lesson), and re-probe before editing.
+1. **Isolate:** `cd /Users/homelab-mac-mini/git-personal/monorepo`. Populate an empty submodule with
+   the fail-closed wrapper — **never a bare `git submodule update --init`**, which is precisely what
+   re-introduces the shared `core.worktree` (reproduced 2026-07-14: absent before the command, present
+   after; observed 8× across runs — ksail ×4, go-template, homebrew-tap, `.github-public`,
+   agent-plugins):
+
+   ```sh
+   .claude/scripts/submodule-init.sh <path>   # init at the pinned commit + repair + probe (fail-closed)
+   ```
+
+   Then `git -C <path> worktree add .claude/worktrees/maint-<runid> -b claude/<area>-<desc>` and work
+   **in that worktree**. A stray `core.worktree` makes the worktree resolve back into
+   `.git/modules/<name>`, silently collapsing every parallel session into one physical tree — so on any
+   submodule you did **not** initialise through the wrapper (a tree someone else populated), **probe
+   before you trust it**: `git -C <wt> rev-parse --show-toplevel` must print the worktree's own path,
+   not a `.git/modules/<name>` path. `.claude/scripts/submodule-init.sh --check` probes every
+   initialised submodule read-only and exits non-zero on a break; repair in place before editing
+   anything. Background, diagnosis, and the regression watch:
+   [`worktree-isolation.md`](../../worktree-isolation.md).
    If the tree is unexpectedly dirty / not isolable, do GitHub-API-only work and skip diff work.
 2. **Load the product card** (`products/<name>`) + that submodule's `AGENTS.md` `## Maintenance`.
    Follow them; they carry validate commands, protected/generated files, label set, task menu, and the

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -362,8 +362,9 @@ For each selected product:
    submodule you did **not** initialise through the wrapper (a tree someone else populated), **probe
    before you trust it**: `git -C <wt> rev-parse --show-toplevel` must print the worktree's own path,
    not a `.git/modules/<name>` path. `.claude/scripts/submodule-init.sh --check` probes every
-   initialised submodule read-only and exits non-zero on a break; repair in place before editing
-   anything. Background, diagnosis, and the regression watch:
+   initialised submodule (a non-destructive probe — it never touches content or other sessions'
+   trees, but adds/removes its own throwaway worktree) and exits non-zero on a break; repair in place
+   before editing anything. Background, diagnosis, and the regression watch:
    [`worktree-isolation.md`](../../worktree-isolation.md).
    If the tree is unexpectedly dirty / not isolable, do GitHub-API-only work and skip diff work.
 2. **Load the product card** (`products/<name>`) + that submodule's `AGENTS.md` `## Maintenance`.

--- a/.claude/skills/products/applications/SKILL.md
+++ b/.claude/skills/products/applications/SKILL.md
@@ -10,8 +10,10 @@ Each app's canonical maintenance task menu lives **in its own (private) repo** �
 - `applications/wedding-app/AGENTS.md` — <https://github.com/devantler-tech/wedding-app/blob/main/AGENTS.md>
 - `applications/ascoachingogvaner/AGENTS.md` — <https://github.com/devantler-tech/ascoachingogvaner/blob/main/AGENTS.md>
 
-These submodules are usually not checked out — populate at the pinned commit with
-`git submodule update --init applications/<name>` (never `--remote`), or do GitHub-API-only work.
+These submodules are usually not checked out — populate at the pinned commit with the fail-closed
+wrapper `.claude/scripts/submodule-init.sh applications/<name>` (**never** a bare
+`git submodule update --init`, which re-introduces the shared `core.worktree` and collapses every
+parallel session into one tree; never `--remote`), or do GitHub-API-only work.
 **Private** repos — extra discretion. Shared cross-repo rules are in the monorepo
 [`AGENTS.md`](../../../../AGENTS.md). This card is a pointer by design.
 

--- a/.claude/worktree-isolation.md
+++ b/.claude/worktree-isolation.md
@@ -151,8 +151,10 @@ So the loop is: agent initialises a submodule → isolation silently breaks → 
 in that submodule resolves into the shared main checkout → parallel sessions collide. **Initialising and
 repairing must therefore be one operation**, which is what
 [`.claude/scripts/submodule-init.sh`](scripts/submodule-init.sh) does (init → repair → fail-closed
-probe). `submodule-init.sh --check` probes every initialised submodule read-only and exits non-zero if
-any is not isolated.
+probe). `submodule-init.sh --check` probes every initialised submodule and exits non-zero if any is
+not isolated. The probe is non-destructive — it never modifies submodule content, tracked files, or
+other sessions' worktrees — but not strictly read-only: it adds and removes a throwaway probe
+worktree to catch a dangling `core.worktree` a config read alone would miss.
 
 What made it dangerous is that it fails **silently**: a `git worktree add` still succeeds, and the
 worktree looks real. Three live linked worktrees — including **two belonging to the parallel sibling

--- a/.claude/worktree-isolation.md
+++ b/.claude/worktree-isolation.md
@@ -56,7 +56,7 @@ below). Current state:
 | `templates/platform-template` | ~~set~~ → unset | true | ✅ fixed & verified 2026-06-25 |
 | `platform` | ~~set~~ → unset | true | ✅ fixed 2026-06-25 — **6 live worktrees repaired in place** |
 | `templates/go-template` | ~~set~~ → unset | true | ✅ fixed 2026-06-25 — **1 live worktree repaired in place** |
-| `templates/gitops-tenant-template` | unset | true | ✅ fixed & verified 2026-06-17 |
+| `templates/gitops-tenant-template` | ~~set~~ → unset | true | ⚠️ **REGRESSED 2026-07-14** — re-fixed & verified (see *Regression watch*) |
 | `projects/ksail` | unset | true | ✅ already isolated — **active, do not delete** (see below) |
 
 > **`projects/ksail` is ACTIVE — never treat it as orphaned.** An earlier revision of this doc called it
@@ -129,9 +129,30 @@ correctly. This submodule is left fixed.
 **The 2026-06-25 sweep does not stay fixed.** On **2026-07-14** `applications/ksail` was found **broken
 again**: the stray `core.worktree = ../../../../applications/ksail` was back in the shared
 `.git/modules/applications/ksail/config` (with `extensions.worktreeConfig` still `true` — so the flag
-survived, but the stray value returned and was being inherited again). Some routine submodule operation
-rewrites that key back into the shared config; a green row in the table above is therefore a record of
-*a* fix, **not** a guarantee of current state.
+survived, but the stray value returned and was being inherited again). `templates/gitops-tenant-template`
+was found broken again the **same day**. A green row in the table above is therefore a record of *a* fix,
+**not** a guarantee of current state.
+
+### The culprit: `git submodule update --init` (reproduced 2026-07-14)
+
+The "routine submodule operation" that rewrites the key is **`git submodule update --init <path>`** —
+the very command the contract tells agents to use to populate a submodule. Reproduced on a submodule
+that had just been verified fixed:
+
+```
+$ git config -f .git/modules/templates/dotnet-template/config --get core.worktree
+(unset)
+$ git submodule update --init templates/dotnet-template
+$ git config -f .git/modules/templates/dotnet-template/config --get core.worktree
+../../../../templates/dotnet-template          # ← back, and inherited by every future worktree
+```
+
+So the loop is: agent initialises a submodule → isolation silently breaks → the next `git worktree add`
+in that submodule resolves into the shared main checkout → parallel sessions collide. **Initialising and
+repairing must therefore be one operation**, which is what
+[`.claude/scripts/submodule-init.sh`](scripts/submodule-init.sh) does (init → repair → fail-closed
+probe). `submodule-init.sh --check` probes every initialised submodule read-only and exits non-zero if
+any is not isolated.
 
 What made it dangerous is that it fails **silently**: a `git worktree add` still succeeds, and the
 worktree looks real. Three live linked worktrees — including **two belonging to the parallel sibling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -836,18 +836,28 @@ the maintainer's parallel sessions. For each repo touched:
 `git -C <repo_path> worktree add .claude/worktrees/maint-<runid> -b claude/<area>-<desc>`, work there,
 open the PR, then `git -C <repo_path> worktree remove` to clean up (`<repo_path>` is a local
 filesystem path such as `applications/ksail` — `git -C` takes a path, not an `<owner/repo>` slug; use the
-slug only for `gh` commands). **Submodule worktree isolation is inconsistent** — most submodules carry
-a stray shared `core.worktree` that makes `git worktree add` resolve back into the main checkout (only
-the stale `projects/ksail` gitdir is correct; `templates/gitops-tenant-template` was fixed 2026-06-17).
-**A past fix does NOT stay fixed — probe every time** (`applications/ksail` regressed on 2026-07-14 and
-was silently colliding three live worktrees, two of them the sibling agent's). Before relying on an
-isolated submodule worktree, confirm `git -C <wt> rev-parse --show-toplevel` returns the worktree's own
-path, not a `.git/modules/<name>` path; if it doesn't, repair it in place before editing anything. The
-diagnosis table, the regression watch, and the verified per-submodule fix are in
-[`.claude/worktree-isolation.md`](.claude/worktree-isolation.md). Populate an
-un-checked-out submodule at its pinned commit with
-`git submodule update --init <path>` (never `--remote`). If a repo's working area is unexpectedly
-dirty or you can't get an isolated tree, do GitHub-API-only work (triage/comment) there.
+slug only for `gh` commands). **Submodule worktree isolation breaks whenever a submodule is
+initialised** — a stray shared `core.worktree` makes `git worktree add` resolve back into the main
+checkout, silently collapsing every parallel session into one physical tree.
+
+**`git submodule update --init <path>` is what (re-)introduces it** — reproduced 2026-07-14 on a
+submodule that was verified fixed: the key was absent before the command and present after. This is why
+"the fix does not stay fixed" (`applications/ksail` regressed 2026-07-14, silently colliding three live
+worktrees — two of them the sibling agent's; `templates/gitops-tenant-template` regressed the same day).
+The init command is *required* to populate a submodule, so **initialising and repairing are one
+operation, never two**:
+
+```sh
+.claude/scripts/submodule-init.sh <path>     # init at the pinned commit + repair + probe (fail-closed)
+```
+
+Use it instead of a bare `git submodule update --init <path>` (never `--remote`). If you do run a bare
+init — or inherit a tree someone else initialised — **probe before you trust it**: confirm
+`git -C <wt> rev-parse --show-toplevel` returns the worktree's **own** path, not a `.git/modules/<name>`
+path, and repair it in place before editing anything. The diagnosis, the regression watch, and the
+verified per-submodule fix are in
+[`.claude/worktree-isolation.md`](.claude/worktree-isolation.md). If a repo's working area is
+unexpectedly dirty or you can't get an isolated tree, do GitHub-API-only work (triage/comment) there.
 
 ### Git safety
 Never `git reset --hard`, `git stash`, force-push, or discard changes you did not author. Never

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ throwaway probe worktree).
 
 You can also clone the monorepo with the `--recurse-submodules` flag. That initializes the submodules
 the same way, so it breaks isolation the same way — run the wrapper afterwards to repair it (`--check`
-is read-only and would only report the problem, not fix it):
+is a non-destructive probe and would only report the problem, not fix it):
 
 ```bash
 git clone --recurse-submodules git@github.com:devantler-tech/monorepo.git

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ every later `git worktree add` inherits — so worktrees silently resolve back i
 parallel sessions collide. The wrapper repairs that and verifies isolation before returning; run
 `.claude/scripts/submodule-init.sh --check` at any time to re-verify (read-only).
 
-You can also clone the monorepo with the `--recurse-submodules` flag, but still run the wrapper
-afterwards so isolation is repaired and verified:
+You can also clone the monorepo with the `--recurse-submodules` flag. That initializes the submodules
+the same way, so it breaks isolation the same way — run the wrapper afterwards to repair it (`--check`
+is read-only and would only report the problem, not fix it):
 
 ```bash
 git clone --recurse-submodules git@github.com:devantler-tech/monorepo.git
-cd monorepo && .claude/scripts/submodule-init.sh --check
+cd monorepo && .claude/scripts/submodule-init.sh --all
 ```
 
 Make sure that all submodules are checked out on the correct branch the first time you clone the monorepo. Otherwise, you might risk loosing changes as the submodule will be in a detached head state.

--- a/README.md
+++ b/README.md
@@ -9,13 +9,21 @@ This repository is a monorepo that contains all my active projects as submodules
 When you clone the monorepo for the first time, you need to initialize the submodules:
 
 ```bash
-git submodule update --init --recursive
+.claude/scripts/submodule-init.sh --all
 ```
 
-Alternatively, you can clone the monorepo with the `--recurse-submodules` flag:
+This initializes every submodule at its pinned commit and keeps per-worktree isolation intact. A bare
+`git submodule update --init` writes a `core.worktree` key into each submodule's shared config, which
+every later `git worktree add` inherits — so worktrees silently resolve back into the main checkout and
+parallel sessions collide. The wrapper repairs that and verifies isolation before returning; run
+`.claude/scripts/submodule-init.sh --check` at any time to re-verify (read-only).
+
+You can also clone the monorepo with the `--recurse-submodules` flag, but still run the wrapper
+afterwards so isolation is repaired and verified:
 
 ```bash
 git clone --recurse-submodules git@github.com:devantler-tech/monorepo.git
+cd monorepo && .claude/scripts/submodule-init.sh --check
 ```
 
 Make sure that all submodules are checked out on the correct branch the first time you clone the monorepo. Otherwise, you might risk loosing changes as the submodule will be in a detached head state.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ This initializes every submodule at its pinned commit and keeps per-worktree iso
 `git submodule update --init` writes a `core.worktree` key into each submodule's shared config, which
 every later `git worktree add` inherits — so worktrees silently resolve back into the main checkout and
 parallel sessions collide. The wrapper repairs that and verifies isolation before returning; run
-`.claude/scripts/submodule-init.sh --check` at any time to re-verify (read-only).
+`.claude/scripts/submodule-init.sh --check` at any time to re-verify (a non-destructive probe: it
+never touches submodule content or other sessions' worktrees, but does add and remove its own
+throwaway probe worktree).
 
 You can also clone the monorepo with the `--recurse-submodules` flag. That initializes the submodules
 the same way, so it breaks isolation the same way — run the wrapper afterwards to repair it (`--check`


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Parallel agent sessions are supposed to work in isolated git worktrees. In submodules they often
**silently don't** — they all resolve into the same shared checkout, so two sessions edit one physical
tree and a commit can land on another session's branch. Yesterday this was found actively colliding
three live worktrees, two of them the sibling agent's.

We knew it kept coming back but not *why* — the docs said "some routine submodule operation" rewrites
the setting. **It's `git submodule update --init`, the exact command our own instructions tell agents to
run.** Reproduced: the setting is absent before the command and present after. So every time an agent
populates a submodule, it re-breaks isolation for itself and everyone else. That's the loop, and it's
why the fix never stuck.

## What

Make initialising and repairing a submodule **one operation** instead of two, so isolation can't be
left broken:

- A helper that inits at the pinned commit, repairs, and then **probes** — failing closed if the
  worktree still isn't isolated (it also has a read-only `--check` that sweeps every submodule).
- Point the contract at the helper instead of the bare command.
- Record the reproduced cause in the diagnosis doc, and mark the submodule that regressed again.

Verified both directions: the check exits non-zero on a deliberately broken submodule (naming it), and
clean across all 19 once repaired.
