### PR TITLE
fix(site): stop linking the homepage at the archived reusable-workflows repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,8 +38,11 @@ jobs:
               - 'docs/package.json'
               - 'docs/package-lock.json'
             active-projects:
-              - 'docs/src/content/docs/projects/active.mdx'
-              - 'docs/src/content/docs/templates/**'
+              # The retired-link guard greps the WHOLE content tree, so it must
+              # run for ANY content change — gating it on the two pages the
+              # drift lists live in would let a retired link ship from a blog
+              # post or any other page the guard claims to cover.
+              - 'docs/src/content/**'
               - 'docs/scripts/check-active-projects-drift.sh'
               - 'docs/scripts/check-active-projects-drift.test.sh'
               - '.gitmodules'

--- a/docs/scripts/check-active-projects-drift.sh
+++ b/docs/scripts/check-active-projects-drift.sh
@@ -89,6 +89,7 @@ actions_dir="$repo_root/github/devantler-tech/github-actions/actions"
 rw_workflows_dir="$repo_root/github/devantler-tech/github-actions/actions/.github/workflows"
 gitmodules="$repo_root/.gitmodules"
 templates_dir="$repo_root/docs/src/content/docs/templates"
+content_dir="$repo_root/docs/src/content"
 
 # Anchor each H2 section on the source repo URL it links to — unique and stable.
 actions_anchor="](https://github.com/devantler-tech/actions)"
@@ -103,6 +104,42 @@ die_missing() {
 [ -f "$mdx" ] || die_missing "active.mdx" "$mdx"
 [ -d "$actions_dir" ] || die_missing "actions submodule" "$actions_dir"
 [ -d "$rw_workflows_dir" ] || die_missing "actions submodule workflows directory" "$rw_workflows_dir"
+[ -d "$content_dir" ] || die_missing "docs content directory" "$content_dir"
+
+# --- Retired repos: no page may still link to one -----------------------------
+#
+# The lists above are guarded, so they stay current — but a link somewhere else on
+# the site pointing at a repo we retired is the same drift with no tripwire. It
+# happened: reusable-workflows was merged into actions and archived (2026-07-10,
+# monorepo#1964), active.mdx was updated, and the homepage LinkCard kept pointing
+# at the archived repo — sending readers to a read-only shell (monorepo#1813,
+# theme 2).
+#
+# Network-free by design, like the rest of this script: the retired set is pinned
+# here rather than queried, so add a repo when it is archived/renamed, together
+# with what to link instead.
+retired_repo_urls=(
+  "https://github.com/devantler-tech/reusable-workflows|https://github.com/devantler-tech/actions/tree/main/.github/workflows"
+)
+
+for entry in "${retired_repo_urls[@]}"; do
+  retired_url="${entry%%|*}"
+  replacement_url="${entry##*|}"
+
+  # -F: the URLs are literals, not patterns. Match the whole content tree, not just
+  # active.mdx — an unguarded page is exactly how this drifts.
+  if hits=$(grep -rFl "$retired_url" "$content_dir" 2>/dev/null) && [ -n "$hits" ]; then
+    while IFS= read -r hit; do
+      echo "::error file=${hit#"$repo_root"/}::Retired-repo link: this page links to '${retired_url}', \
+which is archived (read-only). Link '${replacement_url}' instead." >&2
+    done <<<"$hits"
+    fail=1
+  fi
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "OK: no page links to a retired repo (${#retired_repo_urls[@]} pinned)."
+fi
 [ -f "$gitmodules" ] || die_missing ".gitmodules" "$gitmodules"
 [ -d "$templates_dir" ] || die_missing "templates docs directory" "$templates_dir"
 

--- a/docs/scripts/check-active-projects-drift.test.sh
+++ b/docs/scripts/check-active-projects-drift.test.sh
@@ -226,8 +226,24 @@ rm -rf "$c/github/devantler-tech/github-actions/actions"
 fail_match "die_missing: actions submodule not checked out" "$c" \
   "actions submodule not found"
 
+# 13. Retired-repo link: ANY page under docs/src/content linking to an archived
+#     repo trips the guard — not just the guarded lists. Uses the homepage,
+#     because that is exactly where this drifted in production: active.mdx was
+#     updated when reusable-workflows was archived and the homepage LinkCard was
+#     not (monorepo#1813, theme 2).
+c="$tmp/retired-link"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'FIXTURE'
+---
+title: Home
+---
+
+<LinkCard href="https://github.com/devantler-tech/reusable-workflows" />
+FIXTURE
+fail_match "retired-repo link on an unguarded page" "$c" \
+  "Retired-repo link"
+
 if [ "$fail" -ne 0 ]; then
   printf '❌ active-projects drift-guard self-test FAILED\n' >&2
   exit 1
 fi
-printf '✅ active-projects drift-guard self-test passed (13 cases)\n'
+printf '✅ active-projects drift-guard self-test passed (14 cases)\n'

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -76,7 +76,7 @@ export const latestPosts = (await getCollection("docs"))
   <LinkCard
     title="🔄 Reusable Workflows"
     description="A curated library of GitHub Actions reusable workflows for Go, .NET, docs, releases, and repo automation."
-    href="https://github.com/devantler-tech/reusable-workflows"
+    href="https://github.com/devantler-tech/actions/tree/main/.github/workflows"
   />
   <LinkCard
     title="⚡ Actions"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The **Reusable Workflows** card on the devantler.tech homepage sends readers to `devantler-tech/reusable-workflows` — a repo that was merged into `devantler-tech/actions` and **archived** on 2026-07-10. Anyone clicking it lands on a read-only shell instead of the workflows.

The interesting part is *why* it survived: when that repo was archived, the Active Projects page was updated — because a drift guard covers it. The homepage was missed, because nothing did.

## What

Points the card at the workflows in `actions`, matching the link Active Projects already uses.

Then closes the class: the docs drift check now pins retired repos and asserts **no page** under `docs/src/content` links to one — not just the guarded lists. Guarded content stays fresh; unguarded content rots, so the guard now covers the whole content tree. Network-free like the rest of the check (the retired set is pinned, not queried), with a self-test case using the homepage — the exact page that drifted.

Verified both ways: reintroducing the old link fails the guard, naming the file and the correct replacement; site builds with all internal links valid.

Part of #1813 (theme 2: make site content self-sustaining).
