### PR TITLE
docs(agents): add World at Ruin to the portfolio and stack map

### DIFF
--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -202,8 +202,8 @@ public and private — no per-repo loop needed to enumerate):
 
 Portfolio repos (the org-wide search covers them; this is the canonical list to reason over):
 `ksail`, `platform`, `monorepo`, `go-template`, `dotnet-template`, `gitops-tenant-template`,
-`actions`, `reusable-workflows`, `homebrew-tap`, `skills`, `plugins`, `wedding-app` (private),
-`ascoachingogvaner` (private).
+`actions`, `reusable-workflows`, `homebrew-tap`, `skills`, `plugins`, `world-at-ruin`,
+`wedding-app` (private), `ascoachingogvaner` (private).
 
 Keep your *own* footprint small: prefer `--jq` to project just the fields you need, never echo raw
 JSON blobs — summarise as you go. **No silent truncation:** the `--limit` on the org-wide searches is

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -226,9 +226,8 @@ Products → cards: [ksail](../products/ksail/SKILL.md) · [platform](../product
 [github-actions](../products/github-actions/SKILL.md) · [skills (+ plugins)](../products/agent-skills/SKILL.md) ·
 [homebrew-tap](../products/homebrew-tap/SKILL.md) · [applications](../products/applications/SKILL.md) ·
 [provider-upjet-unifi](../products/provider-upjet-unifi/SKILL.md) ·
-[world-at-ruin](../products/world-at-ruin/SKILL.md) *(game — LOWEST priority; its repo is not
-bootstrapped yet, so it produces NO survey signal: select it from this index when nothing else
-demands attention, not from a GitHub search)*.
+[world-at-ruin](../products/world-at-ruin/SKILL.md) *(game — LOWEST priority; the repo exists and
+produces normal survey signal, but select it only when nothing else demands attention)*.
 
 ## 2. Select (the heart of it)
 Pick the **highest-value work across the whole portfolio**, then **go deep where depth is needed**

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -224,7 +224,11 @@ org-wide `gh search` first, deepen only the candidates — never the old per-rep
 Products → cards: [ksail](../products/ksail/SKILL.md) · [platform](../products/platform/SKILL.md) ·
 [monorepo + site](../products/monorepo/SKILL.md) · [templates](../products/templates/SKILL.md) ·
 [github-actions](../products/github-actions/SKILL.md) · [skills (+ plugins)](../products/agent-skills/SKILL.md) ·
-[homebrew-tap](../products/homebrew-tap/SKILL.md) · [applications](../products/applications/SKILL.md).
+[homebrew-tap](../products/homebrew-tap/SKILL.md) · [applications](../products/applications/SKILL.md) ·
+[provider-upjet-unifi](../products/provider-upjet-unifi/SKILL.md) ·
+[world-at-ruin](../products/world-at-ruin/SKILL.md) *(game — LOWEST priority; its repo is not
+bootstrapped yet, so it produces NO survey signal: select it from this index when nothing else
+demands attention, not from a GitHub search)*.
 
 ## 2. Select (the heart of it)
 Pick the **highest-value work across the whole portfolio**, then **go deep where depth is needed**

--- a/.claude/skills/products/world-at-ruin/SKILL.md
+++ b/.claude/skills/products/world-at-ruin/SKILL.md
@@ -14,8 +14,12 @@ declaratively (org-admin `gh api` create → Observe-adopt, per the repo-creatio
 `applications/world-at-ruin` submodule, and move the design below into its `AGENTS.md`. **After that
 this card becomes a thin pointer, like every other product card here.**
 
-Everything below is **already decided — do not re-litigate it.** It was settled with the maintainer
-directly (2026-07-16). Shared cross-repo rules are in the monorepo [`AGENTS.md`](../../../../AGENTS.md).
+**The stack, the product law and the design pillars below were settled with the maintainer directly
+(2026-07-16) — do not re-litigate those.** The directive covers *decisions*, not the whole card: a few
+points are deliberately still **OPEN**, and they are marked **`OPEN DECISION`** where they appear.
+Those you may not treat as settled — decide them when you implement the subsystem, ship the call as a
+draft PR (he redirects there), and update this card with what was chosen. Shared cross-repo rules are
+in the monorepo [`AGENTS.md`](../../../../AGENTS.md).
 
 ## The premise — “as code”, which decides everything else
 
@@ -120,7 +124,7 @@ policing them (there is no undo).
   an agent-ownable CI guard rather than a matter of taste.
 - **Tune content against the *banked floor*, not peak mastery.** Unlosable progress is the only power
   level every player is guaranteed to have; everything above it is skill expression.
-- **Death penalty in group content breeds blame.** A bloodstain is fine solo; “you cost me my mastery”
+- **`OPEN DECISION` — death penalty in group content breeds blame.** A bloodstain is fine solo; “you cost me my mastery”
   on a raid wipe is why WoW removed corpse runs. Consider full risk in open world/solo (his stated
   risk/reward intent) and a softened penalty in organised group content. Flag it as a decision, not a
   detail.
@@ -129,7 +133,7 @@ policing them (there is no undo).
 - **Axis map, to keep balance legible**: **weapons = horizontal** (your arsenal; cosmetic variety
   only). **Armour = your role/agility axis, and the bounded endgame vertical.** Keep them from
   blurring.
-- **Classless + account-bound unlocks make alts near-pointless** — especially with full appearance
+- **`OPEN DECISION` — classless + account-bound unlocks make alts near-pointless** — especially with full appearance
   freedom. Consider **one character per account**: it simplifies the data model and identity, and
   removes mule characters as an economy vector.
 
@@ -148,3 +152,14 @@ Once bootstrapped, the roadmap lives in **GitHub Issues on `devantler-tech/world
 specified, testable, art-free. **The project stalls the moment the next task is “make the combat feel
 good”**: that is a taste judgement and it needs the maintainer, so route those to him rather than
 guessing.
+
+**Phase 0 is the deliberate exception to “testable, art-free”** — it is *entirely* art and it ends in
+a taste judgement, so the rule above would forbid the project's own mandatory first step. Split it so
+the roadmap can carry it honestly:
+- **The machine-verifiable part IS a normal issue**: a headless Blender container runs in CI, an
+  MPFB2 character and a procedural cave build reproducibly from committed scripts, and the glTF loads
+  in Godot. That is testable, and an agent owns it end to end.
+- **The taste gate is a separate, explicitly maintainer-blocked issue** — he looks at the render and
+  says yes or no. Never self-answer it, never infer a pass from CI being green, and never start game
+  code because the pipeline runs. It is the one issue in the backlog that is *supposed* to wait for
+  him.

--- a/.claude/skills/products/world-at-ruin/SKILL.md
+++ b/.claude/skills/products/world-at-ruin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintain-world-at-ruin
-description: Product card for World at Ruin — a source-available, cloud-native MMORPG built almost entirely by agents at LOWEST priority. Carries the settled stack and design decisions until the repo exists. Use when the daily maintainer has no higher-priority work and selects World at Ruin.
+description: Product card for World at Ruin — a source-available, cloud-native MMORPG built almost entirely by agents at LOWEST priority. The repo's own AGENTS.md is authoritative for the settled design; this card keeps the operate notes and open decisions. Use when the daily maintainer has no higher-priority work and selects World at Ruin.
 ---
 
 # Maintain: World at Ruin (game)
@@ -9,10 +9,11 @@ A cloud-native MMORPG the maintainer wants to exist, built **almost entirely by 
 priority** — pick it up only when nothing else demands attention, and expect it to accrete over years.
 He redirects via the **PR workflow**; ship draft PRs as usual.
 
-**Status: the repo does not exist yet.** First task is to bootstrap `devantler-tech/world-at-ruin`
-declaratively (org-admin `gh api` create → Observe-adopt, per the repo-creation pattern), add the
-`applications/world-at-ruin` submodule, and move the design below into its `AGENTS.md`. **After that
-this card becomes a thin pointer, like every other product card here.**
+**Status: bootstrapped 2026-07-16.** The repo exists, the `applications/world-at-ruin` submodule is
+in place, the roadmap is seeded as GitHub Issues (`roadmap` label — Phase 0 art-pipeline taste gate
+first), and the settled design lives in **the repo's own `AGENTS.md`, which is authoritative**. This
+card keeps the operate notes and the deliberately-open **`OPEN DECISION`** items below; once those
+are settled and recorded in the repo, thin this card to a plain pointer like the other product cards.
 
 **The stack, the product law and the design pillars below were settled with the maintainer directly
 (2026-07-16) — do not re-litigate those.** The directive covers *decisions*, not the whole card: a few
@@ -146,7 +147,7 @@ his bar, the premise fails — cheap to learn now, ruinous to learn in Phase 6.
 
 ## Roadmap & enhancement
 
-Once bootstrapped, the roadmap lives in **GitHub Issues on `devantler-tech/world-at-ruin`**
+The roadmap lives in **GitHub Issues on `devantler-tech/world-at-ruin`**
 (`roadmap` label), like every other product. Advance via
 [`product-engineering`](../../product-engineering/SKILL.md). Keep issues **agent-shaped** — small,
 specified, testable, art-free. **The project stalls the moment the next task is “make the combat feel

--- a/.claude/skills/products/world-at-ruin/SKILL.md
+++ b/.claude/skills/products/world-at-ruin/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: maintain-world-at-ruin
+description: Product card for World at Ruin — a source-available, cloud-native MMORPG built almost entirely by agents at LOWEST priority. Carries the settled stack and design decisions until the repo exists. Use when the daily maintainer has no higher-priority work and selects World at Ruin.
+---
+
+# Maintain: World at Ruin (game)
+
+A cloud-native MMORPG the maintainer wants to exist, built **almost entirely by agents** at **lowest
+priority** — pick it up only when nothing else demands attention, and expect it to accrete over years.
+He redirects via the **PR workflow**; ship draft PRs as usual.
+
+**Status: the repo does not exist yet.** First task is to bootstrap `devantler-tech/world-at-ruin`
+declaratively (org-admin `gh api` create → Observe-adopt, per the repo-creation pattern), add the
+`applications/world-at-ruin` submodule, and move the design below into its `AGENTS.md`. **After that
+this card becomes a thin pointer, like every other product card here.**
+
+Everything below is **already decided — do not re-litigate it.** It was settled with the maintainer
+directly (2026-07-16). Shared cross-repo rules are in the monorepo [`AGENTS.md`](../../../../AGENTS.md).
+
+## The premise — “as code”, which decides everything else
+
+No UI clicks, no desktop design tools. Everything text-authored, built headlessly in CI. **If an agent
+cannot author it, it does not get built**, because nobody is hand-making this. So “as code” is the
+*premise* and every other preference — engine, fidelity — yields to it.
+
+- **Client: Godot 4** — chosen *because* `.tscn`/`.tres`/`.gdshader` are text and headless export is
+  first-class. **Unreal was rejected:** `.uasset`/`.umap` are binary, so agents cannot author levels or
+  materials. This knowingly costs the graphics ceiling (Godot ≈ semi-realistic PBR; no Nanite/Lumen).
+- **Art: generated as code, all OSS/CC0 — never commercial assets.** Headless Blender (`bpy`) → glTF;
+  **MPFB2 + Rigify** for characters (core assets CC0, explicitly closed-source-safe); Poly Haven /
+  ambientCG (CC0) materials; WFC interiors, grammar towns, SDF caves, erosion terrain. **Blender's GPL
+  covers the tool, never the output.** Target is **stylised-realistic (“a more realistic WoW”)** — that
+  style is *parametric*, which is exactly why it is expressible as code. Photorealism is unreachable in
+  any engine without a human sculptor; do not re-attempt it.
+- **Weakest link: animation.** CMU mocap (verify licence per dataset — AMASS/LAFAN1 are research-only,
+  never ship them) + procedural IK. Telegraphed combat mitigates this by putting the signal in the
+  ground, not the frames.
+- **AI-generated 3D**: MIT models exist (TRELLIS, TripoSR) but topology is poor and **training-data
+  provenance is murky** — a liability for something he owns outright. Concept/props only, never a
+  shipped hero asset.
+
+## Server
+
+- **Realtime tier**: zone / dungeon-instance **Agones** GameServers (CNCF). **One tick loop per
+  process — NEVER decomposed.** The unit of scale is the *number* of zones. A network hop between
+  “player moved” and “was he in the cone” re-creates the desync problem telegraphs exist to avoid.
+- **Meta tier**: real Go microservices over gRPC — mostly **Nakama** (Apache-2.0) for
+  auth/social/chat/storage. Write only what it doesn't give you.
+- **Postgres/CNPG**; runs on the existing platform via Flux. **Seamless instancing** falls out of
+  Agones: allocate the dungeon server as the player approaches, pre-connect, hand off — no loading
+  screens, no pop-in, ever.
+- **Physics stays OUT of the authoritative path** — capsules/navmesh only. This is what makes a Go
+  authority cheap, deterministic and latency-tolerant.
+
+## Licensing
+
+**Source-available and proprietary — NEVER call it “open source”** (free redistribution is clause 1 of
+the OSD). Copying/redistribution prohibited. Needs a **bespoke EULA** and a **CLA with copyright
+assignment** (EU: assignment plus fallback exclusive licence) gating the first external PR. **No
+GPL/AGPL in the shipped tree** — enforce in CI, don't remember it.
+
+## Product law — the two constraints that outrank the design
+
+1. **No hard resets, ever.** An early player keeps playing as it evolves: no wipes, no seasons, no
+   stat squishes. Every change is **forward-only and non-destructive** (expand/contract migrations,
+   versioned save data, backward-compatible protocols, feature-flag-first). **CI-enforceable, and the
+   guard must exist before the first player does** — an agent must not be able to merge a change that
+   strands a character.
+2. **No power/wealth inflation, no ecosystem corruption.** **There is no undo**: a dupe, a runaway drop
+   rate or a bad migration is permanent. Transactional integrity, idempotency and an audit trail are
+   day-one requirements.
+
+**The collision to keep front of mind: WoW/Diablo-4's answer to inflation IS the reset** (D4 wipes
+seasonally; WoW squishes stats). Both are forbidden, so economics come from **Guild Wars 2** instead:
+horizontal progression, a ceiling that never rises, bound loot, no trading/auction house (kills RMT,
+botting and dupe *value* at the root), hard sinks. WoW/D4 texture, GW2 economics.
+
+## Design — classless weapon mastery (The Secret World-shaped)
+
+- **Classless.** Playstyle is defined by which weapons you master. **Two weapons equipped, or one
+  wielded alone to empower it** — flexibility and multi-specialisation.
+- **Trifecta**: damage / healer / tank. Each weapon leans toward one or more roles.
+- **Progression = weapon mastery, earned by *using* the weapon.** Mastery unlocks **new arsenals —
+  never more damage**: more and more interesting ways to approach combat.
+- **Death**: lose some unbanked mastery, respawn at the nearest respawn point, and **reclaim it or lose
+  it forever** (a Souls bloodstain, kept even though the Souls loop was dropped). A filled bar **banks
+  unlosable progress** — a ratchet floor.
+- **Balance**: mitigation / damage / healing throughputs stay balanced so **all areas stay relevant**.
+  Progression is *advisable* for the hardest content, never *required* — doing it unprogressed should
+  be possible but unwise. Some areas/dungeons are **gated by story or orderly completion**; unlocks are
+  **account-bound**.
+- **Hard, skill-based bosses and elites** spread across open world, dungeons and raids — opt-in risk of
+  losing or gaining larger amounts of mastery, plus the odd cosmetic.
+- **Loot is Elder-Scrolls-shaped: a sword is a sword.** How well you use it is *your* mastery. Huge
+  visual variety so players find the look they want **without touching balance**. **Armour is the
+  exception** — real mitigation/lightness trade-offs: light = agile, heavy = takes a hit.
+- **Endgame**: mythic-like dungeons, regular dungeons, raids, endless dungeons. **Loot-based
+  progression here only** — gear upgraded and specialised to take on harder content. **Outside the
+  endgame, loot is visual only**, so the open world stays relevant.
+
+## Design guards — the traps in the above, and how to hold them
+
+These are the non-obvious failure modes. Treat them as laws, and prefer designing them out over
+policing them (there is no undo).
+
+- **🔴 The endgame ladder is the one place power grows — it MUST be bounded and inert outside itself.**
+  “Gear upgraded to take on harder and harder content” *is* vertical progression, i.e. the exact
+  inflation the product law forbids. It is only coherent if: (a) endgame gear is **stat-normalised or
+  inert outside endgame instances** (GW2 downscaling / WoW Timewalking), or it trivialises the open
+  world and breaks “all areas relevant”; and (b) the ladder has a **ceiling** — beyond it, **difficulty
+  scales, not power** (endless dungeons, mythic keys), and rewards become **score and cosmetics**.
+  That is how “harder and harder” runs forever with no inflation and no reset.
+- **🔴 Usage-based progression's classic exploit is AFK/dummy grinding** (UO, Skyrim, ESO all bled
+  here). With no wipe available this is permanent. **Mastery accrues only from meaningful contested
+  combat** — appropriate-level hostile targets, server-authoritative, diminishing returns, and **zero**
+  progress from training dummies, self-damage, or trivial mobs.
+- **Every new arsenal ability must be a SIDEGRADE, never a strict upgrade.** He is right that more
+  options raise throughput in effect — that is precisely how power creep enters a game that claims to
+  have none. Situational-by-design is the law, and **“no strict dominance” is simulatable**, so it is
+  an agent-ownable CI guard rather than a matter of taste.
+- **Tune content against the *banked floor*, not peak mastery.** Unlosable progress is the only power
+  level every player is guaranteed to have; everything above it is skill expression.
+- **Death penalty in group content breeds blame.** A bloodstain is fine solo; “you cost me my mastery”
+  on a raid wipe is why WoW removed corpse runs. Consider full risk in open world/solo (his stated
+  risk/reward intent) and a softened penalty in organised group content. Flag it as a decision, not a
+  detail.
+- **Classless + dual weapons SOLVES tank/healer scarcity** — the classic MMO queue problem. Any player
+  can swap to fill the missing role. Protect this; it is a genuine strength of the design.
+- **Axis map, to keep balance legible**: **weapons = horizontal** (your arsenal; cosmetic variety
+  only). **Armour = your role/agility axis, and the bounded endgame vertical.** Keep them from
+  blurring.
+- **Classless + account-bound unlocks make alts near-pointless** — especially with full appearance
+  freedom. Consider **one character per account**: it simplifies the data model and identity, and
+  removes mule characters as an economy vector.
+
+## Phase 0 — before ANY game code
+
+**Prove the art pipeline**: headless Blender in CI → one MPFB2 character with proportions pushed
+stylised-realistic → one procedural cave → standing in Godot. It is a **taste gate the maintainer
+judges**, not a test suite, and it is the project's **one unproven bet**. If generated art can't clear
+his bar, the premise fails — cheap to learn now, ruinous to learn in Phase 6.
+
+## Roadmap & enhancement
+
+Once bootstrapped, the roadmap lives in **GitHub Issues on `devantler-tech/world-at-ruin`**
+(`roadmap` label), like every other product. Advance via
+[`product-engineering`](../../product-engineering/SKILL.md). Keep issues **agent-shaped** — small,
+specified, testable, art-free. **The project stalls the moment the next task is “make the combat feel
+good”**: that is a taste judgement and it needs the maintainer, so route those to him rather than
+guessing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,11 +30,47 @@ keeping them healthy *and* moving them forward.
 | Agent skills (shared lib) | `devantler-tech/agent-skills` | `libraries/agent-skills` | [AGENTS.md](https://github.com/devantler-tech/agent-skills/blob/main/AGENTS.md) |
 | Agent plugins (shared lib) | `devantler-tech/agent-plugins` (renamed from `copilot-plugins`) | `libraries/agent-plugins` | [AGENTS.md](https://github.com/devantler-tech/agent-plugins/blob/main/AGENTS.md) |
 | UniFi Crossplane provider (shared lib) | `devantler-tech/provider-upjet-unifi` | `libraries/provider-upjet-unifi` | [AGENTS.md](https://github.com/devantler-tech/provider-upjet-unifi/blob/main/AGENTS.md) |
+| World at Ruin (game) | `devantler-tech/world-at-ruin` (**repo not yet bootstrapped** — see below) | `applications/world-at-ruin` (pending) | (pending) |
 | Wedding app (private) | `devantler-tech/wedding-app` | `applications/wedding-app` | (private) |
 | AS Coaching (private) | `devantler-tech/ascoachingogvaner` | `applications/ascoachingogvaner` | (private) |
 | UniFi network (private) | `devantler-tech/unifi` | `applications/unifi` | [AGENTS.md](https://github.com/devantler-tech/unifi/blob/main/AGENTS.md) |
 
 > Submodule `AGENTS.md` links use full GitHub URLs because those files live in the submodule repos, not this repo's tree (a relative link would 404 on GitHub).
+
+**World at Ruin — newest product, not yet bootstrapped** (maintainer direction 2026-07-16). A
+cloud-native MMORPG the maintainer wants to exist, built **almost entirely by agents** at **lowest
+priority** — pick it up when nothing else demands attention, and expect it to accrete over years.
+Its roadmap and issues live on its own repo once that exists; **the first task is to bootstrap
+`devantler-tech/world-at-ruin`** declaratively (org-admin `gh api` create → Observe-adopt, per the
+repo-creation pattern), then add it as the `applications/world-at-ruin` submodule and write its
+`AGENTS.md`. The stack below is **already decided — do not re-litigate it**; redirect happens via the
+PR workflow.
+
+- **“As code” is the premise, not a preference.** No UI clicks, no desktop design tools, everything
+  text-authored and built headlessly in CI. If an agent can't author it, it doesn't get built.
+- **Client: Godot 4** — chosen *because* `.tscn`/`.tres`/`.gdshader` are text and headless export is
+  first-class. **Unreal was rejected**: `.uasset`/`.umap` are binary, so agents cannot author levels or
+  materials. This overrides the graphics ceiling (Godot ≈ semi-realistic PBR, no Nanite/Lumen).
+- **Art: generated as code, all OSS/CC0 — never commercial assets.** Blender headless (`bpy`) → glTF;
+  **MPFB2 + Rigify** for characters (core assets CC0, explicitly closed-source-safe); Poly Haven /
+  ambientCG (CC0) materials; WFC interiors, grammar towns, SDF caves, erosion terrain. Blender's GPL
+  covers the tool, never the output. Art target is **stylised-realistic (a more realistic WoW)** — the
+  style is *parametric*, which is what makes it expressible as code; photorealism is out of reach in
+  any engine without a human sculptor.
+- **Server: Go.** Realtime tier = zone/dungeon-instance **Agones** GameServers (CNCF) — **one tick loop
+  per process, never decomposed**; the unit of scale is the number of zones. Meta tier = real
+  microservices, mostly **Nakama** (Apache-2.0) for auth/social/chat/storage. Postgres/CNPG. Runs on
+  the existing platform.
+- **Combat: telegraphed** (WildStar/WoW-like), **physics stays out of the authoritative path** —
+  capsules/navmesh only. This is what makes a Go authority cheap and latency-tolerant. Game loop is
+  WoW/Diablo-4-shaped (dungeon crawling, progression through exploration); **no PvP initially**.
+  Seamless instancing is fine; loading screens and pop-in are not.
+- **Licensing: source-available and proprietary — NEVER call it open source.** Copying/redistribution
+  prohibited; needs a bespoke EULA and a **CLA with copyright assignment** (EU: assignment plus
+  fallback exclusive licence) gating the first external PR. No GPL/AGPL in the shipped tree.
+- **Phase 0 before any game code:** prove the art pipeline — headless Blender in CI, one MPFB2
+  character, one procedural cave, in Godot. It is a **taste gate** the maintainer judges, and it is the
+  project's one unproven bet.
 
 **Shared libraries** (leverage points across the whole suite — see *Holistic review* and the
 `product-engineering` skill): the CI building block `devantler-tech/actions` (which
@@ -57,6 +93,7 @@ no row are filed on the **default intake repo** below.
 | Building block | Good for | Owning repo |
 |---|---|---|
 | devantler.tech website | Public web pages on devantler.tech — docs, guides, announcements, portfolio content | `devantler-tech/monorepo` |
+| World at Ruin | THIS suite's own online fantasy game — its world, dungeons, characters, monsters, combat, loot and progression (not games in general) | `devantler-tech/world-at-ruin` |
 | Wedding app | THIS suite's existing deployed wedding website only — its guest pages, RSVPs, schedules, photos and practical info (not new wedding sites in general) | `devantler-tech/wedding-app` |
 | AS Coaching site | THIS suite's existing deployed AS Coaching og Vaner business site only — its pages, offerings, prices, booking information (not new coaching/business sites in general) | `devantler-tech/ascoachingogvaner` |
 | App hosting platform | Running an app or service so people can reach it online — deploys, dashboards, alerts, backups | `devantler-tech/platform` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ no row are filed on the **default intake repo** below.
 | Building block | Good for | Owning repo |
 |---|---|---|
 | devantler.tech website | Public web pages on devantler.tech — docs, guides, announcements, portfolio content | `devantler-tech/monorepo` |
-| World at Ruin | THIS suite's own online fantasy game — its world, dungeons, characters, monsters, combat, loot and progression (not games in general) | `devantler-tech/world-at-ruin` |
+| World at Ruin | THIS suite's own online fantasy game — its world, dungeons, characters, monsters, combat, loot and progression (not games in general) | `devantler-tech/monorepo` (**until `devantler-tech/world-at-ruin` is bootstrapped** — that repo does not exist yet, so intake would 404; repoint this row on bootstrap) |
 | Wedding app | THIS suite's existing deployed wedding website only — its guest pages, RSVPs, schedules, photos and practical info (not new wedding sites in general) | `devantler-tech/wedding-app` |
 | AS Coaching site | THIS suite's existing deployed AS Coaching og Vaner business site only — its pages, offerings, prices, booking information (not new coaching/business sites in general) | `devantler-tech/ascoachingogvaner` |
 | App hosting platform | Running an app or service so people can reach it online — deploys, dashboards, alerts, backups | `devantler-tech/platform` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,25 @@ PR workflow.
 - **Licensing: source-available and proprietary — NEVER call it open source.** Copying/redistribution
   prohibited; needs a bespoke EULA and a **CLA with copyright assignment** (EU: assignment plus
   fallback exclusive licence) gating the first external PR. No GPL/AGPL in the shipped tree.
+- **Continuously evolving, NO hard resets — an early player must keep playing forever** (maintainer
+  direction 2026-07-16). No wipes, no seasons, no fresh starts, no stat squishes. Every schema and
+  content change is **forward-only and non-destructive**: expand/contract migrations, versioned save
+  data, backward-compatible protocols, and the constitution's **feature-flag-first delivery** (land
+  latent, flip on after validation). This is a **CI-enforceable contract** — a migration/compat test
+  suite is the guard, and an agent shipping a breaking schema change would strand real characters, so
+  the guard must exist before the first player does. Corollary: **there is no undo.** A duplication or
+  economy bug is permanent, so transactional integrity, idempotency and an audit trail are required
+  from the first commit, not retrofitted.
+- **No power/wealth inflation, no ecosystem corruption** (maintainer direction 2026-07-16) — and note
+  the **direct tension with the WoW/D4 loop: their answer to inflation IS the reset** (D4 wipes
+  characters every season; WoW squishes stats and invalidates gear each expansion). Those remedies are
+  forbidden here, so the progression model must be **Guild Wars 2-shaped instead: horizontal
+  progression, a reachable gear ceiling that never rises, breadth over power.** Content adds *places
+  and things to do*, never a bigger number. Design the corruption vectors out rather than policing
+  them: bound loot and no open trading/auction house (kills RMT, botting and dupe value at the root),
+  hard currency sinks, diminishing returns, no pay-to-win surface at all. Take the WoW/D4 *texture*
+  (dungeon crawling, exploration) with GW2's *economics* — that synthesis is the product's spine, not
+  a detail.
 - **Phase 0 before any game code:** prove the art pipeline — headless Blender in CI, one MPFB2
   character, one procedural cave, in Godot. It is a **taste gate** the maintainer judges, and it is the
   project's one unproven bet.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,21 +30,21 @@ keeping them healthy *and* moving them forward.
 | Agent skills (shared lib) | `devantler-tech/agent-skills` | `libraries/agent-skills` | [AGENTS.md](https://github.com/devantler-tech/agent-skills/blob/main/AGENTS.md) |
 | Agent plugins (shared lib) | `devantler-tech/agent-plugins` (renamed from `copilot-plugins`) | `libraries/agent-plugins` | [AGENTS.md](https://github.com/devantler-tech/agent-plugins/blob/main/AGENTS.md) |
 | UniFi Crossplane provider (shared lib) | `devantler-tech/provider-upjet-unifi` | `libraries/provider-upjet-unifi` | [AGENTS.md](https://github.com/devantler-tech/provider-upjet-unifi/blob/main/AGENTS.md) |
-| World at Ruin (game) | `devantler-tech/world-at-ruin` (**repo not yet bootstrapped** — see below) | `applications/world-at-ruin` (pending) | [product card](.claude/skills/products/world-at-ruin/SKILL.md) (until the repo exists) |
+| World at Ruin (game) | `devantler-tech/world-at-ruin` | `applications/world-at-ruin` | [AGENTS.md](https://github.com/devantler-tech/world-at-ruin/blob/main/AGENTS.md) |
 | Wedding app (private) | `devantler-tech/wedding-app` | `applications/wedding-app` | (private) |
 | AS Coaching (private) | `devantler-tech/ascoachingogvaner` | `applications/ascoachingogvaner` | (private) |
 | UniFi network (private) | `devantler-tech/unifi` | `applications/unifi` | [AGENTS.md](https://github.com/devantler-tech/unifi/blob/main/AGENTS.md) |
 
 > Submodule `AGENTS.md` links use full GitHub URLs because those files live in the submodule repos, not this repo's tree (a relative link would 404 on GitHub).
 
-**World at Ruin — newest product, not yet bootstrapped** (maintainer direction 2026-07-16). A
+**World at Ruin — newest product, bootstrapped 2026-07-16** (maintainer direction the same day). A
 cloud-native MMORPG the maintainer wants to exist, built **almost entirely by agents** at **lowest
-priority** — pick it up only when nothing else demands attention. **The first task is to bootstrap
-`devantler-tech/world-at-ruin`** (org-admin `gh api` create → Observe-adopt), add the submodule, and
-move the design into its `AGENTS.md`; its roadmap and issues then live there. The stack and design are
-**already settled — do not re-litigate them**: see
-[`.claude/skills/products/world-at-ruin/`](.claude/skills/products/world-at-ruin/SKILL.md), which
-carries them until the repo exists.
+priority** — pick it up only when nothing else demands attention. The repo exists, the
+`applications/world-at-ruin` submodule is in place, and its roadmap lives in **GitHub Issues on
+`devantler-tech/world-at-ruin`**. The stack and design are **already settled — do not re-litigate
+them**: the repo's own `AGENTS.md` is authoritative; the
+[product card](.claude/skills/products/world-at-ruin/SKILL.md) tracks the deliberately-open
+**`OPEN DECISION`** items and the operate notes.
 
 **Shared libraries** (leverage points across the whole suite — see *Holistic review* and the
 `product-engineering` skill): the CI building block `devantler-tech/actions` (which
@@ -67,7 +67,7 @@ no row are filed on the **default intake repo** below.
 | Building block | Good for | Owning repo |
 |---|---|---|
 | devantler.tech website | Public web pages on devantler.tech — docs, guides, announcements, portfolio content | `devantler-tech/monorepo` |
-| World at Ruin | THIS suite's own online fantasy game — its world, dungeons, characters, monsters, combat, loot and progression (not games in general) | `devantler-tech/monorepo` (**until `devantler-tech/world-at-ruin` is bootstrapped** — that repo does not exist yet, so intake would 404; repoint this row on bootstrap) |
+| World at Ruin | THIS suite's own online fantasy game — its world, dungeons, characters, monsters, combat, loot and progression (not games in general) | `devantler-tech/world-at-ruin` |
 | Wedding app | THIS suite's existing deployed wedding website only — its guest pages, RSVPs, schedules, photos and practical info (not new wedding sites in general) | `devantler-tech/wedding-app` |
 | AS Coaching site | THIS suite's existing deployed AS Coaching og Vaner business site only — its pages, offerings, prices, booking information (not new coaching/business sites in general) | `devantler-tech/ascoachingogvaner` |
 | App hosting platform | Running an app or service so people can reach it online — deploys, dashboards, alerts, backups | `devantler-tech/platform` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ keeping them healthy *and* moving them forward.
 | Agent skills (shared lib) | `devantler-tech/agent-skills` | `libraries/agent-skills` | [AGENTS.md](https://github.com/devantler-tech/agent-skills/blob/main/AGENTS.md) |
 | Agent plugins (shared lib) | `devantler-tech/agent-plugins` (renamed from `copilot-plugins`) | `libraries/agent-plugins` | [AGENTS.md](https://github.com/devantler-tech/agent-plugins/blob/main/AGENTS.md) |
 | UniFi Crossplane provider (shared lib) | `devantler-tech/provider-upjet-unifi` | `libraries/provider-upjet-unifi` | [AGENTS.md](https://github.com/devantler-tech/provider-upjet-unifi/blob/main/AGENTS.md) |
-| World at Ruin (game) | `devantler-tech/world-at-ruin` (**repo not yet bootstrapped** — see below) | `applications/world-at-ruin` (pending) | (pending) |
+| World at Ruin (game) | `devantler-tech/world-at-ruin` (**repo not yet bootstrapped** — see below) | `applications/world-at-ruin` (pending) | [product card](.claude/skills/products/world-at-ruin/SKILL.md) (until the repo exists) |
 | Wedding app (private) | `devantler-tech/wedding-app` | `applications/wedding-app` | (private) |
 | AS Coaching (private) | `devantler-tech/ascoachingogvaner` | `applications/ascoachingogvaner` | (private) |
 | UniFi network (private) | `devantler-tech/unifi` | `applications/unifi` | [AGENTS.md](https://github.com/devantler-tech/unifi/blob/main/AGENTS.md) |
@@ -39,57 +39,12 @@ keeping them healthy *and* moving them forward.
 
 **World at Ruin — newest product, not yet bootstrapped** (maintainer direction 2026-07-16). A
 cloud-native MMORPG the maintainer wants to exist, built **almost entirely by agents** at **lowest
-priority** — pick it up when nothing else demands attention, and expect it to accrete over years.
-Its roadmap and issues live on its own repo once that exists; **the first task is to bootstrap
-`devantler-tech/world-at-ruin`** declaratively (org-admin `gh api` create → Observe-adopt, per the
-repo-creation pattern), then add it as the `applications/world-at-ruin` submodule and write its
-`AGENTS.md`. The stack below is **already decided — do not re-litigate it**; redirect happens via the
-PR workflow.
-
-- **“As code” is the premise, not a preference.** No UI clicks, no desktop design tools, everything
-  text-authored and built headlessly in CI. If an agent can't author it, it doesn't get built.
-- **Client: Godot 4** — chosen *because* `.tscn`/`.tres`/`.gdshader` are text and headless export is
-  first-class. **Unreal was rejected**: `.uasset`/`.umap` are binary, so agents cannot author levels or
-  materials. This overrides the graphics ceiling (Godot ≈ semi-realistic PBR, no Nanite/Lumen).
-- **Art: generated as code, all OSS/CC0 — never commercial assets.** Blender headless (`bpy`) → glTF;
-  **MPFB2 + Rigify** for characters (core assets CC0, explicitly closed-source-safe); Poly Haven /
-  ambientCG (CC0) materials; WFC interiors, grammar towns, SDF caves, erosion terrain. Blender's GPL
-  covers the tool, never the output. Art target is **stylised-realistic (a more realistic WoW)** — the
-  style is *parametric*, which is what makes it expressible as code; photorealism is out of reach in
-  any engine without a human sculptor.
-- **Server: Go.** Realtime tier = zone/dungeon-instance **Agones** GameServers (CNCF) — **one tick loop
-  per process, never decomposed**; the unit of scale is the number of zones. Meta tier = real
-  microservices, mostly **Nakama** (Apache-2.0) for auth/social/chat/storage. Postgres/CNPG. Runs on
-  the existing platform.
-- **Combat: telegraphed** (WildStar/WoW-like), **physics stays out of the authoritative path** —
-  capsules/navmesh only. This is what makes a Go authority cheap and latency-tolerant. Game loop is
-  WoW/Diablo-4-shaped (dungeon crawling, progression through exploration); **no PvP initially**.
-  Seamless instancing is fine; loading screens and pop-in are not.
-- **Licensing: source-available and proprietary — NEVER call it open source.** Copying/redistribution
-  prohibited; needs a bespoke EULA and a **CLA with copyright assignment** (EU: assignment plus
-  fallback exclusive licence) gating the first external PR. No GPL/AGPL in the shipped tree.
-- **Continuously evolving, NO hard resets — an early player must keep playing forever** (maintainer
-  direction 2026-07-16). No wipes, no seasons, no fresh starts, no stat squishes. Every schema and
-  content change is **forward-only and non-destructive**: expand/contract migrations, versioned save
-  data, backward-compatible protocols, and the constitution's **feature-flag-first delivery** (land
-  latent, flip on after validation). This is a **CI-enforceable contract** — a migration/compat test
-  suite is the guard, and an agent shipping a breaking schema change would strand real characters, so
-  the guard must exist before the first player does. Corollary: **there is no undo.** A duplication or
-  economy bug is permanent, so transactional integrity, idempotency and an audit trail are required
-  from the first commit, not retrofitted.
-- **No power/wealth inflation, no ecosystem corruption** (maintainer direction 2026-07-16) — and note
-  the **direct tension with the WoW/D4 loop: their answer to inflation IS the reset** (D4 wipes
-  characters every season; WoW squishes stats and invalidates gear each expansion). Those remedies are
-  forbidden here, so the progression model must be **Guild Wars 2-shaped instead: horizontal
-  progression, a reachable gear ceiling that never rises, breadth over power.** Content adds *places
-  and things to do*, never a bigger number. Design the corruption vectors out rather than policing
-  them: bound loot and no open trading/auction house (kills RMT, botting and dupe value at the root),
-  hard currency sinks, diminishing returns, no pay-to-win surface at all. Take the WoW/D4 *texture*
-  (dungeon crawling, exploration) with GW2's *economics* — that synthesis is the product's spine, not
-  a detail.
-- **Phase 0 before any game code:** prove the art pipeline — headless Blender in CI, one MPFB2
-  character, one procedural cave, in Godot. It is a **taste gate** the maintainer judges, and it is the
-  project's one unproven bet.
+priority** — pick it up only when nothing else demands attention. **The first task is to bootstrap
+`devantler-tech/world-at-ruin`** (org-admin `gh api` create → Observe-adopt), add the submodule, and
+move the design into its `AGENTS.md`; its roadmap and issues then live there. The stack and design are
+**already settled — do not re-litigate them**: see
+[`.claude/skills/products/world-at-ruin/`](.claude/skills/products/world-at-ruin/SKILL.md), which
+carries them until the repo exists.
 
 **Shared libraries** (leverage points across the whole suite — see *Holistic review* and the
 `product-engineering` skill): the CI building block `devantler-tech/actions` (which


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

You want World at Ruin to exist and to be built by the agents whenever nothing else demands attention. Nothing points at it today, so no run would ever pick it up. This makes it a visible, lowest-priority product with a clear first task.

It also records the decisions we settled, so a future run does not re-argue them from scratch — the load-bearing one is that **"as code" is the premise** (no UI, no desktop design tools), which is what selects Godot over Unreal and shapes everything downstream.

## What

Adds World at Ruin to the Portfolio map and Stack map — both marked **pending**, since the repo does not exist yet — and names bootstrapping `devantler-tech/world-at-ruin` as the first task, after which its roadmap and issues live there.

The stack and game design live in a **product card** (`.claude/skills/products/world-at-ruin/`), following the existing per-product pattern, rather than in `AGENTS.md` — game design is not an agent instruction, and `AGENTS.md` is read by every agent for every product. It carries the design only until the repo exists, then becomes a thin pointer like its siblings.

Docs only. No repo created, no issues filed — stopping here as asked.

Two things worth your attention rather than burying:

- The game is **source-available and proprietary, never open source**, so it needs a bespoke EULA and a CLA before any external contribution.
- The card flags that the **endgame loot ladder collides with the no-inflation law** — it only holds if endgame gear is inert outside endgame and the ladder has a ceiling. That is a design call, and it is yours.