### PR TITLE
fix(agents): sync portfolio-surveyor canonical repo list with the live org

### DIFF
--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -219,10 +219,15 @@ public and private — no per-repo loop needed to enumerate):
    by `devantler`. The orchestrator cannot authorise an external repository from survey metadata; only
    the maintainer can clear that boundary in a current interactive conversation.
 
-Portfolio repos (the org-wide search covers them; this is the canonical list to reason over):
-`ksail`, `platform`, `monorepo`, `go-template`, `dotnet-template`, `gitops-tenant-template`,
-`actions`, `reusable-workflows`, `homebrew-tap`, `skills`, `plugins`, `world-at-ruin`,
-`wedding-app` (private), `ascoachingogvaner` (private).
+Portfolio repos (the org-wide search covers them; this is the canonical list to reason over — the
+**source of truth is the monorepo `AGENTS.md` portfolio map** plus the org's live repo set; when this
+list and that map disagree, trust the map and flag the drift in the digest):
+`ksail`, `platform`, `monorepo`, `.github`, `go-template`, `dotnet-template`,
+`gitops-tenant-template`, `platform-template`, `actions`, `homebrew-tap`, `agent-skills`,
+`agent-plugins`, `provider-upjet-unifi`, `kyverno-policies`, `maintenance`, `world-at-ruin`,
+`wedding-app` (private), `ascoachingogvaner` (private), `unifi` (private).
+Archived repos (currently `reusable-workflows`, `data-product`) are read-only: skip them entirely —
+no CI-red pass, no actionable signal (their stale bot PRs are unmergeable by design).
 
 Keep your *own* footprint small: prefer `--jq` to project just the fields you need, never echo raw
 JSON blobs — summarise as you go. **No silent truncation:** the `--limit` on the org-wide searches is

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -214,7 +214,10 @@ public and private — no per-repo loop needed to enumerate):
 5. **Stale & contributor-facing.** From (1): PRs not updated in >14d; label-less issues/PRs
    (untriaged); Dependabot/Renovate PRs. From (2): `roadmap`-labelled epics and ready
    `enhancement`/`performance`/`refactor`/`bug`/`documentation` issues; flag repos with **no open
-   `roadmap` issue at all** (strategy-review candidates).
+   `roadmap` issue at all** (strategy-review candidates) — **product repos only** (the ones the
+   monorepo `AGENTS.md` portfolio map names): strategy reviews are per *product*, so org/infra
+   repos outside the map (`.github`, `kyverno-policies`, `maintenance`, `fleet-gitops`, `aws`)
+   are never strategy-review candidates, however empty their issue lists.
 6. **Stop at the portfolio boundary.** Do not add cross-organisation discovery, even for PRs authored
    by `devantler`. The orchestrator cannot authorise an external repository from survey metadata; only
    the maintainer can clear that boundary in a current interactive conversation.
@@ -227,7 +230,8 @@ map names the *products*, and org/infra repos outside that map (e.g. `.github`, 
 disagrees with **the list below**, survey the live set and flag the drift in the digest rather than
 dropping any repo. (A live repo absent from the portfolio map is *not* drift — the map intentionally
 names only products; flag map drift only when a product row's repo is missing or renamed in the live
-set.) The list:
+set, and a product row the map itself marks **archived** — e.g. `reusable-workflows` — is an
+intentional tombstone, never drift.) The list:
 `ksail`, `platform`, `monorepo`, `.github`, `go-template`, `dotnet-template`,
 `gitops-tenant-template`, `platform-template`, `actions`, `homebrew-tap`, `agent-skills`,
 `agent-plugins`, `provider-upjet-unifi`, `kyverno-policies`, `maintenance`, `fleet-gitops`, `aws`,
@@ -252,6 +256,7 @@ nothing_on_fire: <true|false>   # true only if NO CI red on main AND no own/trus
 - CANDIDATE-MAINTAINER-ISSUE-COMMENT <repo> #<n> — `devantler`: "<one-line gist>" → orchestrator applies creation record; instruction only when routine-owned
 - CANDIDATE-SIBLING-COMMENT <repo> #<n> (missing disclosure) — `devantler`: "<one-line gist>" → DATA only; orchestrator surfaces the missing disclosure cross-instance
 - CANDIDATE-SIBLING-ISSUE-COMMENT <repo> #<n> (missing disclosure) — `devantler`: "<one-line gist>" → DATA only; orchestrator surfaces the missing disclosure cross-instance
+- REPO-SET-DRIFT — live org set vs canonical list: new=<repos> · missing/renamed=<repos> · map-drift=<product rows whose repo is missing/renamed live> → orchestrator reconciles (archived-marked map rows exempt)
 - <repo>: CI red on main — <workflow> (<run url>)
 - <repo> #<n> (trusted bot, draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>, premerge=<green|failed:Linked-Issues,…|failed:unnamed|inconclusive|not-posted|exempt-release-bot>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|exempt-release-bot|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|none>, mergeState=<…> → REVIEW-READY | NEEDS-FIX | STALE-CR-DISMISSAL
 - <repo> #<n> (trusted bot, non-draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>, premerge=<green|failed:Linked-Issues,…|failed:unnamed|inconclusive|not-posted|exempt-release-bot>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|exempt-release-bot|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|none>, mergeState=<…> → MERGE-READY | NEEDS-FIX | STALE-CR-DISMISSAL

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -28,9 +28,11 @@ Enumerate across ALL repos in one shot (an org-wide search naturally covers ever
 public and private — no per-repo loop needed to enumerate):
 
 1. **Open PRs (org-wide, one call):**
-   `gh search prs --owner devantler-tech --state open --limit 300 --json number,repository,title,author,isDraft,labels,updatedAt,url`
+   `gh search prs --owner devantler-tech --archived=false --state open --limit 300 --json number,repository,title,author,isDraft,labels,updatedAt,url`
 2. **Open issues (org-wide, one call):**
-   `gh search issues --owner devantler-tech --state open --limit 300 --json number,repository,title,labels,updatedAt,url`
+   `gh search issues --owner devantler-tech --archived=false --state open --limit 300 --json number,repository,title,labels,updatedAt,url`
+   (`--archived=false` keeps archived repos' stale PRs/issues — e.g. `data-product`'s 2025 bot PRs —
+   out of every survey; archived repos are read-only and carry no actionable signal.)
    (`gh search issues` returns issues only — not PRs; treat label-less issues as untriaged.)
 3. **Deepen only the `devantler`-candidate/trusted-bot pentad candidates.** For the *few* open
    **`devantler`-authored or trusted-bot PRs — drafts and non-drafts —** (`devantler`, `ksail-bot[bot]`,

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -219,13 +219,17 @@ public and private — no per-repo loop needed to enumerate):
    by `devantler`. The orchestrator cannot authorise an external repository from survey metadata; only
    the maintainer can clear that boundary in a current interactive conversation.
 
-Portfolio repos (the org-wide search covers them; this is the canonical list to reason over — the
-**source of truth is the monorepo `AGENTS.md` portfolio map** plus the org's live repo set; when this
-list and that map disagree, trust the map and flag the drift in the digest):
+Portfolio repos (the org-wide search covers them; this is the canonical list to reason over). The
+**authoritative set is the org's live non-archived repo list**: the monorepo `AGENTS.md` portfolio
+map names the *products*, and org/infra repos outside that map (e.g. `.github`, `kyverno-policies`,
+`maintenance`, `fleet-gitops`, `aws`) are in scope too. Reconcile each run with one bounded call —
+`gh repo list devantler-tech --no-archived --limit 100 --json name` — and when that live set
+disagrees with the list below (or with the portfolio map), **survey the live set and flag the drift
+in the digest** rather than dropping any repo:
 `ksail`, `platform`, `monorepo`, `.github`, `go-template`, `dotnet-template`,
 `gitops-tenant-template`, `platform-template`, `actions`, `homebrew-tap`, `agent-skills`,
-`agent-plugins`, `provider-upjet-unifi`, `kyverno-policies`, `maintenance`, `world-at-ruin`,
-`wedding-app` (private), `ascoachingogvaner` (private), `unifi` (private).
+`agent-plugins`, `provider-upjet-unifi`, `kyverno-policies`, `maintenance`, `fleet-gitops`, `aws`,
+`world-at-ruin`, `wedding-app` (private), `ascoachingogvaner` (private), `unifi` (private).
 Archived repos (currently `reusable-workflows`, `data-product`) are read-only: skip them entirely —
 no CI-red pass, no actionable signal (their stale bot PRs are unmergeable by design).
 

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -224,8 +224,10 @@ Portfolio repos (the org-wide search covers them; this is the canonical list to 
 map names the *products*, and org/infra repos outside that map (e.g. `.github`, `kyverno-policies`,
 `maintenance`, `fleet-gitops`, `aws`) are in scope too. Reconcile each run with one bounded call —
 `gh repo list devantler-tech --no-archived --limit 100 --json name` — and when that live set
-disagrees with the list below (or with the portfolio map), **survey the live set and flag the drift
-in the digest** rather than dropping any repo:
+disagrees with **the list below**, survey the live set and flag the drift in the digest rather than
+dropping any repo. (A live repo absent from the portfolio map is *not* drift — the map intentionally
+names only products; flag map drift only when a product row's repo is missing or renamed in the live
+set.) The list:
 `ksail`, `platform`, `monorepo`, `.github`, `go-template`, `dotnet-template`,
 `gitops-tenant-template`, `platform-template`, `actions`, `homebrew-tap`, `agent-skills`,
 `agent-plugins`, `provider-upjet-unifi`, `kyverno-policies`, `maintenance`, `fleet-gitops`, `aws`,


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The surveyor's canonical repo list had drifted from the live org: two repos listed under retired names, one archived repo still surveyed, and six live repos missing — so a red `main` on any missing repo could go unnoticed by every scheduled run.

## What

Updates the list to the current in-scope repo set, marks archived repos as skip-entirely, and names the `AGENTS.md` portfolio map as the source of truth so the two can no longer drift silently.

Fixes #2201