### PR TITLE
docs(agents): World at Ruin is a first-class product, not lowest priority

### DIFF
--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -228,8 +228,8 @@ Products → cards: [ksail](../products/ksail/SKILL.md) · [platform](../product
 [github-actions](../products/github-actions/SKILL.md) · [skills (+ plugins)](../products/agent-skills/SKILL.md) ·
 [homebrew-tap](../products/homebrew-tap/SKILL.md) · [applications](../products/applications/SKILL.md) ·
 [provider-upjet-unifi](../products/provider-upjet-unifi/SKILL.md) ·
-[world-at-ruin](../products/world-at-ruin/SKILL.md) *(game — LOWEST priority; the repo exists and
-produces normal survey signal, but select it only when nothing else demands attention)*.
+[world-at-ruin](../products/world-at-ruin/SKILL.md) *(game — a first-class product in the normal
+rotation and fairness rules, like every other card; maintainer direction 2026-07-17)*.
 
 ## 2. Select (the heart of it)
 Pick the **highest-value work across the whole portfolio**, then **go deep where depth is needed**

--- a/.claude/skills/products/world-at-ruin/SKILL.md
+++ b/.claude/skills/products/world-at-ruin/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: maintain-world-at-ruin
-description: Product card for World at Ruin — a source-available, cloud-native MMORPG built almost entirely by agents at LOWEST priority. The repo's own AGENTS.md is authoritative for the settled design; this card keeps the operate notes and open decisions. Use when the daily maintainer has no higher-priority work and selects World at Ruin.
+description: Product card for World at Ruin — a source-available, cloud-native MMORPG built almost entirely by agents, a first-class portfolio product. The repo's own AGENTS.md is authoritative for the settled design; this card keeps the operate notes and open decisions. Use when the daily maintainer selects World at Ruin.
 ---
 
 # Maintain: World at Ruin (game)
 
-A cloud-native MMORPG the maintainer wants to exist, built **almost entirely by agents** at **lowest
-priority** — pick it up only when nothing else demands attention, and expect it to accrete over years.
+A cloud-native MMORPG the maintainer wants to exist, built **almost entirely by agents** as a
+**first-class portfolio product** (maintainer direction 2026-07-17: it needs the same attention and
+love as the rest of the portfolio — not a back-of-queue pick). It participates in the normal
+selection rules — oldest-actionable-first and the `last_worked` fairness rotation — like every other
+product; expect the game itself to accrete over years all the same.
 He redirects via the **PR workflow**; ship draft PRs as usual.
 
 **Status: bootstrapped 2026-07-16.** The repo exists, the `applications/world-at-ruin` submodule is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,10 @@ keeping them healthy *and* moving them forward.
 > Submodule `AGENTS.md` links use full GitHub URLs because those files live in the submodule repos, not this repo's tree (a relative link would 404 on GitHub).
 
 **World at Ruin — newest product, bootstrapped 2026-07-16** (maintainer direction the same day). A
-cloud-native MMORPG the maintainer wants to exist, built **almost entirely by agents** at **lowest
-priority** — pick it up only when nothing else demands attention. The repo exists, the
+cloud-native MMORPG the maintainer wants to exist, built **almost entirely by agents** as a
+**first-class portfolio product** — it gets the same attention and love as every other product and
+participates in the normal selection and fairness rules (maintainer direction 2026-07-17,
+superseding the bootstrap-day "lowest priority" note). The repo exists, the
 `applications/world-at-ruin` submodule is in place, and its roadmap lives in **GitHub Issues on
 `devantler-tech/world-at-ruin`**. The stack and design are **already settled — do not re-litigate
 them**: the repo's own `AGENTS.md` is authoritative; the


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Your direction today: World at Ruin was not meant to be less prioritized — it needs the same attention and love as the rest of the portfolio. The bootstrap-day definition baked "lowest priority / pick it up only when nothing else demands attention" into three places, which would keep every future run treating it as back-of-queue.

## What

Rewords the constitution's portfolio-map note, the run-loop's card index, and the product card: World at Ruin is a first-class product in the normal selection and fairness rotation. The game repo's own AGENTS.md gets a matching PR.

Supersedes the 2026-07-16 lowest-priority note.