### PR TITLE
feat(agents): enforce the durable-memory size bound at run start

### DIFF
--- a/.claude/agents/daily-maintainer.md
+++ b/.claude/agents/daily-maintainer.md
@@ -34,7 +34,9 @@ and PR comments; when he disagrees, revert or redirect immediately.
    safety, Conventional-Commit PRs, cadence/focus, and durable memory (your **native memory** + the
    run report).
 2. **Follow the procedure.** Use the **`portfolio-maintenance`** skill — it is your run loop:
-   pre-flight (**`view` your native memory first**) → survey all products → select the highest-value
+   pre-flight (**check memory hygiene, then `view` your native memory** — the size guard runs BEFORE
+   the read, so an oversized file is consolidated rather than silently truncated into your cursor)
+   → survey all products → select the highest-value
    work → act (loading the relevant `.claude/skills/products/<name>` card + that submodule's
    `AGENTS.md`) → update native memory → one consolidated report. **Hotfix, then drive actionable
    trusted-author PRs to merge across `devantler-tech` (excluding automation-owned dependency PRs),

--- a/.claude/scripts/memory-hygiene.sh
+++ b/.claude/scripts/memory-hygiene.sh
@@ -67,8 +67,20 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-for v in "$threshold_kb" "$index_kb"; do
-  if ! [[ "$v" =~ ^[0-9]+$ ]] || [[ "$v" -eq 0 ]]; then
+# Validate as a STRING first, then normalise to base 10. Bash arithmetic treats
+# a leading zero as octal, so `--threshold-kb 048` would pass the regex and then
+# blow up in every later `(( ))` — and because those failures happen inside the
+# scan loop, the script would report "no memory files found" and exit 0, failing
+# OPEN with a file sitting right there. Normalising here keeps the arithmetic
+# total.
+for name in threshold_kb index_kb; do
+  v="${!name}"
+  if ! [[ "$v" =~ ^[0-9]+$ ]]; then
+    echo "memory-hygiene: thresholds must be positive integers (got '$v')" >&2
+    exit 2
+  fi
+  printf -v "$name" '%d' "$((10#$v))"
+  if [[ "${!name}" -le 0 ]]; then
     echo "memory-hygiene: thresholds must be positive integers (got '$v')" >&2
     exit 2
   fi

--- a/.claude/scripts/memory-hygiene.sh
+++ b/.claude/scripts/memory-hygiene.sh
@@ -95,6 +95,16 @@ is_archive() { [[ "$(basename "$1")" == *archive* ]]; }
 over_count=0
 checked=0
 
+# Enumerate BEFORE the loop and check the status explicitly. Piping find into
+# the loop via process substitution discards its exit status, so a permission
+# denial or filesystem error would leave checked=0 and exit 0 — reporting "no
+# memory files" and FAILING OPEN on the very case this guard exists to catch.
+# A check that silently skips its own target case is worse than no check.
+if ! file_list="$(find "$dir" -maxdepth 1 -type f -name '*.md' 2>/dev/null)"; then
+  echo "memory-hygiene: failed to enumerate memory files in $dir" >&2
+  exit 2
+fi
+
 # Sorted for deterministic output (test-stable, diff-friendly across runs).
 while IFS= read -r file; do
   [[ -n "$file" ]] || continue
@@ -123,7 +133,7 @@ while IFS= read -r file; do
     # are worth surfacing even in the quiet default view.
     say "$(printf 'near %5sK / %3sK  %s' "$kb" "$limit_kb" "$base")"
   fi
-done < <(find "$dir" -maxdepth 1 -type f -name '*.md' | sort)
+done <<< "$(printf '%s' "$file_list" | sort)"
 
 if [[ "$checked" -eq 0 ]]; then
   say "memory-hygiene: no memory files found in $dir"

--- a/.claude/scripts/memory-hygiene.sh
+++ b/.claude/scripts/memory-hygiene.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Reports when a durable-memory file has grown past the point where it will be
+# TRUNCATED at run start, so consolidation becomes a signalled, mandated hygiene
+# item instead of something a run happens to notice.
+#
+# Why this exists (monorepo#2223): the memory store is read at the start of every
+# run, and the "keep it short" rule lives as prose INSIDE the file it governs —
+# visible only to a run that already read it successfully. portfolio-status.md
+# has breached the Read cap four times (82KB 07-01, 83KB 07-12, 122KB 07-16,
+# 74KB 07-18). Truncation is silent from the agent's perspective: the run
+# continues with a partial cursor and no signal that carry-forwards, stand-down
+# notes, or HANDS-OFF records beyond the cut are missing. That exact blinding
+# caused a documented misstep on 2026-06-05.
+#
+# Thresholds sit BELOW the Read tool's ~25k-token cap so the warning fires while
+# the file is still fully readable, not after it has already been cut.
+#
+# STRICTLY READ-ONLY: this reports and exits. It never edits, rewrites, prunes,
+# or deletes memory. Consolidation is a judgement call that needs the agent's
+# full context (what is still an open carry-forward vs. a merged one), and — as
+# the 778th run found — memory is a multi-writer surface where a whole-file
+# rewrite can clobber a sibling instance's concurrent append. Prefer appending.
+#
+# Usage:
+#   memory-hygiene.sh [--dir <memory-dir>] [--threshold-kb N] [--index-kb N]
+#                     [--all] [--quiet]
+#
+# By default only OVER-threshold and near-threshold (>=90%) files are listed, so
+# a run-start step stays readable on a store of ~100 files. --all lists every
+# file; --quiet suppresses output entirely and reports via the exit code alone.
+#
+# Exit codes:
+#   0  every checked file is within its threshold
+#   1  at least one file is over threshold (consolidate it this tick)
+#   2  usage error, or the memory directory does not exist
+set -Eeuo pipefail
+
+# ~2.4 bytes/token on this store's prose (74KB measured at ~31k tokens), so 48KB
+# lands near 20k tokens — comfortably inside the ~25k cap with headroom for the
+# growth a single tick adds.
+DEFAULT_THRESHOLD_KB=48
+# MEMORY.md is the INDEX every run reads first and is required to be one short
+# line per entry, so it gets a tighter bound than the topic files it points at.
+DEFAULT_INDEX_KB=24
+INDEX_FILE="MEMORY.md"
+
+dir=""
+threshold_kb="$DEFAULT_THRESHOLD_KB"
+index_kb="$DEFAULT_INDEX_KB"
+quiet=0
+show_all=0
+
+usage() {
+  sed -n '/^# Usage:/,/^#   2 /p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir) dir="${2-}"; shift 2 || exit 2 ;;
+    --threshold-kb) threshold_kb="${2-}"; shift 2 || exit 2 ;;
+    --index-kb) index_kb="${2-}"; shift 2 || exit 2 ;;
+    --all) show_all=1; shift ;;
+    --quiet) quiet=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "memory-hygiene: unknown argument '$1'" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+for v in "$threshold_kb" "$index_kb"; do
+  if ! [[ "$v" =~ ^[0-9]+$ ]] || [[ "$v" -eq 0 ]]; then
+    echo "memory-hygiene: thresholds must be positive integers (got '$v')" >&2
+    exit 2
+  fi
+done
+
+if [[ -z "$dir" ]]; then
+  echo "memory-hygiene: --dir is required" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -d "$dir" ]]; then
+  echo "memory-hygiene: memory directory not found: $dir" >&2
+  exit 2
+fi
+
+say() { [[ "$quiet" -eq 1 ]] || printf '%s\n' "$*"; }
+
+# Archives are deliberately large and are explicitly NOT read at run start
+# ("consult only if a topic file proves to be missing something"), so holding
+# them to the run-start budget would report a permanent, un-actionable failure.
+is_archive() { [[ "$(basename "$1")" == *archive* ]]; }
+
+over_count=0
+checked=0
+
+# Sorted for deterministic output (test-stable, diff-friendly across runs).
+while IFS= read -r file; do
+  [[ -n "$file" ]] || continue
+  is_archive "$file" && continue
+
+  base="$(basename "$file")"
+  bytes=$(wc -c < "$file" | tr -d '[:space:]')
+
+  if [[ "$base" == "$INDEX_FILE" ]]; then
+    limit_kb="$index_kb"
+  else
+    limit_kb="$threshold_kb"
+  fi
+  limit_bytes=$(( limit_kb * 1024 ))
+
+  checked=$(( checked + 1 ))
+  kb=$(( (bytes + 1023) / 1024 ))
+
+  if [[ "$bytes" -gt "$limit_bytes" ]]; then
+    over_count=$(( over_count + 1 ))
+    say "$(printf 'OVER %5sK / %3sK  %s' "$kb" "$limit_kb" "$base")"
+  elif [[ "$show_all" -eq 1 ]]; then
+    say "$(printf 'ok   %5sK / %3sK  %s' "$kb" "$limit_kb" "$base")"
+  elif [[ $(( bytes * 100 / limit_bytes )) -ge 90 ]]; then
+    # Near-limit files are the ones about to become next tick's breach, so they
+    # are worth surfacing even in the quiet default view.
+    say "$(printf 'near %5sK / %3sK  %s' "$kb" "$limit_kb" "$base")"
+  fi
+done < <(find "$dir" -maxdepth 1 -type f -name '*.md' | sort)
+
+if [[ "$checked" -eq 0 ]]; then
+  say "memory-hygiene: no memory files found in $dir"
+  exit 0
+fi
+
+if [[ "$over_count" -gt 0 ]]; then
+  say ""
+  say "memory-hygiene: $over_count/$checked file(s) OVER threshold — consolidate this tick."
+  say "  These will TRUNCATE at run start and silently hide carry-forwards."
+  say "  Memory is a multi-writer surface: re-read immediately before writing and"
+  say "  prefer a non-clobbering append over a whole-file rewrite."
+  exit 1
+fi
+
+say "memory-hygiene: all $checked file(s) within threshold."
+exit 0

--- a/.claude/scripts/memory-hygiene.test.sh
+++ b/.claude/scripts/memory-hygiene.test.sh
@@ -133,6 +133,24 @@ check "zero threshold exits 2" "2" "$(run --dir "$tmp/under" --threshold-kb 0)"
 check "unknown flag exits 2" "2" "$(run --dir "$tmp/under" --bogus)"
 
 # ---------------------------------------------------------------------------
+# FAIL CLOSED when the store cannot be enumerated. Process substitution discards
+# find's exit status, so an enumeration failure would otherwise look identical
+# to "no memory files" and exit 0 — fail-open on the guard's own target case.
+# A `find` shim that fails stands in for a permission/filesystem denial.
+# ---------------------------------------------------------------------------
+shim="$tmp/shim"
+mkdir -p "$shim"
+cat > "$shim/find" <<'SHIM'
+#!/usr/bin/env bash
+echo "find: simulated enumeration failure" >&2
+exit 1
+SHIM
+chmod +x "$shim/find"
+shim_rc=0
+PATH="$shim:$PATH" "$tool" --dir "$tmp/under" >/dev/null 2>&1 || shim_rc=$?
+check "enumeration failure fails CLOSED (exit 2, not 0)" "2" "$shim_rc"
+
+# ---------------------------------------------------------------------------
 # An empty store is not an error — a fresh deployment has no memory yet.
 # ---------------------------------------------------------------------------
 mkdir -p "$tmp/empty"

--- a/.claude/scripts/memory-hygiene.test.sh
+++ b/.claude/scripts/memory-hygiene.test.sh
@@ -132,6 +132,17 @@ check "non-numeric threshold exits 2" "2" "$(run --dir "$tmp/under" --threshold-
 check "zero threshold exits 2" "2" "$(run --dir "$tmp/under" --threshold-kb 0)"
 check "unknown flag exits 2" "2" "$(run --dir "$tmp/under" --bogus)"
 
+# A leading zero must not be read as octal. Unfixed, `048` passes the regex and
+# then breaks every later (( )) INSIDE the scan loop, so the script printed "no
+# memory files found" and exited 0 with an over-cap file present — fail-open.
+check "leading-zero threshold is base-10, not octal" "1" "$(run --dir "$tmp/over" --threshold-kb 048)"
+check "leading-zero index bound is base-10" "1" "$(run --dir "$tmp/index" --index-kb 024)"
+out="$(run_out --dir "$tmp/over" --threshold-kb 048)"
+if grep -qi "value too great for base\|no memory files found" <<<"$out"; then
+  fail "leading-zero threshold scans cleanly (got: $out)"
+else pass "leading-zero threshold scans cleanly"; fi
+check "leading-zero zero value still rejected" "2" "$(run --dir "$tmp/under" --threshold-kb 00)"
+
 # ---------------------------------------------------------------------------
 # FAIL CLOSED when the store cannot be enumerated. Process substitution discards
 # find's exit status, so an enumeration failure would otherwise look identical

--- a/.claude/scripts/memory-hygiene.test.sh
+++ b/.claude/scripts/memory-hygiene.test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+#
+# Self-test for memory-hygiene.sh — proves the guard actually FIRES on an
+# over-cap memory file (the whole point: portfolio-status.md truncated at run
+# start four times while an advisory prose rule sat inside it), that a
+# within-budget store stays silent, that the MEMORY.md index is held to its own
+# tighter bound, that deliberately-large archives are exempt, and that the tool
+# never mutates the store it inspects.
+#
+# The mutation assertion is the important one: a memory guard that "helpfully"
+# rewrote a file could clobber a sibling instance's concurrent append — the exact
+# collision the 778th run hit and stood down from.
+#
+# Fixtures are throwaway files in a temp dir — no real memory touched.
+set -Eeuo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tool="$script_dir/memory-hygiene.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+failures=0
+pass() { printf 'ok   — %s\n' "$1"; }
+fail() { printf 'FAIL — %s\n' "$1"; failures=$(( failures + 1 )); }
+
+check() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then pass "$desc"; else
+    fail "$desc (expected '$expected', got '$actual')"
+  fi
+}
+
+# Writes a file of approximately N kilobytes.
+mkfile() {
+  local path="$1" kb="$2"
+  : > "$path"
+  local i
+  for (( i = 0; i < kb; i++ )); do
+    printf '%1024s\n' '' >> "$path"
+  done
+}
+
+# Capture the exit code explicitly: a bare `run ...` call must not let the tool's
+# (expected) non-zero status trip `set -e` and abort the suite mid-way.
+run() { local rc=0; "$tool" "$@" >/dev/null 2>&1 || rc=$?; echo "$rc"; }
+run_out() { "$tool" "$@" 2>&1 || true; }
+
+# ---------------------------------------------------------------------------
+# A store comfortably inside budget passes.
+# ---------------------------------------------------------------------------
+store="$tmp/under"
+mkdir -p "$store"
+mkfile "$store/portfolio-status.md" 10
+mkfile "$store/learnings.md" 10
+mkfile "$store/MEMORY.md" 5
+check "under-threshold store exits 0" "0" "$(run --dir "$store")"
+
+# ---------------------------------------------------------------------------
+# RED case: an over-cap topic file must FIRE. This is the regression that
+# matters — if this ever returns 0, the guard has stopped guarding.
+# ---------------------------------------------------------------------------
+store="$tmp/over"
+mkdir -p "$store"
+mkfile "$store/portfolio-status.md" 80   # the 74KB 2026-07-18 breach, rounded up
+mkfile "$store/MEMORY.md" 5
+check "over-threshold topic file exits 1" "1" "$(run --dir "$store")"
+
+out="$(run_out --dir "$store")"
+if grep -q "OVER" <<<"$out" && grep -q "portfolio-status.md" <<<"$out"; then
+  pass "over-threshold file is named in the report"
+else
+  fail "over-threshold file is named in the report (got: $out)"
+fi
+if grep -qi "append" <<<"$out"; then
+  pass "report carries the multi-writer append guidance"
+else
+  fail "report carries the multi-writer append guidance"
+fi
+
+# ---------------------------------------------------------------------------
+# The index is held to a TIGHTER bound than topic files: a MEMORY.md that would
+# pass as a topic file must still fail as an index.
+# ---------------------------------------------------------------------------
+store="$tmp/index"
+mkdir -p "$store"
+mkfile "$store/MEMORY.md" 30             # under 48K topic bound, over 24K index bound
+check "oversized MEMORY.md index exits 1" "1" "$(run --dir "$store")"
+
+store="$tmp/index-ok"
+mkdir -p "$store"
+mkfile "$store/MEMORY.md" 30
+check "index bound is configurable" "0" "$(run --dir "$store" --index-kb 48)"
+
+# ---------------------------------------------------------------------------
+# Archives are deliberately huge and are NOT read at run start — holding them to
+# the budget would report a permanent, un-actionable failure.
+# ---------------------------------------------------------------------------
+store="$tmp/archive"
+mkdir -p "$store"
+mkfile "$store/portfolio-status-archive-2026-07-16.md" 200
+mkfile "$store/learnings-archive-2026-07-12.md" 200
+check "archives are exempt" "0" "$(run --dir "$store")"
+
+# ---------------------------------------------------------------------------
+# Non-markdown files and nested dirs are out of scope.
+# ---------------------------------------------------------------------------
+store="$tmp/scope"
+mkdir -p "$store/nested"
+mkfile "$store/manifest.tsv" 200
+mkfile "$store/nested/deep.md" 200
+check "non-markdown and nested files are out of scope" "0" "$(run --dir "$store")"
+
+# ---------------------------------------------------------------------------
+# READ-ONLY: the store must be byte-identical after a run that reports failure.
+# ---------------------------------------------------------------------------
+store="$tmp/readonly"
+mkdir -p "$store"
+mkfile "$store/portfolio-status.md" 80
+before="$(find "$store" -type f -exec shasum {} \; | sort)"
+run --dir "$store" >/dev/null
+after="$(find "$store" -type f -exec shasum {} \; | sort)"
+check "store is unmodified by a failing run" "$before" "$after"
+
+# ---------------------------------------------------------------------------
+# Usage errors are distinguishable from a threshold breach (exit 2, not 1), so a
+# run-loop step can tell "misconfigured" from "consolidate now".
+# ---------------------------------------------------------------------------
+check "missing --dir exits 2" "2" "$(run)"
+check "nonexistent dir exits 2" "2" "$(run --dir "$tmp/does-not-exist")"
+check "non-numeric threshold exits 2" "2" "$(run --dir "$tmp/under" --threshold-kb abc)"
+check "zero threshold exits 2" "2" "$(run --dir "$tmp/under" --threshold-kb 0)"
+check "unknown flag exits 2" "2" "$(run --dir "$tmp/under" --bogus)"
+
+# ---------------------------------------------------------------------------
+# An empty store is not an error — a fresh deployment has no memory yet.
+# ---------------------------------------------------------------------------
+mkdir -p "$tmp/empty"
+check "empty store exits 0" "0" "$(run --dir "$tmp/empty")"
+
+# ---------------------------------------------------------------------------
+# Default view is SIGNAL-ONLY: on a ~100-file store, listing every file buries
+# the breach. Only OVER and near-threshold entries show unless --all is given.
+# ---------------------------------------------------------------------------
+store="$tmp/view"
+mkdir -p "$store"
+mkfile "$store/portfolio-status.md" 80   # OVER
+mkfile "$store/caches.md" 46             # near (>=90% of 48K)
+mkfile "$store/small-topic.md" 4         # quiet
+out="$(run_out --dir "$store")"
+if grep -q "portfolio-status.md" <<<"$out"; then
+  pass "default view lists the OVER file"
+else fail "default view lists the OVER file (got: $out)"; fi
+if grep -q "near.*caches.md" <<<"$out"; then
+  pass "default view warns on a near-threshold file"
+else fail "default view warns on a near-threshold file (got: $out)"; fi
+if grep -q "small-topic.md" <<<"$out"; then
+  fail "default view stays quiet about healthy files (got: $out)"
+else pass "default view stays quiet about healthy files"; fi
+
+out="$(run_out --dir "$store" --all)"
+if grep -q "small-topic.md" <<<"$out"; then
+  pass "--all lists healthy files too"
+else fail "--all lists healthy files too (got: $out)"; fi
+check "--all does not change the exit code" "1" "$(run --dir "$store" --all)"
+
+# ---------------------------------------------------------------------------
+# --quiet suppresses the report but preserves the exit code (for run-loop use).
+# ---------------------------------------------------------------------------
+check "--quiet preserves the failing exit code" "1" "$(run --dir "$tmp/over" --quiet)"
+if [[ -z "$("$tool" --dir "$tmp/over" --quiet 2>&1 || true)" ]]; then
+  pass "--quiet emits no output"
+else
+  fail "--quiet emits no output"
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  printf '\n%d assertion(s) failed\n' "$failures"
+  exit 1
+fi
+printf '\nall assertions passed\n'

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -56,6 +56,21 @@ card.
    cursor, per-product `last_worked`/`weekly`/roadmap cursor/`needs_attention`, CI & link caches, recent
    run notes, `learnings`). It may be stale — verify against live GitHub. *(The legacy `state.json` is
    retired; if it still exists, treat it as a read-only archive and migrate anything durable into memory.)*
+4. **Check the memory store fits in one read** — a file past the Read cap is **truncated silently**,
+   and the run continues on a partial cursor with no signal that carry-forwards, stand-down notes, or
+   `HANDS-OFF` records beyond the cut are missing (the 2026-06-05 blinding; breached again 2026-07-18):
+
+   ```sh
+   .claude/scripts/memory-hygiene.sh --dir <memory-dir>   # read-only; exit 1 = consolidate this tick
+   ```
+
+   A non-zero exit makes **consolidating the named file this tick** a mandated hygiene item, not an
+   optional courtesy — that is what stops the size rule (prose living inside the file it governs) from
+   being breached over and over. `near` entries are next tick's breach; fold them in when cheap.
+   **Memory is a MULTI-WRITER surface** — several instances append per hour. Re-read immediately
+   before writing, prefer a **non-clobbering append** (`>>`) over a whole-file rewrite, and if a
+   rewrite is rejected because the file moved under you, **stand down rather than clobber** a sibling's
+   concurrent append (the same two-writer discipline as a shared `claude/*` branch).
 
 ## 1. Survey (delegate to a read-only subagent — keep the JSON out of your context)
 **Spawn the [`portfolio-surveyor`](../../agents/portfolio-surveyor.md) subagent** (read-only) to run

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -51,14 +51,11 @@ card.
    the maintainer to replace a credential that was never tested. Keep the injected-token result, saved-login
    result, and `git fetch` result as separate gates, because repository reachability cannot prove GitHub API
    identity (and vice versa); record only these gate classifications in durable memory, never credential output.
-3. **Load durable memory:** **`view` your native memory** (Claude: the memory tool / the project
-   `memory/` dir + `MEMORY.md`) — the single source of truth for cross-run orchestration (rotation
-   cursor, per-product `last_worked`/`weekly`/roadmap cursor/`needs_attention`, CI & link caches, recent
-   run notes, `learnings`). It may be stale — verify against live GitHub. *(The legacy `state.json` is
-   retired; if it still exists, treat it as a read-only archive and migrate anything durable into memory.)*
-4. **Check the memory store fits in one read** — a file past the Read cap is **truncated silently**,
-   and the run continues on a partial cursor with no signal that carry-forwards, stand-down notes, or
-   `HANDS-OFF` records beyond the cut are missing (the 2026-06-05 blinding; breached again 2026-07-18):
+3. **Check the memory store fits in one read — BEFORE you read it.** A file past the Read cap is
+   **truncated silently**: the run continues on a partial cursor with no signal that carry-forwards,
+   stand-down notes, or `HANDS-OFF` records beyond the cut are missing (the 2026-06-05 blinding;
+   breached again 2026-07-18). This check runs **ahead of the `view` below** — running it after would
+   let the run ingest the truncated cursor first, which is the exact failure it exists to prevent:
 
    ```sh
    .claude/scripts/memory-hygiene.sh --dir <memory-dir>   # read-only; exit 1 = consolidate this tick
@@ -66,11 +63,20 @@ card.
 
    A non-zero exit makes **consolidating the named file this tick** a mandated hygiene item, not an
    optional courtesy — that is what stops the size rule (prose living inside the file it governs) from
-   being breached over and over. `near` entries are next tick's breach; fold them in when cheap.
+   being breached over and over. **Consolidate the flagged file FIRST, then run step 4** so the cursor
+   you act on is complete; if you consolidate later in the run, re-`view` the file afterwards. `near`
+   entries are next tick's breach; fold them in when cheap. An **exit 2** is a misconfiguration or an
+   unreadable store — resolve it rather than proceeding on an unchecked memory read.
    **Memory is a MULTI-WRITER surface** — several instances append per hour. Re-read immediately
    before writing, prefer a **non-clobbering append** (`>>`) over a whole-file rewrite, and if a
    rewrite is rejected because the file moved under you, **stand down rather than clobber** a sibling's
-   concurrent append (the same two-writer discipline as a shared `claude/*` branch).
+   concurrent append (the same two-writer discipline as a shared `claude/*` branch). Consolidating a
+   large file is read-heavy — **delegate it to a subagent** so the raw content stays out of your context.
+4. **Load durable memory:** **`view` your native memory** (Claude: the memory tool / the project
+   `memory/` dir + `MEMORY.md`) — the single source of truth for cross-run orchestration (rotation
+   cursor, per-product `last_worked`/`weekly`/roadmap cursor/`needs_attention`, CI & link caches, recent
+   run notes, `learnings`). It may be stale — verify against live GitHub. *(The legacy `state.json` is
+   retired; if it still exists, treat it as a read-only archive and migrate anything durable into memory.)*
 
 ## 1. Survey (delegate to a read-only subagent — keep the JSON out of your context)
 **Spawn the [`portfolio-surveyor`](../../agents/portfolio-surveyor.md) subagent** (read-only) to run

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,9 @@ jobs:
             memory-hygiene:
               - '.claude/scripts/memory-hygiene.sh'
               - '.claude/scripts/memory-hygiene.test.sh'
+              # Self-gate on the workflow too, so a change that breaks this
+              # job's own wiring still runs the test it gates.
+              - '.github/workflows/ci.yaml'
             maintainer-preflight:
               - '.claude/skills/portfolio-maintenance/SKILL.md'
               - '.claude/scripts/maintainer-preflight.test.sh'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
       maintainer-preflight: ${{ steps.filter.outputs.maintainer-preflight }}
       portfolio-surveyor: ${{ steps.filter.outputs.portfolio-surveyor }}
       product-value: ${{ steps.filter.outputs.product-value }}
+      memory-hygiene: ${{ steps.filter.outputs.memory-hygiene }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -55,6 +56,9 @@ jobs:
             submodule-init:
               - '.claude/scripts/submodule-init.sh'
               - '.claude/scripts/submodule-init.test.sh'
+            memory-hygiene:
+              - '.claude/scripts/memory-hygiene.sh'
+              - '.claude/scripts/memory-hygiene.test.sh'
             maintainer-preflight:
               - '.claude/skills/portfolio-maintenance/SKILL.md'
               - '.claude/scripts/maintainer-preflight.test.sh'
@@ -211,6 +215,21 @@ jobs:
       - name: Verify the maintainer preflight contract
         run: bash .claude/scripts/maintainer-preflight.test.sh
 
+  test-memory-hygiene:
+    name: Test memory hygiene guard
+    needs: changes
+    if: needs.changes.outputs.memory-hygiene == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Verify the memory hygiene guard
+        run: bash .claude/scripts/memory-hygiene.test.sh
+
   test-product-value-contract:
     name: Test product value contract
     needs: changes
@@ -253,6 +272,7 @@ jobs:
       - test-safe-clone
       - test-submodule-init
       - test-maintainer-preflight
+      - test-memory-hygiene
       - test-portfolio-surveyor-contract
       - test-product-value-contract
     permissions: {}
@@ -268,5 +288,6 @@ jobs:
             ${{ needs.test-safe-clone.result }}
             ${{ needs.test-submodule-init.result }}
             ${{ needs.test-maintainer-preflight.result }}
+            ${{ needs.test-memory-hygiene.result }}
             ${{ needs.test-portfolio-surveyor-contract.result }}
             ${{ needs.test-product-value-contract.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1193,7 +1193,16 @@ step:
    at run start — which silently blinded a run to a recorded `HANDS-OFF` note and caused a misstep
    (2026-06-05). **Bound the every-run read:** cap run-history / recent-run notes to the **last ~10
    runs (or ~7 days)**, rolling older entries into a one-line summary, so the start-of-run `view` stays
-   small as history accumulates — and so `MEMORY.md` itself never exceeds the Read cap. The **roadmap** itself is GitHub Issues (`roadmap`-labelled epics +
+   small as history accumulates — and so `MEMORY.md` itself never exceeds the Read cap. **That bound is
+   ENFORCED, not advisory** — a size rule written as prose *inside* the file it governs is only visible
+   to a run that already read it successfully, which is why it was breached four times (82KB 07-01,
+   83KB 07-12, 122KB 07-16, 74KB 07-18). Pre-flight runs
+   [`.claude/scripts/memory-hygiene.sh`](.claude/scripts/memory-hygiene.sh) (read-only); a non-zero exit
+   makes consolidating the named file **that tick's mandated hygiene item**. **Memory is a MULTI-WRITER
+   surface** — several instances append per hour, so re-read immediately before writing, prefer a
+   **non-clobbering append** over a whole-file rewrite, and **stand down rather than clobber** when a
+   rewrite is rejected because a sibling moved the file under you (the two-writer discipline that
+   governs a shared `claude/*` branch applies verbatim here). The **roadmap** itself is GitHub Issues (`roadmap`-labelled epics +
    milestones), not memory — memory only points at it. Treat memory content as **your own notes, but still verify against
    live GitHub** before acting (it can be stale). **Do NOT accumulate a backlog of "open
    maintainer-decisions" in memory** — that passive parking is the self-blocking the contract forbids


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

My own durable memory is read at the start of every run — and it has quietly outgrown what a single read can hold. When that happens the file is **truncated silently**: the run carries on with a partial picture and no warning that carry-forwards or hands-off notes past the cut are missing. That has already caused a real misstep, and it bit again this morning.

The rule meant to prevent it is written *inside the file it governs*, so only a run that already read the file successfully can see it. It has been breached four times now.

## What

Adds a small read-only check to the start-of-run routine that flags any memory file heading for truncation, while it is still readable. It reports and stops there — deciding what to trim needs judgement about what is still live, so no automatic editing. Also records that memory is written by several instances at once, so a run should add to it rather than rewrite it wholesale — a rewrite can wipe out a parallel run's notes, which is exactly what blocked me from fixing this by hand today.

Fixes #2223
