### PR TITLE
docs: rewrite the monorepo root README for a first-time reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Check that each project landed on the right branch. One left on a detached commi
 | Point one at a new URL | `git submodule set-url -- <path> <new-url>` |
 | Remove one | `./delete-submodule.sh <path>` |
 
-Each project is pinned to a specific commit, and your checkout stays on that pin — the init script
-deliberately does not jump to the tip of the branch. Automated pull requests here move the pins
-forward, so to catch up, pull this repository and run the init script again.
+Each project is pinned to a specific commit, and your checkout stays on that pin. Automated pull
+requests here move the pins forward, but **your existing checkout does not follow — and re-running
+the init script will not move it either.**
+
+That is deliberate: the script only populates projects that are empty, and leaves already-populated
+ones alone so it can never discard work you have sitting in one. Moving a populated project to a
+newer pin is a manual, per-project decision — commit or push anything you care about there first.

--- a/README.md
+++ b/README.md
@@ -1,75 +1,42 @@
 # 🗂️ Devantler's Monorepo
 
-This repository is a monorepo that contains all my active projects as submodules, effectively bridging a manyrepo and monorepo. This allows me to keep all my projects in one place and easily manage them in VSCode, while avoiding common pitfalls introduced with monorepos (e.g. no repo-per-product, complex release-strategy, overpriviliged access)
+Every project I actively work on, gathered in one place.
+
+Each project stays its own repository and is linked in here as a *submodule* — a pointer to another
+repository, checked out inside this one. So one clone opens everything in VS Code, while each project
+keeps its own releases, issues, and access.
 
 <img width="1800" alt="image" src="https://github.com/devantler/monorepo/assets/26203420/615d3085-1c58-4718-9d40-ab511c5b1da9">
 
-## Initializing the Monorepo
-
-When you clone the monorepo for the first time, you need to initialize the submodules:
+## Getting started
 
 ```bash
+git clone git@github.com:devantler-tech/monorepo.git
+cd monorepo
 .claude/scripts/submodule-init.sh --all
 ```
 
-This initializes every submodule at its pinned commit and keeps per-worktree isolation intact. A bare
-`git submodule update --init` writes a `core.worktree` key into each submodule's shared config, which
-every later `git worktree add` inherits — so worktrees silently resolve back into the main checkout and
-parallel sessions collide. The wrapper repairs that and verifies isolation before returning; run
-`.claude/scripts/submodule-init.sh --check` at any time to re-verify (a non-destructive probe: it
-never touches submodule content or other sessions' worktrees, but does add and remove its own
-throwaway probe worktree).
+Use that script rather than `git submodule update --init`. The plain Git command lets separate
+working copies of a project resolve back to the same folder, so parallel sessions overwrite each
+other; the script does the same job and repairs that. It also works after a
+`git clone --recurse-submodules`, which has the same problem. Run
+`.claude/scripts/submodule-init.sh --check` any time to confirm things are still separated — see
+[worktree isolation](.claude/worktree-isolation.md) for the full story.
 
-You can also clone the monorepo with the `--recurse-submodules` flag. That initializes the submodules
-the same way, so it breaks isolation the same way — run the wrapper afterwards to repair it (`--check`
-is a non-destructive probe and would only report the problem, not fix it):
-
-```bash
-git clone --recurse-submodules git@github.com:devantler-tech/monorepo.git
-cd monorepo && .claude/scripts/submodule-init.sh --all
-```
-
-Make sure that all submodules are checked out on the correct branch the first time you clone the monorepo. Otherwise, you might risk loosing changes as the submodule will be in a detached head state.
+Check that each project landed on the right branch. One left on a detached commit can lose work.
 
 > [!NOTE]
-> Submodules are configured to clone with SSH, so it requires adding your public SSH key to GitHub. You will not be able to clone the submodules with HTTPS. This decision was made, as HTTPS will require authentication on every request, where as SSH can do this automatically when the public key is shared.
+> Projects clone over SSH, so add your public SSH key to GitHub first — HTTPS won't work. SSH
+> authenticates from your key; HTTPS would ask for credentials on every request.
 
-## Adding a submodule
+## Working with projects
 
-```sh
-git submodule add -b <branch> <ssh-url> <path>
-```
+| Task | Command |
+| --- | --- |
+| Add one | `git submodule add -b <branch> <ssh-url> <path>` |
+| Move or rename one | `git mv <old-path> <new-path>` |
+| Point one at a new URL | `git submodule set-url -- <path> <new-url>` |
+| Remove one | `./delete-submodule.sh <path>` |
 
-## Updating a submodule
-
-There are three scenarios for updating a submodule:
-
-1. You want to update the submodule to the latest commit on the branch it is tracking.
-2. You want to update a submodule's upstream url.
-3. You want to rename/move a submodule.
-
-### Updating to the latest commit on the branch
-
-All submodules are configured to automatically update to the latest commit on the branch they are tracking.
-
-### Updating a submodule's upstream url
-
-To update a submodule's upstream url, you need to run the following command:
-
-```sh
-git submodule set-url -- <path> <newurl>
-```
-
-### Renaming or moving a submodule
-
-To rename or move a submodule, you need to run the following command:
-
-```sh
-git mv old/path/to/submodule new/path/to/submodule
-```
-
-## Removing a submodule
-
-```sh
-./delete-submodule.sh <path>
-```
+Projects follow their tracked branch and pick up its latest commit automatically, so there is nothing
+to run to stay current.

--- a/README.md
+++ b/README.md
@@ -38,5 +38,6 @@ Check that each project landed on the right branch. One left on a detached commi
 | Point one at a new URL | `git submodule set-url -- <path> <new-url>` |
 | Remove one | `./delete-submodule.sh <path>` |
 
-Projects follow their tracked branch and pick up its latest commit automatically, so there is nothing
-to run to stay current.
+Each project is pinned to a specific commit, and your checkout stays on that pin — the init script
+deliberately does not jump to the tip of the branch. Automated pull requests here move the pins
+forward, so to catch up, pull this repository and run the init script again.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Someone opening this repository for the first time had to read past a run-on sentence about repo
layout (with two typos) and 15 lines of internal git-worktree failure-mode detail before learning
what the repository actually holds. The front page was written from memory rather than for a reader.

## What

The root README now opens with what the repository holds and why, explains "submodule" in common
words, and keeps the worktree-isolation rationale to the one instruction that matters plus a link to
the existing reference doc. The four submodule operations become one scannable table. 75 lines → 42,
with nothing a reader needs removed.

First repository in a portfolio-wide pass.

Fixes #2226
Part of #2225
