### PR TITLE
docs(agents): require jargon-free voice for user-facing documents

### DIFF
--- a/.claude/skills/product-engineering/SKILL.md
+++ b/.claude/skills/product-engineering/SKILL.md
@@ -184,6 +184,22 @@ Treat docs as part of the product — keep them **in sync** with what ships and 
   inaccuracies and stale examples, fill a missing how-to/quickstart/troubleshooting entry, tighten
   clarity and onboarding flow, repair dead links and broken samples, align terminology. Verify
   examples actually run; build-verify the site (the monorepo card's `docs` build) before the PR.
+- **Voice (every user-facing doc).** Write in the `jargon-free-voice` register — concise, and for
+  humans rather than machines (maintainer direction 2026-07-18; contract → *Enhancement work →
+  Documentation*). In practice:
+  - **Frame each item by what the reader gets**, never a bare inventory. *"Secrets — OpenBao holds
+    them, External Secrets pulls them into the cluster at runtime"* beats *"Secrets — OpenBao,
+    External Secrets Operator, SOPS"*.
+  - **Concrete outcomes over abstract process language.** *"so network configuration lives in Git"*
+    beats *"managed declaratively and reconciled by GitOps"*.
+  - **Cut repetition and filler** — bullets restating the sentence above them, an intro re-listing
+    what the next section covers, empty adjectives ("industry-standard", "batteries-included").
+  - **Calibrate to the audience — the SPIRIT, not a literal noun-strip.** For technical readers the
+    **stack nouns stay** (a reader hunting a Talos-based template must see "Talos"); dropping the
+    names that let someone identify what they are getting is a regression. Strip stack nouns only
+    for a genuinely non-technical reader — the vibe-coding case the skill was written for.
+  - Adding explanation where there was none may make a page *longer*; that is an acceptable trade
+    when it raises usefulness per word. Say so plainly in the PR rather than implying it shrank.
 - **Scope.** Spans **every product's own docs** (README, `AGENTS.md`, usage/reference) and the central
   **devantler.tech site** (`docs/`). The site's recurring slice (Site QA, Content Sync, Content Review)
   lives in the [monorepo card](../products/monorepo/SKILL.md); this section is the cross-product

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -690,6 +690,21 @@ standing substitute** for moving the real backlog:
   *Cadence & focus*), improve existing docs: accuracy, gaps, clarity, onboarding flow, dead links,
   stale examples. Spans each product's own docs (README/`AGENTS.md`/usage/reference) and the
   devantler.tech site; a `docs:`-only change is real advance work, not filler.
+  **VOICE — every user-facing document is written in the `jargon-free-voice` register: concise, and
+  written for humans rather than machines** (maintainer direction 2026-07-18). Concretely: **frame
+  every item by what the reader gets**, never as a bare inventory ("Secrets — OpenBao holds them,
+  External Secrets pulls them into the cluster at runtime" beats "Secrets — OpenBao, External Secrets
+  Operator, SOPS"); **prefer concrete outcomes to abstract process language** ("so network
+  configuration lives in Git" beats "managed declaratively and reconciled by GitOps"); and **cut
+  repetition and filler** — bullets restating the sentence above them, intros re-listing what the
+  next section covers, empty adjectives ("industry-standard", "batteries-included"). **Calibrate the
+  register to the audience — this is the SPIRIT of the skill, not a literal noun-strip.** For
+  technical readers the **stack nouns STAY**: someone looking for a Talos-based platform template
+  needs to see "Talos", so removing the names that let a reader identify what they are getting is a
+  regression, not simplification. Strip stack nouns only where the reader genuinely has no technical
+  background (the vibe-coding case the skill was written for). Scope is every user-facing doc —
+  site pages, product docs, READMEs, usage/reference. This governs **docs**; PR bodies have their own
+  PM-level rule under *GitHub artifact conventions*.
 - **Product communication & marketing** — **Blog posts are a maintained public product**, not a
   changelog dump or one-time launch task. On the low-priority blog cadence, choose an evidence-backed
   story that helps a defined outside audience understand a real problem and Devantler Tech's response.


### PR DESCRIPTION
## Why

Our public docs had drifted into writing that reads like an inventory rather than an explanation — the platform template listed around 40 product names with no hint of what any of them do for a reader, and the about page repeated the same bullet six times. Nothing in the contract said docs had to be written for a human, so nothing caught it.

## What

Makes the jargon-free voice a standing requirement for every user-facing document, recorded in both places that carry docs conventions (`AGENTS.md` and the product-engineering skill).

The rule carries its own calibration so it can't be misread as a blanket ban on technical terms: for technical readers the product names stay, since removing the words that let someone identify what they're getting is a regression, not simplification. The strict version applies only to genuinely non-technical readers.

Definition change — leaving it to you to promote. Prose-only; no behaviour or configuration changes.

Companion docs PR: #2228

🤖 Generated with [Claude Code](https://claude.com/claude-code)