### PR TITLE
docs(site): say World at Ruin is playable now, and how to get it

### DIFF
--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -43,7 +43,7 @@ I use this cluster to learn and experiment with new technologies — striving to
 
 A **source-available, cloud-native MMORPG built almost entirely by AI agents** — the newest and most experimental project in the portfolio. Everything is authored as code and built headlessly in CI: a [Godot 4](https://godotengine.org/) client with procedurally generated worlds, and an [Agones](https://agones.dev/)-based server tier planned on the Platform above. Progress is meant to be watched by *playing* — every player-visible change lands in the in-game dev log.
 
-Currently in **pre-alpha**, and playable now on macOS — `brew install --cask world-at-ruin` from my [tap](https://github.com/devantler-tech/homebrew-tap), or download the app from the latest release. You wake in a cave, shape your character, and walk out into the ruins; combat and networking come later. The full settled design lives in the repo's [AGENTS.md](https://github.com/devantler-tech/world-at-ruin/blob/main/AGENTS.md).
+Currently in **pre-alpha**, and playable now on macOS — install it with Homebrew from my [tap](https://github.com/devantler-tech/homebrew-tap), or download the app straight from the latest release. You wake in a cave, shape your character, and walk out into the ruins; combat and networking come later. The full settled design lives in the repo's [AGENTS.md](https://github.com/devantler-tech/world-at-ruin/blob/main/AGENTS.md).
 
 🎮 [Install & play](https://github.com/devantler-tech/world-at-ruin#play-it) · 📦 [Latest release](https://github.com/devantler-tech/world-at-ruin/releases/latest)
 

--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -43,9 +43,9 @@ I use this cluster to learn and experiment with new technologies — striving to
 
 A **source-available, cloud-native MMORPG built almost entirely by AI agents** — the newest and most experimental project in the portfolio. Everything is authored as code and built headlessly in CI: a [Godot 4](https://godotengine.org/) client with procedurally generated worlds, and an [Agones](https://agones.dev/)-based server tier planned on the Platform above. Progress is meant to be watched by *playing* — every player-visible change lands in the in-game dev log.
 
-Currently in **pre-alpha**, and playable now on macOS — install it with Homebrew from my [tap](https://github.com/devantler-tech/homebrew-tap), or download the app straight from the latest release. You wake in a cave, shape your character, and walk out into the ruins; combat and networking come later. The full settled design lives in the repo's [AGENTS.md](https://github.com/devantler-tech/world-at-ruin/blob/main/AGENTS.md).
+Currently in **pre-alpha**, and playable now on macOS — [install it with Homebrew, or download the app directly](https://github.com/devantler-tech/world-at-ruin#play-it). You wake in a cave, shape your character, and walk out into the ruins; combat and networking come later. The full settled design lives in the repo's [AGENTS.md](https://github.com/devantler-tech/world-at-ruin/blob/main/AGENTS.md).
 
-🎮 [Install & play](https://github.com/devantler-tech/world-at-ruin#play-it) · 📦 [Latest release](https://github.com/devantler-tech/world-at-ruin/releases/latest)
+🎮 [Install & play](https://github.com/devantler-tech/world-at-ruin#play-it)
 
 ## 🏠 Self-Hosted Personal Apps
 

--- a/docs/src/content/docs/projects/active.mdx
+++ b/docs/src/content/docs/projects/active.mdx
@@ -43,7 +43,9 @@ I use this cluster to learn and experiment with new technologies — striving to
 
 A **source-available, cloud-native MMORPG built almost entirely by AI agents** — the newest and most experimental project in the portfolio. Everything is authored as code and built headlessly in CI: a [Godot 4](https://godotengine.org/) client with procedurally generated worlds, and an [Agones](https://agones.dev/)-based server tier planned on the Platform above. Progress is meant to be watched by *playing* — every player-visible change lands in the in-game dev log.
 
-Currently in **pre-alpha** — a first walkable slice exists. The full settled design lives in the repo's [AGENTS.md](https://github.com/devantler-tech/world-at-ruin/blob/main/AGENTS.md).
+Currently in **pre-alpha**, and playable now on macOS — `brew install --cask world-at-ruin` from my [tap](https://github.com/devantler-tech/homebrew-tap), or download the app from the latest release. You wake in a cave, shape your character, and walk out into the ruins; combat and networking come later. The full settled design lives in the repo's [AGENTS.md](https://github.com/devantler-tech/world-at-ruin/blob/main/AGENTS.md).
+
+🎮 [Install & play](https://github.com/devantler-tech/world-at-ruin#play-it) · 📦 [Latest release](https://github.com/devantler-tech/world-at-ruin/releases/latest)
 
 ## 🏠 Self-Hosted Personal Apps
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The projects page describes World at Ruin but never tells a visitor they can install and play it. Now that the game ships a Homebrew cask and real releases, someone who reads the section and wants to try it has no idea it is possible, let alone how.

## What

Adds a line to the World at Ruin section saying it is playable on macOS today, with a link to the tap and to the latest release, plus a concrete sentence about what a new player walks into. Follows the page's existing form — it links out to the repo README rather than repeating the install sequence in a second place that would drift.

✅ **Merge-order gate satisfied.** This page links readers to the README's install section, which had to document the cask first. devantler-tech/world-at-ruin#164 merged ahead of this, so that link now lands on the Homebrew instructions.