### PR TITLE
docs(agents): name World at Ruin's CD cask PRs in the programmed release-path carve-out

### DIFF
--- a/.claude/skills/product-engineering/SKILL.md
+++ b/.claude/skills/product-engineering/SKILL.md
@@ -357,7 +357,7 @@ coverage and performance (contract → *Enhancement work → Security posture*).
 - **monorepo + site**: advance = docs/site features, accessibility, performance (bundle/Lighthouse),
   content quality, evidence-led discovery/adoption, and low-priority blog stewardship (see the
   monorepo card's Site QA / Content Review / Blog Stewardship).
-- **homebrew-tap**: Casks are GoReleaser-generated (`# DO NOT EDIT`) — advance is limited to CI/tap
-  hygiene; never chase version/sha bumps.
+- **homebrew-tap**: Casks are machine-generated (`# DO NOT EDIT` — GoReleaser for ksail, World at
+  Ruin's CD for its cask) — advance is limited to CI/tap hygiene; never chase version/sha bumps.
 - **applications** (private, SvelteKit): conservative, extra discretion; coverage/quality/perf within
   the app owner's intent.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -554,11 +554,17 @@ touch the bot PR branch. This actor-wide no-action rule is stronger than the tru
 below and is separate from the narrower programmed release-bot review exemption.
 
 **Carve-out — trusted programmed release-bot PRs need NO review** (maintainer direction 2026-07-13,
-ksail#6095): PRs produced by the suite's own programmed release paths — GoReleaser's Homebrew-tap
-cask PRs and KSail release version bumps — are gated by their required checks and auto-merge on
-their own; do **not** request a CodeRabbit/Codex review or chase a pre-merge evaluator result on
-them, and never count their `green_review=none` or `premerge=not-posted` as a hygiene gap (their
-checks/threads/conflicts hygiene still counts). The green-review gate governs
+ksail#6095): PRs produced by the suite's own programmed release paths — **every product's**
+Homebrew-tap cask PR (GoReleaser's for ksail, and World at Ruin's CD-generated
+`chore(cask): update world-at-ruin to vX.Y.Z` PRs on the evergreen `goreleaser/world-at-ruin`
+branch — maintainer direction 2026-07-18: these were wrongly review-gated because only GoReleaser's
+were named here, wasting a review lane per release) and KSail release version bumps — are gated by
+their required checks and auto-merge on their own; do **not** request a CodeRabbit/Codex review or
+chase a pre-merge evaluator result on them, and never count their `green_review=none` or
+`premerge=not-posted` as a hygiene gap (their checks/threads/conflicts hygiene still counts). The
+identifying mark of this class is the **programmed path** (a `goreleaser/*` head branch on the tap,
+machine-generated content), never the commit identity — cask PRs are authored by the tap token as
+`devantler` and are still programmed-path PRs. The green-review gate governs
 **own/human-authored** PRs (and any bot PR that leaves its programmed path, e.g. one you push
 adaptation commits to — your commit makes it review-bearing again).
 **AUTO-REVIEW IS DISABLED — requesting reviews is the agent's job** (maintainer direction


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
Agent runs were spending CodeRabbit/Codex reviews on World at Ruin's machine-generated Homebrew cask version bumps and leaving them unmerged, because the programmed release-path carve-out named only GoReleaser's cask PRs — tap#1212 and tap#1213 each consumed a review lane for a two-line bump while brew players fell six releases behind. These PRs must auto-merge and must not waste reviews.

## What
Names every product's tap cask PR in the carve-out — identified by its programmed path (a `goreleaser/*` head branch, machine-generated content), never by commit identity — and syncs the homebrew-tap product note. Companion to devantler-tech/world-at-ruin#197, which makes those PRs arm their own check-gated auto-merge.
