### PR TITLE
ci(docs): guard featured project parity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,8 +48,12 @@ jobs:
               - 'docs/src/content/**'
               - 'docs/scripts/check-active-projects-drift.sh'
               - 'docs/scripts/check-active-projects-drift.test.sh'
+              - 'docs/scripts/check-homepage-project-parity.mjs'
+              - 'docs/package.json'
+              - 'docs/package-lock.json'
               - '.gitmodules'
               - 'github/devantler-tech/github-actions/actions'
+              - '.github/workflows/ci.yaml'
             safe-clone:
               - '.claude/scripts/safe-clone.sh'
               - '.claude/scripts/safe-clone.test.sh'
@@ -146,6 +150,15 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: docs/package-lock.json
+      - name: Install MDX parser dependencies
+        working-directory: docs
+        run: npm ci
       # Verify the drift checker itself first — self-contained fixtures, no
       # submodule checkout needed, so it fails fast if a refactor broke a check.
       - name: Self-test the drift checker

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -18,6 +18,7 @@
         "starlight-links-validator": "^0.25.2"
       },
       "devDependencies": {
+        "@mdx-js/mdx": "^3.1.1",
         "starlight-github-alerts": "^0.4.0"
       }
     },

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,6 +19,7 @@
     "starlight-links-validator": "^0.25.2"
   },
   "devDependencies": {
+    "@mdx-js/mdx": "^3.1.1",
     "starlight-github-alerts": "^0.4.0"
   },
   "overrides": {

--- a/docs/scripts/check-active-projects-drift.sh
+++ b/docs/scripts/check-active-projects-drift.sh
@@ -76,6 +76,15 @@
 #                          the doc page and the marker disposition to be updated
 #                          in lockstep. (Reads only the marker and the in-repo doc
 #                          pages, so it stays network-free.)
+#   - Homepage featured  — the homepage intentionally promotes a curated subset
+#                          of Active Projects, but both surfaces are hand-written.
+#                          We extract the literal LinkCard titles from only the
+#                          Featured Projects section and require that set to be a
+#                          subset of the linked H2 titles on Active Projects. A
+#                          stale or renamed featured card therefore fails CI,
+#                          while projects that are active but not featured remain
+#                          valid. Dynamic blog LinkCards are outside the section
+#                          and cannot enter the comparison.
 #
 # Run from the repository root (CI sets the working directory there); falls back
 # to a path relative to this script for local runs.
@@ -85,11 +94,13 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="${GITHUB_WORKSPACE:-$(cd "$script_dir/../.." && pwd)}"
 
 mdx="$repo_root/docs/src/content/docs/projects/active.mdx"
+homepage="$repo_root/docs/src/content/docs/index.mdx"
 actions_dir="$repo_root/github/devantler-tech/github-actions/actions"
 rw_workflows_dir="$repo_root/github/devantler-tech/github-actions/actions/.github/workflows"
 gitmodules="$repo_root/.gitmodules"
 templates_dir="$repo_root/docs/src/content/docs/templates"
 content_dir="$repo_root/docs/src/content"
+homepage_parity_checker="$script_dir/check-homepage-project-parity.mjs"
 
 # Anchor each H2 section on the source repo URL it links to — unique and stable.
 actions_anchor="](https://github.com/devantler-tech/actions)"
@@ -102,6 +113,8 @@ die_missing() {
 }
 
 [ -f "$mdx" ] || die_missing "active.mdx" "$mdx"
+[ -f "$homepage" ] || die_missing "homepage index.mdx" "$homepage"
+[ -f "$homepage_parity_checker" ] || die_missing "homepage parity checker" "$homepage_parity_checker"
 [ -d "$actions_dir" ] || die_missing "actions submodule" "$actions_dir"
 [ -d "$rw_workflows_dir" ] || die_missing "actions submodule workflows directory" "$rw_workflows_dir"
 [ -d "$content_dir" ] || die_missing "docs content directory" "$content_dir"
@@ -140,6 +153,13 @@ done
 if [ "$fail" -eq 0 ]; then
   echo "OK: no page links to a retired repo (${#retired_repo_urls[@]} pinned)."
 fi
+
+# The homepage/Active Projects relation is semantic MDX, so parse its AST rather
+# than guessing at comments, code fences, JSX attributes, or JavaScript strings.
+if ! node "$homepage_parity_checker" "$homepage" "$mdx"; then
+  fail=1
+fi
+
 [ -f "$gitmodules" ] || die_missing ".gitmodules" "$gitmodules"
 [ -d "$templates_dir" ] || die_missing "templates docs directory" "$templates_dir"
 

--- a/docs/scripts/check-active-projects-drift.test.sh
+++ b/docs/scripts/check-active-projects-drift.test.sh
@@ -54,9 +54,9 @@ fail_match() { # name root expected-substring
 # reusable (workflow_call) workflows living in the actions submodule's
 # .github/workflows (the standalone reusable-workflows repo is archived —
 # monorepo#1964) alongside a non-workflow_call workflow the guard must ignore,
-# four submodules (two infra-section, one grouped, one templates-page), and one
-# matching template doc page — all four markers in active.mdx agreeing with the
-# live sources.
+# four submodules (two infra-section, one grouped, one templates-page), one
+# matching template doc page, and a homepage whose featured project is present
+# on Active Projects — all guarded surfaces agreeing with their live sources.
 build_fixture() {
   local root="$1"
   rm -rf "$root"
@@ -102,6 +102,8 @@ EOF
 title: Active Projects
 ---
 
+<div class="projects-page">
+
 {/* projects-submodules: applications/bar=grouped,github/devantler-tech/github-actions/actions=section,github/devantler-tech/github-actions/reusable-workflows=omitted,templates/foo-template=templates-page */}
 
 ## [⚡ Actions](https://github.com/devantler-tech/actions)
@@ -111,6 +113,11 @@ title: Active Projects
 
 {/* actions-dirs: alpha,beta */}
 
+## [☯️ Platform](https://github.com/devantler-tech/platform)
+
+An active project that is intentionally not featured on the homepage. This
+proves the guarded relation is a strict subset rather than set equality.
+
 ## 🔄 Reusable Workflows
 
 - CI bucket
@@ -118,6 +125,28 @@ title: Active Projects
 
 {/* reusable-workflows-count: 2 */}
 {/* reusable-workflows-names: cd-two,ci-one */}
+
+</div>
+EOF
+
+  cat > "$root/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<CardGrid>
+  <Card title="About the portfolio" />
+  <LinkCard
+    title="⚡ Actions"
+    href="https://github.com/devantler-tech/actions"
+  />
+</CardGrid>
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
 EOF
 }
 
@@ -242,8 +271,652 @@ FIXTURE
 fail_match "retired-repo link on an unguarded page" "$c" \
   "Retired-repo link"
 
+# 14. Homepage featured-project set: a literal card with no matching linked H2
+#     on Active Projects must fail. The blog's dynamic LinkCard is deliberately
+#     outside the Featured Projects section and must not enter the comparison.
+c="$tmp/homepage-featured-project"; build_fixture "$c"
+sed -i.bak 's/title="⚡ Actions"/title="👻 Ghost Project"/' \
+  "$c/docs/src/content/docs/index.mdx"
+fail_match "Homepage: featured project absent from Active Projects" "$c" \
+  "Homepage featured-project drift"
+
+# 15. The homepage is now a required source for the cross-page invariant. A
+#     missing file must fail closed instead of silently skipping the check.
+c="$tmp/homepage-missing"; build_fixture "$c"
+rm "$c/docs/src/content/docs/index.mdx"
+fail_match "Homepage: source file missing" "$c" \
+  "homepage index.mdx not found"
+
+# 16. A rendered LinkCard without a literal title cannot participate in the
+#     invariant and must fail closed with the card-shape error.
+c="$tmp/homepage-empty-featured"; build_fixture "$c"
+sed -i.bak '/title="⚡ Actions"/d' "$c/docs/src/content/docs/index.mdx"
+fail_match "Homepage: Featured Projects has no literal card titles" "$c" \
+  "Every homepage Featured Projects LinkCard must have exactly one literal title"
+
+# 17. Bracketed text without an inline-link target is not a linked project H2.
+#     Removing every target must identify the broken Active Projects source,
+#     not masquerade as unrelated stale homepage cards.
+c="$tmp/active-projects-empty-linked-headings"; build_fixture "$c"
+sed -i.bak -E 's|^## \[([^]]+)\]\([^)]*\).*$|## [\1]|' "$(mdx_path "$c")"
+fail_match "Active Projects: no linked project headings" "$c" \
+  "No linked H2 project titles found on Active Projects"
+
+# 18. Single quotes are valid MDX literal syntax. A ghost card using them must
+#     not disappear merely because another double-quoted card was extracted.
+c="$tmp/homepage-single-quoted-title"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<CardGrid>
+  <LinkCard title='👻 Ghost Project' href="https://example.invalid/ghost" />
+  <LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+</CardGrid>
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: single-quoted ghost project is not omitted" "$c" \
+  "Homepage featured-project drift"
+
+# 19. Two LinkCards on one line are still separate rendered MDX nodes. Both must
+#     enter the comparison, so the Ghost card is caught.
+c="$tmp/homepage-compact-cards"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<CardGrid>
+  <LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" /> <LinkCard title="👻 Ghost Project" href="https://example.invalid/ghost" />
+</CardGrid>
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: compact LinkCards fail closed" "$c" \
+  "Homepage featured-project drift"
+
+# 20. Attribute order is irrelevant in MDX. A preceding data-title must not
+#     impersonate the real Ghost title.
+c="$tmp/homepage-data-title"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<CardGrid>
+  <LinkCard data-title="⚡ Actions" title='👻 Ghost Project' href="https://example.invalid/ghost" />
+</CardGrid>
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: data-title cannot mask the real title" "$c" \
+  "Homepage featured-project drift"
+
+# 21. Two cards with the same visible identity are not a valid set. Raw title
+#     and LinkCard counts still agree, so only the uniqueness guard catches it.
+c="$tmp/homepage-duplicate-title"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<CardGrid>
+  <LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+  <LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+</CardGrid>
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: duplicate featured title" "$c" \
+  "titles must be unique"
+
+# 22. Attribute-looking text inside another quoted value must not mask the real
+#     title; the MDX AST identifies the Ghost title semantically.
+c="$tmp/homepage-quoted-title-text"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<CardGrid>
+  <LinkCard description='See title="⚡ Actions" docs' title="👻 Ghost Project" href="https://example.invalid/ghost" />
+</CardGrid>
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: quoted title text cannot mask the real title" "$c" \
+  "Homepage featured-project drift"
+
+# 23. A preceding component on the same line is a separate MDX node and cannot
+#     donate its title to the following Ghost LinkCard.
+c="$tmp/homepage-preceding-card"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<CardGrid>
+  <Card title="⚡ Actions" /> <LinkCard title="👻 Ghost Project" href="https://example.invalid/ghost" />
+</CardGrid>
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: preceding Card cannot mask LinkCard title" "$c" \
+  "Homepage featured-project drift"
+
+# 24. An MDX comment is not rendered content. A commented-out card must not
+#     satisfy an otherwise-empty Featured Projects section.
+c="$tmp/homepage-commented-card"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+{/* <LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" /> */}
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: commented LinkCard is not rendered content" "$c" \
+  "No literal LinkCard titles found in the homepage Featured Projects section"
+
+# 25. A fenced example is likewise source text rather than a rendered card. It
+#     must not satisfy the required live-card extraction.
+c="$tmp/homepage-fenced-card"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+```mdx
+<LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+```
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: fenced LinkCard is not rendered content" "$c" \
+  "No literal LinkCard titles found in the homepage Featured Projects section"
+
+# 26. A closing fence must use at least as many markers as its opener. The
+#     triple-backtick line inside this four-backtick example is literal content,
+#     so the Actions card remains excluded; the matching closer must then restore
+#     parsing so the live Ghost card is caught.
+c="$tmp/homepage-long-fence"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+````mdx
+```
+<LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+````
+
+<LinkCard title="👻 Ghost Project" href="https://example.invalid/ghost" />
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: shorter fence marker does not close a long fence" "$c" \
+  "Homepage featured-project drift"
+
+# 27. A linked H2 inside an MDX comment is not a rendered Active Project and
+#     cannot satisfy a ghost homepage card.
+c="$tmp/active-projects-commented-heading"; build_fixture "$c"
+sed -i.bak 's/title="⚡ Actions"/title="👻 Ghost Project"/' \
+  "$c/docs/src/content/docs/index.mdx"
+cat >>"$(mdx_path "$c")" <<'EOF'
+
+{/*
+## [👻 Ghost Project](https://example.invalid/ghost)
+*/}
+EOF
+fail_match "Active Projects: commented heading cannot satisfy homepage" "$c" \
+  "Homepage featured-project drift"
+
+# 28. A linked H2 inside a fenced example is likewise non-rendered source and
+#     must not enter the independently navigable project-title set.
+c="$tmp/active-projects-fenced-heading"; build_fixture "$c"
+sed -i.bak 's/title="⚡ Actions"/title="👻 Ghost Project"/' \
+  "$c/docs/src/content/docs/index.mdx"
+cat >>"$(mdx_path "$c")" <<'EOF'
+
+````mdx
+```
+## [👻 Ghost Project](https://example.invalid/ghost)
+````
+EOF
+fail_match "Active Projects: fenced heading cannot satisfy homepage" "$c" \
+  "Homepage featured-project drift"
+
+# 29. Comment-looking text inside inline code is rendered text, not an MDX
+#     comment opener. It must not hide the real Ghost card that follows.
+c="$tmp/homepage-inline-code-comment-marker"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+`{/*`
+<LinkCard title="👻 Ghost Project" href="https://example.invalid/ghost" />
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: inline-code comment marker cannot hide a card" "$c" \
+  "Homepage featured-project drift"
+
+# 30. CommonMark forbids a backtick in a backtick fence info string, so this is
+#     rendered text rather than a fence opener and cannot hide the Ghost card.
+c="$tmp/homepage-invalid-backtick-fence"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+```foo`bar
+<LinkCard title="👻 Ghost Project" href="https://example.invalid/ghost" />
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: invalid backtick fence cannot hide a card" "$c" \
+  "Homepage featured-project drift"
+
+# 31. An escaped comment opener is rendered text too. Reject the ambiguous
+#     source shape rather than entering comment state and hiding the real card.
+c="$tmp/homepage-escaped-comment-marker"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+\{/*
+<LinkCard title="👻 Ghost Project" href="https://example.invalid/ghost" />
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: escaped comment marker cannot hide a card" "$c" \
+  "Homepage featured-project drift"
+
+# 32. Attribute-looking text inside a multiline template expression is not a
+#     literal title attribute. The actual expression-valued title is unsupported
+#     by the cross-page invariant and must fail closed.
+c="$tmp/homepage-template-string-title"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<LinkCard
+  description={`example
+title="⚡ Actions"
+`}
+  title={"👻 Ghost Project"}
+  href="https://example.invalid/ghost"
+/>
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: template text cannot impersonate literal title" "$c" \
+  "Every homepage Featured Projects LinkCard must have exactly one literal title"
+
+# 33. A linked-H2-looking line inside MDX ESM is JavaScript data, not a rendered
+#     Active Project section, and cannot satisfy the homepage subset.
+c="$tmp/active-projects-template-heading"; build_fixture "$c"
+sed -i.bak 's/title="⚡ Actions"/title="👻 Ghost Project"/' \
+  "$c/docs/src/content/docs/index.mdx"
+cat >>"$(mdx_path "$c")" <<'EOF'
+
+export const fakeProject = `
+## [👻 Ghost Project](https://example.invalid/ghost)
+`;
+EOF
+fail_match "Active Projects: JS template heading cannot satisfy homepage" "$c" \
+  "Homepage featured-project drift"
+
+# 34. Conditional JSX is runtime-dependent and cannot be enumerated from the
+#     static LinkCard nodes. Reject it rather than silently omitting Ghost.
+c="$tmp/homepage-conditional-card"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+{showGhost && <LinkCard title="👻 Ghost Project" href="https://example.invalid/ghost" />}
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: conditional LinkCard fails closed" "$c" \
+  "Featured Projects must remain statically inspectable"
+
+# 35. A spread can override a literal title at runtime, so a card using one is
+#     not statically safe even when it also declares an accepted title.
+c="$tmp/homepage-spread-card"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<LinkCard title="⚡ Actions" {...projectProps} />
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: spread attributes fail closed" "$c" \
+  "Every homepage Featured Projects LinkCard must have exactly one literal title"
+
+# 36. Inline JSX uses mdxJsxTextElement rather than mdxJsxFlowElement. It is
+#     still rendered and must enter the comparison.
+c="$tmp/homepage-inline-linkcard"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+Featured now: <LinkCard title="👻 Ghost Project" href="https://example.invalid/ghost" />
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: inline LinkCard enters comparison" "$c" \
+  "Homepage featured-project drift"
+
+# 37. The section boundary must be unique, otherwise choosing one silently
+#     leaves another rendered Featured Projects section unchecked.
+c="$tmp/homepage-duplicate-featured-heading"; build_fixture "$c"
+cat >>"$c/docs/src/content/docs/index.mdx" <<'EOF'
+
+## Featured Projects
+
+<LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+EOF
+fail_match "Homepage: duplicate Featured Projects headings fail closed" "$c" \
+  "Expected exactly one rendered '## Featured Projects' heading"
+
+# 38. Malformed MDX must fail at the semantic parser rather than degrading to
+#     an incomplete text scan.
+c="$tmp/homepage-malformed-mdx"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<LinkCard title="⚡ Actions"
+EOF
+fail_match "Homepage: malformed MDX fails closed" "$c" \
+  "Unable to parse project metadata as MDX"
+
+# 39. A non-LinkCard JSX element can still render a card through an expression-
+#     valued prop. Reject all runtime JSX attributes in the guarded section.
+c="$tmp/homepage-expression-attribute-card"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+<CardGrid children={<LinkCard title="👻 Ghost Project" href="https://example.invalid/ghost" />} />
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: expression-valued JSX attributes fail closed" "$c" \
+  "Featured Projects must remain statically inspectable"
+
+# 40. Decoded title text is untrusted workflow-command data. Newlines must be
+#     escaped so a title cannot inject a second GitHub Actions command.
+c="$tmp/homepage-annotation-injection"; build_fixture "$c"
+sed -i.bak 's/title="⚡ Actions"/title="👻 Ghost\&#10;::notice::Injected"/' \
+  "$c/docs/src/content/docs/index.mdx"
+fail_match "Homepage: annotation data escapes decoded newlines" "$c" \
+  "%0A::notice::Injected"
+
+# 41. Parse failures must identify the source file that failed, including the
+#     Active Projects side of the comparison.
+c="$tmp/active-projects-malformed-mdx"; build_fixture "$c"
+cat >>"$(mdx_path "$c")" <<'EOF'
+
+<Broken
+EOF
+fail_match "Active Projects: malformed MDX reports its own file" "$c" \
+  "file=docs/src/content/docs/projects/active.mdx::Unable to parse project metadata as MDX"
+
+# 42. Astro frontmatter is metadata, not rendered Markdown. A linked-H2-looking
+#     YAML block scalar cannot satisfy the homepage subset.
+c="$tmp/active-projects-frontmatter-heading"; build_fixture "$c"
+sed -i.bak '/title: Active Projects/a\
+fake: |\
+  ## [👻 Ghost Project](https://example.invalid/ghost)' "$(mdx_path "$c")"
+sed -i.bak 's/title="⚡ Actions"/title="👻 Ghost Project"/' \
+  "$c/docs/src/content/docs/index.mdx"
+fail_match "Active Projects: frontmatter heading cannot satisfy homepage" "$c" \
+  "Homepage featured-project drift"
+
+# 43. The whole section must not sit beneath a runtime-controlled JSX ancestor.
+#     Keeping its H2 top-level makes the section boundary statically meaningful.
+c="$tmp/homepage-runtime-wrapper"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+<Conditional show={false}>
+
+## Featured Projects
+
+<LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+
+</Conditional>
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: runtime-wrapped Featured section fails closed" "$c" \
+  "Featured Projects heading must remain top-level"
+
+# 44. A nested or blockquoted H2 is rendered content inside the section, not the
+#     top-level boundary. It must not truncate inspection before a later card.
+c="$tmp/homepage-nested-h2"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+## Featured Projects
+
+<LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+
+> ## Note
+>
+> Featured projects can change over time.
+
+<LinkCard title="👻 Ghost Project" href="https://example.invalid/ghost" />
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: nested H2 cannot truncate Featured section" "$c" \
+  "Homepage featured-project drift"
+
+# 45. A linked project H2 beneath a runtime JSX ancestor is not a statically
+#     rendered Active Projects section and cannot satisfy homepage parity.
+c="$tmp/active-projects-runtime-wrapper"; build_fixture "$c"
+cat >>"$(mdx_path "$c")" <<'EOF'
+
+<Conditional show={false}>
+
+## [👻 Ghost Project](https://example.invalid/ghost)
+
+</Conditional>
+EOF
+sed -i.bak 's/title="⚡ Actions"/title="👻 Ghost Project"/' \
+  "$c/docs/src/content/docs/index.mdx"
+fail_match "Active Projects: runtime-wrapped H2 cannot satisfy homepage" "$c" \
+  "Homepage featured-project drift"
+
+# 46. Runtime content inside a linked Active Project H2 changes its rendered
+#     identity. It must not be dropped by literal-text extraction.
+c="$tmp/active-projects-computed-title"; build_fixture "$c"
+sed -i.bak '/<div class="projects-page">/i\
+export const suffix = " Renamed";\
+' "$(mdx_path "$c")"
+sed -i.bak 's/\[⚡ Actions\]/[⚡ Actions{suffix}]/' "$(mdx_path "$c")"
+fail_match "Active Projects: computed linked-H2 title fails closed" "$c" \
+  "Linked Active Projects H2 titles must remain literal"
+
+# 47. Attribute-free JSX can still compute rendered link text. Literal-title
+#     validation must reject the component itself, not just computed props.
+c="$tmp/active-projects-jsx-title"; build_fixture "$c"
+sed -i.bak '/<div class="projects-page">/i\
+export const Suffix = () => " Renamed";\
+' "$(mdx_path "$c")"
+sed -i.bak 's/\[⚡ Actions\]/[⚡ Actions<Suffix \/>]/' "$(mdx_path "$c")"
+fail_match "Active Projects: JSX inside linked-H2 title fails closed" "$c" \
+  "Linked Active Projects H2 titles must remain literal"
+
+# 48. A rendered LinkCard can be imported under another component name. Unknown
+#     JSX in the guarded section must fail closed instead of disappearing from
+#     the comparison while a different normal LinkCard keeps the set non-empty.
+c="$tmp/homepage-aliased-linkcard"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+import { CardGrid, LinkCard, LinkCard as FeaturedLink } from "@astrojs/starlight/components";
+
+## Featured Projects
+
+<CardGrid>
+  <LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+  <FeaturedLink title="👻 Ghost Project" href="https://example.invalid/ghost" />
+</CardGrid>
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: aliased LinkCard renderer fails closed" "$c" \
+  "Unsupported JSX component in Featured Projects"
+
+# 49. A custom component can suppress children without accepting any props.
+#     Only the page's known static layout wrapper may contain source headings.
+c="$tmp/active-projects-static-custom-wrapper"; build_fixture "$c"
+sed -i.bak '/<div class="projects-page">/i\
+export const Hidden = () => null;\
+' "$(mdx_path "$c")"
+cat >>"$(mdx_path "$c")" <<'EOF'
+
+<Hidden>
+
+## [👻 Ghost Project](https://example.invalid/ghost)
+
+</Hidden>
+EOF
+sed -i.bak 's/title="⚡ Actions"/title="👻 Ghost Project"/' \
+  "$c/docs/src/content/docs/index.mdx"
+fail_match "Active Projects: custom wrapper cannot satisfy homepage" "$c" \
+  "Homepage featured-project drift"
+
+# 50. An allowlisted JSX tag name is not sufficient when an import aliases a
+#     different renderer under it. This valid MDX renders Ghost via LinkCard-as-
+#     Card while retaining a normal LinkCard that keeps the inspected set nonempty.
+c="$tmp/homepage-rebound-linkcard"; build_fixture "$c"
+cat >"$c/docs/src/content/docs/index.mdx" <<'EOF'
+---
+title: Home
+---
+
+import { CardGrid, LinkCard, LinkCard as Card } from "@astrojs/starlight/components";
+
+## Featured Projects
+
+<CardGrid>
+  <Card title="👻 Ghost Project" href="https://example.invalid/ghost" />
+  <LinkCard title="⚡ Actions" href="https://github.com/devantler-tech/actions" />
+</CardGrid>
+
+## Latest from the Blog
+
+<LinkCard title={post.data.title} href={`/${post.id}/`} />
+EOF
+fail_match "Homepage: rebound LinkCard binding fails closed" "$c" \
+  "Featured Projects component bindings must use named exports"
+
 if [ "$fail" -ne 0 ]; then
   printf '❌ active-projects drift-guard self-test FAILED\n' >&2
   exit 1
 fi
-printf '✅ active-projects drift-guard self-test passed (14 cases)\n'
+printf '✅ active-projects drift-guard self-test passed (51 cases)\n'

--- a/docs/scripts/check-homepage-project-parity.mjs
+++ b/docs/scripts/check-homepage-project-parity.mjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+
+import { createProcessor } from "@mdx-js/mdx";
+import { readFile } from "node:fs/promises";
+import { relative } from "node:path";
+
+const [homepagePath, activeProjectsPath] = process.argv.slice(2);
+if (!homepagePath || !activeProjectsPath) {
+  console.error("usage: check-homepage-project-parity.mjs <homepage.mdx> <active-projects.mdx>");
+  process.exit(2);
+}
+
+const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+const displayPath = (path) => relative(workspace, path) || path;
+const escapeCommandData = (value) =>
+  String(value).replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+const escapeCommandProperty = (value) =>
+  escapeCommandData(value).replaceAll(":", "%3A").replaceAll(",", "%2C");
+const annotate = (path, message) => {
+  console.error(
+    `::error file=${escapeCommandProperty(displayPath(path))}::${escapeCommandData(message)}`,
+  );
+  process.exitCode = 1;
+};
+
+const descendants = (tree) => {
+  const found = [];
+  const visit = (node, ancestors = []) => {
+    found.push({ node, ancestors });
+    for (const child of node.children || []) visit(child, [...ancestors, node]);
+  };
+  visit(tree);
+  return found;
+};
+const nodes = (tree) => descendants(tree).map(({ node }) => node);
+
+const isJsxNode = (node) =>
+  node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement";
+const hasRuntimeJsxAttribute = (node) =>
+  isJsxNode(node) &&
+  (node.attributes || []).some(
+    (attribute) =>
+      attribute.type === "mdxJsxExpressionAttribute" ||
+      (attribute.type === "mdxJsxAttribute" &&
+        attribute.value !== null &&
+        typeof attribute.value === "object"),
+  );
+const isRuntimeControlledNode = (node) =>
+  ((node.type === "mdxFlowExpression" || node.type === "mdxTextExpression") &&
+    (node.data?.estree?.body?.length || 0) > 0) ||
+  hasRuntimeJsxAttribute(node);
+
+const text = (node) => {
+  if (typeof node.value === "string" && (node.type === "text" || node.type === "inlineCode")) {
+    return node.value;
+  }
+  return (node.children || []).map(text).join("");
+};
+
+const maskAstroFrontmatter = (source) => {
+  if (!/^(?:\uFEFF)?---[ \t]*\r?\n/.test(source)) return source;
+
+  const frontmatter = source.match(/^(?:\uFEFF)?---[ \t]*\r?\n[\s\S]*?^---[ \t]*(?:\r?\n|$)/m);
+  if (!frontmatter) throw new Error("Unterminated Astro frontmatter block");
+
+  return frontmatter[0].replace(/[^\r\n]/g, " ") + source.slice(frontmatter[0].length);
+};
+
+const parse = async (path) => {
+  try {
+    const source = maskAstroFrontmatter(await readFile(path, "utf8"));
+    return createProcessor({ format: "mdx" }).parse({ path, value: source });
+  } catch (error) {
+    error.inputPath = path;
+    throw error;
+  }
+};
+
+let homepage;
+let activeProjects;
+try {
+  [homepage, activeProjects] = await Promise.all([parse(homepagePath), parse(activeProjectsPath)]);
+} catch (error) {
+  annotate(error.inputPath || homepagePath, `Unable to parse project metadata as MDX: ${error.message}`);
+  process.exit(1);
+}
+
+const homepageNodes = nodes(homepage);
+const homepageH2s = homepageNodes
+  .filter((node) => node.type === "heading" && node.depth === 2)
+  .sort((left, right) => left.position.start.offset - right.position.start.offset);
+const topLevelHomepageH2s = homepage.children
+  .filter((node) => node.type === "heading" && node.depth === 2)
+  .sort((left, right) => left.position.start.offset - right.position.start.offset);
+const featuredHeadings = homepageH2s.filter((heading) => text(heading).trim() === "Featured Projects");
+
+if (featuredHeadings.length !== 1) {
+  annotate(
+    homepagePath,
+    `Expected exactly one rendered '## Featured Projects' heading, found ${featuredHeadings.length}.`,
+  );
+  process.exit(1);
+}
+
+const featuredHeading = featuredHeadings[0];
+if (!homepage.children.includes(featuredHeading)) {
+  annotate(
+    homepagePath,
+    "The Featured Projects heading must remain top-level so no runtime JSX ancestor can conditionally hide the guarded section.",
+  );
+  process.exit(1);
+}
+
+const featuredStart = featuredHeading.position.end.offset;
+const nextH2 = topLevelHomepageH2s.find(
+  (heading) => heading.position.start.offset > featuredStart,
+);
+const featuredEnd = nextH2?.position.start.offset ?? Number.POSITIVE_INFINITY;
+const featuredSectionNodes = homepageNodes.filter(
+  (node) => node.position?.start.offset > featuredStart && node.position.start.offset < featuredEnd,
+);
+const supportedFeaturedComponents = new Set(["Card", "CardGrid", "LinkCard"]);
+const unsupportedFeaturedComponents = featuredSectionNodes
+  .filter((node) => isJsxNode(node) && !supportedFeaturedComponents.has(node.name))
+  .map((node) => node.name || "fragment");
+
+if (unsupportedFeaturedComponents.length > 0) {
+  annotate(
+    homepagePath,
+    `Unsupported JSX component in Featured Projects: [${[
+      ...new Set(unsupportedFeaturedComponents),
+    ].join(",")}]. Only Card, CardGrid, and statically inspected LinkCard components may render inside the guarded section.`,
+  );
+  process.exit(1);
+}
+
+const collectPatternNames = (pattern) => {
+  if (!pattern) return [];
+  if (pattern.type === "Identifier") return [pattern.name];
+  if (pattern.type === "AssignmentPattern") return collectPatternNames(pattern.left);
+  if (pattern.type === "RestElement") return collectPatternNames(pattern.argument);
+  if (pattern.type === "ArrayPattern") return pattern.elements.flatMap(collectPatternNames);
+  if (pattern.type === "ObjectPattern") {
+    return pattern.properties.flatMap((property) =>
+      collectPatternNames(property.type === "Property" ? property.value : property.argument),
+    );
+  }
+  return [];
+};
+
+const explicitBindings = new Map();
+const recordBinding = (name, binding) => {
+  if (!name) return;
+  explicitBindings.set(name, [...(explicitBindings.get(name) || []), binding]);
+};
+const esmStatements = homepageNodes
+  .filter((node) => node.type === "mdxjsEsm")
+  .flatMap((node) => node.data?.estree?.body || []);
+
+for (const statement of esmStatements) {
+  if (statement.type === "ImportDeclaration") {
+    for (const specifier of statement.specifiers) {
+      recordBinding(specifier.local?.name, {
+        kind: "import",
+        source: statement.source.value,
+        imported:
+          specifier.type === "ImportSpecifier"
+            ? specifier.imported.name || specifier.imported.value
+            : specifier.type === "ImportDefaultSpecifier"
+              ? "default"
+              : "*",
+      });
+    }
+    continue;
+  }
+
+  const declaration = statement.declaration || statement;
+  if (declaration.type === "VariableDeclaration") {
+    for (const declarator of declaration.declarations) {
+      for (const name of collectPatternNames(declarator.id)) recordBinding(name, { kind: "local" });
+    }
+  } else if (
+    declaration.type === "FunctionDeclaration" ||
+    declaration.type === "ClassDeclaration"
+  ) {
+    recordBinding(declaration.id?.name, { kind: "local" });
+  }
+}
+
+const starlightComponentsModule = "@astrojs/starlight/components";
+const usedFeaturedComponents = new Set(
+  featuredSectionNodes.filter(isJsxNode).map((node) => node.name),
+);
+const invalidFeaturedBindings = [...usedFeaturedComponents].filter((name) => {
+  const bindings = explicitBindings.get(name) || [];
+  return (
+    bindings.length > 0 &&
+    (bindings.length !== 1 ||
+      bindings[0].kind !== "import" ||
+      bindings[0].source !== starlightComponentsModule ||
+      bindings[0].imported !== name)
+  );
+});
+
+if (invalidFeaturedBindings.length > 0) {
+  annotate(
+    homepagePath,
+    `Featured Projects component bindings must use named exports from ${starlightComponentsModule} without rebinding. Invalid binding(s): [${invalidFeaturedBindings.join(",")}].`,
+  );
+  process.exit(1);
+}
+
+const hasRuntimeExpression = featuredSectionNodes.some(
+  (node) =>
+    (node.type === "mdxFlowExpression" || node.type === "mdxTextExpression") &&
+    (node.data?.estree?.body?.length || 0) > 0,
+);
+const hasRuntimeContainerAttribute = featuredSectionNodes.some(
+  (node) =>
+    node.name !== "LinkCard" && hasRuntimeJsxAttribute(node),
+);
+
+if (hasRuntimeExpression || hasRuntimeContainerAttribute) {
+  annotate(
+    homepagePath,
+    "Featured Projects must remain statically inspectable. Conditional or computed MDX content can hide rendered LinkCards from the cross-page invariant.",
+  );
+  process.exit(1);
+}
+
+const featuredCards = featuredSectionNodes.filter(
+  (node) =>
+    (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") &&
+    node.name === "LinkCard",
+);
+
+if (featuredCards.length === 0) {
+  annotate(
+    homepagePath,
+    "No literal LinkCard titles found in the homepage Featured Projects section. Keep literal featured-project titles under that H2 so drift remains checkable.",
+  );
+  process.exit(1);
+}
+
+const featuredTitles = [];
+let unsupportedCard = false;
+for (const card of featuredCards) {
+  const attributes = card.attributes || [];
+  const titleAttributes = attributes.filter(
+    (attribute) => attribute.type === "mdxJsxAttribute" && attribute.name === "title",
+  );
+  const hasRuntimeAttribute = attributes.some(
+    (attribute) =>
+      attribute.type === "mdxJsxExpressionAttribute" ||
+      (attribute.type === "mdxJsxAttribute" &&
+        attribute.value !== null &&
+        typeof attribute.value === "object"),
+  );
+  const title = titleAttributes[0]?.value;
+
+  if (
+    titleAttributes.length !== 1 ||
+    typeof title !== "string" ||
+    title.trim() === "" ||
+    hasRuntimeAttribute
+  ) {
+    unsupportedCard = true;
+    continue;
+  }
+  featuredTitles.push(title.trim());
+}
+
+const uniqueFeaturedTitles = [...new Set(featuredTitles)].sort();
+if (
+  unsupportedCard ||
+  featuredTitles.length !== featuredCards.length ||
+  uniqueFeaturedTitles.length !== featuredTitles.length
+) {
+  annotate(
+    homepagePath,
+    `Every homepage Featured Projects LinkCard must have exactly one literal title, and titles must be unique. Found ${featuredCards.length} LinkCard(s), ${featuredTitles.length} literal title(s), and ${uniqueFeaturedTitles.length} unique title(s). Expression-valued attributes and spread attributes are unsupported.`,
+  );
+  process.exit(1);
+}
+
+const isActiveProjectsLayoutWrapper = (node) => {
+  if (node.type === "root") return true;
+  if (node.type !== "mdxJsxFlowElement" || node.name !== "div") return false;
+
+  const attributes = node.attributes || [];
+  return (
+    attributes.length === 1 &&
+    attributes[0].type === "mdxJsxAttribute" &&
+    attributes[0].name === "class" &&
+    attributes[0].value === "projects-page"
+  );
+};
+
+const activeHeadings = descendants(activeProjects)
+  .filter(
+    ({ node, ancestors }) =>
+      node.type === "heading" &&
+      node.depth === 2 &&
+      ancestors.every(isActiveProjectsLayoutWrapper),
+  )
+  .map(({ node }) => node)
+  .filter((heading) => heading.children?.[0]?.type === "link");
+
+const literalActiveTitleNodeTypes = new Set([
+  "link",
+  "text",
+  "inlineCode",
+  "emphasis",
+  "strong",
+  "delete",
+]);
+if (activeHeadings.some((heading) =>
+  descendants(heading.children[0]).some(
+    ({ node }) => !literalActiveTitleNodeTypes.has(node.type),
+  ),
+)) {
+  annotate(
+    activeProjectsPath,
+    "Linked Active Projects H2 titles must remain literal. Runtime expressions or computed JSX can change a rendered project identity without a statically verifiable title.",
+  );
+  process.exit(1);
+}
+
+const activeTitles = [
+  ...new Set(
+    activeHeadings
+      .map((heading) => text(heading.children[0]).trim())
+      .filter(Boolean),
+  ),
+].sort();
+
+if (activeTitles.length === 0) {
+  annotate(
+    activeProjectsPath,
+    "No linked H2 project titles found on Active Projects. The homepage featured-project guard cannot verify its source set.",
+  );
+  process.exit(1);
+}
+
+const activeTitleSet = new Set(activeTitles);
+const homepageOnly = uniqueFeaturedTitles.filter((title) => !activeTitleSet.has(title));
+if (homepageOnly.length > 0) {
+  annotate(
+    homepagePath,
+    `Homepage featured-project drift: these Featured Projects have no matching linked H2 on Active Projects: [${homepageOnly.join(
+      ",",
+    )}]. Add or rename the Active Projects section, or remove the stale featured card.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `OK: Homepage Featured Projects are present on Active Projects (${uniqueFeaturedTitles.length} featured within ${activeTitles.length} linked sections).`,
+);


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The homepage curates Featured Projects separately from the Active Projects page, so a rename or removal can leave stale project promotion behind.

## What

- compare rendered Featured Project LinkCard titles with rendered linked Active Project H2s using the MDX AST
- fail closed on dynamic, aliased, rebound, or otherwise ambiguous MDX shapes and escape annotation data
- self-test the parity guard across 51 positive and negative controls
- install and cache the declared MDX parser in the targeted CI job

Fixes #2257
Part of #1813
