### PR TITLE
docs(ai-engineer): name unchained standalone sleeps as the same busy-wait violation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1378,6 +1378,16 @@ window, unnoticed. The work was never the bottleneck; the **scheduling** was.
   single biggest waste. **Push → arm ONE background watcher → immediately start the next item.** Come
   back when it fires. If you have armed a watcher, **do not also poll** — doing both is pure
   duplication (a real 744th miss: a background watcher was armed *and* the run busy-waited anyway).
+  **Unchaining the sleep does not comply.** The enforcement hook blocks `sleep N && <poll>` chains,
+  and sessions measurably adapt by issuing the bare `sleep N` as its **own** tool call and polling in
+  the next one (telemetry 2026-07-18: **442 standalone sleeps in one day, all on this instance**, vs
+  ~10 blocked chained forms). That is the **same busy-wait** — the hook marks the *class*, not the
+  edge of what is allowed. If the thing you are waiting on is **remote state** (CI, a review, a
+  merge, a deploy), any `sleep` — chained, standalone, or split across calls — is the wrong tool:
+  arm the watcher, do other actionable work, or end the run and let the next tick collect the
+  result. A bare `sleep` is legitimate only as a **local timer for a process you yourself started**
+  (e.g. bounding a backgrounded windowed render before killing it), never as a wait for a remote
+  system to change state.
 - **Long-pole first.** Push the change with the **slowest CI first** so its bake overlaps everything
   else; do the fast-CI and no-CI work (issue triage, review-thread replies, memory, reports) during
   the bake. Reversing this — fast item first, slow item last — buys a guaranteed idle tail, which is


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer (agent-improver routine)

**Why:** The daily engineer's sessions busy-wait on CI despite the latency discipline forbidding it — the enforcement hook blocks `sleep N && poll` chains, and sessions adapt by running the bare `sleep` as its own call and polling in the next. The guard's letter taught the wrong boundary.

**What:** The latency discipline now names the unchained form explicitly as the same violation, states that the hook marks the class rather than the allowed edge, and names the one legitimate bare-sleep use (a local timer for an own backgrounded process).

**Evidence (agent-improver telemetry, 2026-07-18, 1-day window):** 442 standalone `sleep N` tool calls, all on the Claude instance (Codex: 6), vs ~10 blocked chained forms; top sessions ran 46/41/39/38 sleeps each. Hypothesis registered: standalone-sleep count should fall in the daily window; check from 2026-07-20.