### PR TITLE
feat(ai-engineer): report transcript credential hits per shape, boundary-anchored

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -674,20 +674,32 @@ if want safety; then
       #     the wrapped form (the most common real-leak shape, since grep's
       #     LEFTMOST-match rule hands it to the generic alternative) would be
       #     classified by its key instead of its value.
+      # ANSI escapes are stripped BEFORE matching: a styled credential
+      # (`ESC[31mghp_…`) puts the sequence's terminating letter right before
+      # the token prefix, which the boundary anchor would misread as blob
+      # noise and silently NOT count — the worst failure for this table.
+      # Compounds split on `;&|` — the shell separators the generic value
+      # class admits; none appears in any token alphabet, so splitting costs
+      # no true positives.
       { jq -Rr 'select(length>0)|(try (fromjson|..|strings) catch empty)' "$f" 2>/dev/null; \
         cat "$f" 2>/dev/null; } \
+        | sed -E "s/$(printf '\033')\[[0-9;]*[A-Za-z]//g" \
         | grep -hoEi "$CRED_TABLE_RE" 2>/dev/null \
-        | tr ';' '\n' | grep -v '^$' \
+        | tr ';&|' '\n' | grep -v '^$' \
         | sed -E -e 's/^[^A-Za-z0-9_-]//' -e "s/^[^:=]*[:=][[:space:]]*[\"']?//" \
         | grep -E . | sort -u
     done | sort -u | awk '
+      # FULL-shape validation, not prefix sniffing: a generic value that merely
+      # BEGINS like a token (`token=ghp_abcdefgh`, too short to be one) must
+      # stay in the weak bucket, or the high-signal rows inherit false
+      # positives from the generic alternative. Input is lowercased.
       function shape_of(x) {
-        if (index(x, "github_pat_") == 1) return "github-pat (fine-grained)"
-        if (x ~ /^gh[pousr]_/)            return "github-token (classic/app)"
-        if (index(x, "akia") == 1)        return "aws-access-key-id"
-        if (x ~ /^xox[baprs]-/)           return "slack-token"
-        if (index(x, "eyj") == 1)         return "jwt-like"
-        if (index(x, "-----begin") == 1)  return "private-key-block"
+        if (x ~ /^github_pat_[a-z0-9_]{20,}/)            return "github-pat (fine-grained)"
+        if (x ~ /^gh[pousr]_[a-z0-9]{16,}/)              return "github-token (classic/app)"
+        if (x ~ /^akia[0-9a-z]{12,}/)                    return "aws-access-key-id"
+        if (x ~ /^xox[baprs]-[a-z0-9-]{10,}/)            return "slack-token"
+        if (x ~ /^eyj[a-z0-9_-]{10,}\.[a-z0-9_-]{10,}/)  return "jwt-like"
+        if (index(x, "-----begin") == 1)                 return "private-key-block"
         return ""
       }
       {

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -694,7 +694,7 @@ if want safety; then
       #     while not splitting silently drops a real second credential.
       { jq -Rr 'select(length>0)|(try (fromjson|..|strings) catch empty)' "$f" 2>/dev/null; \
         cat "$f" 2>/dev/null; } \
-        | sed -E "s/$(printf '\033')\[[0-9;]*[A-Za-z]//g" \
+        | sed -E "s/$(printf '\033')\[[0-9;:]*[A-Za-z]//g" \
         | grep -hoEi "$CRED_TABLE_RE" 2>/dev/null \
         | tr ';&|' '\n' | grep -v '^$' \
         | sed -E -e 's/^[^A-Za-z0-9_-]//' -e "s/^[^:=]*[:=][[:space:]]*[\"']?//" \

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -681,6 +681,17 @@ if want safety; then
       # Compounds split on `;&|` — the shell separators the generic value
       # class admits; none appears in any token alphabet, so splitting costs
       # no true positives.
+      # KNOWN IDENTITY LIMITS (deliberate, do not "fix" by carrying values):
+      # (a) PEM rows count header lines and the JWT alternative stops at
+      #     header.payload, so N distinct keys/signatures can read as one row —
+      #     the operator action (triage, rotate) is identical either way, and
+      #     hashing full key material through more pipeline stages contradicts
+      #     the value-minimisation this table exists for. Counts are
+      #     DIRECTIONAL, as the report banner states.
+      # (b) A generic value legitimately containing `;&|` splits into extra
+      #     weak-bucket rows; the asymmetry is chosen — a splittable fragment
+      #     only ever reaches a high-signal row by passing a FULL shape regex,
+      #     while not splitting silently drops a real second credential.
       { jq -Rr 'select(length>0)|(try (fromjson|..|strings) catch empty)' "$f" 2>/dev/null; \
         cat "$f" 2>/dev/null; } \
         | sed -E "s/$(printf '\033')\[[0-9;]*[A-Za-z]//g" \

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -667,18 +667,33 @@ if want safety; then
       { jq -Rr 'select(length>0)|(try (fromjson|..|strings) catch empty)' "$f" 2>/dev/null; \
         cat "$f" 2>/dev/null; } \
         | grep -hoEi "$CRED_TABLE_RE" 2>/dev/null | sed -E 's/^[^A-Za-z0-9_-]//' | sort -u
-    done | sort -u | awk '{
+    done | sort -u | awk '
+      function shape_of(x) {
+        if (index(x, "github_pat_") == 1) return "github-pat (fine-grained)"
+        if (x ~ /^gh[pousr]_/)            return "github-token (classic/app)"
+        if (index(x, "akia") == 1)        return "aws-access-key-id"
+        if (x ~ /^xox[baprs]-/)           return "slack-token"
+        if (index(x, "eyj") == 1)         return "jwt-like"
+        if (index(x, "-----begin") == 1)  return "private-key-block"
+        return ""
+      }
+      {
         t = tolower($0)
-        if      (index(t, "github_pat_") == 1) s = "github-pat (fine-grained)"
-        else if (t ~ /^gh[pousr]_/)            s = "github-token (classic/app)"
-        else if (index(t, "akia") == 1)        s = "aws-access-key-id"
-        else if (t ~ /^xox[baprs]-/)           s = "slack-token"
-        else if (index(t, "eyj") == 1)         s = "jwt-like"
-        else if (index(t, "-----begin") == 1)  s = "private-key-block"
+        s = shape_of(t)
+        if (s == "") {
+          # An ASSIGNMENT-wrapped token (`GITHUB_TOKEN=ghp_…`, `token=eyJ…`) is
+          # consumed by the generic alternative first — grep returns the
+          # LEFTMOST match, and the assignment keyword starts before the token
+          # prefix — so the most common real-leak form would land in the weak
+          # bucket. Classify the VALUE part before falling back to generic.
+          v = t
+          sub("^[^:=]*[:=][ \t]*[\"\047]?", "", v)
+          s = shape_of(v)
+        }
         # NB: the label itself passes through the output-boundary redactor, so
         # it must not be credential-SHAPED ("token=…" would come out mangled
         # as "token=<redacted>").
-        else s = "generic-assignment [WEAK signal: secret/token assignment shapes, names as often as values]"
+        if (s == "") s = "generic-assignment [WEAK signal: secret/token assignment shapes, names as often as values]"
         print s
       }' | sort | uniq -c | sort -rn | sed 's/^/    /'
     echo "    (empty = clean. A HIGH-SIGNAL shape count means rotate the credential AND"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -664,9 +664,22 @@ if want safety; then
     printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | while IFS= read -r f; do
       # Dedupe per file: a credential visible in BOTH decoded and raw JSON was
       # emitted twice, doubling every count in the leak table.
+      # Normalise every match to its UNDERLYING VALUE before any dedup:
+      # (1) split compound assignments on `;` — the generic alternative's value
+      #     class includes `;`, so `GITHUB_TOKEN=ghp_…;AWS_…=AKIA…` is ONE
+      #     greedy match and the second credential's shape would vanish;
+      # (2) strip the boundary char the anchored alternatives capture;
+      # (3) strip the `KEY=`/`key:` assignment wrapper — otherwise the same
+      #     token standalone and wrapped counts as two "distinct" values, and
+      #     the wrapped form (the most common real-leak shape, since grep's
+      #     LEFTMOST-match rule hands it to the generic alternative) would be
+      #     classified by its key instead of its value.
       { jq -Rr 'select(length>0)|(try (fromjson|..|strings) catch empty)' "$f" 2>/dev/null; \
         cat "$f" 2>/dev/null; } \
-        | grep -hoEi "$CRED_TABLE_RE" 2>/dev/null | sed -E 's/^[^A-Za-z0-9_-]//' | sort -u
+        | grep -hoEi "$CRED_TABLE_RE" 2>/dev/null \
+        | tr ';' '\n' | grep -v '^$' \
+        | sed -E -e 's/^[^A-Za-z0-9_-]//' -e "s/^[^:=]*[:=][[:space:]]*[\"']?//" \
+        | grep -E . | sort -u
     done | sort -u | awk '
       function shape_of(x) {
         if (index(x, "github_pat_") == 1) return "github-pat (fine-grained)"
@@ -678,18 +691,7 @@ if want safety; then
         return ""
       }
       {
-        t = tolower($0)
-        s = shape_of(t)
-        if (s == "") {
-          # An ASSIGNMENT-wrapped token (`GITHUB_TOKEN=ghp_…`, `token=eyJ…`) is
-          # consumed by the generic alternative first — grep returns the
-          # LEFTMOST match, and the assignment keyword starts before the token
-          # prefix — so the most common real-leak form would land in the weak
-          # bucket. Classify the VALUE part before falling back to generic.
-          v = t
-          sub("^[^:=]*[:=][ \t]*[\"\047]?", "", v)
-          s = shape_of(v)
-        }
+        s = shape_of(tolower($0))
         # NB: the label itself passes through the output-boundary redactor, so
         # it must not be credential-SHAPED ("token=…" would come out mangled
         # as "token=<redacted>").

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -209,6 +209,18 @@ redact() {
 # lists together or the test fails.
 CRED_RE='(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{12,}|-----BEGIN [A-Z ]*PRIVATE KEY-----|xox[baprs]-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|(secret|token|password|passwd|api[_-]?key)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?[^"'"'"'[:space:],}]{8,})'
 
+# TABLE variant of CRED_RE — identical shapes, but the prefix-identified ones
+# (gh?_ / github_pat_ / AKIA / xox / eyJ) are BOUNDARY-ANCHORED: the char before
+# the prefix must fall outside [A-Za-z0-9_-]. Triage of the first live run
+# (2026-07-18) showed the top "real-looking" GitHub-token hits were substrings
+# INSIDE base64url blobs (signed-URL params, JWT signatures) — base64url's
+# alphabet includes `-` and `_`, so only a boundary outside that alphabet
+# separates a pasted token (preceded by a quote, space, `=`, `:`, or line
+# start) from blob noise. The anchor costs no true positives and is used ONLY
+# for the leak TABLE; redact() keeps the broad unanchored CRED_RE, so
+# over-redaction is preserved even where the table refuses to count.
+CRED_TABLE_RE='((^|[^A-Za-z0-9_-])(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})|-----BEGIN [A-Z ]*PRIVATE KEY-----|(secret|token|password|passwd|api[_-]?key)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?[^"'"'"'[:space:],}]{8,})'
+
 # Portable mtime listing. GNU `stat -f` means --file-system (it SUCCEEDS and
 # prints filesystem status), so a `stat -f … || stat -c …` fallback never fires
 # on Linux and its output pollutes the file list — six phantom paths for one
@@ -630,7 +642,7 @@ if want safety; then
     echo "        definition text itself. A rising count with no new external source"
     echo "        means the docs were read, not that the deployment is under attack."
     echo
-    echo "  credential-shaped strings reaching a transcript (each is a LEAK to triage):"
+    echo "  credential-shaped strings reaching a transcript (distinct values, BY SHAPE):"
     echo "  [BOTH instances — this detector is format-agnostic, so it covers Codex too]"
     # Includes github_pat_ (fine-grained PATs). Omitting it meant a modern GitHub
     # token leak reported "clean" — the worst possible failure for a leak detector.
@@ -640,15 +652,38 @@ if want safety; then
     # begin and misses it — while redact(), which runs on decoded output, masks
     # it. Same detector/redactor drift, new disguise. Raw is still scanned too,
     # so a malformed line cannot turn the leak scan into a silent no-op.
+    # Per-SHAPE counts, never one redacted bucket. The first live run printed a
+    # single line `871 <redacted-key-material>` — every shape collapsed into one
+    # opaque number that needed an hour of ad-hoc probing to triage (verdict: 89%
+    # weak-signal generic-assignment matches, the rest test fixtures and mid-blob
+    # substrings; zero real leaks). A table that cannot tell a fine-grained PAT
+    # from a k8s secret NAME buries the one real hit it exists to surface — so
+    # the shapes are counted separately, the weak-signal generic bucket is
+    # labelled as such, and the counts are of DISTINCT matched values (one leak
+    # pasted into fifty transcripts is one credential to rotate, not fifty).
     printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | while IFS= read -r f; do
       # Dedupe per file: a credential visible in BOTH decoded and raw JSON was
       # emitted twice, doubling every count in the leak table.
       { jq -Rr 'select(length>0)|(try (fromjson|..|strings) catch empty)' "$f" 2>/dev/null; \
         cat "$f" 2>/dev/null; } \
-        | grep -hoEi "$CRED_RE" 2>/dev/null | sort -u
-    done | redact | sort | uniq -c | sort -rn | head -8 | sed 's/^/    /'
-    echo "    (empty = clean; any line here means rotate the credential AND fix the"
-    echo "     path that logged it — see the cross-system rotation rule)"
+        | grep -hoEi "$CRED_TABLE_RE" 2>/dev/null | sed -E 's/^[^A-Za-z0-9_-]//' | sort -u
+    done | sort -u | awk '{
+        t = tolower($0)
+        if      (index(t, "github_pat_") == 1) s = "github-pat (fine-grained)"
+        else if (t ~ /^gh[pousr]_/)            s = "github-token (classic/app)"
+        else if (index(t, "akia") == 1)        s = "aws-access-key-id"
+        else if (t ~ /^xox[baprs]-/)           s = "slack-token"
+        else if (index(t, "eyj") == 1)         s = "jwt-like"
+        else if (index(t, "-----begin") == 1)  s = "private-key-block"
+        # NB: the label itself passes through the output-boundary redactor, so
+        # it must not be credential-SHAPED ("token=…" would come out mangled
+        # as "token=<redacted>").
+        else s = "generic-assignment [WEAK signal: secret/token assignment shapes, names as often as values]"
+        print s
+      }' | sort | uniq -c | sort -rn | sed 's/^/    /'
+    echo "    (empty = clean. A HIGH-SIGNAL shape count means rotate the credential AND"
+    echo "     fix the path that logged it — see the cross-system rotation rule; triage"
+    echo "     the weak-signal generic bucket before treating it as a leak)"
     echo
     echo "  build/codegen commands run in a session that ALSO checked out a"
     echo "  non-own branch (candidates for untrusted-code execution):"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -508,6 +508,21 @@ if printf '%s' "$TABLE" | grep -q 'github-token (classic/app)'; then
   ok "ANSI-styled real token is still counted"
 else bad "ANSI-styled real token is still counted" "$TABLE"; fi
 
+# CSI parameters may use COLONS (ITU truecolor `ESC[38:2:255:0:0m`) — a strip
+# that only knows `;` leaves the terminator letter before the token and the
+# boundary anchor silently drops a real credential (CodeRabbit finding).
+mkdir -p "$FIX/ansi2"
+ANSI2_SAMPLE=$(printf 'log \033[38:2:255:0:0m__GHPE__\033[0m end')
+printf '{"type":"user","message":{"content":[{"type":"text","text":%s}]}}\n' \
+  "$(printf '%s' "$ANSI2_SAMPLE" | jq -Rs .)" > "$FIX/ansi2/s.jsonl"
+subst "$FIX/ansi2/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/ansi2" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -q 'github-token (classic/app)'; then
+  ok "colon-parameter CSI-styled token is still counted"
+else bad "colon-parameter CSI-styled token is still counted" "$TABLE"; fi
+
 # ── 6e. round-3 findings ──────────────────────────────────────────────────────
 echo
 echo "round-3 regressions"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -128,7 +128,7 @@ check "normalises digits for grouping" "$OUT" "<n>"
 echo
 echo "safety"
 OUT=$(run --section safety)
-check   "redacts credential-shaped strings" "$OUT" "…<redacted>"
+check   "reports the credential by SHAPE, not value" "$OUT" "github-token (classic/app)"
 nocheck "never echoes a full credential"    "$OUT" "$(ex __GHPA__)"
 # The fixture's injected prose contains a literal "Permission to use Bash with command
 # rm -rf /". The detector is deliberately anchored, so a transcript quoting that shape
@@ -201,7 +201,7 @@ OUT=$(runleak --section safety)
 nocheck "P2: quoted prose is not counted as a denial" "$OUT" "rm -rf"
 check   "P2: a real errored tool_result is still counted" "$OUT" "Blocked:"
 nocheck "P2: never echoes a fine-grained PAT"  "$OUT" "$(ex __PATZ__)"
-if printf '%s' "$OUT" | grep -qE 'github_pat_[A-Za-z0-9_]{4,}…<redacted>'; then
+if printf '%s' "$OUT" | grep -qF 'github-pat (fine-grained)'; then
   ok "P2: fine-grained PAT detected AND redacted"
 else bad "P2: fine-grained PAT detected AND redacted" "not flagged"; fi
 
@@ -289,8 +289,10 @@ EOF
 subst "$FIX/projects/jwt/s.jsonl"
 OUT=$(CLAUDE_PROJECTS_DIR="$FIX/projects/jwt" CODEX_HOME="$FIX/codex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
       bash "$TARGET" --since-days 3650 --section safety 2>&1)
-if printf '%s' "$OUT" | grep -q 'redacted-jwt\|__JWTHEAD__'; then
-  printf '%s' "$OUT" | grep -q '__JWTTAIL__' \
+if printf '%s' "$OUT" | grep -q 'jwt-like'; then
+  # NB: match the EXPANDED token, not the literal placeholder — grepping OUT for
+  # "__JWTTAIL__" post-subst could never fire, making the echo check vacuous.
+  printf '%s' "$OUT" | grep -qF "$(ex __JWTTAIL__)" \
     && bad "JWT flagged AND redacted" "raw JWT echoed" || ok "JWT flagged AND redacted"
 else bad "JWT flagged AND redacted" "not detected at all"; fi
 
@@ -307,7 +309,7 @@ subst "$FIX/cxonly/sessions/r.jsonl"
 OUT=$(CLAUDE_PROJECTS_DIR="$FIX/empty" CODEX_HOME="$FIX/cxonly" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
       bash "$TARGET" --since-days 3650 --section safety 2>&1)
 nocheck "Codex-only window is not skipped as empty" "$OUT" "no sessions in window — neither"
-if printf '%s' "$OUT" | grep -qE 'AKIA[0-9A-Z]{4}…<redacted>'; then
+if printf '%s' "$OUT" | grep -qF 'aws-access-key-id'; then
   ok "Codex-only credential leak is still caught"
 else bad "Codex-only credential leak is still caught" "missed"; fi
 
@@ -369,6 +371,25 @@ parity_case "aws"        "leak __AWS__" "__AWS__"
 parity_case "slack"      "leak __SLACK__" "__SLACK__"
 parity_case "jwt"        "leak __JWT__" "__JWTTAIL__"
 parity_case "generic"    "config token=__GEN__" "__GEN__"
+
+# ── 6d². leak-table boundary anchoring ────────────────────────────────────────
+# First live run (2026-07-18): the top "real-looking" GitHub-token hits were
+# substrings INSIDE base64url blobs (signed-URL params, JWT signatures) —
+# base64url's alphabet includes `-` and `_`, so the TABLE anchors prefix shapes
+# on a preceding char outside [A-Za-z0-9_-]. Redaction stays unanchored.
+echo
+echo "leak-table boundary anchoring"
+mkdir -p "$FIX/blob"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"sig=AAAA__GHPE__zz"}]}}\n' > "$FIX/blob/s.jsonl"
+subst "$FIX/blob/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/blob" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+if printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p' | grep -q 'github-token'; then
+  bad "mid-blob gh?_ substring is NOT counted" "counted as a token"
+else ok "mid-blob gh?_ substring is NOT counted"; fi
+# …but the output-boundary redactor still masks it (broad CRED_RE unchanged),
+# so refusing to COUNT blob noise never means ECHOING it.
+nocheck "mid-blob token is still redacted on output" "$OUT" "$(ex __GHPE__)"
 
 # ── 6e. round-3 findings ──────────────────────────────────────────────────────
 echo

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -466,6 +466,48 @@ if printf '%s' "$TABLE" | grep -q 'github-token (classic/app)' && printf '%s' "$
   ok "compound assignment surfaces BOTH credential shapes"
 else bad "compound assignment surfaces BOTH credential shapes" "$TABLE"; fi
 
+# `&&`-separated compounds evade a `;`-only split the same way (Codex, round 3):
+# every shell separator the generic value class admits must split.
+mkdir -p "$FIX/compound2"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"run GITHUB_TOKEN=__GHPE__&&AWS_ACCESS_KEY_ID=__AWS__"}]}}\n' > "$FIX/compound2/s.jsonl"
+subst "$FIX/compound2/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/compound2" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -q 'github-token (classic/app)' && printf '%s' "$TABLE" | grep -q 'aws-access-key-id'; then
+  ok "ampersand-compound surfaces BOTH credential shapes"
+else bad "ampersand-compound surfaces BOTH credential shapes" "$TABLE"; fi
+
+# A value that merely BEGINS like a token but fails its full shape must stay
+# weak-signal — prefix sniffing would let the generic alternative inject false
+# positives into the high-signal rows (Codex, round 3).
+mkdir -p "$FIX/shortval"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"cfg token=ghp_abcdefgh"}]}}\n' > "$FIX/shortval/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/shortval" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -q 'github-token'; then
+  bad "short prefix-only value stays weak-signal" "upgraded to github-token"
+else ok "short prefix-only value stays weak-signal"; fi
+if printf '%s' "$TABLE" | grep -q 'generic-assignment'; then
+  ok "short prefix-only value still counted as generic"
+else bad "short prefix-only value still counted as generic" "$TABLE"; fi
+
+# An ANSI-styled credential (`ESC[31mghp_…`) puts the escape terminator letter
+# right before the prefix; without pre-match stripping the boundary anchor
+# rejects a REAL token as blob noise — a silent real-leak miss (Codex, round 3).
+mkdir -p "$FIX/ansi"
+ANSI_SAMPLE=$(printf 'log \033[31m__GHPE__\033[0m end')
+printf '{"type":"user","message":{"content":[{"type":"text","text":%s}]}}\n' \
+  "$(printf '%s' "$ANSI_SAMPLE" | jq -Rs .)" > "$FIX/ansi/s.jsonl"
+subst "$FIX/ansi/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/ansi" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -q 'github-token (classic/app)'; then
+  ok "ANSI-styled real token is still counted"
+else bad "ANSI-styled real token is still counted" "$TABLE"; fi
+
 # ── 6e. round-3 findings ──────────────────────────────────────────────────────
 echo
 echo "round-3 regressions"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -399,16 +399,30 @@ parity_case "generic"    "config token=__GEN__" "__GEN__"
 echo
 echo "leak-table boundary anchoring"
 mkdir -p "$FIX/blob"
-printf '{"type":"user","message":{"content":[{"type":"text","text":"sig=AAAA__GHPE__zz"}]}}\n' > "$FIX/blob/s.jsonl"
+{
+  printf '{"type":"user","message":{"content":[{"type":"text","text":"sig=AAAA__GHPE__zz"}]}}\n'
+  # The blob ALSO flows through a real errored tool result, so the redaction
+  # half below is exercised by an output path that actually prints corpus text
+  # (reliability error signatures) — asserting raw-absent on the label-only
+  # safety table alone would stay green even with the redactor broken.
+  printf '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"b1","name":"Bash","input":{"command":"true"}}]}}\n'
+  printf '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"b1","is_error":true,"content":[{"type":"text","text":"boom sig=AAAA__GHPE__zz tail"}]}]}}\n'
+} > "$FIX/blob/s.jsonl"
 subst "$FIX/blob/s.jsonl"
 OUT=$(CLAUDE_PROJECTS_DIR="$FIX/blob" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
       bash "$TARGET" --since-days 3650 --section safety 2>&1)
+ROUT=$(CLAUDE_PROJECTS_DIR="$FIX/blob" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section reliability 2>&1)
 if printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p' | grep -q 'github-token'; then
   bad "mid-blob gh?_ substring is NOT counted" "counted as a token"
 else ok "mid-blob gh?_ substring is NOT counted"; fi
 # …but the output-boundary redactor still masks it (broad CRED_RE unchanged),
-# so refusing to COUNT blob noise never means ECHOING it.
-nocheck "mid-blob token is still redacted on output" "$OUT" "$(ex __GHPE__)"
+# so refusing to COUNT blob noise never means ECHOING it — proven POSITIVELY
+# on the error-signature path, not by absence alone.
+if printf '%s' "$ROUT" | grep 'boom' | grep -q 'redacted'; then
+  ok "mid-blob token is still redacted on output"
+else bad "mid-blob token is still redacted on output" "$(printf '%s' "$ROUT" | grep 'boom' | head -1)"; fi
+nocheck "mid-blob raw token never appears" "$ROUT" "$(ex __GHPE__)"
 
 # An ASSIGNMENT-wrapped token (`GITHUB_TOKEN=ghp_…`) is the most common real
 # leak form, and grep's leftmost-match rule hands the whole string to the
@@ -426,6 +440,31 @@ else bad "assignment-wrapped token classifies by its VALUE shape" "$TABLE"; fi
 if printf '%s' "$TABLE" | grep -q 'generic-assignment'; then
   bad "assignment-wrapped token is not buried in the weak bucket" "counted as generic"
 else ok "assignment-wrapped token is not buried in the weak bucket"; fi
+
+# The SAME credential standalone and assignment-wrapped is ONE value to rotate:
+# normalisation to the underlying value must happen BEFORE dedup, or the table
+# double-counts and its "distinct values" promise is false (Codex, round 2).
+mkdir -p "$FIX/dedup"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"saw __GHPE__ and GITHUB_TOKEN=__GHPE__"}]}}\n' > "$FIX/dedup/s.jsonl"
+subst "$FIX/dedup/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/dedup" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+if printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p' | grep -qE '^[[:space:]]+1 github-token'; then
+  ok "standalone + wrapped same token dedups to ONE distinct value"
+else bad "standalone + wrapped same token dedups to ONE distinct value" \
+  "$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p' | grep 'github-token')"; fi
+
+# A compound `KEY=tok;KEY2=tok2` is ONE greedy generic match; both credentials'
+# shapes must still surface or the second is never rotated (Codex, round 2).
+mkdir -p "$FIX/compound"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"env GITHUB_TOKEN=__GHPE__;AWS_ACCESS_KEY_ID=__AWS__"}]}}\n' > "$FIX/compound/s.jsonl"
+subst "$FIX/compound/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/compound" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -q 'github-token (classic/app)' && printf '%s' "$TABLE" | grep -q 'aws-access-key-id'; then
+  ok "compound assignment surfaces BOTH credential shapes"
+else bad "compound assignment surfaces BOTH credential shapes" "$TABLE"; fi
 
 # ── 6e. round-3 findings ──────────────────────────────────────────────────────
 echo

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -344,23 +344,42 @@ parity_case() { # name, sample-with-placeholders, distinctive-secret-placeholder
   sample=$(ex "$2"); secret=$(ex "$3")
   local dir="$FIX/parity_$name"
   mkdir -p "$dir"
-  printf '{"type":"user","message":{"content":[{"type":"text","text":%s}]}}\n' \
-    "$(printf '%s' "$sample" | jq -Rs .)" > "$dir/s.jsonl"
-  local out
+  # TWO copies of the credential: plain text for the DETECTOR leg (the leak
+  # table), and inside a REAL errored tool result for the REDACTOR leg — the
+  # label-only table no longer passes values through redact(), so asserting
+  # the raw secret is absent from the table output alone became vacuous (it
+  # would pass even with the redaction rule deleted). The reliability error
+  # signatures DO print corpus text through redact(); the "boom" marker proves
+  # that path was actually reached, so the redactor leg cannot pass by the
+  # credential simply never flowing anywhere.
+  {
+    printf '{"type":"user","message":{"content":[{"type":"text","text":%s}]}}\n' \
+      "$(printf '%s' "$sample" | jq -Rs .)"
+    printf '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"p1","name":"Bash","input":{"command":"true"}}]}}\n'
+    printf '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"p1","is_error":true,"content":[{"type":"text","text":%s}]}]}}\n' \
+      "$(printf 'boom %s tail' "$sample" | jq -Rs .)"
+  } > "$dir/s.jsonl"
+  local out rout
   out=$(CLAUDE_PROJECTS_DIR="$dir" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
         bash "$TARGET" --since-days 3650 --section safety 2>&1)
-  local detected=no redacted=yes
-  printf '%s' "$out" | grep -q 'empty = clean' && \
-    printf '%s' "$out" | grep -qE '^[[:space:]]+[0-9]+[[:space:]]' || true
+  rout=$(CLAUDE_PROJECTS_DIR="$dir" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+        bash "$TARGET" --since-days 3650 --section reliability 2>&1)
+  local detected=no redacted=yes exercised=no masked=no
   # detected = the credential section lists at least one count line
   if printf '%s' "$out" | sed -n '/credential-shaped/,/rotate the credential/p' | grep -qE '^[[:space:]]+[0-9]+ '; then
     detected=yes
   fi
-  printf '%s' "$out" | grep -qF "$secret" && redacted=no
-  if [ "$detected" = yes ] && [ "$redacted" = yes ]; then
-    ok "$name: detected AND redacted"
+  # exercised = the errored result reached the printed error signatures at all;
+  # masked = redact() visibly fired on that very line. Digit normalisation in
+  # the signature pipeline mangles digit-bearing secrets, so a raw-absent grep
+  # alone could miss a leak — the POSITIVE marker is the guard.
+  printf '%s' "$rout" | grep -q 'boom' && exercised=yes
+  printf '%s' "$rout" | grep 'boom' | grep -q 'redacted' && masked=yes
+  { printf '%s' "$out"; printf '%s' "$rout"; } | grep -qF "$secret" && redacted=no
+  if [ "$detected" = yes ] && [ "$redacted" = yes ] && [ "$exercised" = yes ] && [ "$masked" = yes ]; then
+    ok "$name: detected AND redacted (redactor exercised)"
   else
-    bad "$name: detected AND redacted" "detected=$detected redacted=$redacted"
+    bad "$name: detected AND redacted" "detected=$detected redacted=$redacted exercised=$exercised masked=$masked"
   fi
 }
 
@@ -390,6 +409,23 @@ else ok "mid-blob gh?_ substring is NOT counted"; fi
 # …but the output-boundary redactor still masks it (broad CRED_RE unchanged),
 # so refusing to COUNT blob noise never means ECHOING it.
 nocheck "mid-blob token is still redacted on output" "$OUT" "$(ex __GHPE__)"
+
+# An ASSIGNMENT-wrapped token (`GITHUB_TOKEN=ghp_…`) is the most common real
+# leak form, and grep's leftmost-match rule hands the whole string to the
+# generic alternative — so the classifier must look INSIDE the value or the
+# highest-value catch lands in the weak bucket (Codex review finding, #2263).
+mkdir -p "$FIX/assign"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"env GITHUB_TOKEN=__GHPE__"}]}}\n' > "$FIX/assign/s.jsonl"
+subst "$FIX/assign/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/assign" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -q 'github-token (classic/app)'; then
+  ok "assignment-wrapped token classifies by its VALUE shape"
+else bad "assignment-wrapped token classifies by its VALUE shape" "$TABLE"; fi
+if printf '%s' "$TABLE" | grep -q 'generic-assignment'; then
+  bad "assignment-wrapped token is not buried in the weak bucket" "counted as generic"
+else ok "assignment-wrapped token is not buried in the weak bucket"; fi
 
 # ── 6e. round-3 findings ──────────────────────────────────────────────────────
 echo


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer (agent-improver routine)

**Why:** The telemetry leak table's first live run collapsed 871 credential-shaped hits into one opaque redacted line — the stateful PEM range redactor masked everything after a BEGIN header with no END — so triaging "is anything real?" took an hour of ad-hoc probing (verdict: zero real leaks, 89% weak-signal noise). A leak detector that cries 871 daily buries the one real hit it exists to surface.

**What:** The table now reports per-shape counts (labels, never values), marks the weak-signal generic bucket as such, and boundary-anchors prefix shapes so substrings inside base64url blobs no longer count. Redaction stays broad and unanchored — this narrows what is *counted*, never what is *masked*, and the count surfaces remain otherwise unchanged.

**Evidence (agent-improver run 2026-07-18, 1-day window):** old output `871 <redacted-key-material>`; new output on the same corpus: 292 weak-signal generic / 7 github-token / 6 github-pat / 3 jwt / 3 aws / 1 slack / 1 private-key — the high-signal residue is traceable to yesterday's miner-build fixture sessions and ages out with the window. 84/84 tests pass (4 updated to the label format, 2 new).