### PR TITLE
feat(ai-engineer): label tool-masked credential prefixes as masked-display in the leak table

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -219,7 +219,7 @@ CRED_RE='(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{1
 # start) from blob noise. The anchor costs no true positives and is used ONLY
 # for the leak TABLE; redact() keeps the broad unanchored CRED_RE, so
 # over-redaction is preserved even where the table refuses to count.
-CRED_TABLE_RE='((^|[^A-Za-z0-9_-])(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})|-----BEGIN [A-Z ]*PRIVATE KEY-----|(secret|token|password|passwd|api[_-]?key)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?[^"'"'"'[:space:],}]{8,})'
+CRED_TABLE_RE='((^|[^A-Za-z0-9_-])(github_pat_[A-Za-z0-9_]{20,}\**|gh[pousr]_[A-Za-z0-9]{16,}\**|AKIA[0-9A-Z]{12,}\**|xox[baprs]-[A-Za-z0-9-]{10,}\**|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})|-----BEGIN [A-Z ]*PRIVATE KEY-----|(secret|token|password|passwd|api[_-]?key)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?[^"'"'"'[:space:],}]{8,})'
 
 # Portable mtime listing. GNU `stat -f` means --file-system (it SUCCEEDS and
 # prints filesystem status), so a `stat -f … || stat -c …` fallback never fires
@@ -673,7 +673,16 @@ if want safety; then
       #     token standalone and wrapped counts as two "distinct" values, and
       #     the wrapped form (the most common real-leak shape, since grep's
       #     LEFTMOST-match rule hands it to the generic alternative) would be
-      #     classified by its key instead of its value.
+      #     classified by its key instead of its value;
+      # (4) canonicalise a masked display: a value that is token chars running
+      #     straight into a mask run (>=3 asterisks) is truncated to
+      #     `<prefix>***`, dropping mask-length differences AND raw-scan tails
+      #     (the raw JSONL leg captures `…***\nShell cwd…` as escaped text) —
+      #     the same tool-masked display captured at different widths is ONE
+      #     display to verify, not N distinct values. A weak generic value
+      #     shaped `aaa***bbb` also truncates; that can merge weak-bucket
+      #     rows, which is accepted — no token alphabet contains `*`, so a
+      #     real high-signal credential can never be merged away.
       # ANSI escapes are stripped BEFORE matching: a styled credential
       # (`ESC[31mghp_…`) puts the sequence's terminating letter right before
       # the token prefix, which the boundary anchor would misread as blob
@@ -698,6 +707,7 @@ if want safety; then
         | grep -hoEi "$CRED_TABLE_RE" 2>/dev/null \
         | tr ';&|' '\n' | grep -v '^$' \
         | sed -E -e 's/^[^A-Za-z0-9_-]//' -e "s/^[^:=]*[:=][[:space:]]*[\"']?//" \
+        -e 's/^([A-Za-z0-9_-]+)\*\*\*+.*$/\1***/' \
         | grep -E . | sort -u
     done | sort -u | awk '
       # FULL-shape validation, not prefix sniffing: a generic value that merely
@@ -714,16 +724,30 @@ if want safety; then
         return ""
       }
       {
-        s = shape_of(tolower($0))
+        x = tolower($0)
+        s = shape_of(x)
         # NB: the label itself passes through the output-boundary redactor, so
         # it must not be credential-SHAPED ("token=…" would come out mangled
         # as "token=<redacted>").
         if (s == "") s = "generic-assignment [WEAK signal: secret/token assignment shapes, names as often as values]"
+        # A token-shape match whose chars run straight into >=3 asterisks is a
+        # tool'\''s own prefix+mask rendering (gh auth status prints
+        # "Token: github_pat_<prefix>***…" every boot) — the secret segment
+        # never reached the transcript. Label it distinctly so the count stays
+        # visible but the triage is precomputed; a single asterisk (a shell
+        # glob) or anything ambiguous fails closed into the plain row. Scope:
+        # the four single-token shapes — a JWT/PEM cannot surface in
+        # prefix+mask form under these regexes, and the weak generic bucket
+        # keeps its own label.
+        else if (x ~ /^[a-z0-9_-]+\*\*\*/) s = s " [masked-display]"
         print s
       }' | sort | uniq -c | sort -rn | sed 's/^/    /'
     echo "    (empty = clean. A HIGH-SIGNAL shape count means rotate the credential AND"
     echo "     fix the path that logged it — see the cross-system rotation rule; triage"
-    echo "     the weak-signal generic bucket before treating it as a leak)"
+    echo "     the weak-signal generic bucket before treating it as a leak."
+    echo "     [masked-display] = a tool's own prefix+mask token rendering, e.g."
+    echo "     gh auth status — the secret segment never reached the transcript;"
+    echo "     verify the mask is the tool's own display, don't rotate)"
     echo
     echo "  build/codegen commands run in a session that ALSO checked out a"
     echo "  non-own branch (candidates for untrusted-code execution):"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -35,6 +35,7 @@ S_GHPD=$(_j 'gh' 'p_DDDDDDDDDDDDDDDDDDDDDDDDDDDD')
 S_GHPE=$(_j 'gh' 'p_EEEEEEEEEEEEEEEEEEEEEEEE')
 S_PATA=$(_j 'github_' 'pat_11ABCDEFG0123456789_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ')
 S_PATZ=$(_j 'github_' 'pat_11ZZZZZZZ0123456789_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ')
+S_PATP=$(_j 'github_' 'pat_11PREFIXQRSTUV0123456')
 S_JWTHEAD=$(_j 'eyJ' 'hbGciOiJIUzI1')
 S_JWTTAIL=$(_j 'eyJ' 'zdWIiOiIxMjM0NTY3ODkwIn0.abcdefghijklmnop')
 S_JWT="${S_JWTHEAD}NiJ9.${S_JWTTAIL}"
@@ -50,7 +51,8 @@ subst() {
       -e "s|__GHPA__|$S_GHPA|g"   -e "s|__GHPB__|$S_GHPB|g" \
       -e "s|__GHPC__|$S_GHPC|g"   -e "s|__GHPD__|$S_GHPD|g" \
       -e "s|__GHPE__|$S_GHPE|g"   -e "s|__PATA__|$S_PATA|g" \
-      -e "s|__PATZ__|$S_PATZ|g"   -e "s|__JWTTAIL__|$S_JWTTAIL|g" \
+      -e "s|__PATZ__|$S_PATZ|g"   -e "s|__PATP__|$S_PATP|g" \
+      -e "s|__JWTTAIL__|$S_JWTTAIL|g" \
       -e "s|__JWTHEAD__|$S_JWTHEAD|g" -e "s|__JWT__|$S_JWT|g" \
       -e "s|__AWS__|$S_AWS|g"     -e "s|__SLACK__|$S_SLACK|g" \
       -e "s|__GEN__|$S_GEN|g" "$_f" && rm -f "$_f.bak"
@@ -61,7 +63,8 @@ ex() { printf '%s' "$1" | sed \
       -e "s|__GHPA__|$S_GHPA|g"   -e "s|__GHPB__|$S_GHPB|g" \
       -e "s|__GHPC__|$S_GHPC|g"   -e "s|__GHPD__|$S_GHPD|g" \
       -e "s|__GHPE__|$S_GHPE|g"   -e "s|__PATA__|$S_PATA|g" \
-      -e "s|__PATZ__|$S_PATZ|g"   -e "s|__JWTTAIL__|$S_JWTTAIL|g" \
+      -e "s|__PATZ__|$S_PATZ|g"   -e "s|__PATP__|$S_PATP|g" \
+      -e "s|__JWTTAIL__|$S_JWTTAIL|g" \
       -e "s|__JWTHEAD__|$S_JWTHEAD|g" -e "s|__JWT__|$S_JWT|g" \
       -e "s|__AWS__|$S_AWS|g"     -e "s|__SLACK__|$S_SLACK|g" \
       -e "s|__GEN__|$S_GEN|g"; }
@@ -522,6 +525,79 @@ TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/
 if printf '%s' "$TABLE" | grep -q 'github-token (classic/app)'; then
   ok "colon-parameter CSI-styled token is still counted"
 else bad "colon-parameter CSI-styled token is still counted" "$TABLE"; fi
+
+# A tool's own MASKED token display (`gh auth status` prints
+# `Token: github_pat_<prefix>***…`) is a prefix+mask rendering: the secret
+# segment never reached the transcript. Second live run (2026-07-19): one such
+# display accounted for 97 of 97 non-fixture github-pat occurrences across ~53
+# sessions of BOTH instances — a permanent false positive that would force
+# re-triage of the table's highest-severity rows every day. It gets a DISTINCT
+# label — the measurement is subdivided, never dropped — and only a run of ≥3
+# asterisks immediately after the token chars counts as a mask, so anything
+# ambiguous fails closed into the plain high-signal row.
+echo
+echo "masked-display labelling"
+mkdir -p "$FIX/masked"
+{
+  printf '{"type":"user","message":{"content":[{"type":"text","text":"  - Token: __PATP__**********"}]}}\n'
+  printf '{"type":"user","message":{"content":[{"type":"text","text":"leak __PATZ__"}]}}\n'
+} > "$FIX/masked/s.jsonl"
+subst "$FIX/masked/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/masked" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -qF 'github-pat (fine-grained) [masked-display]'; then
+  ok "gh-style masked token prefix labels as masked-display"
+else bad "gh-style masked token prefix labels as masked-display" "$TABLE"; fi
+if printf '%s' "$TABLE" | grep -Eq 'github-pat \(fine-grained\)$'; then
+  ok "full unmasked token keeps its plain high-signal row"
+else bad "full unmasked token keeps its plain high-signal row" "$TABLE"; fi
+
+# Standalone masked prefix (no assignment wrapper) reaches the classifier via
+# the boundary-anchored alternative, which must carry the mask run through.
+mkdir -p "$FIX/masked2"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"status shows __GHPE__******** here"}]}}\n' > "$FIX/masked2/s.jsonl"
+subst "$FIX/masked2/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/masked2" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -qF 'github-token (classic/app) [masked-display]'; then
+  ok "standalone masked token prefix labels as masked-display"
+else bad "standalone masked token prefix labels as masked-display" "$TABLE"; fi
+
+# The SAME masked token rendered with different mask lengths (line truncation,
+# tool version drift) — or captured by the RAW JSONL leg with an escaped-text
+# tail (`…***\nShell cwd…`) — is ONE display to verify, not N: the value is
+# canonicalised to `<prefix>***` before dedup or the table's "distinct values"
+# promise is false (13 rows for one display on the 2026-07-19 live corpus).
+mkdir -p "$FIX/masked3"
+{
+  printf '{"type":"user","message":{"content":[{"type":"text","text":"a Token: __PATP__*****"}]}}\n'
+  printf '{"type":"user","message":{"content":[{"type":"text","text":"b Token: __PATP__***********"}]}}\n'
+  printf '{"type":"user","message":{"content":[{"type":"text","text":"c Token: __PATP__*****\\nShell cwd was reset"}]}}\n'
+} > "$FIX/masked3/s.jsonl"
+subst "$FIX/masked3/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/masked3" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -qE '^[[:space:]]+1 github-pat \(fine-grained\) \[masked-display\]'; then
+  ok "same token under different mask lengths dedups to ONE masked row"
+else bad "same token under different mask lengths dedups to ONE masked row" "$TABLE"; fi
+
+# NEGATIVE CONTROL: a single trailing asterisk is a shell glob, not a mask —
+# it must stay a PLAIN high-signal row (fail closed toward "leak").
+mkdir -p "$FIX/maskedglob"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"ls __GHPD__*"}]}}\n' > "$FIX/maskedglob/s.jsonl"
+subst "$FIX/maskedglob/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/maskedglob" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -Eq 'github-token \(classic/app\)$'; then
+  ok "single-glob-asterisk token stays a plain high-signal row"
+else bad "single-glob-asterisk token stays a plain high-signal row" "$TABLE"; fi
+if printf '%s' "$TABLE" | grep -qF '[masked-display]'; then
+  bad "single-glob-asterisk token is NOT labelled masked" "labelled masked"
+else ok "single-glob-asterisk token is NOT labelled masked"; fi
 
 # ── 6e. round-3 findings ──────────────────────────────────────────────────────
 echo


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer (agent-improver routine)

## Why
The telemetry miner's leak table counted `gh auth status`'s own masked token display (prefix + asterisks — the secret is never printed) as a real fine-grained-PAT leak: 97 occurrences across ~53 sessions of both agent instances in one day. Every future daily audit would re-triage the same benign display in the table's highest-severity rows.

## What
Tool-masked token prefixes now get a distinct `[masked-display]` label and dedup to one row per display — the count stays visible, the triage is precomputed, and anything ambiguous fails closed into the plain leak row. Verified on the live corpus: the table drops from 19 apparent PAT hits to 6 fixture leftovers + 1 labelled display.

Evidence: 2026-07-19 agent-improver run — hash-based triage attributed all 97 occurrences to one PAT prefix rendered by gh's own masking; 0 real leaks.