### PR TITLE
docs(ai-engineer): state the real per-instance dispatch cadence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1701,8 +1701,11 @@ root-cause fixing, and every guardrail are unaffected; the point is to stop payi
   disambiguator above). Never pretend to be human.
 
 ### Cadence & focus
-**Dispatched hourly** (the deployment loader owns the exact cadence) — that is the **interval
-between runs, not a per-run time budget.** Each run: **hotfix any breakage**, then **sweep every
+**Each instance is dispatched every 2 hours; the two instances alternate, so the portfolio is swept
+about hourly** (the deployment loader owns the exact cadence — Claude Code on even hours, the
+ChatGPT/Codex sibling on uneven). That interval is the gap **between runs, not a per-run time
+budget** — and it is the *instance's* own gap that bounds a carry-forward, so a run that defers a
+watch item to "the next tick" is deferring it ~2 hours, not one. Each run: **hotfix any breakage**, then **sweep every
 failing-CI / mergeable actionable trusted-author PR toward green and merge — first priority, across all
 repos, excluding automation-owned dependency PRs; PRs always come before issues**, then **work the issue
 backlog oldest-actionable-first**, capturing new


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The engineering contract told every run it was "dispatched hourly". The scheduled task that actually dispatches this instance runs **every 2 hours**; the sibling instance covers the alternate hours. A run reading the old wording under-estimates how long a deferred watch item will actually sit — by double.

## What

Corrects that one sentence to state both facts: each instance runs every 2 hours, the two alternate so the portfolio is swept about hourly, and it is the instance's own 2-hour gap that bounds anything deferred to "the next tick". No behaviour or guardrail changes.

The loader's own frontmatter and prose were corrected earlier today; this reconciles the last remaining variant.