### PR TITLE
ci(coderabbit): keep docstring coverage advisory instead of merge-blocking

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit configuration. Only the settings that differ from CodeRabbit's defaults are
+# listed here; everything else stays at the default.
+#
+# inheritance: without this, a repository .coderabbit.yaml is the sole config source and
+# REPLACES any organization/UI settings (the docstring ERROR gate itself lives in the UI,
+# since the YAML default is `warning`). Enabling inheritance keeps every UI/org setting —
+# path filters, request_changes_workflow, custom checks — and only overrides the one value
+# defined below, so this change stays scoped to docstrings.
+inheritance: true
+reviews:
+  pre_merge_checks:
+    # Docstring Coverage measures a single coverage percentage across a PR's changed files
+    # and cannot be scoped per-path (the only path mechanism, reviews.path_filters, would
+    # drop the files from the whole review rather than from just this metric).
+    #
+    # This repository's executable code is the agent tooling under .claude/scripts — 17 bash
+    # scripts holding ~95 shell functions — plus a small Astro docs site. Shell functions do
+    # not idiomatically carry doc comments, so a PR that touches those scripts is scored far
+    # below the 80% threshold and its merge is blocked on a documentation gap that does not
+    # exist. This is the same failure devantler-tech/.github#103 hit: a changeset of YAML
+    # manifests, a bash test and Markdown scored 0.00% and the ONLY failed pre-merge check
+    # was Docstring Coverage.
+    #
+    # Keep the check as an advisory WARNING — CodeRabbit still reports coverage — instead of
+    # a hard merge ERROR. Mirrors devantler-tech/ksail#6145 and devantler-tech/.github, which
+    # made the same change for the same un-scopeable-metric reason.
+    docstrings:
+      mode: warning


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

CodeRabbit's Docstring Coverage pre-merge check scores one coverage percentage across everything a
PR touches, and it cannot be limited to particular files. This repository's executable code is the
agent tooling under `.claude/scripts` — 17 bash scripts holding around 95 shell functions — which do
not carry doc comments, because shell scripts are not written that way.

The result is that a PR changing those scripts is marked as failing a documentation standard it was
never in breach of, and a failed pre-merge check blocks the merge. We ship changes to those scripts
constantly, so this sits directly in the path of routine work.

## What

Adds a CodeRabbit config that keeps Docstring Coverage as advisory rather than merge-blocking. The
coverage number is still reported; it just stops holding up merges.

The same change was already made for `ksail` and `.github` for the same reason. This is the third
repository, not a new policy.

Part of #2108