### PR TITLE
fix(ai-engineer): measure what a sleep waits on, not how it was launched

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -820,20 +820,60 @@ if want efficiency; then
       # every sleep scored as a poll. Measured on a 1-day corpus, the loose form
       # reclassified 131 sleeps (~46% of all of them) — implausible on its face,
       # and the reason this asks for the enclosing do...done instead.
-      function in_loop(i,   j, before, after) {
-        for (j = 1; j <= i; j++) before = before " " lines[j]
-        for (j = i; j <= nlines; j++) after = after " " lines[j]
+      # The ENCLOSING loop region for sleeping line i, or "" when it is not in a
+      # loop. Returning the region rather than a boolean is the point: the poll
+      # must be searched INSIDE the loop, not across the whole command, or
+      # `gh pr view 1; while c; do sleep 30; done` is scored a loop-wrapped
+      # busy-wait even though that gh sits outside the loop and the back-edge
+      # never revisits it.
+      #
+      # The region starts at the LAST loop KEYWORD at or before the sleep — not
+      # at the `do`. That distinction is load-bearing: in the canonical busy-wait
+      # `while ! gh pr checks 7; do sleep 30; done` the poll lives in the loop
+      # CONDITION, which the back-edge re-executes, so a body-only region would
+      # miss exactly the shape this rule exists to catch. Taking the LAST keyword
+      # before and the FIRST `done` after yields the innermost enclosing loop,
+      # which is what nesting requires.
+      # The split is at the OFFSET OF THE SLEEP WITHIN ITS LINE, not at the line
+      # boundary. Splitting per line looks equivalent and is not: a whole loop
+      # routinely sits on ONE line, so line-granular halves both contain the
+      # entire command and carry no information about where the sleep sits. That
+      # error attributed an earlier, already-exited loop to a later sleep.
+      # (No apostrophes anywhere in this awk program — it is single-quoted, and
+      #  one ends the quote and breaks the script hundreds of lines away.)
+      function loop_region(i,   j, before, after, p, off, q, seg) {
+        for (j = 1; j < i; j++) before = before " " lines[j]
+        if (match(lines[i], sre)) {
+          before = before " " substr(lines[i], 1, RSTART + RLENGTH - 1)
+          after  = substr(lines[i], RSTART + RLENGTH)
+        } else { before = before " " lines[i] }
+        for (j = i + 1; j <= nlines; j++) after = after " " lines[j]
         before = exec_text(before); after = exec_text(after)
-        return (before ~ lre && before ~ /(^|[[:space:];])do([[:space:]]|$)/ \
-                && after ~ /(^|[[:space:];])done([[:space:]]|$)/)
+        # LAST loop keyword at or before the sleep = the innermost enclosing loop.
+        p = 0; off = 0; seg = before
+        while (match(seg, lre)) {
+          p = off + RSTART
+          off = off + RSTART + RLENGTH - 1
+          seg = substr(seg, RSTART + RLENGTH)
+        }
+        if (p <= 0) return ""
+        # ...and it must actually still be open: a `done` between that keyword
+        # and the sleep means the loop already closed, so the sleep is not in it.
+        seg = substr(before, p)
+        if (seg ~ /(^|[[:space:];])done([[:space:]]|$)/) return ""
+        if (!match(after, /(^|[[:space:];])done([[:space:]]|$)/)) return ""
+        q = RSTART + RLENGTH - 1
+        return seg " " substr(after, 1, q)
       }
-      function remote_after(i,   j, tail) {
+      function remote_after(i,   j, tail, rgn) {
         # A LOOP re-enters its own body, so a poll before the sleep still runs
         # after it. Order is a property of straight-line code only; inside a loop
         # body the poll is reachable again and the forward-scan rule stops
         # holding — which is what makes `while ! gh pr checks 7; do sleep 30;
         # done`, the canonical busy-wait, read as permitted without this.
-        if (in_loop(i) && is_remote(buf)) return 1
+        # Search the enclosing loop REGION, never the whole command.
+        rgn = loop_region(i)
+        if (rgn != "" && is_remote(rgn)) return 1
         # Same line, to the RIGHT of the sleep token only.
         if (match(lines[i], sre)) {
           tail = substr(lines[i], RSTART + RLENGTH)
@@ -961,7 +1001,7 @@ if want efficiency; then
     echo "          the UNCHAINED figure has been materially corrected TWICE by"
     echo "          review, each time after being declared the trustworthy basis"
     echo "          for the monorepo#2262 experiment — 12 -> 78 (poll ORDER within"
-    echo "          a command was ignored), then 81 -> 22 (loop BACK-EDGES were"
+    echo "          a command was ignored), then 81 -> 30 (loop BACK-EDGES were"
     echo "          filed as unchained or as permitted local timers). Treat the"
     echo "          current number as the best available estimate, not a settled"
     echo "          one, and re-derive a baseline after any classifier change."

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -291,9 +291,20 @@ tagged_commands_in() {
     .. | objects
     | (
         (select(.type=="tool_use")
-         | ((if .input?.run_in_background == true then "BG" else "FG" end)) as $c
          | (.id? // "") as $i
-         | select($i == "" or (($errs | index($i)) | not))
+         # A DENIED call never ran, so it must not be counted as a launch — but
+         # deleting it outright destroys the ADJACENCY it defines. An executed
+         # `sleep 30` followed by a permission-denied `gh pr checks` was waiting
+         # to poll a remote system; drop the poll and that sleep either reads as
+         # a permitted local timer or, worse, binds to some later unrelated
+         # command and manufactures an adjacency that never happened. So denied
+         # commands are tagged DN: the wait-target pass reads them as boundaries
+         # and as remote-poll evidence, while every launch-mode count ignores
+         # them (class_lines only ever asks for FG/BG/CX), which keeps the
+         # class-sum invariant true by construction rather than by luck.
+         | ((if ($i != "" and (($errs | index($i)) != null)) then "DN"
+             elif .input?.run_in_background == true then "BG"
+             else "FG" end)) as $c
          | (.input?.command? // empty) | select(type=="string") | select(length>0)
          | split("\n") | to_entries
          | map("\u0001" + $c + (if .key==0 then "*" else "" end) + "\u0002" + .value)
@@ -707,7 +718,27 @@ if want efficiency; then
     # (`mygh`, `re-gh`). `git` counts only for its network-touching subcommands —
     # a bare `git status` is local and would otherwise make every sleep near any
     # git call look like remote polling.
-    REMOTE_RE='(^|[^[:alnum:]_-])(gh|curl|wget|kubectl|flux|talosctl|argocd|helm|az|aws|docker[[:space:]]+(pull|push)|git[[:space:]]+(ls-remote|fetch|push|pull|clone))([[:space:]]|$)'
+    REMOTE_RE='(^|[^[:alnum:]_-])(gh|kubectl|flux|talosctl|argocd|helm|az|aws|docker[[:space:]]+(pull|push)|git[[:space:]]+(ls-remote|fetch|push|pull|clone))([[:space:]]|$)'
+    # `curl`/`wget` are the one AMBIGUOUS pair: they are the standard way to poll
+    # a remote endpoint AND the standard way to wait for a locally started server
+    # to come up — which the contract explicitly permits. Counting them
+    # unconditionally classified `sleep 2; curl localhost:8080/health` as a
+    # violation, i.e. exactly the permitted case, so they are matched separately
+    # and only count when the target is not a loopback address.
+    FETCH_RE='(^|[^[:alnum:]_-])(curl|wget)([[:space:]]|$)'
+    LOCALHOST_RE='(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|::1)'
+    # Shell-level detachment. `nohup … &`, `setsid`, or a trailing `&` returns the
+    # tool call immediately, so the agent is NOT foreground-blocked — that is a
+    # compliant way to arm a watcher, and the `run_in_background` flag alone
+    # cannot see it. A trailing `&` must not match `&&`: the negative lookbehind
+    # is spelled as "not an ampersand before it" because POSIX ERE has none.
+    DETACH_RE='(^|[[:space:]])(nohup|setsid|disown)([[:space:]]|$)|([^&]|^)&[[:space:]]*$'
+    # A loop BACK-EDGE makes a poll that sits textually BEFORE the sleep run
+    # again AFTER it: `while ! gh pr checks 7; do sleep 30; done` is the canonical
+    # busy-wait, yet a strictly forward scan sees no remote tool after the sleep
+    # and reports it permitted. When a sleeping command is a loop, the whole
+    # command body is reachable from the sleep, so order stops applying.
+    LOOP_RE='(^|[[:space:];])(while|until|for)([[:space:]]|$)'
     # Strip the class tag but KEEP boundaries: \003 marks a command's first line,
     # \004 a file boundary. class_lines deliberately strips both, because the
     # sleep regex is anchored at line start and a marker would break it.
@@ -734,9 +765,45 @@ if want efficiency; then
     # rejects outright ("illegal primary in regular expression"). ENVIRON hands
     # the string over verbatim, which is what keeps ONE regex definition usable
     # by both grep -E and awk instead of forcing a second, drifting copy.
-    export SLEEP_RE REMOTE_RE
+    export SLEEP_RE REMOTE_RE FETCH_RE LOCALHOST_RE DETACH_RE LOOP_RE
     WT=$(boundary_lines | strip_heredocs $'\003\004' | awk '
-      BEGIN { sre = ENVIRON["SLEEP_RE"]; rre = ENVIRON["REMOTE_RE"] }
+      BEGIN { sre = ENVIRON["SLEEP_RE"]; rre = ENVIRON["REMOTE_RE"]
+              fre = ENVIRON["FETCH_RE"]; lhre = ENVIRON["LOCALHOST_RE"]
+              dre = ENVIRON["DETACH_RE"]; lre = ENVIRON["LOOP_RE"] }
+      # Only EXECUTED text can be a poll. A shell comment or a quoted literal
+      # that merely mentions a tool (`sleep 5 # check gh later`, or this suite
+      # generating its own fixtures) is data, not a command — and counting it let
+      # the corpus fabricate the very violations this metric reports.
+      #
+      # Quote-stripping has a HARD EXCEPTION, and it is the whole reason this is
+      # not a one-line gsub: `sh -c "sleep 30 && gh pr checks"` carries a REAL
+      # command inside quotes, and it is the standard shape for arming a detached
+      # watcher. Blanking every quoted body would erase that poll and report the
+      # compliant watcher as a permitted local timer — trading a small
+      # over-count for a large under-count on exactly the shape the detachment
+      # rule above exists to recognise. So a command passing `-c` to a shell
+      # keeps its quoted text; everything else has literals blanked.
+      # Residual gap, stated rather than papered over: a tool named inside a
+      # quoted literal in a `-c` command still counts.
+      function exec_text(s) {
+        if (s !~ /-c[[:space:]]*["\047]/) {
+          gsub(/"[^"]*"/, "\"\"", s)
+          gsub(/\047[^\047]*\047/, "\047\047", s)
+        }
+        sub(/(^|[[:space:]])#.*$/, "", s)
+        return s
+      }
+      # A remote poll is a recognised remote tool, or a fetch whose target is not
+      # loopback. The fetch test reads the WHOLE command for a loopback token
+      # rather than parsing the URL: a readiness probe names its local target in
+      # the same command, and mis-reading one as remote would report the
+      # explicitly PERMITTED case as a violation.
+      function is_remote(s,   e) {
+        e = exec_text(s)
+        if (e ~ rre) return 1
+        if (e ~ fre && e !~ lhre) return 1
+        return 0
+      }
       # UNIT: a sleeping LINE, exactly as count_sleeps counts it (grep -c counts
       # matching lines). Counting sleeping COMMANDS instead would make this split
       # a different unit from the launch-mode split above — the two could never
@@ -747,13 +814,32 @@ if want efficiency; then
       # the poll happened BEFORE the sleep — that sleep is waiting on something
       # else, and its real follower may be in the next tool call. So each
       # sleeping line asks only: does a remote poll occur AT OR AFTER me?
-      function remote_after(i,   j, m, tail) {
+      # Is the sleeping line i actually INSIDE a loop BODY? Testing only whether
+      # the command mentions a loop keyword is far too loose: a long command that
+      # iterates files somewhere and separately calls gh and sleeps would have
+      # every sleep scored as a poll. Measured on a 1-day corpus, the loose form
+      # reclassified 131 sleeps (~46% of all of them) — implausible on its face,
+      # and the reason this asks for the enclosing do...done instead.
+      function in_loop(i,   j, before, after) {
+        for (j = 1; j <= i; j++) before = before " " lines[j]
+        for (j = i; j <= nlines; j++) after = after " " lines[j]
+        before = exec_text(before); after = exec_text(after)
+        return (before ~ lre && before ~ /(^|[[:space:];])do([[:space:]]|$)/ \
+                && after ~ /(^|[[:space:];])done([[:space:]]|$)/)
+      }
+      function remote_after(i,   j, tail) {
+        # A LOOP re-enters its own body, so a poll before the sleep still runs
+        # after it. Order is a property of straight-line code only; inside a loop
+        # body the poll is reachable again and the forward-scan rule stops
+        # holding — which is what makes `while ! gh pr checks 7; do sleep 30;
+        # done`, the canonical busy-wait, read as permitted without this.
+        if (in_loop(i) && is_remote(buf)) return 1
         # Same line, to the RIGHT of the sleep token only.
         if (match(lines[i], sre)) {
           tail = substr(lines[i], RSTART + RLENGTH)
-          if (tail ~ rre) return 1
+          if (is_remote(tail)) return 1
         }
-        for (j = i + 1; j <= nlines; j++) if (lines[j] ~ rre) return 1
+        for (j = i + 1; j <= nlines; j++) if (is_remote(lines[j])) return 1
         return 0
       }
       # A pending sleep is resolved by the FIRST remote poll in the next command,
@@ -761,21 +847,40 @@ if want efficiency; then
       # the sleep itself belongs to, which it has already left.
       # (No apostrophes in this awk program: it is single-quoted, and one would
       #  end the quote and break the whole script far from here.)
-      function classify(   i, irem) {
+      # EFFECTIVE class, not the launch flag. A watcher detached inside an
+      # otherwise synchronous call (`nohup sh -c "sleep 30 && gh pr checks 7" &`)
+      # returns immediately, so the agent never blocks — it is the compliant
+      # watcher, and scoring it FOREGROUND would report the contract-following
+      # behaviour as the violation. `run_in_background` cannot see shell-level
+      # detachment, so the command text has to.
+      function eff_cls(   e) {
+        if (cls != "FG") return cls
+        e = exec_text(buf)
+        return (e ~ dre) ? "BG" : "FG"
+      }
+      function classify(   i, irem, ec) {
         if (!started) return
-        irem = (buf ~ rre)
+        irem = is_remote(buf)
+        ec = eff_cls()
         # Resolve sleeps left pending by the PREVIOUS command first: they slept
         # without a remote poll after them, so this command decides the bucket.
+        # A DENIED command still counts here: the sleep before it was waiting to
+        # make that call, and the intent is what this metric measures.
         if (pending) {
           if (irem) { n_next += pending; if (pcls=="FG") { fg_rem += pending; fg_next += pending } }
           else        n_none += pending
           pending = 0
         }
+        # A denied command never RAN, so its own sleeps are not launches and must
+        # not enter the totals — that is what keeps the wait-target total equal
+        # to the launch-mode sum, which class_lines derives from FG/BG/CX only.
+        # It still served as a boundary and as remote evidence above.
+        if (cls == "DN") { nlines = 0; buf = ""; started = 0; return }
         for (i = 1; i <= nlines; i++) {
           if (lines[i] !~ sre) continue
           n_tot++
-          if (remote_after(i)) { n_same++; if (cls=="FG") fg_rem++ }
-          else                 { pending++; pcls = cls }
+          if (remote_after(i)) { n_same++; if (ec=="FG") fg_rem++ }
+          else                 { pending++; pcls = ec }
         }
         nlines = 0; buf = ""; started = 0
       }
@@ -852,6 +957,20 @@ if want efficiency; then
     echo "          when the wait uses a tool outside the recognised set (a"
     echo "          custom script, an SDK, a curl-less HTTP client). Read it as"
     echo "          an estimate to investigate, never as a census or a ceiling."
+    echo "          REVISION HISTORY, because it bears on how far to trust this:"
+    echo "          the UNCHAINED figure has been materially corrected TWICE by"
+    echo "          review, each time after being declared the trustworthy basis"
+    echo "          for the monorepo#2262 experiment — 12 -> 78 (poll ORDER within"
+    echo "          a command was ignored), then 81 -> 22 (loop BACK-EDGES were"
+    echo "          filed as unchained or as permitted local timers). Treat the"
+    echo "          current number as the best available estimate, not a settled"
+    echo "          one, and re-derive a baseline after any classifier change."
+    echo "          KNOWN RESIDUAL GAPS: a sleep inside a quoted -c command"
+    echo "          (sh -c 'sleep 30 && gh ...') is invisible to SLEEP_RE, which"
+    echo "          only recognises sleep at a line start or after a separator;"
+    echo "          loop-body detection is a do...done heuristic, not a parse;"
+    echo "          and a tool named in a quoted literal inside a -c command"
+    echo "          still counts, because blanking it would erase real watchers."
     echo "    NOTE: this splits LAUNCH MODE, which is NOT a compliance verdict."
     echo "          run_in_background says how Bash started the command, never"
     echo "          why the sleep exists. The contract permits a FOREGROUND bare"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -348,8 +348,18 @@ commands_in() {
 # doc containing `sleep 60` is not busy-waiting — the text is data it emits, not
 # a command it runs. Counting it inflated the very metric used to argue the
 # agent busy-waits (and this suite's own fixtures do exactly that).
+# $1, when set, is a line-start marker that RESETS heredoc state: a new command
+# can never continue the previous command's heredoc. The per-class callers feed
+# one class at a time, so an unterminated heredoc there swallows only that
+# class's later lines; the wait-target caller feeds every class interleaved in
+# one stream, where the same unterminated heredoc swallowed commands wholesale
+# and made the two passes disagree by 37% on a 7-day corpus (634 vs 1001) while
+# reconciling exactly on a 1-day one. Parameterised rather than duplicated —
+# two hand-maintained copies of this stripper is how detector parity broke six
+# times on the redactor.
 strip_heredocs() {
-  awk '
+  awk -v resetmark="${1:-}" '
+    resetmark != "" && index($0, resetmark) == 1 { inhd = 0 }
     {
       line = $0
       if (inhd) { if (line ~ ("^[[:space:]]*" tag "[[:space:]]*$")) { inhd = 0 }; next }
@@ -615,8 +625,15 @@ if want efficiency; then
     # counts drift apart and stop summing — the exact failure that broke
     # redactor parity six times.
     SLEEP_RE='(^|[;&|(]|&&|\|\||[[:space:]](do|then|else)[[:space:]])[[:space:]]*sleep[[:space:]]+["'"'"']?[$0-9{]'
+    # Heredoc state is reset at each COMMAND boundary here too, exactly as the
+    # wait-target pass does it. Without the marker an unterminated heredoc in one
+    # command swallowed every LATER command in the same class — so this counter
+    # was silently UNDER-counting before the two passes were cross-checked
+    # (7-day corpus: 1001 with leakage vs 1272 without). The marker is stripped
+    # again before matching, because the sleep regex is anchored at line start
+    # and a leading marker would stop `sleep …` from matching at all.
     count_sleeps() {
-      strip_heredocs | grep -cE "$SLEEP_RE" || true
+      strip_heredocs $'\003' | tr -d '\003' | grep -cE "$SLEEP_RE" || true
     }
     # The corpus is LIVE: the sibling instance writes transcripts while we read.
     # Scanning once per class could observe a different corpus each time, so a
@@ -649,9 +666,11 @@ if want efficiency; then
     # anchored sleep regex and the heredoc stripper both depend on. A command's
     # FIRST line carries a "*" after the class, so command boundaries survive
     # the tagging without a second traversal.
+    # A command's first line keeps a \003 marker so the heredoc stripper can
+    # reset its state per command; count_sleeps removes it before matching.
     class_lines() { printf '%s\n' "$TAGGED" | awk -v c="$1" '
         index($0, "\001" c "\002")==1  { print substr($0, length(c)+3); next }
-        index($0, "\001" c "*\002")==1 { print substr($0, length(c)+4) }'; }
+        index($0, "\001" c "*\002")==1 { print "\003" substr($0, length(c)+4) }'; }
     SLEEP_FG=$(class_lines FG | count_sleeps)
     SLEEP_BG=$(class_lines BG | count_sleeps)
     SLEEP_CX=$(class_lines CX | count_sleeps)
@@ -703,7 +722,7 @@ if want efficiency; then
     # the string over verbatim, which is what keeps ONE regex definition usable
     # by both grep -E and awk instead of forcing a second, drifting copy.
     export SLEEP_RE REMOTE_RE
-    WT=$(boundary_lines | strip_heredocs | awk '
+    WT=$(boundary_lines | strip_heredocs $'\003' | awk '
       BEGIN { sre = ENVIRON["SLEEP_RE"]; rre = ENVIRON["REMOTE_RE"] }
       # UNIT: a sleeping LINE, exactly as count_sleeps counts it (grep -c counts
       # matching lines). Counting sleeping COMMANDS instead would make this split

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -694,7 +694,12 @@ if want efficiency; then
     #   next    — sleep whose NEXT command polls remote: the UNCHAINED form the
     #             hook cannot block and monorepo#2262 targets
     #   none    — no remote poll adjacent: a local timer, contract-permitted
-    REMOTE_RE='(^|[^[:alnum:]_./-])(gh|curl|wget|kubectl|flux|talosctl|argocd|helm)([[:space:]]|$)'
+    # An absolute path is still the same tool, so `/usr/bin/gh` must match; only
+    # a word character or a dash before the name means it is a DIFFERENT command
+    # (`mygh`, `re-gh`). `git` counts only for its network-touching subcommands —
+    # a bare `git status` is local and would otherwise make every sleep near any
+    # git call look like remote polling.
+    REMOTE_RE='(^|[^[:alnum:]_-])(gh|curl|wget|kubectl|flux|talosctl|argocd|helm|az|aws|docker[[:space:]]+(pull|push)|git[[:space:]]+(ls-remote|fetch|push|pull|clone))([[:space:]]|$)'
     # Strip the class tag but KEEP boundaries: \003 marks a command's first line,
     # \004 a file boundary. class_lines deliberately strips both, because the
     # sleep regex is anchored at line start and a marker would break it.
@@ -729,25 +734,45 @@ if want efficiency; then
       # a different unit from the launch-mode split above — the two could never
       # sum to the same total, and the drift guard would fire forever on a
       # difference that was never a defect. Both splits now count the same thing.
-      function classify(   irem) {
+      # ORDER MATTERS WITHIN A COMMAND. Testing the whole command for a remote
+      # tool scored `gh pr view 1; sleep 30` as a chained busy-wait even though
+      # the poll happened BEFORE the sleep — that sleep is waiting on something
+      # else, and its real follower may be in the next tool call. So each
+      # sleeping line asks only: does a remote poll occur AT OR AFTER me?
+      function remote_after(i,   j, m, tail) {
+        # Same line, to the RIGHT of the sleep token only.
+        if (match(lines[i], sre)) {
+          tail = substr(lines[i], RSTART + RLENGTH)
+          if (tail ~ rre) return 1
+        }
+        for (j = i + 1; j <= nlines; j++) if (lines[j] ~ rre) return 1
+        return 0
+      }
+      # A pending sleep is resolved by the FIRST remote poll in the next command,
+      # wherever it sits in that command — position only constrains the command
+      # the sleep itself belongs to, which it has already left.
+      # (No apostrophes in this awk program: it is single-quoted, and one would
+      #  end the quote and break the whole script far from here.)
+      function classify(   i, irem) {
         if (!started) return
         irem = (buf ~ rre)
         # Resolve sleeps left pending by the PREVIOUS command first: they slept
-        # without a remote poll of their own, so this command decides the bucket.
+        # without a remote poll after them, so this command decides the bucket.
         if (pending) {
-          if (irem) { n_next += pending; if (pcls=="FG") fg_rem += pending }
+          if (irem) { n_next += pending; if (pcls=="FG") { fg_rem += pending; fg_next += pending } }
           else        n_none += pending
           pending = 0
         }
-        if (nsleep) {
-          n_tot += nsleep
-          if (irem) { n_same += nsleep; if (cls=="FG") fg_rem += nsleep }
-          else      { pending = nsleep; pcls = cls }
+        for (i = 1; i <= nlines; i++) {
+          if (lines[i] !~ sre) continue
+          n_tot++
+          if (remote_after(i)) { n_same++; if (cls=="FG") fg_rem++ }
+          else                 { pending++; pcls = cls }
         }
-        nsleep = 0; buf = ""; started = 0
+        nlines = 0; buf = ""; started = 0
       }
       function resolve() { if (pending) { n_none += pending; pending = 0 } }
-      function addline(s) { buf = buf " " s; if (s ~ sre) nsleep++ }
+      function addline(s) { buf = buf " " s; lines[++nlines] = s }
       # A pending sleep at a file boundary has no next command in ITS session.
       /^\004$/ { classify(); resolve(); next }
       /^\003/  { classify()
@@ -756,11 +781,11 @@ if want efficiency; then
                  started = 1; addline(substr($0, i+1)); next }
                  { if (started) addline($0) }
       END { classify(); resolve()
-            printf "%d %d %d %d %d", n_tot, n_same, n_next, n_none, fg_rem }')
-    WT_TOT=${WT%% *};  WT_REST=${WT#* }
-    WT_SAME=${WT_REST%% *}; WT_REST=${WT_REST#* }
-    WT_NEXT=${WT_REST%% *}; WT_REST=${WT_REST#* }
-    WT_NONE=${WT_REST%% *}; WT_FGREM=${WT_REST##* }
+            printf "%d %d %d %d %d %d", n_tot, n_same, n_next, n_none, fg_rem, fg_next }')
+    # `read`, not `set --`: the latter would clobber the script's positional
+    # parameters. (A here-string is a bash/zsh extension — fine under this
+    # file's bash shebang, and never to be copied into a /bin/sh script.)
+    read -r WT_TOT WT_SAME WT_NEXT WT_NONE WT_FGREM WT_FGNEXT <<< "$WT"
     # The total is the SUM of the classes, not a separate scan. That makes
     # class-vs-total drift impossible instead of detectable — and a drift
     # warning over a sum would be a vacuous guard, which is worse than none.
@@ -795,6 +820,11 @@ if want efficiency; then
     echo "    ├ remote poll, next command .. ${WT_NEXT}   [busy-wait, UNCHAINED]"
     echo "    └ no remote poll adjacent .... ${WT_NONE}   [local timer — PERMITTED]"
     echo "  ⇒ FOREGROUND ∧ remote-adjacent . ${WT_FGREM}   [THE BUSY-WAIT VIOLATION]"
+    # The aggregate remote-next bucket mixes in compliant BACKGROUND watchers and
+    # unattributed Codex sleeps, so it moves when neither the rule nor foreground
+    # behaviour changed. Only this foreground-only figure tests the unchained-wait
+    # tightening — trend THIS, never the aggregate.
+    echo "      of which UNCHAINED (fg) ... ${WT_FGNEXT}   [tests the #2262 rule]"
     if [ "$SF_COUNT" -gt 0 ]; then
       echo "    per-session (Claude, n=${SF_COUNT}): $(awk -v a="$WT_FGREM" -v b="$SF_COUNT" 'BEGIN{printf "%.2f", a/b}')/session   ← the metric to trend"
     fi
@@ -808,9 +838,12 @@ if want efficiency; then
     echo "          the busy-wait the latency discipline forbids; 'next command'"
     echo "          is the unchained form the PreToolUse hook cannot see, which"
     echo "          is what monorepo#2262 tightened the constitution against."
-    echo "          STATED GAP: adjacency is a heuristic, not intent — a sleep"
-    echo "          followed by an unrelated gh call scores 'next'. It bounds"
-    echo "          the busy-wait count from ABOVE; treat it as a ceiling."
+    echo "          STATED GAP: adjacency is a heuristic, not intent, and it is"
+    echo "          NOT a bound in either direction. It OVER-counts when a sleep"
+    echo "          is followed by an unrelated remote call, and UNDER-counts"
+    echo "          when the wait uses a tool outside the recognised set (a"
+    echo "          custom script, an SDK, a curl-less HTTP client). Read it as"
+    echo "          an estimate to investigate, never as a census or a ceiling."
     echo "    NOTE: this splits LAUNCH MODE, which is NOT a compliance verdict."
     echo "          run_in_background says how Bash started the command, never"
     echo "          why the sleep exists. The contract permits a FOREGROUND bare"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -359,7 +359,15 @@ commands_in() {
 # times on the redactor.
 strip_heredocs() {
   awk -v resetmark="${1:-}" '
-    resetmark != "" && index($0, resetmark) == 1 { inhd = 0 }
+    # resetmark is a SET of line-start marker characters, not one string: the
+    # wait-target stream carries BOTH a command marker and a transcript
+    # separator, and an unterminated heredoc at the end of one transcript would
+    # otherwise swallow the separator and defer the pending-sleep resolution
+    # into the NEXT transcript — reintroducing exactly the cross-session
+    # correlation the separator exists to prevent.
+    # length($0) guards the empty line: index(s, "") returns 1 in awk, which
+    # would reset the state machine on every blank line inside a heredoc body.
+    resetmark != "" && length($0) > 0 && index(resetmark, substr($0,1,1)) > 0 { inhd = 0 }
     {
       line = $0
       if (inhd) { if (line ~ ("^[[:space:]]*" tag "[[:space:]]*$")) { inhd = 0 }; next }
@@ -727,7 +735,7 @@ if want efficiency; then
     # the string over verbatim, which is what keeps ONE regex definition usable
     # by both grep -E and awk instead of forcing a second, drifting copy.
     export SLEEP_RE REMOTE_RE
-    WT=$(boundary_lines | strip_heredocs $'\003' | awk '
+    WT=$(boundary_lines | strip_heredocs $'\003\004' | awk '
       BEGIN { sre = ENVIRON["SLEEP_RE"]; rre = ENVIRON["REMOTE_RE"] }
       # UNIT: a sleeping LINE, exactly as count_sleeps counts it (grep -c counts
       # matching lines). Counting sleeping COMMANDS instead would make this split

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -295,18 +295,24 @@ tagged_commands_in() {
          | (.id? // "") as $i
          | select($i == "" or (($errs | index($i)) | not))
          | (.input?.command? // empty) | select(type=="string") | select(length>0)
-         | split("\n") | map("\u0001" + $c + "\u0002" + .) | .[]),
+         | split("\n") | to_entries
+         | map("\u0001" + $c + (if .key==0 then "*" else "" end) + "\u0002" + .value)
+         | .[]),
         (select(.type=="function_call")
          | (.arguments? // empty)
          | (try (fromjson | (.command? // .cmd? // empty)) catch empty)
          | select(type=="string") | select(length>0)
-         | split("\n") | map("\u0001CX\u0002" + .) | .[]),
+         | split("\n") | to_entries
+         | map("\u0001CX" + (if .key==0 then "*" else "" end) + "\u0002" + .value)
+         | .[]),
         (select(.type=="custom_tool_call")
          | .input? // empty | select(type=="string")
          | [scan("cmd:\\s*\"((?:[^\"\\\\]|\\\\.)*)\"")] | .[]? | .[0]?
          | select(type=="string") | select(length>0)
          | gsub("\\\\n"; "\n") | gsub("\\\\t"; " ") | gsub("\\\\\""; "\"")
-         | split("\n") | map("\u0001CX\u0002" + .) | .[])
+         | split("\n") | to_entries
+         | map("\u0001CX" + (if .key==0 then "*" else "" end) + "\u0002" + .value)
+         | .[])
       )
   ' "$f" 2>/dev/null
 }
@@ -604,12 +610,13 @@ if want efficiency; then
     # STRUCTURAL, not a text grep: only commands the agent actually ran count.
     # A grep would let untrusted prose that merely mentions `sleep 60` fabricate
     # a busy-wait pattern, and this metric is evidence for definition changes.
-    # ONE definition of "this command sleeps", shared by the total and every
-    # class count below. Duplicating the regex is how the two would drift apart
-    # and stop summing.
+    # ONE definition of "this command sleeps", shared by the total, every launch
+    # class, AND the wait-target split below. Duplicating the regex is how two
+    # counts drift apart and stop summing — the exact failure that broke
+    # redactor parity six times.
+    SLEEP_RE='(^|[;&|(]|&&|\|\||[[:space:]](do|then|else)[[:space:]])[[:space:]]*sleep[[:space:]]+["'"'"']?[$0-9{]'
     count_sleeps() {
-      strip_heredocs \
-        | grep -cE '(^|[;&|(]|&&|\|\||[[:space:]](do|then|else)[[:space:]])[[:space:]]*sleep[[:space:]]+["'"'"']?[$0-9{]' || true
+      strip_heredocs | grep -cE "$SLEEP_RE" || true
     }
     # The corpus is LIVE: the sibling instance writes transcripts while we read.
     # Scanning once per class could observe a different corpus each time, so a
@@ -628,15 +635,113 @@ if want efficiency; then
     # a single pass is inherently self-consistent, needs no snapshot, and cannot
     # leave anything on disk to clean up.
     TAGGED=$(printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' \
-             | while IFS= read -r f; do tagged_commands_in "$f"; done)
+             | while IFS= read -r f; do
+                 tagged_commands_in "$f"
+                 # File boundary. The wait-target split below asks "did the NEXT
+                 # command poll a remote system", and without this the last
+                 # command of one transcript would be adjacent to the first of
+                 # the next — manufacturing a cross-session correlation that
+                 # never happened.
+                 printf '\001EOF\002\n'
+               done)
     # Each LINE of a command carries its class tag, so multi-line commands keep
     # their structure and their order within a class — which the separator-
-    # anchored sleep regex and the heredoc stripper both depend on.
+    # anchored sleep regex and the heredoc stripper both depend on. A command's
+    # FIRST line carries a "*" after the class, so command boundaries survive
+    # the tagging without a second traversal.
     class_lines() { printf '%s\n' "$TAGGED" | awk -v c="$1" '
-        index($0, "\001" c "\002")==1 { print substr($0, length(c)+3) }'; }
+        index($0, "\001" c "\002")==1  { print substr($0, length(c)+3); next }
+        index($0, "\001" c "*\002")==1 { print substr($0, length(c)+4) }'; }
     SLEEP_FG=$(class_lines FG | count_sleeps)
     SLEEP_BG=$(class_lines BG | count_sleeps)
     SLEEP_CX=$(class_lines CX | count_sleeps)
+    # ── WAIT TARGET ────────────────────────────────────────────────────────
+    # The launch-mode classes above say HOW a sleep was started. They cannot say
+    # whether it violated anything, and the note below the report has always told
+    # the reader to "correlate with what was being waited on" — without ever
+    # doing that correlation. This does it.
+    #
+    # The contract's actual line is the WAIT TARGET: a sleep waiting on REMOTE
+    # state (CI, a review, a merge, a deploy) is the forbidden busy-wait; a sleep
+    # bounding a LOCAL process the agent itself started is explicitly permitted.
+    # Measured 2026-07-20 over 102 Claude sessions, those two are of the same
+    # order (252 remote-adjacent vs 297 local-bounding of 761 sleeping commands),
+    # so roughly half of what the launch-mode metric counts is permitted
+    # behaviour — which is why a foreground RATE moving 2.70→3.38/session could
+    # not be read as a compliance regression.
+    #
+    # Three buckets, summing to the total by construction:
+    #   same    — sleep chained to a remote poll in the SAME command
+    #   next    — sleep whose NEXT command polls remote: the UNCHAINED form the
+    #             hook cannot block and monorepo#2262 targets
+    #   none    — no remote poll adjacent: a local timer, contract-permitted
+    REMOTE_RE='(^|[^[:alnum:]_./-])(gh|curl|wget|kubectl|flux|talosctl|argocd|helm)([[:space:]]|$)'
+    # Strip the class tag but KEEP boundaries: \003 marks a command's first line,
+    # \004 a file boundary. class_lines deliberately strips both, because the
+    # sleep regex is anchored at line start and a marker would break it.
+    boundary_lines() {
+      printf '%s\n' "$TAGGED" | awk '
+        index($0, "\001EOF\002")==1 { print "\004"; next }
+        {
+          i = index($0, "\002"); if (i == 0) next
+          tag = substr($0, 2, i-2); rest = substr($0, i+1)
+          # A command-first line keeps its LAUNCH CLASS after the \003 marker, so
+          # the wait-target pass can cross the two dimensions. Neither alone is a
+          # verdict: a BACKGROUND sleep polling a remote system is the compliant
+          # watcher the contract mandates, while a FOREGROUND one is the busy-wait
+          # it forbids. Only the cross identifies the violation.
+          if (tag ~ /\*$/) { sub(/\*$/, "", tag); print "\003" tag "\002" rest }
+          else print rest
+        }'
+    }
+    # Heredocs are stripped BEFORE grouping, by the same shared stripper the
+    # class counts use — a command that writes a fixture containing `sleep 60`
+    # is emitting data, not waiting.
+    # Passed via ENVIRON, NOT -v: awk's -v processes escape sequences, so the
+    # shared SLEEP_RE's `\|\|` arrives as `||` — an empty alternation that awk
+    # rejects outright ("illegal primary in regular expression"). ENVIRON hands
+    # the string over verbatim, which is what keeps ONE regex definition usable
+    # by both grep -E and awk instead of forcing a second, drifting copy.
+    export SLEEP_RE REMOTE_RE
+    WT=$(boundary_lines | strip_heredocs | awk '
+      BEGIN { sre = ENVIRON["SLEEP_RE"]; rre = ENVIRON["REMOTE_RE"] }
+      # UNIT: a sleeping LINE, exactly as count_sleeps counts it (grep -c counts
+      # matching lines). Counting sleeping COMMANDS instead would make this split
+      # a different unit from the launch-mode split above — the two could never
+      # sum to the same total, and the drift guard would fire forever on a
+      # difference that was never a defect. Both splits now count the same thing.
+      function classify(   irem) {
+        if (!started) return
+        irem = (buf ~ rre)
+        # Resolve sleeps left pending by the PREVIOUS command first: they slept
+        # without a remote poll of their own, so this command decides the bucket.
+        if (pending) {
+          if (irem) { n_next += pending; if (pcls=="FG") fg_rem += pending }
+          else        n_none += pending
+          pending = 0
+        }
+        if (nsleep) {
+          n_tot += nsleep
+          if (irem) { n_same += nsleep; if (cls=="FG") fg_rem += nsleep }
+          else      { pending = nsleep; pcls = cls }
+        }
+        nsleep = 0; buf = ""; started = 0
+      }
+      function resolve() { if (pending) { n_none += pending; pending = 0 } }
+      function addline(s) { buf = buf " " s; if (s ~ sre) nsleep++ }
+      # A pending sleep at a file boundary has no next command in ITS session.
+      /^\004$/ { classify(); resolve(); next }
+      /^\003/  { classify()
+                 i = index($0, "\002")
+                 cls = substr($0, 2, i-2)
+                 started = 1; addline(substr($0, i+1)); next }
+                 { if (started) addline($0) }
+      END { classify(); resolve()
+            printf "%d %d %d %d %d", n_tot, n_same, n_next, n_none, fg_rem }')
+    WT_TOT=${WT%% *};  WT_REST=${WT#* }
+    WT_SAME=${WT_REST%% *}; WT_REST=${WT_REST#* }
+    WT_NEXT=${WT_REST%% *}; WT_REST=${WT_REST#* }
+    WT_NONE=${WT_REST%% *}; WT_FGREM=${WT_REST##* }
     # The total is the SUM of the classes, not a separate scan. That makes
     # class-vs-total drift impossible instead of detectable — and a drift
     # warning over a sum would be a vacuous guard, which is worse than none.
@@ -666,6 +771,27 @@ if want efficiency; then
     if [ "$CX_COUNT" -gt 0 ]; then
       echo "    per-session (Codex,  n=${CX_COUNT}): unclassified $(awk -v a="$SLEEP_CX" -v b="$CX_COUNT" 'BEGIN{printf "%.2f", a/b}')/session"
     fi
+    echo "  wait target (WHAT the sleep waits on — the contract's actual line):"
+    echo "    ├ remote poll, same command .. ${WT_SAME}   [busy-wait]"
+    echo "    ├ remote poll, next command .. ${WT_NEXT}   [busy-wait, UNCHAINED]"
+    echo "    └ no remote poll adjacent .... ${WT_NONE}   [local timer — PERMITTED]"
+    echo "  ⇒ FOREGROUND ∧ remote-adjacent . ${WT_FGREM}   [THE BUSY-WAIT VIOLATION]"
+    if [ "$SF_COUNT" -gt 0 ]; then
+      echo "    per-session (Claude, n=${SF_COUNT}): $(awk -v a="$WT_FGREM" -v b="$SF_COUNT" 'BEGIN{printf "%.2f", a/b}')/session   ← the metric to trend"
+    fi
+    if [ "$WT_TOT" != "$SLEEPS" ]; then
+      echo "    ⚠️  wait-target total ${WT_TOT} != launch-mode total ${SLEEPS} —"
+      echo "        the two passes disagree; treat BOTH as unreliable this run."
+    fi
+    echo "    NOTE: 'no remote poll adjacent' is the CONTRACT-PERMITTED case (a"
+    echo "          bare sleep bounding a local process the agent started), so a"
+    echo "          high number there is not waste. The two remote buckets ARE"
+    echo "          the busy-wait the latency discipline forbids; 'next command'"
+    echo "          is the unchained form the PreToolUse hook cannot see, which"
+    echo "          is what monorepo#2262 tightened the constitution against."
+    echo "          STATED GAP: adjacency is a heuristic, not intent — a sleep"
+    echo "          followed by an unrelated gh call scores 'next'. It bounds"
+    echo "          the busy-wait count from ABOVE; treat it as a ceiling."
     echo "    NOTE: this splits LAUNCH MODE, which is NOT a compliance verdict."
     echo "          run_in_background says how Bash started the command, never"
     echo "          why the sleep exists. The contract permits a FOREGROUND bare"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1308,7 +1308,64 @@ if printf '%s' "$OUT" | grep -qE 'remote poll, same command \.+ 0'; then
   ok "a heredoc BODY does not inflate the wait-target count"
 else bad "a heredoc BODY does not inflate the wait-target count" "$(printf '%s' "$OUT" | grep -E 'remote poll')"; fi
 
-check "the adjacency heuristic states it is a ceiling" "$OUT" "treat it as a ceiling"
+# The heuristic is imprecise in BOTH directions, so claiming it bounds the count
+# from above was itself a false claim: a wait performed through a tool outside
+# the recognised set is scored as a permitted local timer and UNDER-counts.
+check "the heuristic is not claimed as a bound in either direction" "$OUT" "NOT a bound in either direction"
+check "the under-count direction is stated too" "$OUT" "UNDER-counts"
+
+# Order within a command matters: a poll BEFORE a sleep is not what that sleep is
+# waiting on, and treating it as chained also hides the unchained case.
+mkdir -p "$FIX/wtorder"
+cat > "$FIX/wtorder/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"o1","name":"Bash","input":{"command":"gh pr view 1; sleep 30"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtorder" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'remote poll, same command \.+ 0'; then
+  ok "a poll BEFORE the sleep is not counted as a chained busy-wait"
+else bad "a poll BEFORE the sleep is not counted as a chained busy-wait" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
+# A remote wait through a path-qualified binary or a network git subcommand is
+# still a remote wait; scoring it "permitted local timer" understates violations.
+mkdir -p "$FIX/wtalias"
+cat > "$FIX/wtalias/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"a1","name":"Bash","input":{"command":"sleep 30 && /usr/bin/gh pr view 1"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"a2","name":"Bash","input":{"command":"sleep 20 && git ls-remote origin"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtalias" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'remote poll, same command \.+ 2'; then
+  ok "a path-qualified gh and a network git subcommand both count as remote"
+else bad "a path-qualified gh and a network git subcommand both count as remote" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
+# ...but a LOCAL git subcommand must not, or every sleep near any git call reads
+# as remote polling.
+mkdir -p "$FIX/wtgitlocal"
+cat > "$FIX/wtgitlocal/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"g1","name":"Bash","input":{"command":"git status; sleep 15; git status"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtgitlocal" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'no remote poll adjacent \.+ 1'; then
+  ok "a LOCAL git subcommand does not count as a remote poll"
+else bad "a LOCAL git subcommand does not count as a remote poll" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
+# The aggregate remote-next bucket mixes in compliant background watchers, so it
+# cannot test a foreground rule. Only the foreground-only figure can.
+mkdir -p "$FIX/wtfgnext"
+cat > "$FIX/wtfgnext/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"q1","name":"Bash","input":{"command":"sleep 45","run_in_background":true}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"q2","name":"Bash","input":{"command":"gh pr view 12"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtfgnext" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'remote poll, next command \.+ 1'; then
+  ok "a BACKGROUND unchained sleep still counts in the aggregate next bucket"
+else bad "a BACKGROUND unchained sleep still counts in the aggregate next bucket" "$(printf '%s' "$OUT" | grep -E 'remote poll')"; fi
+if printf '%s' "$OUT" | grep -qE 'of which UNCHAINED \(fg\) \.+ 0'; then
+  ok "...but is EXCLUDED from the foreground-only figure that tests the rule"
+else bad "...but is EXCLUDED from the foreground-only figure that tests the rule" "$(printf '%s' "$OUT" | grep -E 'UNCHAINED')"; fi
 
 # An UNTERMINATED heredoc must not swallow the NEXT command. The stripper is a
 # state machine, so without a per-command reset one malformed command silently

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1266,6 +1266,29 @@ if printf '%s' "$OUT" | grep -qE 'FOREGROUND.*remote-adjacent \.+ 1'; then
   ok "a FOREGROUND remote poll IS counted as the busy-wait violation"
 else bad "a FOREGROUND remote poll IS counted as the busy-wait violation" "$(printf '%s' "$OUT" | grep -E 'FOREGROUND')"; fi
 
+# An unterminated heredoc at the END of a transcript must not swallow the file
+# separator: if it does, the pending sleep survives into the NEXT transcript and
+# gets resolved by an unrelated session's first command — the cross-session
+# correlation the separator exists to prevent, reintroduced through the stripper.
+mkdir -p "$FIX/wthdsep"
+# The SLEEPING command must itself open the unterminated heredoc and be LAST in
+# its transcript. Any later command in the same file would resolve the pending
+# sleep before the separator was ever consulted, which is what made an earlier
+# version of this test pass with the fix ablated.
+cat > "$FIX/wthdsep/a.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"z1","name":"Bash","input":{"command":"sleep 45\ncat > f <<'NEVERCLOSED'\nbody"}}]}}
+EOF
+cat > "$FIX/wthdsep/b.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"z3","name":"Bash","input":{"command":"gh pr view 3"}}]}}
+EOF
+touch -t 202607200101 "$FIX/wthdsep/b.jsonl"
+touch -t 202607200202 "$FIX/wthdsep/a.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wthdsep" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'remote poll, next command \.+ 0'; then
+  ok "an unterminated heredoc cannot swallow the transcript separator"
+else bad "an unterminated heredoc cannot swallow the transcript separator" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
 # In the UNCHAINED form the two halves are separate tool calls with their own
 # launch modes. The violation belongs to the SLEEP's class, not the poll's: a
 # foreground sleep is a foreground block even when the poll that follows it was

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1180,6 +1180,120 @@ if printf '%s' "$OUT" | grep -qE 'foreground launch \.+ 1' && printf '%s' "$OUT"
   ok "command text cannot forge a class tag"
 else bad "command text cannot forge a class tag" "$(printf '%s' "$OUT" | grep -E 'foreground|background')"; fi
 
+# ── 6b. wait target (WHAT the sleep waits on) ────────────────────────────────
+echo
+echo "sleep classification (wait target: remote vs local)"
+
+# The launch-mode split says HOW a sleep started and cannot say whether it
+# violated anything. The contract's line is the WAIT TARGET: polling a remote
+# system is the forbidden busy-wait; bounding a local process the agent itself
+# started is explicitly permitted. These two fixtures differ ONLY in that.
+mkdir -p "$FIX/wtremote"
+cat > "$FIX/wtremote/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"r1","name":"Bash","input":{"command":"sleep 30 && gh pr checks 7"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtremote" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'remote poll, same command \.+ 1'; then
+  ok "a sleep chained to a remote poll is scored remote-adjacent"
+else bad "a sleep chained to a remote poll is scored remote-adjacent" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
+# The PERMITTED case. If this ever scored as remote, the metric would condemn
+# exactly the behaviour AGENTS.md allows (a bare sleep bounding a local process).
+mkdir -p "$FIX/wtlocal"
+cat > "$FIX/wtlocal/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"l1","name":"Bash","input":{"command":"godot --headless --render out.png & sleep 20; kill %1"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtlocal" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'no remote poll adjacent \.+ 1'; then
+  ok "a sleep bounding a local process is scored PERMITTED, not a violation"
+else bad "a sleep bounding a local process is scored PERMITTED, not a violation" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
+# The UNCHAINED form: the PreToolUse hook blocks `sleep N && poll`, and sessions
+# adapt by splitting it across two tool calls. Same busy-wait, invisible to the
+# hook — this is the shape monorepo#2262 tightened the constitution against, and
+# a same-command-only classifier scores it as permitted.
+mkdir -p "$FIX/wtnext"
+cat > "$FIX/wtnext/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"n1","name":"Bash","input":{"command":"sleep 45"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"n2","name":"Bash","input":{"command":"gh pr view 12 --json state"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtnext" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'remote poll, next command \.+ 1'; then
+  ok "an UNCHAINED sleep-then-poll is caught across two tool calls"
+else bad "an UNCHAINED sleep-then-poll is caught across two tool calls" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
+# Adjacency must not reach ACROSS transcripts. Without the file sentinel, the
+# last command of one session pairs with the first of the next, manufacturing a
+# correlation that never happened in either.
+mkdir -p "$FIX/wtcross"
+cat > "$FIX/wtcross/a.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"c1","name":"Bash","input":{"command":"sleep 45"}}]}}
+EOF
+cat > "$FIX/wtcross/b.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"c2","name":"Bash","input":{"command":"gh pr view 3"}}]}}
+EOF
+# Transcripts are walked NEWEST-FIRST, so the sleeping session must be the newer
+# file for it to be followed by the polling one. Without pinning these mtimes the
+# order is whatever the filesystem reports, the sleep lands last with nothing
+# after it, and the assertion below passes no matter what the sentinel does —
+# it was VACUOUS until an ablation proved it could not go red.
+touch -t 202607200101 "$FIX/wtcross/b.jsonl"
+touch -t 202607200202 "$FIX/wtcross/a.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtcross" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'remote poll, next command \.+ 0'; then
+  ok "adjacency does NOT cross a transcript boundary"
+else bad "adjacency does NOT cross a transcript boundary" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
+# THE metric: only the CROSS of the two dimensions is a verdict. A backgrounded
+# sleep polling a remote system is the compliant watcher the contract mandates;
+# scoring it as a violation is what made the old foreground count unusable.
+mkdir -p "$FIX/wtcross2"
+cat > "$FIX/wtcross2/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"x1","name":"Bash","input":{"command":"sleep 300 && gh pr checks 1","run_in_background":true}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtcross2" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'FOREGROUND.*remote-adjacent \.+ 0'; then
+  ok "a BACKGROUND remote poll is NOT counted as the busy-wait violation"
+else bad "a BACKGROUND remote poll is NOT counted as the busy-wait violation" "$(printf '%s' "$OUT" | grep -E 'FOREGROUND')"; fi
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtremote" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'FOREGROUND.*remote-adjacent \.+ 1'; then
+  ok "a FOREGROUND remote poll IS counted as the busy-wait violation"
+else bad "a FOREGROUND remote poll IS counted as the busy-wait violation" "$(printf '%s' "$OUT" | grep -E 'FOREGROUND')"; fi
+
+# Both splits must count the SAME unit (a sleeping LINE, as grep -c counts it).
+# Counting sleeping COMMANDS instead made the totals differ by 100 on the live
+# corpus and fired the drift warning on a difference that was never a defect.
+mkdir -p "$FIX/wtsum"
+cat > "$FIX/wtsum/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"s1","name":"Bash","input":{"command":"sleep 5\nsleep 6\ngh pr view 1"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"s2","name":"Bash","input":{"command":"godot --render & sleep 9; kill %1"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtsum" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'wait-target total'; then
+  bad "wait-target buckets sum to the launch-mode total" "$(printf '%s' "$OUT" | grep -E 'wait-target total|remote poll|no remote')"
+else ok "wait-target buckets sum to the launch-mode total"; fi
+
+# A heredoc that WRITES `sleep 30 && gh ...` into a fixture is emitting data, not
+# waiting on anything. The shared stripper must run before wait-target grouping.
+mkdir -p "$FIX/wthd"
+cat > "$FIX/wthd/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"h1","name":"Bash","input":{"command":"cat > f.sh <<'XX'\nsleep 30 && gh pr checks 1\nXX"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wthd" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'remote poll, same command \.+ 0'; then
+  ok "a heredoc BODY does not inflate the wait-target count"
+else bad "a heredoc BODY does not inflate the wait-target count" "$(printf '%s' "$OUT" | grep -E 'remote poll')"; fi
+
+check "the adjacency heuristic states it is a ceiling" "$OUT" "treat it as a ceiling"
+
 # ── 7. robustness ─────────────────────────────────────────────────────────────
 echo
 echo "robustness"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1266,6 +1266,22 @@ if printf '%s' "$OUT" | grep -qE 'FOREGROUND.*remote-adjacent \.+ 1'; then
   ok "a FOREGROUND remote poll IS counted as the busy-wait violation"
 else bad "a FOREGROUND remote poll IS counted as the busy-wait violation" "$(printf '%s' "$OUT" | grep -E 'FOREGROUND')"; fi
 
+# In the UNCHAINED form the two halves are separate tool calls with their own
+# launch modes. The violation belongs to the SLEEP's class, not the poll's: a
+# foreground sleep is a foreground block even when the poll that follows it was
+# backgrounded. Attributing it to the poll would silently exonerate exactly the
+# case this bucket exists to catch.
+mkdir -p "$FIX/wtpendcls"
+cat > "$FIX/wtpendcls/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"p1","name":"Bash","input":{"command":"sleep 45"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"p2","name":"Bash","input":{"command":"gh pr view 12","run_in_background":true}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtpendcls" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'FOREGROUND.*remote-adjacent \.+ 1'; then
+  ok "an unchained violation is attributed to the SLEEP's class, not the poll's"
+else bad "an unchained violation is attributed to the SLEEP's class, not the poll's" "$(printf '%s' "$OUT" | grep -E 'FOREGROUND|remote poll')"; fi
+
 # Both splits must count the SAME unit (a sleeping LINE, as grep -c counts it).
 # Counting sleeping COMMANDS instead made the totals differ by 100 on the live
 # corpus and fired the drift warning on a difference that was never a defect.

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1409,6 +1409,127 @@ if printf '%s' "$OUT" | grep -qE 'wait-target total'; then
   bad "both passes stay reconciled across a heredoc leak" "$(printf '%s' "$OUT" | grep -E 'wait-target total')"
 else ok "both passes stay reconciled across a heredoc leak"; fi
 
+# ── wait target: EXECUTED REMOTE INTENT ───────────────────────────────────────
+# Five ways textual adjacency diverged from what the sleep was actually waiting
+# on. Each is a real classification error found by review on a suite that was
+# 134/134 green, so each gets a fixture whose ONLY correct answer requires the
+# fix — and, where the fix could pass by over-narrowing, a counter-fixture that
+# fails if it does.
+
+# A loop BACK-EDGE: the poll sits textually before the sleep but runs again after
+# it. This is the canonical busy-wait and a forward-only scan calls it permitted.
+mkdir -p "$FIX/wtloop"
+cat > "$FIX/wtloop/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"l1","name":"Bash","input":{"command":"while ! gh pr checks 7; do sleep 30; done"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtloop" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'FOREGROUND.*remote-adjacent \.+ 1'; then
+  ok "a loop-wrapped poll AFTER the sleep counts (back-edge)"
+else bad "a loop-wrapped poll AFTER the sleep counts (back-edge)" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote|FOREGROUND')"; fi
+
+# ...but the back-edge rule must not swallow straight-line code: without a loop,
+# a poll before the sleep is still NOT adjacent (the round-1 finding this PR
+# already fixed). This fails if the loop rule is written as "any poll in buf".
+mkdir -p "$FIX/wtnoloop"
+cat > "$FIX/wtnoloop/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"n1","name":"Bash","input":{"command":"gh pr view 1; sleep 30"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtnoloop" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'no remote poll adjacent \.+ 1'; then
+  ok "...but a straight-line poll before the sleep is still not adjacent"
+else bad "...but a straight-line poll before the sleep is still not adjacent" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
+# A readiness probe against a LOCAL endpoint is the contract-PERMITTED case, and
+# curl/wget are how it is written. Counting them unconditionally reported the
+# permitted shape as the violation.
+mkdir -p "$FIX/wtlocalcurl"
+cat > "$FIX/wtlocalcurl/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"c1","name":"Bash","input":{"command":"sleep 2; curl -sf localhost:8080/health"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtlocalcurl" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'no remote poll adjacent \.+ 1'; then
+  ok "a curl at a LOOPBACK address is a permitted local timer"
+else bad "a curl at a LOOPBACK address is a permitted local timer" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
+# ...and the counter-case: dropping curl/wget from the remote set entirely would
+# also pass the test above. A real remote fetch must still count.
+mkdir -p "$FIX/wtremotecurl"
+cat > "$FIX/wtremotecurl/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"c2","name":"Bash","input":{"command":"sleep 2; curl -sf https://api.github.com/repos/o/r"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtremotecurl" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'remote poll, same command \.+ 1'; then
+  ok "...but a curl at a REMOTE host still counts"
+else bad "...but a curl at a REMOTE host still counts" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
+# Shell-level detachment is a compliant way to arm a watcher; run_in_background
+# cannot see it, so the tool flag alone reported the compliant shape as the
+# violation.
+# NOTE the fixture shape: a `sh -c 'sleep …'` watcher is NOT usable here, because
+# SLEEP_RE only recognises `sleep` at a line start or after a shell separator and
+# a quote is neither — such a sleep is invisible to the counter entirely. That is
+# a PRE-EXISTING limit of the sleep regex, not of this classifier, and it is why
+# the detached form under test is the trailing-`&` one.
+mkdir -p "$FIX/wtdetach"
+cat > "$FIX/wtdetach/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"d1","name":"Bash","input":{"command":"sleep 30 && gh pr checks 7 &"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtdetach" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'remote poll, same command \.+ 1' \
+   && printf '%s' "$OUT" | grep -qE 'FOREGROUND.*remote-adjacent \.+ 0'; then
+  ok "a shell-DETACHED watcher is remote-adjacent but NOT a foreground violation"
+else bad "a shell-DETACHED watcher is remote-adjacent but NOT a foreground violation" "$(printf '%s' "$OUT" | grep -E 'remote poll|FOREGROUND')"; fi
+
+# ...and `&&` must not read as a trailing `&`, or every chained busy-wait would
+# be excused as detached — the loosening this rule most easily becomes.
+mkdir -p "$FIX/wtandand"
+cat > "$FIX/wtandand/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"d2","name":"Bash","input":{"command":"sleep 30 && gh pr checks 7"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtandand" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'FOREGROUND.*remote-adjacent \.+ 1'; then
+  ok "...but a trailing && is not detachment"
+else bad "...but a trailing && is not detachment" "$(printf '%s' "$OUT" | grep -E 'FOREGROUND')"; fi
+
+# A DENIED poll never ran, so it is not a launch — but it still marks what the
+# sleep was waiting for. Deleting it outright let the sleep read as permitted.
+mkdir -p "$FIX/wtdenied"
+cat > "$FIX/wtdenied/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"p1","name":"Bash","input":{"command":"sleep 30"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"p2","name":"Bash","input":{"command":"gh pr checks 7"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"p2","is_error":true,"content":"Claude requested permissions to use Bash, but you haven't granted it yet."}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtdenied" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'remote poll, next command \.+ 1'; then
+  ok "a DENIED poll still marks the sleep before it as remote-adjacent"
+else bad "a DENIED poll still marks the sleep before it as remote-adjacent" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
+# ...and the denied command must NOT re-enter the launch counts, or the two
+# passes stop reconciling and the drift warning fires.
+if printf '%s' "$OUT" | grep -qE 'explicit sleep/poll calls \.+ 1' \
+   && ! printf '%s' "$OUT" | grep -qE 'wait-target total'; then
+  ok "...without counting the denied command as a launch"
+else bad "...without counting the denied command as a launch" "$(printf '%s' "$OUT" | grep -E 'explicit sleep|wait-target total')"; fi
+
+# Non-executed text: a comment mentioning a tool is not a poll. Left unstripped,
+# the corpus could fabricate the very violations this metric reports.
+mkdir -p "$FIX/wtcomment"
+cat > "$FIX/wtcomment/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"m1","name":"Bash","input":{"command":"sleep 5 # check with gh pr view later"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtcomment" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'no remote poll adjacent \.+ 1'; then
+  ok "a tool named in a COMMENT is not a poll"
+else bad "a tool named in a COMMENT is not a poll" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
 # ── 7. robustness ─────────────────────────────────────────────────────────────
 echo
 echo "robustness"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1310,6 +1310,25 @@ else bad "a heredoc BODY does not inflate the wait-target count" "$(printf '%s' 
 
 check "the adjacency heuristic states it is a ceiling" "$OUT" "treat it as a ceiling"
 
+# An UNTERMINATED heredoc must not swallow the NEXT command. The stripper is a
+# state machine, so without a per-command reset one malformed command silently
+# deletes every later one from the count — a 22% undercount on a 7-day corpus,
+# invisible on a 1-day one because the two passes happened to lose the same
+# lines. Both passes now reset at the command boundary.
+mkdir -p "$FIX/wthdleak"
+cat > "$FIX/wthdleak/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"k1","name":"Bash","input":{"command":"cat > f.sh <<'NEVERCLOSED'\nbody line"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"k2","name":"Bash","input":{"command":"sleep 30 && gh pr checks 4"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wthdleak" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'explicit sleep/poll calls \.+ 1'; then
+  ok "an unterminated heredoc does not swallow the NEXT command's sleep"
+else bad "an unterminated heredoc does not swallow the NEXT command's sleep" "$(printf '%s' "$OUT" | grep -E 'explicit sleep|remote poll')"; fi
+if printf '%s' "$OUT" | grep -qE 'wait-target total'; then
+  bad "both passes stay reconciled across a heredoc leak" "$(printf '%s' "$OUT" | grep -E 'wait-target total')"
+else ok "both passes stay reconciled across a heredoc leak"; fi
+
 # ── 7. robustness ─────────────────────────────────────────────────────────────
 echo
 echo "robustness"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1518,6 +1518,44 @@ if printf '%s' "$OUT" | grep -qE 'explicit sleep/poll calls \.+ 1' \
   ok "...without counting the denied command as a launch"
 else bad "...without counting the denied command as a launch" "$(printf '%s' "$OUT" | grep -E 'explicit sleep|wait-target total')"; fi
 
+# The back-edge rule must scope the poll search to the ENCLOSING LOOP, not the
+# whole command: a poll sequenced BEFORE an unrelated loop is never revisited by
+# that loop, so attributing it to the sleep inside is a false violation.
+mkdir -p "$FIX/wtloopscope"
+cat > "$FIX/wtloopscope/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"q1","name":"Bash","input":{"command":"gh pr view 1; while [ ! -f /tmp/f ]; do sleep 30; done"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtloopscope" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'no remote poll adjacent \.+ 1'; then
+  ok "a poll OUTSIDE the loop is not attributed to a sleep inside it"
+else bad "a poll OUTSIDE the loop is not attributed to a sleep inside it" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
+# ...and the counter-case that a body-only region would break: in the canonical
+# busy-wait the poll sits in the loop CONDITION, which the back-edge re-executes.
+# Scoping the region to `do`...`done` would silently stop counting it.
+mkdir -p "$FIX/wtloopcond"
+cat > "$FIX/wtloopcond/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"q2","name":"Bash","input":{"command":"while ! gh pr checks 7; do sleep 30; done"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtloopcond" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'FOREGROUND.*remote-adjacent \.+ 1'; then
+  ok "...but a poll in the loop CONDITION still counts (back-edge revisits it)"
+else bad "...but a poll in the loop CONDITION still counts (back-edge revisits it)" "$(printf '%s' "$OUT" | grep -E 'remote poll|FOREGROUND')"; fi
+
+# Sequential loops: the region must be the INNERMOST enclosing one, so a poll in
+# an earlier, already-exited loop is not attributed to a later loop's sleep.
+mkdir -p "$FIX/wtloopseq"
+cat > "$FIX/wtloopseq/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"q3","name":"Bash","input":{"command":"for f in a b; do gh pr view 1; done; while [ ! -f /tmp/f ]; do sleep 30; done"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wtloopseq" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if printf '%s' "$OUT" | grep -qE 'no remote poll adjacent \.+ 1'; then
+  ok "a poll in an EARLIER sequential loop is not attributed to a later one"
+else bad "a poll in an EARLIER sequential loop is not attributed to a later one" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
+
 # Non-executed text: a comment mentioning a tool is not a poll. Left unstripped,
 # the corpus could fabricate the very violations this metric reports.
 mkdir -p "$FIX/wtcomment"

--- a/.claude/skills/agent-improvement/SKILL.md
+++ b/.claude/skills/agent-improvement/SKILL.md
@@ -67,7 +67,7 @@ reliability:  tool_error_count, top_signatures[], timeout_count
 safety:       blocked_actions[], near_misses[], credential_hits, injection_attempts_in_corpus
 efficiency:   sleep_poll_calls{total, fg_per_session, bg_per_session, codex_unclassified},
               wait_target{remote_same, remote_next, none},
-              busy_wait_violations{fg_and_remote, per_session},   # ← THE metric
+              busy_wait_violations{fg_and_remote, fg_unchained, per_session},  # ← THE metric
               timeouts, redundant_call_patterns[]
 quality:      merged_prs, reverts, post_merge_red, review_findings_per_pr
 coordination: two_writer_races, push_collisions, duplicate_artifacts[]
@@ -92,9 +92,15 @@ violation is the **cross**: a **foreground** sleep **adjacent to a remote poll**
 remote poll is the compliant watcher the contract mandates, and a foreground sleep with no remote
 poll near it is a permitted local timer. Measured 2026-07-20 (48 Claude sessions): 162 foreground
 sleeps, but only **129** were remote-adjacent — the launch-mode rate overstated violations by ~26%.
-Baseline **2.69/session**. The `remote_next` bucket is the **unchained** form the PreToolUse hook
-cannot see, so it is the one that tests whether a constitution tightening actually worked.
-Adjacency is a heuristic that bounds the count from **above** — treat it as a ceiling, not a census.
+Baseline **2.40/session** (115/48, 2026-07-20). The **unchained** form the PreToolUse hook cannot see
+is what tests whether a constitution tightening worked — but trend the **foreground-only** figure
+(`of which UNCHAINED (fg)`, baseline **78**), never the aggregate `remote_next`, which also contains
+compliant background watchers and unattributed Codex sleeps and so moves when neither the rule nor
+foreground behaviour changed.
+
+Adjacency is a heuristic and is **not a bound in either direction**: it over-counts a sleep followed
+by an unrelated remote call, and under-counts a wait performed through a tool outside the recognised
+set. Treat it as an estimate to investigate, never a census or a ceiling.
 
 **The class is a LAUNCH MODE, never a compliance verdict.** `foreground launch` and `background
 launch` say only how the command was started. The contract permits a foreground bare sleep as a

--- a/.claude/skills/agent-improvement/SKILL.md
+++ b/.claude/skills/agent-improvement/SKILL.md
@@ -92,9 +92,11 @@ violation is the **cross**: a **foreground** sleep **adjacent to a remote poll**
 remote poll is the compliant watcher the contract mandates, and a foreground sleep with no remote
 poll near it is a permitted local timer. Measured 2026-07-20 (48 Claude sessions): 162 foreground
 sleeps, but only **129** were remote-adjacent — the launch-mode rate overstated violations by ~26%.
-Baseline **2.40/session** (115/48, 2026-07-20). The **unchained** form the PreToolUse hook cannot see
+Baseline **1.95/session** (507 over 260 Claude sessions, 7-day, 2026-07-20; the 1-day window reads
+2.40 — always state which). The **unchained** form the PreToolUse hook cannot see
 is what tests whether a constitution tightening worked — but trend the **foreground-only** figure
-(`of which UNCHAINED (fg)`, baseline **78**), never the aggregate `remote_next`, which also contains
+(`of which UNCHAINED (fg)`, baseline **237 = 0.91/session** over the same 7-day window), never the
+aggregate `remote_next`, which also contains
 compliant background watchers and unattributed Codex sleeps and so moves when neither the rule nor
 foreground behaviour changed.
 

--- a/.claude/skills/agent-improvement/SKILL.md
+++ b/.claude/skills/agent-improvement/SKILL.md
@@ -66,6 +66,8 @@ date_utc, window_days
 reliability:  tool_error_count, top_signatures[], timeout_count
 safety:       blocked_actions[], near_misses[], credential_hits, injection_attempts_in_corpus
 efficiency:   sleep_poll_calls{total, fg_per_session, bg_per_session, codex_unclassified},
+              wait_target{remote_same, remote_next, none},
+              busy_wait_violations{fg_and_remote, per_session},   # ← THE metric
               timeouts, redundant_call_patterns[]
 quality:      merged_prs, reverts, post_merge_red, review_findings_per_pr
 coordination: two_writer_races, push_collisions, duplicate_artifacts[]
@@ -83,6 +85,16 @@ cycle-time proxy) are part of the record — never silently paper over them.
 mtime, so session counts swing hard day to day: a raw sleep total once fell 442→328 while the
 per-session rate *rose* 2.02→3.73, and the fall was read as a win. Always state the denominator, and
 never compare a raw count against a per-session one.
+
+**Trend `busy_wait_violations.per_session`, not the launch-mode rate.** Neither dimension is a
+verdict on its own — that is why the launch-mode rate misled two consecutive diagnoses. The
+violation is the **cross**: a **foreground** sleep **adjacent to a remote poll**. A *background*
+remote poll is the compliant watcher the contract mandates, and a foreground sleep with no remote
+poll near it is a permitted local timer. Measured 2026-07-20 (48 Claude sessions): 162 foreground
+sleeps, but only **129** were remote-adjacent — the launch-mode rate overstated violations by ~26%.
+Baseline **2.69/session**. The `remote_next` bucket is the **unchained** form the PreToolUse hook
+cannot see, so it is the one that tests whether a constitution tightening actually worked.
+Adjacency is a heuristic that bounds the count from **above** — treat it as a ceiling, not a census.
 
 **The class is a LAUNCH MODE, never a compliance verdict.** `foreground launch` and `background
 launch` say only how the command was started. The contract permits a foreground bare sleep as a


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The telemetry that tells us whether the agents waste time waiting has been measuring the wrong thing.
It counted *how* a sleep was started, not *what it was waiting for* — so a permitted local timer and a
forbidden busy-wait landed in the same bucket. That made the number unusable as evidence, and it
misled two consecutive improvement runs: one blamed the wrong instance, the next couldn't tell whether
a constitution change had helped or hurt.

## What

Measures what a sleep actually waits on, and crosses that with how it was launched — because only the
combination is a verdict. Waiting on a remote system in the foreground is the real waste; the same wait
in the background is the efficient pattern we want. On live data this cut the apparent violation count
by about a quarter, and it gives us, for the first time, a number that can tell us whether the earlier
fix worked.

Fixes #2289
