### PR TITLE
docs(agents): add Cursor Cloud dev-environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1944,3 +1944,31 @@ performance, security, and reliability. The `self-improvement` skill is the proc
   high-value or security/reliability fix); minimal, reversible changes; one concern per PR; don't
   churn. A run with nothing worth changing proposes nothing — but it still banks its daily 1% learning
   (capture is not proposing; see *The 1% rule* above).
+
+## Cursor Cloud specific instructions
+
+Scope note for Cloud Agents: in a fresh cloud checkout the **only buildable product is the
+`docs/` Astro Starlight site** (devantler.tech). Every entry in the *Portfolio map* is a Git
+submodule wired over SSH (`git@github.com:` in `.gitmodules`), and cloud VMs have no SSH key, so
+`submodule-init.sh` / `git submodule update` cannot populate them — those products can't be built
+or run here. `docs/` lives in this repo (not a submodule), so it always works.
+
+- **Toolchain:** Node 22 + npm (already on the VM). Standard site commands live in `docs/README.md`
+  and `.github/workflows/ci.yaml` — don't duplicate them. In short: work from `docs/`, `npm run dev`
+  (dev server at `http://localhost:4321/`, no base path), `npm run build` (what CI validates).
+- **The dependency-refresh update script only installs `docs/` deps.** Starting the dev server,
+  building, and running tests are NOT in it — run them yourself.
+- **Search is disabled under `npm run dev`.** Starlight builds the Pagefind search index only during
+  `npm run build`, so the dev-server search box shows "Search is only available in production
+  builds". To exercise search, run `npm run build` then `npm run preview`.
+- **`npm run build` is the effective lint/validate step** — it runs `starlight-links-validator`
+  (internal-link check) and builds the Pagefind index; there is no separate `lint` script.
+- **Automated tests are bash self-tests**, not a JS test runner: `.claude/scripts/*.test.sh` and
+  `docs/scripts/check-active-projects-drift.test.sh` (these are the suites CI runs). Known
+  pre-existing failure unrelated to the site: `agent-telemetry.test.sh` fails one case
+  ("JWT flagged AND redacted", 114/115 pass) — a fixture/detector mismatch in an internal
+  maintenance script, not an environment problem.
+- **`drift-check-active-projects` cannot fully run in cloud.** It greps the checked-out
+  `github/devantler-tech/github-actions/actions` submodule; CI rewrites that submodule's URL to
+  public HTTPS before init, but the cloud VM's SSH-only `.gitmodules` means it stays empty here.
+  Its self-test (`check-active-projects-drift.test.sh`) still runs (self-contained fixtures).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> 🤖 Generated by the Daily AI Engineer

**Why:** A Cloud Agent setting up this repo has no way to know that only the `docs/` site is buildable in a fresh cloud checkout — every portfolio product is an SSH-only submodule that can't populate without a key — or about non-obvious dev caveats (dev-mode search disabled, no separate lint script, bash-based tests). Without this, future cloud runs waste time rediscovering it.

**What:** Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing durable, non-obvious startup/run notes for the `docs/` Astro Starlight site and pointing at existing docs (`docs/README.md`, `.github/workflows/ci.yaml`) rather than duplicating standard commands. Verified end-to-end: `npm ci` + `npm run build` (63 pages, links validated), the bash self-test suites, and a live `npm run dev` session with hot-reload.

No product code changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0aed8cdf-36c2-4b5d-b4db-5ca59f8e6c99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0aed8cdf-36c2-4b5d-b4db-5ca59f8e6c99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

