### PR TITLE
docs(ai-engineer): read a file at the worktree path before editing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1625,11 +1625,12 @@ slug only for `gh` commands). **Submodule worktree isolation breaks whenever a s
 initialised** — a stray shared `core.worktree` makes `git worktree add` resolve back into the main
 checkout, silently collapsing every parallel session into one physical tree.
 
-**A fresh worktree is a fresh PATH — `Read` a file THERE before your first edit of it.** Read-tracking
-is keyed on the **absolute path**, so every file in a newly-created worktree counts as unread even when
-you read the same file in the main checkout minutes earlier — the edit is refused with *"File has not
-been read yet"* and the run pays a wasted round-trip. Knowing a file's contents is not the same as
-having read it *at the path you are editing*; the path, not the filename, is the identity. Measured
+**A fresh worktree is a fresh COPY — `Read` a file THERE before your first edit of it.** Reading a file
+in the main checkout does **not** count as having read the worktree's copy: it is a different file on
+disk and the read record does not carry across, so the edit is refused with *"File has not been read
+yet"* and the run pays a wasted round-trip. Knowing a file's contents is not the same as having read it
+*where you are about to edit it*. That is the observed behaviour and the whole of it — the exact key
+the runtime tracks is **not** established, so do not reason from an assumed one. Measured
 2026-07-14→21 on the Claude instance (the only lane whose tool errors are attributable — the sibling
 runtimes record no error flag, so this is scoped to that lane rather than asserted for all three):
 **134 such refusals, 73 of them under this monorepo; 126 were on a path never read in that session,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1625,6 +1625,20 @@ slug only for `gh` commands). **Submodule worktree isolation breaks whenever a s
 initialised** — a stray shared `core.worktree` makes `git worktree add` resolve back into the main
 checkout, silently collapsing every parallel session into one physical tree.
 
+**A fresh worktree is a fresh PATH — `Read` a file THERE before your first edit of it.** Read-tracking
+is keyed on the **absolute path**, so every file in a newly-created worktree counts as unread even when
+you read the same file in the main checkout minutes earlier — the edit is refused with *"File has not
+been read yet"* and the run pays a wasted round-trip. Knowing a file's contents is not the same as
+having read it *at the path you are editing*; the path, not the filename, is the identity. Measured
+2026-07-14→21 on the Claude instance (the only lane whose tool errors are attributable — the sibling
+runtimes record no error flag, so this is scoped to that lane rather than asserted for all three):
+**134 such refusals, 73 of them under this monorepo; 126 were on a path never read in that session,
+and 102 of those — 81% — were inside a `.claude/worktrees/` path.** The repeat targets are exactly the
+files an agent is surest it already knows: `AGENTS.md`, `SKILL.md`, `MEMORY.md`, `ci.yaml`,
+`kustomization.yaml`. It is the single largest tool-error signature in both the 1-day and 7-day
+windows. So after `worktree add`, the first touch of each file is a `Read` at the **worktree** path —
+and the same applies to `Write` over a file that already exists there.
+
 **`git submodule update --init <path>` is what (re-)introduces it** — reproduced 2026-07-14 on a
 submodule that was verified fixed: the key was absent before the command and present after. This is why
 "the fix does not stay fixed" (`applications/ksail` regressed 2026-07-14, silently colliding three live


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Every run creates a throwaway worktree, and the agents then routinely try to edit a file there without reading it first — because they *did* read it, in the main checkout, minutes earlier. The tool refuses the edit, the run pays a wasted round-trip, and it happens often enough to be the **largest single tool-error signature in both the 1-day and 7-day telemetry windows**. It has sat at the top of four consecutive scorecards without anyone naming the cause.

## What

Adds a short rule to the *Execution model* section: a fresh worktree is a fresh path, so the first touch of each file there is a `Read`. The evidence is in the text so a future run can re-verify rather than trust it.

Measured 2026-07-14→21 on the Claude instance: 134 refusals (73 under this monorepo), 126 on a path never read in that session, **102 of those — 81% — inside a `.claude/worktrees/` path**. Scoped explicitly to the Claude lane, since the sibling runtimes record no error flag and this could not be measured for them.