### PR TITLE
fix(ai-engineer): stop Cursor cloud lane from skipping product submodules

### DIFF
--- a/.claude/loaders/cursor-daily-ai-engineer.md
+++ b/.claude/loaders/cursor-daily-ai-engineer.md
@@ -62,13 +62,30 @@ a third instance selecting simultaneously with a sibling is what the claim proto
 > - **Claim before you build** (contract → *Claim protocol*): push `cursor/<area>-<desc>-<issue>` with
 >   a real commit and open the draft PR after the first substantive commit. You are the third writer
 >   on one queue — check open PRs, remote branches and assignees before selecting, and stand down on a
->   lost race rather than duplicating.
-> - **You run in a cloud sandbox with a single-repo checkout.** You have **no** initialised submodules,
->   **no** live cluster access, **no** local render/GPU toolchain, and **no** private operator notes.
->   So the live-cluster security-posture work, the World at Ruin frame-capture work, and any task
->   requiring a submodule worktree are **not yours** — leave them to the local instances rather than
->   attempting a degraded version. Your lane is monorepo-native advance work (`docs/`, `.claude/`,
->   `AGENTS.md`, repo scripts) delivered as pushed branches and drafts.
+>   lost race rather than duplicating. Put the issue number in the branch name on the **product
+>   repo's** remote when the work lives there (not only on monorepo).
+> - **Product submodules are in scope — init them on demand.** Boot leaves submodule directories empty
+>   (`git submodule status` shows `-`), but that is a **checkout state**, not a lane boundary
+>   (measured 2026-07-22 on this same environment: `.claude/scripts/submodule-init.sh <path>`
+>   populates the product; `git push` to that product remote succeeds). When the oldest actionable
+>   issue is on ksail / platform / world-at-ruin / actions / …, **enter that submodule**, work
+>   there, and push `cursor/<area>-<desc>-<issue>` to **its** origin — do not skip product work
+>   just because the superproject booted with empty submodule dirs. Prefer a sibling multi-repo
+>   checkout of the same product if the environment already cloned one; otherwise init the
+>   portfolio-map path from `AGENTS.md`. Never bump the monorepo gitlink as a substitute for a
+>   product PR.
+> - **Opening a product-repo draft PR needs that repo in the Cursor environment's `repos` list.**
+>   `gh pr create` is 403 for `app/cursor`; Cursor's `ManagePullRequest` only targets environment
+>   member repos (a submodule push alone is not enough — measured: after `SetActiveBranch` on a
+>   ksail submodule path, MPR still looked for the branch on monorepo). Until product repos are
+>   added to the environment ([#2394](https://github.com/devantler-tech/monorepo/issues/2394)),
+>   you can still init/investigate/file issues on them, and you can push claim branches, but deliver
+>   **opened** drafts only on repos MPR can target (today: monorepo; after #2394: the expanded set).
+>   Do not leave orphaned product branches without either an opened draft or a well-formed product
+>   issue that names the ready `cursor/*` branch for a local instance to open.
+> - **Still not yours (real capability gaps):** live-cluster security-posture work, World at Ruin
+>   frame-capture / GPU tooling, and anything that needs the private out-of-repo operator notes —
+>   leave those to the local instances.
 > - **Your checkout is the sandbox root — do NOT run the run-loop's fixed local path.** The
 >   `portfolio-maintenance` preflight `cd`s to a machine-local Mac checkout that does not exist here;
 >   following it literally would stop your run before it starts. Use your workspace root and verify it
@@ -135,3 +152,25 @@ Resolving this is a **maintainer decision** — widen the App's scopes and give 
 `devantler`, or narrow this loader's mandate to push-plus-draft and hand the rest to the local
 instances. Tracked in [#2297](https://github.com/devantler-tech/monorepo/issues/2297). Until it is
 decided, treat the operate mandate above as aspirational for this lane.
+
+## Submodule / product-repo scope — measured 2026-07-22
+
+⚠️ **An earlier revision of this loader told the instance it had "no initialised submodules" and that
+product worktrees were "not yours". That was wrong as a lane boundary** and is why automation ticks
+only opened monorepo PRs. Corrected facts (same cloud environment the automation uses):
+
+| Capability | Result |
+|---|---|
+| Boot submodule state | empty dirs (`git submodule status` → `-`) — Cursor clones with `--recurse-submodules=no` |
+| `.claude/scripts/submodule-init.sh applications/ksail` | succeeds; checkout populated |
+| `git push` to a product remote (`devantler-tech/ksail` `cursor/*`) | succeeds |
+| `gh pr create` as `app/cursor` | **403** |
+| `ManagePullRequest` after `SetActiveBranch` on a submodule path | still targets **monorepo** member repos only |
+
+**Instructional fix (this file + `#2395`):** product submodules are in scope; init on demand; do not
+skip portfolio issues because dirs started empty.
+
+**Environment fix (maintainer, `#2394`):** add product repos to the Cursor environment's `repos`
+list (multi-repo) so `ManagePullRequest` can open drafts on them. `repositoryDependencies` in
+`.cursor/environment.json` widens token scope for clones; it does **not** by itself make MPR target
+those remotes — the dashboard `repos` membership does.

--- a/.claude/scripts/cloud-install.sh
+++ b/.claude/scripts/cloud-install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Idempotent Cursor cloud `install` / update hook for the monorepo environment.
+#
+# Boot leaves Git submodules uninitialised (`--recurse-submodules=no`). Product work is still in
+# scope for the Cursor Agentic Engineer lane — it inits the submodule it needs on demand via
+# `.claude/scripts/submodule-init.sh`. This hook only refreshes the always-needed docs deps so
+# cold starts stay fast; it does NOT init every submodule (that would dominate every tick).
+#
+# Wired from `.cursor/environment.json` → `install`.
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$root"
+
+if [[ -f docs/package.json ]]; then
+  npm ci --prefix docs
+fi

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,25 @@
+{
+  "name": "devantler-tech",
+  "install": ".claude/scripts/cloud-install.sh",
+  "repositoryDependencies": [
+    "github.com/devantler-tech/ksail",
+    "github.com/devantler-tech/platform",
+    "github.com/devantler-tech/world-at-ruin",
+    "github.com/devantler-tech/actions",
+    "github.com/devantler-tech/homebrew-tap",
+    "github.com/devantler-tech/agent-skills",
+    "github.com/devantler-tech/agent-plugins",
+    "github.com/devantler-tech/kyverno-policies",
+    "github.com/devantler-tech/provider-upjet-unifi",
+    "github.com/devantler-tech/go-template",
+    "github.com/devantler-tech/dotnet-template",
+    "github.com/devantler-tech/gitops-tenant-template",
+    "github.com/devantler-tech/platform-template",
+    "github.com/devantler-tech/unifi",
+    "github.com/devantler-tech/fleet-gitops",
+    "github.com/devantler-tech/maintenance",
+    "github.com/devantler-tech/.github",
+    "github.com/devantler-tech/wedding-app",
+    "github.com/devantler-tech/ascoachingogvaner"
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> 🤖 Generated by the Agentic Engineer (Cursor cloud instance)

## Why

The Cursor Daily AI Engineer automation only ever opened monorepo PRs because its loader told it product submodules were out of scope. That instruction was wrong for this shared cloud environment.

## What

Corrects the loader so the lane inits product submodules on demand and works there; adds `.cursor/environment.json` token scope + install hook. Opening product drafts still needs the dashboard multi-repo step in #2394 — after merge, re-paste the Instructions block into the Automations UI.

Fixes #2395
Related: #2394

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3259efb0-8d44-45c7-a3a3-0005f552d2de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3259efb0-8d44-45c7-a3a3-0005f552d2de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

