### PR TITLE
fix(ai-engineer): ignore image data in leak telemetry

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1150,10 +1150,12 @@ if want safety; then
     # (`api_key=\"…\"`), so a raw grep sees a backslash where the value should
     # begin and misses it — while redact(), which runs on decoded output, masks
     # it. Same detector/redactor drift, new disguise. Structurally parsed
-    # base64 image data URLs are excluded: they are encoded binary, and random
-    # `/` or `+` boundaries in image bytes manufacture high-signal token shapes. A
-    # malformed line is still scanned whole because its field boundaries cannot
-    # be established safely.
+    # base64 image data URLs are excluded only in the measured Codex storage
+    # shape: a complete `input_image.image_url` value. They are encoded binary,
+    # and random `/` or `+` boundaries in image bytes manufacture high-signal
+    # token shapes. Requiring a full base64 data URL keeps trailing ordinary text
+    # visible, and a malformed line is still scanned whole because its field
+    # boundaries cannot be established safely.
     # Per-SHAPE counts, never one redacted bucket. The first live run printed a
     # single line `871 <redacted-key-material>` — every shape collapsed into one
     # opaque number that needed an hour of ad-hoc probing to triage (verdict: 89%
@@ -1203,18 +1205,44 @@ if want safety; then
       #     only ever reaches a high-signal row by passing a FULL shape regex,
       #     while not splitting silently drops a real second credential.
       jq -Rr '
+        def image_payload_entry($parent):
+          if (($parent.type? // "") == "input_image"
+              and .key == "image_url"
+              and (.value | type) == "string")
+          then (.value | test("^data:image/[^,]*;base64,[A-Za-z0-9+/]*={0,2}$"; "i"))
+          else false
+          end;
+
+        def decoded_strings:
+          if type == "object" then
+            . as $parent
+            | (
+                keys_unsorted[],
+                (to_entries[]
+                 # Preserve the key/value association only where the generic
+                 # credential regex needs it; duplicating every large text
+                 # field as `key=value` would double the scan volume.
+                 | select((.key | test("(secret|token|password|passwd|api[_-]?key)"; "i"))
+                          and ((.value | type) == "string")
+                          and (image_payload_entry($parent) | not))
+                 | "\(.key)=\(.value)"),
+                (to_entries[]
+                 | select(image_payload_entry($parent) | not)
+                 | .value
+                 | decoded_strings)
+              )
+          elif type == "array" then .[] | decoded_strings
+          elif type == "string" then .
+          else empty
+          end;
+
         select(length > 0) as $raw
         | try (
-            $raw | fromjson | ..
-            | if type == "object" then keys_unsorted[]
-              elif type == "string" then .
-              else empty
-              end
-            | select(test("^data:image/[^,]*;base64,"; "i") | not)
+            $raw | fromjson | decoded_strings
           ) catch $raw
       ' "$f" 2>/dev/null \
         | sed -E "s/$(printf '\033')\[[0-9;:]*[A-Za-z]//g" \
-        | grep -hoEi "$CRED_TABLE_RE" 2>/dev/null \
+        | grep -ahoEi "$CRED_TABLE_RE" 2>/dev/null \
         | tr ';&|' '\n' | grep -v '^$' \
         | sed -E -e 's/^[^A-Za-z0-9_-]//' -e "s/^[^:=]*[:=][[:space:]]*[\"']?//" \
         -e 's/^([A-Za-z0-9_-]+)\*\*\*+.*$/\1***/' \

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1205,7 +1205,11 @@ if want safety; then
       jq -Rr '
         select(length > 0) as $raw
         | try (
-            $raw | fromjson | .. | strings
+            $raw | fromjson | ..
+            | if type == "object" then keys_unsorted[]
+              elif type == "string" then .
+              else empty
+              end
             | select(test("^data:image/[^,]*;base64,"; "i") | not)
           ) catch $raw
       ' "$f" 2>/dev/null \

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1144,12 +1144,16 @@ if want safety; then
     echo "  [BOTH instances — this detector is format-agnostic, so it covers Codex too]"
     # Includes github_pat_ (fine-grained PATs). Omitting it meant a modern GitHub
     # token leak reported "clean" — the worst possible failure for a leak detector.
-    # Scan the DECODED strings as well as the raw file. A quoted secret
+    # Scan every DECODED string, with the raw line as a fail-closed fallback
+    # only when the record is malformed. A quoted secret
     # (`api_key="abcdefghij"`) is stored in JSONL with ESCAPED quotes
     # (`api_key=\"…\"`), so a raw grep sees a backslash where the value should
     # begin and misses it — while redact(), which runs on decoded output, masks
-    # it. Same detector/redactor drift, new disguise. Raw is still scanned too,
-    # so a malformed line cannot turn the leak scan into a silent no-op.
+    # it. Same detector/redactor drift, new disguise. Structurally parsed
+    # base64 image data URLs are excluded: they are encoded binary, and random
+    # `/` or `+` boundaries in image bytes manufacture high-signal token shapes. A
+    # malformed line is still scanned whole because its field boundaries cannot
+    # be established safely.
     # Per-SHAPE counts, never one redacted bucket. The first live run printed a
     # single line `871 <redacted-key-material>` — every shape collapsed into one
     # opaque number that needed an hour of ad-hoc probing to triage (verdict: 89%
@@ -1160,8 +1164,7 @@ if want safety; then
     # labelled as such, and the counts are of DISTINCT matched values (one leak
     # pasted into fifty transcripts is one credential to rotate, not fifty).
     printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | while IFS= read -r f; do
-      # Dedupe per file: a credential visible in BOTH decoded and raw JSON was
-      # emitted twice, doubling every count in the leak table.
+      # Dedupe per file before the portfolio-wide distinct-value reduction.
       # Normalise every match to its UNDERLYING VALUE before any dedup:
       # (1) split compound assignments on `;` — the generic alternative's value
       #     class includes `;`, so `GITHUB_TOKEN=ghp_…;AWS_…=AKIA…` is ONE
@@ -1199,8 +1202,13 @@ if want safety; then
       #     weak-bucket rows; the asymmetry is chosen — a splittable fragment
       #     only ever reaches a high-signal row by passing a FULL shape regex,
       #     while not splitting silently drops a real second credential.
-      { jq -Rr 'select(length>0)|(try (fromjson|..|strings) catch empty)' "$f" 2>/dev/null; \
-        cat "$f" 2>/dev/null; } \
+      jq -Rr '
+        select(length > 0) as $raw
+        | try (
+            $raw | fromjson | .. | strings
+            | select(test("^data:image/[^,]*;base64,"; "i") | not)
+          ) catch $raw
+      ' "$f" 2>/dev/null \
         | sed -E "s/$(printf '\033')\[[0-9;:]*[A-Za-z]//g" \
         | grep -hoEi "$CRED_TABLE_RE" 2>/dev/null \
         | tr ';&|' '\n' | grep -v '^$' \

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -405,7 +405,7 @@ echo "binary data URL exclusion"
 mkdir -p "$FIX/binary/projects" "$FIX/binary/codex/sessions"
 cat > "$FIX/binary/codex/sessions/s.jsonl" <<'EOF'
 {"type":"session_meta","payload":{"cwd":"__FIX__/monorepo"}}
-{"type":"response_item","payload":{"type":"custom_tool_call_output","output":[{"type":"input_text","text":"text leak __SLACK__","__PATA__":"metadata"},{"type":"image","image_url":"data:image/png;base64,AAAA/__AWS__BBBB"}]}}
+{"type":"response_item","payload":{"type":"custom_tool_call_output","output":[{"type":"input_text","text":"text leak __SLACK__","__PATA__":"metadata"},{"type":"input_image","detail":"auto","image_url":"data:image/png;base64,AAAA/__AWS__BBBB"}]}}
 malformed raw leak __GHPE__
 EOF
 sed -i.bak "s|__FIX__|$FIX|g" "$FIX/binary/codex/sessions/s.jsonl" && rm -f "$FIX/binary/codex/sessions/s.jsonl.bak"
@@ -427,6 +427,57 @@ if printf '%s' "$TABLE" | grep -q 'github-pat (fine-grained)'; then
   ok "credential-shaped JSON object keys are still scanned"
 else bad "credential-shaped JSON object keys are still scanned" "$TABLE"; fi
 nocheck "credential-shaped JSON object keys are sanitized" "$OUT" "$(ex __PATA__)"
+
+echo
+echo "reviewed credential extraction adversaries"
+
+mkdir -p "$FIX/association/projects" "$FIX/association/codex/sessions"
+cat > "$FIX/association/codex/sessions/s.jsonl" <<'EOF'
+{"type":"session_meta","payload":{"cwd":"__FIX__/monorepo"}}
+{"type":"response_item","payload":{"type":"custom_tool_call_output","output":{"api_key":"__GEN__"}}}
+EOF
+sed -i.bak "s|__FIX__|$FIX|g" "$FIX/association/codex/sessions/s.jsonl" && rm -f "$FIX/association/codex/sessions/s.jsonl.bak"
+subst "$FIX/association/codex/sessions/s.jsonl"
+ASSOC_OUT=$(CLAUDE_PROJECTS_DIR="$FIX/association/projects" CODEX_HOME="$FIX/association/codex" \
+            MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+            bash "$TARGET" --since-days 3650 --section safety 2>&1)
+ASSOC_TABLE=$(printf '%s' "$ASSOC_OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$ASSOC_TABLE" | grep -q 'generic-assignment'; then
+  ok "generic JSON key/value associations are still scanned"
+else bad "generic JSON key/value associations are still scanned" "$ASSOC_TABLE"; fi
+
+mkdir -p "$FIX/prefix/projects" "$FIX/prefix/codex/sessions"
+cat > "$FIX/prefix/codex/sessions/s.jsonl" <<'EOF'
+{"type":"session_meta","payload":{"cwd":"__FIX__/monorepo"}}
+{"type":"response_item","payload":{"type":"custom_tool_call_output","output":[{"type":"input_text","text":"data:image/png;base64,AAAA\nJWT=__JWT__"},{"type":"input_image","detail":"auto","image_url":"data:image/png;base64,AAAA/__AWS__BBBB"}]}}
+EOF
+sed -i.bak "s|__FIX__|$FIX|g" "$FIX/prefix/codex/sessions/s.jsonl" && rm -f "$FIX/prefix/codex/sessions/s.jsonl.bak"
+subst "$FIX/prefix/codex/sessions/s.jsonl"
+PREFIX_OUT=$(CLAUDE_PROJECTS_DIR="$FIX/prefix/projects" CODEX_HOME="$FIX/prefix/codex" \
+             MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+             bash "$TARGET" --since-days 3650 --section safety 2>&1)
+PREFIX_TABLE=$(printf '%s' "$PREFIX_OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$PREFIX_TABLE" | grep -q 'jwt-like'; then
+  ok "data-URL-prefixed ordinary text cannot suppress a credential"
+else bad "data-URL-prefixed ordinary text cannot suppress a credential" "$PREFIX_TABLE"; fi
+if printf '%s' "$PREFIX_TABLE" | grep -q 'aws-access-key-id'; then
+  bad "only actual image payload fields are excluded" "$PREFIX_TABLE"
+else ok "only actual image payload fields are excluded"; fi
+
+mkdir -p "$FIX/nulkey/projects" "$FIX/nulkey/codex/sessions"
+cat > "$FIX/nulkey/codex/sessions/s.jsonl" <<'EOF'
+{"type":"session_meta","payload":{"cwd":"__FIX__/monorepo"}}
+{"type":"response_item","payload":{"type":"custom_tool_call_output","output":{"\u0000":"noise","text":"leak __PATZ__"}}}
+EOF
+sed -i.bak "s|__FIX__|$FIX|g" "$FIX/nulkey/codex/sessions/s.jsonl" && rm -f "$FIX/nulkey/codex/sessions/s.jsonl.bak"
+subst "$FIX/nulkey/codex/sessions/s.jsonl"
+NUL_OUT=$(CLAUDE_PROJECTS_DIR="$FIX/nulkey/projects" CODEX_HOME="$FIX/nulkey/codex" \
+          MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+          bash "$TARGET" --since-days 3650 --section safety 2>&1)
+NUL_TABLE=$(printf '%s' "$NUL_OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$NUL_TABLE" | grep -q 'github-pat (fine-grained)'; then
+  ok "NUL-bearing object keys cannot switch credential grep to binary mode"
+else bad "NUL-bearing object keys cannot switch credential grep to binary mode" "$NUL_TABLE"; fi
 
 # ── 6d². leak-table boundary anchoring ────────────────────────────────────────
 # First live run (2026-07-18): the top "real-looking" GitHub-token hits were

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -394,6 +394,36 @@ parity_case "slack"      "leak __SLACK__" "__SLACK__"
 parity_case "jwt"        "leak __JWT__" "__JWTTAIL__"
 parity_case "generic"    "config token=__GEN__" "__GEN__"
 
+# Codex image tools persist rendered images as very large `data:` strings in
+# custom tool outputs. Those strings are encoded binary, not transcript text;
+# scanning their random byte alphabet produces high-signal credential rows that
+# tell the operator to rotate credentials which never existed. Keep the
+# exclusion structural and narrow: an adjacent text field and a malformed raw
+# record must still reach the detector.
+echo
+echo "binary data URL exclusion"
+mkdir -p "$FIX/binary/projects" "$FIX/binary/codex/sessions"
+cat > "$FIX/binary/codex/sessions/s.jsonl" <<'EOF'
+{"type":"session_meta","payload":{"cwd":"__FIX__/monorepo"}}
+{"type":"response_item","payload":{"type":"custom_tool_call_output","output":[{"type":"input_text","text":"text leak __SLACK__"},{"type":"image","image_url":"data:image/png;base64,AAAA/__AWS__BBBB"}]}}
+malformed raw leak __GHPE__
+EOF
+sed -i.bak "s|__FIX__|$FIX|g" "$FIX/binary/codex/sessions/s.jsonl" && rm -f "$FIX/binary/codex/sessions/s.jsonl.bak"
+subst "$FIX/binary/codex/sessions/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/binary/projects" CODEX_HOME="$FIX/binary/codex" \
+      MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -q 'aws-access-key-id'; then
+  bad "binary image data does not create a credential alert" "$TABLE"
+else ok "binary image data does not create a credential alert"; fi
+if printf '%s' "$TABLE" | grep -q 'slack-token'; then
+  ok "adjacent ordinary text is still scanned"
+else bad "adjacent ordinary text is still scanned" "$TABLE"; fi
+if printf '%s' "$TABLE" | grep -q 'github-token (classic/app)'; then
+  ok "malformed raw records remain fail-closed"
+else bad "malformed raw records remain fail-closed" "$TABLE"; fi
+
 # ── 6d². leak-table boundary anchoring ────────────────────────────────────────
 # First live run (2026-07-18): the top "real-looking" GitHub-token hits were
 # substrings INSIDE base64url blobs (signed-URL params, JWT signatures) —

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -405,7 +405,7 @@ echo "binary data URL exclusion"
 mkdir -p "$FIX/binary/projects" "$FIX/binary/codex/sessions"
 cat > "$FIX/binary/codex/sessions/s.jsonl" <<'EOF'
 {"type":"session_meta","payload":{"cwd":"__FIX__/monorepo"}}
-{"type":"response_item","payload":{"type":"custom_tool_call_output","output":[{"type":"input_text","text":"text leak __SLACK__"},{"type":"image","image_url":"data:image/png;base64,AAAA/__AWS__BBBB"}]}}
+{"type":"response_item","payload":{"type":"custom_tool_call_output","output":[{"type":"input_text","text":"text leak __SLACK__","__PATA__":"metadata"},{"type":"image","image_url":"data:image/png;base64,AAAA/__AWS__BBBB"}]}}
 malformed raw leak __GHPE__
 EOF
 sed -i.bak "s|__FIX__|$FIX|g" "$FIX/binary/codex/sessions/s.jsonl" && rm -f "$FIX/binary/codex/sessions/s.jsonl.bak"
@@ -423,6 +423,10 @@ else bad "adjacent ordinary text is still scanned" "$TABLE"; fi
 if printf '%s' "$TABLE" | grep -q 'github-token (classic/app)'; then
   ok "malformed raw records remain fail-closed"
 else bad "malformed raw records remain fail-closed" "$TABLE"; fi
+if printf '%s' "$TABLE" | grep -q 'github-pat (fine-grained)'; then
+  ok "credential-shaped JSON object keys are still scanned"
+else bad "credential-shaped JSON object keys are still scanned" "$TABLE"; fi
+nocheck "credential-shaped JSON object keys are sanitized" "$OUT" "$(ex __PATA__)"
 
 # ── 6d². leak-table boundary anchoring ────────────────────────────────────────
 # First live run (2026-07-18): the top "real-looking" GitHub-token hits were


### PR DESCRIPTION
## Summary

- exclude only complete base64 payloads stored as `input_image.image_url` from credential-shape scanning
- preserve ordinary JSON text, secret key/value associations, object member names, malformed raw records, and NUL-bearing decoded streams
- add deterministic regressions for the measured false positives and every preserved fail-closed path

## Evidence

The daily scan reported three high-signal values whose only source was image `data:` payloads: one Slack-shaped substring and two AWS-key-shaped substrings. Value-free structural triage confirmed they were random base64 substrings, not credentials.

The initial regression failed at 148 pass / 1 fail. Review then found four genuine fail-open edges: credential-shaped object keys, generic secret key/value associations, data-URL prefix smuggling in ordinary text, and NUL-triggered grep binary mode. Each was reproduced before implementation. The final suite passes 155/155, and all review threads are resolved.

## Security floor

No credential class or output redaction was loosened. Only a structurally identified `input_image.image_url` whose entire value is a valid base64 image data URL is excluded. Ordinary text, secret assignments, credential-shaped keys, decoded NULs, and malformed JSON continue through the detector; malformed input retains the raw fail-closed fallback.

## Everyday path

The Agent Improver no longer tells the operator to rotate credentials that never existed inside rendered image bytes, while real text-shaped evidence keeps the same triage path.

## Verification

- `bash .claude/scripts/agent-telemetry.test.sh` — 155 passed, 0 failed
- `bash -n .claude/scripts/agent-telemetry.sh .claude/scripts/agent-telemetry.test.sh`
- `shellcheck --severity=error .claude/scripts/agent-telemetry.sh .claude/scripts/agent-telemetry.test.sh`
- `git diff --check`
- live one-day safety scan: measured image-sourced AWS rows 2 → 0; remaining high-signal rows were value-free triaged as documentation, masked-display, or reviewer-example data

Fixes #2399