### PR TITLE
fix(agents): allow Cursor product repository work

### DIFF
--- a/.claude/loaders/cursor-daily-ai-engineer.md
+++ b/.claude/loaders/cursor-daily-ai-engineer.md
@@ -63,12 +63,16 @@ a third instance selecting simultaneously with a sibling is what the claim proto
 >   a real commit and open the draft PR after the first substantive commit. You are the third writer
 >   on one queue — check open PRs, remote branches and assignees before selecting, and stand down on a
 >   lost race rather than duplicating.
-> - **You run in a cloud sandbox with a single-repo checkout.** You have **no** initialised submodules,
->   **no** live cluster access, **no** local render/GPU toolchain, and **no** private operator notes.
->   So the live-cluster security-posture work, the World at Ruin frame-capture work, and any task
->   requiring a submodule worktree are **not yours** — leave them to the local instances rather than
->   attempting a degraded version. Your lane is monorepo-native advance work (`docs/`, `.claude/`,
->   `AGENTS.md`, repo scripts) delivered as pushed branches and drafts.
+> - **Product repositories are in scope when present in the cloud workspace.** Do not mistake an
+>   empty monorepo submodule directory for a lane boundary: a current Cursor tick demonstrably opened
+>   and delivered a `cursor/*` PR in `devantler-tech/platform-template` on 2026-07-22. Resolve the
+>   current checkout against the contract's Portfolio map, work in that product repository, and push
+>   the branch to that repository's origin. A repository absent from the workspace is an honest
+>   capability limit for that product, not evidence that all product work belongs to local instances.
+> - **Cloud-only capability gaps still apply.** You have **no** live cluster access, **no** local
+>   render/GPU toolchain, and **no** private operator notes. Leave live-cluster security-posture work,
+>   World at Ruin frame capture, and sensitive operator-note work to the local instances rather than
+>   attempting a degraded version.
 > - **Your checkout is the sandbox root — do NOT run the run-loop's fixed local path.** The
 >   `portfolio-maintenance` preflight `cd`s to a machine-local Mac checkout that does not exist here;
 >   following it literally would stop your run before it starts. Use your workspace root and verify it

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -87,6 +87,11 @@ grep -Fq 'siblings may build, run, review,' "${cursor_loader}" ||
   fail "Cursor loader still prevents trusted sibling instances from driving Cursor-authored PRs"
 grep -Fq 'and drive your PRs' "${cursor_loader}" ||
   fail "Cursor loader does not authorize the sibling handoff through merge"
+grep -Fq 'Product repositories are in scope' "${cursor_loader}" ||
+  fail "Cursor loader still treats its empty boot checkout as a product-repository boundary"
+if grep -Fq 'any task requiring a submodule worktree are **not yours**' "${cursor_loader}"; then
+  fail "Cursor loader still forbids product work that the cloud lane demonstrably delivers"
+fi
 grep -Fq -- "- '.claude/loaders/cursor-daily-ai-engineer.md'" "${ci_workflow}" ||
   fail "Cursor loader changes do not trigger the portfolio surveyor contract job"
 if grep -Fq '`app/cursor` is **not** in the contract' "${cursor_loader}"; then


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The versioned Cursor loader still classified product-repository work as unavailable. Live behavior now disproves that deployment fact: `app/cursor` opened and delivered [platform-template#111](https://github.com/devantler-tech/platform-template/pull/111) from a `cursor/*` branch on 2026-07-22.

## What changed

- Treat product repositories as in scope when they are actually present in the cloud workspace.
- Keep absent repositories as explicit capability gaps rather than a portfolio-wide prohibition.
- Preserve the real cloud limits: no live-cluster access, local GPU/frame capture, or private operator notes.
- Add a contract assertion so the obsolete product-work prohibition cannot return silently.

## Verification

- RED: `portfolio-surveyor.test.sh` failed with `Cursor loader still treats its empty boot checkout as a product-repository boundary` before the loader change.
- GREEN: `.claude/scripts/portfolio-surveyor.test.sh`
- `bash -n .claude/scripts/portfolio-surveyor.test.sh`
- `git diff --check`

Fixes #2395
