### PR TITLE
fix(ai-engineer): exempt programmed agent-skills updates

### DIFF
--- a/.claude/agents/daily-maintainer.md
+++ b/.claude/agents/daily-maintainer.md
@@ -29,8 +29,10 @@ take this same path** — maintainer direction 2026-07-18 retired the separate p
 to keep (see the contract's *Self-improvement*).
 You drive *other* actionable trusted-author PRs to merge the same way — actionable single-author bots
 can arm `--auto`, but never via a branch-protection bypass; exact Renovate/Dependabot dependency PRs
-are automation-owned and receive no agent action. The maintainer steers after the fact via sessions
-and PR comments; when he disagrees, revert or redirect immediately.
+are automation-owned and receive no agent action. Programmed `chore(deps): update agent skills` PRs
+that pass the contract's exact classifier are CI-and-auto-merge-only: never request a review for them.
+The maintainer steers after the fact via sessions and PR comments; when he disagrees, revert or
+redirect immediately.
 
 ## How you operate
 1. **Follow the contract** — [`AGENTS.md`](../../AGENTS.md) is already in your context via the

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -80,7 +80,8 @@ public and private — no per-repo loop needed to enumerate):
    Other API surfaces may render the same actors as `app/renovate` or `app/dependabot`; do not
    use search's unreliable `is_bot` field, a title, or a branch pattern as the classifier.
    For the *few* remaining open **`devantler`-authored or actionable trusted-bot PRs — drafts and
-   non-drafts —** (`devantler`, `ksail-bot[bot]`, `github-actions[bot]`, `coderabbitai[bot]`,
+   non-drafts —**, plus the candidate-only `botantler-1[bot]` updater rows defined below
+   (`devantler`, `ksail-bot[bot]`, `github-actions[bot]`, `coderabbitai[bot]`,
    `cursor[bot]` — **exact login match, never a substring**; `cursor[bot]` is trusted here only on the PR-author surface;
    `Copilot`/`copilot-swe-agent[bot]` are NOT trusted), pull the
    heavy fields one PR at a time:
@@ -90,6 +91,12 @@ public and private — no per-repo loop needed to enumerate):
    review), classify trusted-bot **non-drafts** as **MERGE-READY** and trusted-bot **drafts** as
    **REVIEW-READY**; otherwise **NEEDS-FIX** and name the gate. A `devantler` PR always follows the
    ownership-unverified rule below first.
+   **`botantler-1[bot]` is a candidate only for the programmed agent-skills updater classifier**:
+   deepen its row only when the cheap search result has branch `deps/agent-skills-update` and exact
+   title `chore(deps): update agent skills`, then require the classifier below to exit 0. The cheap
+   branch/title test only selects a candidate; it never grants the exemption. If the classifier
+   returns 1, the App is untrusted outside that programmed path and the PR is static-review-only.
+   Exit 2 is a survey error and fails closed.
    - **`devantler`-authored PRs: classify the CI state, NOT the ownership — report them as
      `OWNERSHIP-UNVERIFIED`, never "MERGE-READY own".** You cannot tell the routine's *own* PRs from the
      **maintainer's interactive** ones (an active feature campaign, `repo-assist`, a hand-driven session):
@@ -160,11 +167,12 @@ public and private — no per-repo loop needed to enumerate):
      merge-ready without ≥1 green review on top of green CI; a successful current-head review from any one provider completes the review gate**
      (maintainer direction 2026-07-11, clarified 2026-07-22).
      This includes drafts and promoted PRs from humans and actionable trusted bots — EXCEPT trusted
-     **programmed release-bot PRs** (Homebrew-tap cask PRs — GoReleaser's for `ksail`/`ksail-desktop`
-     and World at Ruin's CD-generated ones on `goreleaser/world-at-ruin`, maintainer direction
-     2026-07-18 — plus KSail release bumps; maintainer direction 2026-07-13, ksail#6095): apply this
+     **programmed bot PRs**: the shared agent-skills updater's exact generated path (maintainer
+     direction 2026-07-23), Homebrew-tap cask PRs (GoReleaser's for `ksail`/`ksail-desktop` and
+     World at Ruin's CD-generated ones on `goreleaser/world-at-ruin`, maintainer direction
+     2026-07-18), and KSail release bumps (maintainer direction 2026-07-13, ksail#6095). Apply this
      exemption **only** when the checked-in exact classifier exits 0:
-     `.claude/scripts/release-bot-exemption.sh "$repo" "$author_login" "$headRefName" "$title" "$headRefOid" "$files_json" "$commits_json"`.
+     `.claude/scripts/programmed-bot-review-exemption.sh "$repo" "$author_login" "$headRefName" "$title" "$headRefOid" "$files_json" "$commits_json"`.
      Pass the repository basename (`ksail`, not `devantler-tech/ksail`) and the exact API author login.
      Encode all paths from the deepening query as one compact JSON string array in `files_json`. Fetch
      the complete commit list separately from the REST endpoint `repos/devantler-tech/<repo>/pulls/<n>/commits`
@@ -181,7 +189,7 @@ public and private — no per-repo loop needed to enumerate):
      approved repository, PR actor, branch, title/version, current-head commit provenance, and exact
      changed-file set; do not recreate a
      looser predicate in the survey. Qualifying PRs are check-gated + auto-merging, so report
-     their review state as `green_review=exempt-release-bot` — never classify them NEEDS-FIX for
+     their review state as `green_review=exempt-programmed-bot` — never classify them NEEDS-FIX for
      lacking a review (their (a)/(b)/(c)/(d) hygiene still counts). Report
      `green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|self@<sha>|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>`. The
      evidence suffix belongs to `green_review` ONLY — never decorate `rd=none`, which is GitHub's
@@ -522,8 +530,8 @@ budget: graphql=<start_remaining>→<end_remaining>/<limit> · core=<start_remai
 - REPO-SET-DRIFT — live org set vs canonical list: new=<repos> · missing/renamed=<repos> · map-drift=<product rows whose repo is missing/renamed live> → orchestrator reconciles (archived-marked map rows exempt)
 - <repo>: CI red on main @<sha> — <check name> <conclusion> (<run url>)   # judged at main's current head; omit the repo entirely when that head is green
 - <repo> #<n> "<title>" — <renovate[bot]|dependabot[bot]> → AUTOMATION-OWNED (NO-ACTION)
-- <repo> #<n> (trusted bot, draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>|0-resolved@<sha>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|exempt-release-bot|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>, review_reservation=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|none>, mergeState=<…> → REVIEW-READY | NEEDS-FIX | STALE-CR-DISMISSAL
-- <repo> #<n> (trusted bot, non-draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>|0-resolved@<sha>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|exempt-release-bot|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>, review_reservation=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|none>, mergeState=<…> → MERGE-READY | NEEDS-FIX | STALE-CR-DISMISSAL
+- <repo> #<n> (trusted bot, draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>|0-resolved@<sha>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|exempt-programmed-bot|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>, review_reservation=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|none>, mergeState=<…> → REVIEW-READY | NEEDS-FIX | STALE-CR-DISMISSAL
+- <repo> #<n> (trusted bot, non-draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>|0-resolved@<sha>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|exempt-programmed-bot|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>, review_reservation=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|none>, mergeState=<…> → MERGE-READY | NEEDS-FIX | STALE-CR-DISMISSAL
 - <repo> #<n> "<title>" — `devantler`, draft=<true|false> → OWNERSHIP-UNVERIFIED: branch=<headRefName>, disclosure=<yes|no>, pentad=<…>, review_reservation=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none> (orchestrator applies creation-record test before action; NOT asserted mine)
 - <repo>: untriaged → issues #a,#b · PRs #c   |   stale (>14d) → #d
 - <repo> #<n> "<title>" — <author>: EXTERNAL/Copilot — review statically only (never auto-drive/merge)

--- a/.claude/plugin-consumption/automated-ai-engineer-surveyor-diff.md
+++ b/.claude/plugin-consumption/automated-ai-engineer-surveyor-diff.md
@@ -49,7 +49,8 @@ plugin carries them (or an explicit, tested subset):
    takeover-suffix / normalised-stem match), not `claude/*` alone.
 7. **Board-claim token / Projects coverage** signals and fail-closed truncation handling.
 8. **GraphQL/core budget line** at survey start/end (monorepo#2365).
-9. **Release-bot review exemption** classification.
+9. **Programmed-bot review exemption** classification, including generated agent-skills updater PRs
+   and release PRs without weakening the normal bot review gate.
 10. **Lane-signal** reporting for provider quota (e.g. Bugbot usage-limit) without treating it as a
    code verdict.
 

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -200,6 +200,8 @@ grep -Fq 'automation-owned dependency PRs' "${agent_skills_card}" ||
   fail "agent-skills product card still treats dependency PRs as agent work"
 grep -Fq 'never spend a review lane on them' "${agent_skills_card}" ||
   fail "agent-skills product card still requires review for programmed updater PRs"
+grep -Fq 'classification succeeds' "${agent_skills_card}" ||
+  fail "agent-skills product card can skip review without a successful classifier result"
 grep -Fq 'automation-owned dependency PRs' "${ksail_card}" ||
   fail "KSail product card still treats dependency PRs as agent work"
 if grep -Fq 'Bot PRs are first-priority work, not background noise' "${constitution}"; then
@@ -405,6 +407,30 @@ agent_plugins_skills_commits="$(jq -cn --arg head "${agent_plugins_skills_head}"
   committer_email: "41898282+github-actions[bot]@users.noreply.github.com",
   message: "chore(deps): update agent skills"
 }]')"
+
+multi_agent_skills_head="6666666666666666666666666666666666666666"
+multi_agent_skills_commits="$(jq -cn --arg head "${multi_agent_skills_head}" '[
+  {
+    sha: "7777777777777777777777777777777777777777",
+    author_login: "devantler",
+    author_name: "devantler",
+    author_email: "26203420+devantler@users.noreply.github.com",
+    committer_login: "github-actions[bot]",
+    committer_name: "github-actions[bot]",
+    committer_email: "41898282+github-actions[bot]@users.noreply.github.com",
+    message: "chore(deps): update agent skills"
+  },
+  {
+    sha: $head,
+    author_login: "github-merge-queue[bot]",
+    author_name: "github-merge-queue",
+    author_email: "118344674+github-merge-queue@users.noreply.github.com",
+    committer_login: "github-actions[bot]",
+    committer_name: "github-actions[bot]",
+    committer_email: "41898282+github-actions[bot]@users.noreply.github.com",
+    message: "chore(deps): update agent skills"
+  }
+]')"
 
 platform_skills_head="d668b9d0f52c22473abc75a7d7457505e3624cc6"
 platform_skills_files='[".agents/skills/gitops-cluster-debug/SKILL.md",".agents/skills/gitops-knowledge/SKILL.md"]'
@@ -628,6 +654,16 @@ expect_review_gated \
   "${adapted_agent_skills_head}" \
   "${agent_plugins_skills_files}" \
   "${adapted_agent_skills_commits}"
+
+expect_review_gated \
+  "agent-skills updater carrying two otherwise compliant commits" \
+  "agent-plugins" \
+  "app/botantler-1" \
+  "deps/agent-skills-update" \
+  "chore(deps): update agent skills" \
+  "${multi_agent_skills_head}" \
+  "${agent_plugins_skills_files}" \
+  "${multi_agent_skills_commits}"
 
 expect_review_gated \
   "agent-skills updater shape in an unapproved repository" \

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -67,6 +67,10 @@ grep -Fq 'report `scanners_alive: cve=PARTIAL:<why>`' "${platform_security_surve
 [[ -x "${classifier}" ]] || fail "release-bot exemption classifier is missing or not executable"
 grep -Fq '.claude/scripts/release-bot-exemption.sh' "${surveyor}" ||
   fail "surveyor does not delegate exemption decisions to the exact classifier"
+grep -Fq 'programmed agent-skills updater PRs' "${constitution}" ||
+  fail "constitution does not exempt programmed agent-skills updater PRs from review"
+grep -Fq 'green_review=exempt-programmed-bot' "${surveyor}" ||
+  fail "surveyor cannot report a programmed bot review exemption"
 grep -Fq 'ksail-bot[bot]' "${surveyor}" ||
   fail "surveyor does not recognize the exact KSail App identity returned by search"
 grep -Fq '/pulls/<n>/commits' "${surveyor}" ||
@@ -377,6 +381,45 @@ platform_commits="$(jq -cn --arg head "${platform_head}" '[{
   message: "chore(deps): update dependency devantler-tech/ksail to v7.172.1"
 }]')"
 
+agent_plugins_skills_head="e9cf0d8f34ef5e235d11b5141d71bb067d96538d"
+agent_plugins_skills_files='["plugins/github/skills/gh-stack/SKILL.md","plugins/gitops-kubernetes/skills/gitops-knowledge/SKILL.md"]'
+agent_plugins_skills_commits="$(jq -cn --arg head "${agent_plugins_skills_head}" '[{
+  sha: $head,
+  author_login: "devantler",
+  author_name: "devantler",
+  author_email: "26203420+devantler@users.noreply.github.com",
+  committer_login: "github-actions[bot]",
+  committer_name: "github-actions[bot]",
+  committer_email: "41898282+github-actions[bot]@users.noreply.github.com",
+  message: "chore(deps): update agent skills"
+}]')"
+
+platform_skills_head="d668b9d0f52c22473abc75a7d7457505e3624cc6"
+platform_skills_files='[".agents/skills/gitops-cluster-debug/SKILL.md",".agents/skills/gitops-knowledge/SKILL.md"]'
+platform_skills_commits="$(jq -cn --arg head "${platform_skills_head}" '[{
+  sha: $head,
+  author_login: "github-merge-queue[bot]",
+  author_name: "github-merge-queue",
+  author_email: "118344674+github-merge-queue@users.noreply.github.com",
+  committer_login: "github-actions[bot]",
+  committer_name: "github-actions[bot]",
+  committer_email: "41898282+github-actions[bot]@users.noreply.github.com",
+  message: "chore(deps): update agent skills"
+}]')"
+
+ksail_skills_head="fdffbf83c8c0c1cc01050dc3d5c79ab18c3a45b4"
+ksail_skills_files='[".agents/skills/gh-stack/SKILL.md"]'
+ksail_skills_commits="$(jq -cn --arg head "${ksail_skills_head}" '[{
+  sha: $head,
+  author_login: "github-merge-queue[bot]",
+  author_name: "github-merge-queue",
+  author_email: "118344674+github-merge-queue@users.noreply.github.com",
+  committer_login: "github-actions[bot]",
+  committer_name: "github-actions[bot]",
+  committer_email: "41898282+github-actions[bot]@users.noreply.github.com",
+  message: "chore(deps): update agent skills"
+}]')"
+
 adapted_ksail_head="2222222222222222222222222222222222222222"
 adapted_ksail_commits="$(jq -c --arg head "${adapted_ksail_head}" '. + [{
   sha: $head,
@@ -410,6 +453,36 @@ expect_exempt \
   "${ksail_head}" \
   "${ksail_files}" \
   "${ksail_commits}"
+
+expect_exempt \
+  "agent-plugins programmed agent-skills update" \
+  "agent-plugins" \
+  "app/botantler-1" \
+  "deps/agent-skills-update" \
+  "chore(deps): update agent skills" \
+  "${agent_plugins_skills_head}" \
+  "${agent_plugins_skills_files}" \
+  "${agent_plugins_skills_commits}"
+
+expect_exempt \
+  "Platform programmed agent-skills update" \
+  "platform" \
+  "app/botantler-1" \
+  "deps/agent-skills-update" \
+  "chore(deps): update agent skills" \
+  "${platform_skills_head}" \
+  "${platform_skills_files}" \
+  "${platform_skills_commits}"
+
+expect_exempt \
+  "KSail programmed agent-skills update" \
+  "ksail" \
+  "app/ksail-bot" \
+  "deps/agent-skills-update" \
+  "chore(deps): update agent skills" \
+  "${ksail_skills_head}" \
+  "${ksail_skills_files}" \
+  "${ksail_skills_commits}"
 
 expect_exempt \
   "GoReleaser KSail cask" \
@@ -491,6 +564,37 @@ expect_review_gated \
   "${multi_cycle_cask_head}" \
   '["Casks/ksail.rb"]' \
   "${multi_cycle_cask_commits}"
+
+expect_review_gated \
+  "agent-skills updater lookalike from the wrong actor" \
+  "agent-plugins" \
+  "app/cursor" \
+  "deps/agent-skills-update" \
+  "chore(deps): update agent skills" \
+  "${agent_plugins_skills_head}" \
+  "${agent_plugins_skills_files}" \
+  "${agent_plugins_skills_commits}"
+
+expect_review_gated \
+  "agent-skills updater lookalike from the wrong branch" \
+  "agent-plugins" \
+  "app/botantler-1" \
+  "feature/agent-skills-update" \
+  "chore(deps): update agent skills" \
+  "${agent_plugins_skills_head}" \
+  "${agent_plugins_skills_files}" \
+  "${agent_plugins_skills_commits}"
+
+expect_review_gated \
+  "agent-skills updater carrying a non-generated file" \
+  "agent-plugins" \
+  "app/botantler-1" \
+  "deps/agent-skills-update" \
+  "chore(deps): update agent skills" \
+  "${agent_plugins_skills_head}" \
+  '["README.md","plugins/github/skills/gh-stack/SKILL.md"]' \
+  "${agent_plugins_skills_commits}"
+
 expect_not_release_exempt \
   "Platform Renovate KSail bump" \
   "platform" \

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-classifier="${repo_root}/.claude/scripts/release-bot-exemption.sh"
+classifier="${repo_root}/.claude/scripts/programmed-bot-review-exemption.sh"
 surveyor="${repo_root}/.claude/agents/portfolio-surveyor.md"
 constitution="${repo_root}/AGENTS.md"
 maintenance_skill="${repo_root}/.claude/skills/portfolio-maintenance/SKILL.md"
@@ -64,13 +64,21 @@ grep -Fq 'cve=<yes|PARTIAL:why|BROKEN:why>' "${platform_security_surveyor}" ||
 grep -Fq 'report `scanners_alive: cve=PARTIAL:<why>`' "${platform_security_surveyor}" ||
   fail "platform security surveyor does not route an incoherent CVE pair to the PARTIAL state"
 
-[[ -x "${classifier}" ]] || fail "release-bot exemption classifier is missing or not executable"
-grep -Fq '.claude/scripts/release-bot-exemption.sh' "${surveyor}" ||
+[[ -x "${classifier}" ]] || fail "programmed-bot exemption classifier is missing or not executable"
+grep -Fq '.claude/scripts/programmed-bot-review-exemption.sh' "${surveyor}" ||
   fail "surveyor does not delegate exemption decisions to the exact classifier"
 grep -Fq 'programmed agent-skills updater PRs' "${constitution}" ||
   fail "constitution does not exempt programmed agent-skills updater PRs from review"
+# Literal Markdown code spans; command substitution is intentionally disabled.
+# shellcheck disable=SC2016
+grep -Fq '`app/botantler-1` is narrowly trusted only for programmed agent-skills updater PRs' "${constitution}" ||
+  fail "constitution either misses botantler updater PRs or trusts the App globally"
 grep -Fq 'green_review=exempt-programmed-bot' "${surveyor}" ||
   fail "surveyor cannot report a programmed bot review exemption"
+# Literal Markdown code spans; command substitution is intentionally disabled.
+# shellcheck disable=SC2016
+grep -Fq '`botantler-1[bot]` is a candidate only for the programmed agent-skills updater classifier' "${surveyor}" ||
+  fail "surveyor either misses botantler updater PRs or trusts the App outside the programmed path"
 grep -Fq 'ksail-bot[bot]' "${surveyor}" ||
   fail "surveyor does not recognize the exact KSail App identity returned by search"
 grep -Fq '/pulls/<n>/commits' "${surveyor}" ||
@@ -175,6 +183,8 @@ grep -Fq 'count it against' "${surveyor}" ||
   fail "surveyor may still turn dependency automation into operate work"
 grep -Fq 'automation-owned dependency PRs' "${maintenance_skill}" ||
   fail "portfolio-maintenance skill does not defer dependency PRs to automation"
+grep -Fq 'agent-skills updater PRs' "${maintenance_skill}" ||
+  fail "portfolio-maintenance skill still review-gates programmed agent-skills updater PRs"
 grep -Fq 'Compatibility overlay' "${maintenance_skill}" ||
   fail "plugin surveyor can run without the hardened local behavior before digest parity"
 grep -Fq 'read and follow the local' "${maintenance_skill}" ||
@@ -188,6 +198,8 @@ grep -Fq 'automation-owned dependency PRs' "${product_engineering_skill}" ||
   fail "product-engineering skill still treats dependency PRs as agent work"
 grep -Fq 'automation-owned dependency PRs' "${agent_skills_card}" ||
   fail "agent-skills product card still treats dependency PRs as agent work"
+grep -Fq 'never spend a review lane on them' "${agent_skills_card}" ||
+  fail "agent-skills product card still requires review for programmed updater PRs"
 grep -Fq 'automation-owned dependency PRs' "${ksail_card}" ||
   fail "KSail product card still treats dependency PRs as agent work"
 if grep -Fq 'Bot PRs are first-priority work, not background noise' "${constitution}"; then
@@ -420,6 +432,18 @@ ksail_skills_commits="$(jq -cn --arg head "${ksail_skills_head}" '[{
   message: "chore(deps): update agent skills"
 }]')"
 
+adapted_agent_skills_head="5555555555555555555555555555555555555555"
+adapted_agent_skills_commits="$(jq -c --arg head "${adapted_agent_skills_head}" '. + [{
+  sha: $head,
+  author_login: "devantler",
+  author_name: "Nikolai Emil Damm",
+  author_email: "26203420+devantler@users.noreply.github.com",
+  committer_login: "devantler",
+  committer_name: "Nikolai Emil Damm",
+  committer_email: "26203420+devantler@users.noreply.github.com",
+  message: "fix: adapt generated skill update"
+}]' <<<"${agent_plugins_skills_commits}")"
+
 adapted_ksail_head="2222222222222222222222222222222222222222"
 adapted_ksail_commits="$(jq -c --arg head "${adapted_ksail_head}" '. + [{
   sha: $head,
@@ -593,6 +617,26 @@ expect_review_gated \
   "chore(deps): update agent skills" \
   "${agent_plugins_skills_head}" \
   '["README.md","plugins/github/skills/gh-stack/SKILL.md"]' \
+  "${agent_plugins_skills_commits}"
+
+expect_review_gated \
+  "agent-skills updater carrying a human adaptation commit" \
+  "agent-plugins" \
+  "app/botantler-1" \
+  "deps/agent-skills-update" \
+  "chore(deps): update agent skills" \
+  "${adapted_agent_skills_head}" \
+  "${agent_plugins_skills_files}" \
+  "${adapted_agent_skills_commits}"
+
+expect_review_gated \
+  "agent-skills updater shape in an unapproved repository" \
+  "agent-skills" \
+  "app/botantler-1" \
+  "deps/agent-skills-update" \
+  "chore(deps): update agent skills" \
+  "${agent_plugins_skills_head}" \
+  "${agent_plugins_skills_files}" \
   "${agent_plugins_skills_commits}"
 
 expect_not_release_exempt \

--- a/.claude/scripts/programmed-bot-review-exemption.sh
+++ b/.claude/scripts/programmed-bot-review-exemption.sh
@@ -83,7 +83,7 @@ matches_agent_skills_provenance() {
       .author_login == "github-merge-queue[bot]" and
       .author_name == "github-merge-queue" and
       .author_email == "118344674+github-merge-queue@users.noreply.github.com";
-    length > 0 and
+    length == 1 and
     all(.[];
       (app_authored or merge_queue_authored) and
       .committer_login == "github-actions[bot]" and

--- a/.claude/scripts/programmed-bot-review-exemption.sh
+++ b/.claude/scripts/programmed-bot-review-exemption.sh
@@ -50,6 +50,49 @@ matches_exact_files() {
     <<<"${files_json}" >/dev/null
 }
 
+# The shared update-agent-skills workflow creates one recurring PR shape in each current consumer.
+# Bind the exemption to generated skill roots and workflow commit provenance; branch/title alone are
+# only candidate signals and never sufficient to skip review.
+matches_agent_skills_files() {
+  local path_pattern
+
+  case "${repo}" in
+  agent-plugins)
+    path_pattern='^plugins/[^/]+/skills/[^/]+/.+'
+    ;;
+  ksail | platform)
+    path_pattern='^\.agents/skills/[^/]+/.+'
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+
+  jq -e --arg pattern "${path_pattern}" \
+    'length > 0 and all(.[]; test($pattern))' \
+    <<<"${files_json}" >/dev/null
+}
+
+matches_agent_skills_provenance() {
+  jq -e '
+    def app_authored:
+      .author_login == "devantler" and
+      .author_name == "devantler" and
+      .author_email == "26203420+devantler@users.noreply.github.com";
+    def merge_queue_authored:
+      .author_login == "github-merge-queue[bot]" and
+      .author_name == "github-merge-queue" and
+      .author_email == "118344674+github-merge-queue@users.noreply.github.com";
+    length > 0 and
+    all(.[];
+      (app_authored or merge_queue_authored) and
+      .committer_login == "github-actions[bot]" and
+      .committer_name == "github-actions[bot]" and
+      .committer_email == "41898282+github-actions[bot]@users.noreply.github.com" and
+      .message == "chore(deps): update agent skills")
+  ' <<<"${commits_json}" >/dev/null
+}
+
 is_semver() {
   [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]
 }
@@ -142,6 +185,26 @@ matches_war_cask_provenance() {
       message: "chore(cask): update world-at-ruin to \($version)"
     }]' <<<"${commits_json}" >/dev/null
 }
+
+if [[ "${branch}" == "deps/agent-skills-update" &&
+  "${title}" == "chore(deps): update agent skills" ]]; then
+  expected_author=""
+  case "${repo}" in
+  agent-plugins | platform)
+    expected_author="app/botantler-1"
+    ;;
+  ksail)
+    expected_author="app/ksail-bot"
+    ;;
+  esac
+
+  if [[ -n "${expected_author}" &&
+    "${author}" == "${expected_author}" ]] &&
+    matches_agent_skills_files &&
+    matches_agent_skills_provenance; then
+    exit 0
+  fi
+fi
 
 if [[ "${repo}" == "ksail" &&
   "${author}" == "app/ksail-bot" &&

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -388,7 +388,7 @@ slice. Record the product's `last_value_review` cursor, not live metrics, in nat
    with inline comments** (`event: COMMENT`, disclosure line, `## Self-review (fallback` heading,
    verdict line) so the sibling agent can see and act on it, incremental re-reviews,
    green-while-draft as the promotion precondition, the **automation-owned dependency-PR no-action carve-out**, and the trusted programmed
-   **release-bot carve-out** — tap cask PRs and KSail
+   **bot carve-out** — exact-classifier-matched agent-skills updater PRs, tap cask PRs, and KSail
    release bumps are check-gated, need NO review, and are never review-chased) is the contract's
    **green-review gate** (AGENTS.md *Autonomy → AUTO-REVIEW IS
    DISABLED*) — follow it, don't re-derive it here. When a draft reaches the full pentad AND you have

--- a/.claude/skills/products/agent-skills/SKILL.md
+++ b/.claude/skills/products/agent-skills/SKILL.md
@@ -25,6 +25,8 @@ put product-specific logic here.
 §7): when a generic skill/convention has emerged across 2+ products, extract it here so every product
 inherits it, then migrate consumers. Triage/label issues, drive actionable trusted-author PRs to merge,
 leave automation-owned dependency PRs alone, and keep dependency automation & docs current.
+Programmed `chore(deps): update agent skills` PRs are the no-review exception defined in the root
+contract: let required CI and auto-merge decide them, and never spend a review lane on them.
 
 Shared cross-repo rules are in the monorepo [`AGENTS.md`](../../../../AGENTS.md). This card is a pointer
 by design.

--- a/.claude/skills/products/agent-skills/SKILL.md
+++ b/.claude/skills/products/agent-skills/SKILL.md
@@ -26,7 +26,9 @@ put product-specific logic here.
 inherits it, then migrate consumers. Triage/label issues, drive actionable trusted-author PRs to merge,
 leave automation-owned dependency PRs alone, and keep dependency automation & docs current.
 Programmed `chore(deps): update agent skills` PRs are the no-review exception defined in the root
-contract: let required CI and auto-merge decide them, and never spend a review lane on them.
+contract only when `.claude/scripts/programmed-bot-review-exemption.sh` classification succeeds:
+let required CI and auto-merge decide accepted exemptions, and never spend a review lane on them.
+Route classifier failures, non-matching PRs, and lookalikes through the normal review process.
 
 Shared cross-repo rules are in the monorepo [`AGENTS.md`](../../../../AGENTS.md). This card is a pointer
 by design.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
               - '.claude/skills/products/monorepo/SKILL.md'
               - '.claude/skills/products/platform/SKILL.md'
               - '.claude/scripts/portfolio-surveyor.test.sh'
-              - '.claude/scripts/release-bot-exemption.sh'
+              - '.claude/scripts/programmed-bot-review-exemption.sh'
               - '.github/workflows/ci.yaml'
             product-value:
               - 'AGENTS.md'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -707,22 +707,25 @@ fire. The survey may report one compact `AUTOMATION-OWNED (NO-ACTION)` line from
 identity, but does not deepen its pentad or count it against `nothing_on_fire`. If a merged dependency
 bump breaks `main`, repair that resulting `main` breakage normally on an agent-owned branch; never
 touch the bot PR branch. This actor-wide no-action rule is stronger than the trusted-author permissions
-below and is separate from the narrower programmed release-bot review exemption.
+below and is separate from the narrower programmed-bot review exemption.
 
-**Carve-out — trusted programmed release-bot PRs need NO review** (maintainer direction 2026-07-13,
-ksail#6095): PRs produced by the suite's own programmed release paths — **every product's**
-Homebrew-tap cask PR (GoReleaser's for ksail, and World at Ruin's CD-generated
-`chore(cask): update world-at-ruin to vX.Y.Z` PRs on the evergreen `goreleaser/world-at-ruin`
-branch — maintainer direction 2026-07-18: these were wrongly review-gated because only GoReleaser's
-were named here, wasting a review lane per release) and KSail release version bumps — are gated by
-their required checks and auto-merge on their own; do **not** request a review from any lane (CodeRabbit, Codex, Cursor Bugbot) or
-chase ancillary reviewer output on them, and never count their `green_review=none` as a hygiene gap
-(their checks/threads/conflicts hygiene still counts). The
-identifying mark of this class is the **programmed path** (a `goreleaser/*` head branch on the tap,
-machine-generated content), never the commit identity — cask PRs are authored by the tap token as
-`devantler` and are still programmed-path PRs. The green-review gate governs
-**own/human-authored** PRs (and any bot PR that leaves its programmed path, e.g. one you push
-adaptation commits to — your commit makes it review-bearing again).
+**Carve-out — trusted programmed bot PRs need NO review.** Two suite-owned paths are intentionally
+gated by required CI and auto-merge rather than an AI review:
+- **Programmed agent-skills updater PRs** (maintainer direction 2026-07-23): the shared
+  `update-agent-skills` workflow's exact `deps/agent-skills-update` branch and
+  `chore(deps): update agent skills` title in `agent-plugins`, `platform`, and `ksail`, authored by
+  those repositories' exact updater App and changing only their generated installed-skill roots.
+- **Programmed release PRs** (maintainer direction 2026-07-13, ksail#6095; widened 2026-07-18):
+  every product's Homebrew-tap cask PR, including World at Ruin's CD-generated
+  `chore(cask): update world-at-ruin to vX.Y.Z` PRs on `goreleaser/world-at-ruin`, plus KSail release
+  version bumps.
+
+Apply either exemption only when `.claude/scripts/programmed-bot-review-exemption.sh` validates the
+exact repository, PR actor, branch, title, current-head commit provenance, and changed-file boundary.
+Never infer it from the title alone. Qualifying PRs run through required CI and auto-merge; do **not**
+request CodeRabbit, Codex, Cursor Bugbot, or a local review, chase ancillary reviewer output, or count
+a missing review as a hygiene gap. Their checks, threads, and conflict state still gate auto-merge.
+Any adaptation commit or out-of-bound file revokes the exemption and restores the normal review gate.
 **AUTO-REVIEW IS DISABLED — requesting reviews is the agent's job** (maintainer direction
 2026-07-12: he disabled automatic review on BOTH Copilot code review and CodeRabbit; no reviewer
 fires on its own on any event, including opening or promoting a PR). That makes the green-review
@@ -963,8 +966,8 @@ Conventional-Commit title, then **merge with the command that matches the author
 - an actionable **single-author App** (`github-actions`/`ksail-bot`/`app/cursor`) uses pre-CLEAN
   auto-merge only after the review/current-head parts of that pentad are clear.
   For `app/cursor`, the acting local sibling performs this mutation because the cloud App cannot:
-  `gh pr merge <n> --auto --squash`; for **trusted programmed release-bot PRs** (tap cask PRs, KSail
-  release bumps — the carve-out above) the review parts are intentionally absent and
+  `gh pr merge <n> --auto --squash`; for **trusted programmed bot PRs** (agent-skills updater PRs,
+  tap cask PRs, and KSail release bumps — the carve-out above) the review parts are intentionally absent and
   are NOT required — their required checks, zero threads, and no-conflict state alone gate the
   auto-merge;
 - a **human-trusted author** (`devantler`, i.e. **every machine-local agent-own PR**) **cannot use `--auto`**
@@ -1557,6 +1560,11 @@ automation-owned and the no-action carve-out overrides those permissions. Outsid
 until the current conversation explicitly
 clears the boundary for the named repository; then apply the author trust rules to the authorised task.
 Untrusted (external) authors stay untrusted everywhere.
+**`app/botantler-1` is narrowly trusted only for programmed agent-skills updater PRs.** The App is
+not added to the general trusted-author set. Its PR may be built and auto-merged only when the exact
+programmed-bot classifier named above exits 0; any other `app/botantler-1` PR remains external and
+static-review-only. This path-specific grant covers the updater without trusting every PR the App
+could author.
 **GitHub Copilot — two roles, treated differently:** the maintainer uses Claude Code exclusively, so the
 Copilot **coding agent** (`Copilot`, `copilot-swe-agent[bot]`) is **NOT** trusted — treat its PRs as
 external (never auto-drive, never merge, never run its branch code). Only `copilot-pull-request-reviewer[bot]`


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why
Programmed agent-skills updates were consuming review capacity even though their intended gate is CI plus auto-merge.

## What
Treat only the exact generated updater path as review-exempt. Lookalikes, unexpected files, and human adaptations still require the normal review gate.