### PR TITLE
fix(scripts): compare worktree paths by identity, not spelling

### DIFF
--- a/.claude/scripts/submodule-init.sh
+++ b/.claude/scripts/submodule-init.sh
@@ -28,13 +28,6 @@ die() {
 
 warn() { printf 'submodule-init: %s\n' "$1" >&2; }
 
-# NEVER compute a submodule's gitdir — ask git. Run from a linked superproject worktree (the documented
-# execution model for agent runs), git puts each submodule's gitdir under
-# `.git/worktrees/<super-wt>/modules/<path>`, NOT under `.git/modules/<path>` — and that is where the
-# stray `core.worktree` lands too. Any assumed path is wrong exactly where this script matters most.
-super_root=$(git rev-parse --show-toplevel) || die 'not inside a git repository'
-cd "$super_root"
-
 # The gitdir git is ACTUALLY using for this submodule.
 module_dir() { git -C "$1" rev-parse --path-format=absolute --git-common-dir 2>/dev/null; }
 
@@ -44,12 +37,27 @@ module_dir() { git -C "$1" rev-parse --path-format=absolute --git-common-dir 2>/
 module_tree() { (cd "$1" 2>/dev/null && pwd -P); }
 
 # Do two paths name the SAME directory? Compare filesystem IDENTITY (device+inode, via `-ef`), never
-# the spelling. `pwd -P` resolves symlinks but NOT case, so on a case-insensitive volume — APFS, the
-# default on the macOS agent host — one directory reached as `.Codex/…` and reported back by git as
-# `.codex/…` string-compares unequal while being the same inode. That produced a false ISOLATION
-# BROKEN on a correctly-isolated submodule, which is worse than merely noisy: it blocks edits to a
-# safe tree AND trains the reader to discount the warning that flags a real collision.
-# Fails closed — an empty or non-existent path is never "the same directory".
+# the spelling.
+#
+# Two independent reasons the spellings legitimately differ, and BOTH are load-bearing:
+#
+# 1. CASE, and this is shell-specific — measured, because the wrong shell hides it. Under **bash**
+#    (this script's shebang, 3.2.57 on the host) `pwd -P` resolves symlinks but does NOT fold case:
+#    `cd alpha/beta && pwd -P` prints the typed `alpha/beta`. Under **zsh** the same command prints
+#    the on-disk `Alpha/Beta`. So on a case-insensitive volume (APFS, the host default) a worktree
+#    recorded as `.Codex/…` stays `.Codex/…` here while git reports `.codex/…` — one inode, two
+#    strings, and the old `[ "$got" != "$want" ]` fired. Traced live on `libraries/agent-plugins`:
+#      got  = …/.codex/worktrees/agent-plugins-claude-desktop-83   (git, lowercase)
+#      want = …/.Codex/worktrees/agent-plugins-claude-desktop-83   (bash pwd -P, case preserved)
+#    Reproducing this in zsh shows both sides folded and NO mismatch — verify in bash, not the
+#    interactive shell.
+# 2. An unreadable worktree makes BOTH sides empty (`-d` passes, `cd` and `git -C` both fail), and
+#    `[ "" = "" ]` is TRUE — so without the emptiness guard below this returns "same directory" and
+#    `--check` reports an unverifiable worktree as isolated. That fail-open predates this helper.
+#
+# A false positive here is a safety regression, not just noise: it blocks edits to a safe tree AND
+# trains the reader to discount the warning that flags a real collision. So fail CLOSED — an empty or
+# non-existent path is never "the same directory".
 same_dir() {
   [ -n "${1:-}" ] && [ -n "${2:-}" ] || return 1
   [ "$1" = "$2" ] && return 0
@@ -230,11 +238,25 @@ init_repair_probe() {
 }
 
 # Stop here when SOURCED, so the self-test can exercise the path-comparison helpers directly. The
-# case-only false positive `same_dir` fixes is only reachable on a case-insensitive volume, so an
-# end-to-end reproduction cannot run on the case-sensitive filesystem CI uses — unit-testing the
-# comparison itself is what gives that fix coverage on every platform. `return` outside a function
-# succeeds only in a sourced context, which is what makes this the standard sourced-vs-executed guard.
+# case-only false positive `same_dir` fixes needs a case-insensitive volume, so an end-to-end
+# reproduction cannot run on the filesystem CI uses — unit-testing the comparison itself is what
+# gives the fix coverage on every platform.
+#
+# This sits ABOVE every top-level side effect below deliberately: sourcing must not `cd` the caller,
+# turn on `errexit`/`pipefail` in the caller's shell, or — from a non-git directory — `die` and take
+# the caller's shell down with it. Definitions above are all this needs to export.
+#
+# In bash, `(return 0 2>/dev/null)` succeeds only when the file is being sourced (the subshell is what
+# makes it work); executed, `return` outside a function fails. This idiom is bash-specific — fine
+# here, since the shebang pins bash and CI runs the tests under bash.
 (return 0 2>/dev/null) && return 0
+
+# NEVER compute a submodule's gitdir — ask git. Run from a linked superproject worktree (the documented
+# execution model for agent runs), git puts each submodule's gitdir under
+# `.git/worktrees/<super-wt>/modules/<path>`, NOT under `.git/modules/<path>` — and that is where the
+# stray `core.worktree` lands too. Any assumed path is wrong exactly where this script matters most.
+super_root=$(git rev-parse --show-toplevel) || die 'not inside a git repository'
+cd "$super_root"
 
 [ $# -gt 0 ] || die 'usage: submodule-init.sh <submodule-path>... | --all | --check'
 

--- a/.claude/scripts/submodule-init.sh
+++ b/.claude/scripts/submodule-init.sh
@@ -43,6 +43,19 @@ module_dir() { git -C "$1" rev-parse --path-format=absolute --git-common-dir 2>/
 # the checkout the stray value points at — and repair would then pin the collision back in.
 module_tree() { (cd "$1" 2>/dev/null && pwd -P); }
 
+# Do two paths name the SAME directory? Compare filesystem IDENTITY (device+inode, via `-ef`), never
+# the spelling. `pwd -P` resolves symlinks but NOT case, so on a case-insensitive volume — APFS, the
+# default on the macOS agent host — one directory reached as `.Codex/…` and reported back by git as
+# `.codex/…` string-compares unequal while being the same inode. That produced a false ISOLATION
+# BROKEN on a correctly-isolated submodule, which is worse than merely noisy: it blocks edits to a
+# safe tree AND trains the reader to discount the warning that flags a real collision.
+# Fails closed — an empty or non-existent path is never "the same directory".
+same_dir() {
+  [ -n "${1:-}" ] && [ -n "${2:-}" ] || return 1
+  [ "$1" = "$2" ] && return 0
+  [ -e "$1" ] && [ -e "$2" ] && [ "$1" -ef "$2" ]
+}
+
 # An UNINITIALISED submodule is an empty directory. Distinguish that (legitimately skip) from a
 # populated one (must be checked) — see `probe`, where conflating the two was a fail-open.
 is_populated() {
@@ -59,7 +72,7 @@ resolves_to_itself() {
   abs=$(module_tree "$path") || return 1
   top=$(git -C "$path" rev-parse --show-toplevel 2>/dev/null) || return 1
   top=$(cd "$top" 2>/dev/null && pwd -P) || return 1
-  [ "$top" = "$abs" ]
+  same_dir "$top" "$abs"
 }
 
 # Verify every EXISTING linked worktree of this submodule resolves to its OWN physical path. The main
@@ -87,7 +100,7 @@ check_existing_worktrees() {
     got=$(git -C "$wt" rev-parse --show-toplevel 2>/dev/null) || got=''
     [ -n "$got" ] && got=$(cd "$got" 2>/dev/null && pwd -P)
     want=$(cd "$wt" && pwd -P)
-    if [ "$got" != "$want" ]; then
+    if ! same_dir "$got" "$want"; then
       warn "$path — ISOLATION BROKEN: existing linked worktree '$wt' resolves to '${got:-<unresolvable>}', not its own path. A parallel session there is colliding — do not edit it."
       rc=1
     fi
@@ -158,7 +171,7 @@ probe() {
   if [ -z "$got" ]; then
     warn "$path — ISOLATION BROKEN: git cannot resolve a worktree created there (dangling core.worktree). Do not edit it."
     rc=1
-  elif [ "$got" != "$want" ]; then
+  elif ! same_dir "$got" "$want"; then
     warn "$path — ISOLATION BROKEN: a worktree there resolves to '$got', not its own path ('$want'). Do not edit it — parallel sessions would collide."
     rc=1
   fi
@@ -215,6 +228,13 @@ init_repair_probe() {
   fi
   probe "$path" || die "repair did not restore isolation for '$path' — do not edit it"
 }
+
+# Stop here when SOURCED, so the self-test can exercise the path-comparison helpers directly. The
+# case-only false positive `same_dir` fixes is only reachable on a case-insensitive volume, so an
+# end-to-end reproduction cannot run on the case-sensitive filesystem CI uses — unit-testing the
+# comparison itself is what gives that fix coverage on every platform. `return` outside a function
+# succeeds only in a sourced context, which is what makes this the standard sourced-vs-executed guard.
+(return 0 2>/dev/null) && return 0
 
 [ $# -gt 0 ] || die 'usage: submodule-init.sh <submodule-path>... | --all | --check'
 

--- a/.claude/scripts/submodule-init.test.sh
+++ b/.claude/scripts/submodule-init.test.sh
@@ -142,6 +142,58 @@ report "linked worktree: submodule gitdir lives under the worktree admin dir" \
 out="$(cd "$c5/super-wt" && "$helper" --check 2>&1)" && rc=0 || rc=$?
 report "linked worktree: --check passes" "$([[ $rc -eq 0 ]] && echo yes || echo no)" "$out"
 
+# 6. Path comparison is by filesystem IDENTITY, not by spelling (#2457). The live defect was a
+#    worktree recorded as `.Codex/…` and reported by git as `.codex/…` — one inode on a
+#    case-insensitive volume, string-compared unequal, reported as ISOLATION BROKEN on a tree that
+#    was fine. Case-folding is only reachable on a case-insensitive filesystem, so the portable proof
+#    uses a SYMLINK alias: two spellings, one inode. Under the old `[ "$got" != "$want" ]` the alias
+#    case fails; the negative controls below are what keep the fix from being a blanket "equal".
+c6="$tmp/c6"
+mk_super "$c6"
+# shellcheck source=/dev/null
+( cd "$c6/super" && . "$helper" ) 2>/dev/null || report "sourcing the helper for unit tests" "no" "could not source"
+
+real="$tmp/c6-real"
+mkdir -p "$real"
+alias_link="$tmp/c6-alias"
+ln -s "$real" "$alias_link"
+other="$tmp/c6-other"
+mkdir -p "$other"
+
+# Run each assertion in a subshell that sources the helper, so `same_dir` is the real implementation.
+same_dir_rc() (
+  cd "$c6/super" || exit 2
+  # shellcheck source=/dev/null
+  . "$helper" >/dev/null 2>&1
+  same_dir "$1" "$2"
+)
+
+same_dir_rc "$real" "$alias_link" && ok=yes || ok=no
+report "same_dir: two spellings of ONE directory compare equal (symlink alias)" "$ok" \
+  "real=$real alias=$alias_link"
+
+same_dir_rc "$real" "$other" && ok=no || ok=yes
+report "same_dir: genuinely different directories compare UNEQUAL (negative control)" "$ok" \
+  "real=$real other=$other"
+
+same_dir_rc "" "$real" && ok=no || ok=yes
+report "same_dir: fails closed on an empty path" "$ok"
+
+same_dir_rc "$real" "$tmp/c6-does-not-exist" && ok=no || ok=yes
+report "same_dir: fails closed on a non-existent path" "$ok"
+
+# The case variant that actually bit, end-to-end — only meaningful where the filesystem folds case,
+# so probe for that rather than assuming the platform.
+case_dir="$tmp/c6-CaseProbe"
+mkdir -p "$case_dir"
+if [[ -d "$tmp/c6-caseprobe" ]]; then
+  same_dir_rc "$case_dir" "$tmp/c6-caseprobe" && ok=yes || ok=no
+  report "same_dir: case-only difference compares equal on a case-insensitive filesystem" "$ok" \
+    "$case_dir vs $tmp/c6-caseprobe"
+else
+  echo "SKIP: case-only comparison — filesystem is case-sensitive (covered by the symlink case above)"
+fi
+
 if [[ $fail -ne 0 ]]; then
   echo "submodule-init self-test: FAILURES above" >&2
   exit 1

--- a/.claude/scripts/submodule-init.test.sh
+++ b/.claude/scripts/submodule-init.test.sh
@@ -148,11 +148,6 @@ report "linked worktree: --check passes" "$([[ $rc -eq 0 ]] && echo yes || echo 
 #    was fine. Case-folding is only reachable on a case-insensitive filesystem, so the portable proof
 #    uses a SYMLINK alias: two spellings, one inode. Under the old `[ "$got" != "$want" ]` the alias
 #    case fails; the negative controls below are what keep the fix from being a blanket "equal".
-c6="$tmp/c6"
-mk_super "$c6"
-# shellcheck source=/dev/null
-( cd "$c6/super" && . "$helper" ) 2>/dev/null || report "sourcing the helper for unit tests" "no" "could not source"
-
 real="$tmp/c6-real"
 mkdir -p "$real"
 alias_link="$tmp/c6-alias"
@@ -160,13 +155,20 @@ ln -s "$real" "$alias_link"
 other="$tmp/c6-other"
 mkdir -p "$other"
 
-# Run each assertion in a subshell that sources the helper, so `same_dir` is the real implementation.
+# Sourcing must be side-effect-free (the guard sits above every top-level side effect), so it needs no
+# fixture repo and must not move or kill the caller's shell.
 same_dir_rc() (
-  cd "$c6/super" || exit 2
   # shellcheck source=/dev/null
   . "$helper" >/dev/null 2>&1
   same_dir "$1" "$2"
 )
+
+# PRECONDITION, not a nicety: `same_dir_rc` runs in a subshell, so if sourcing failed to define
+# `same_dir` at all, command-not-found exits non-zero and every "compare UNEQUAL" assertion below
+# would report PASS against nothing. Pin that the helper is really there first.
+# shellcheck source=/dev/null
+( . "$helper" >/dev/null 2>&1 && declare -f same_dir >/dev/null ) && ok=yes || ok=no
+report "same_dir: helper is defined when the script is sourced (guards the controls below)" "$ok"
 
 same_dir_rc "$real" "$alias_link" && ok=yes || ok=no
 report "same_dir: two spellings of ONE directory compare equal (symlink alias)" "$ok" \
@@ -177,7 +179,14 @@ report "same_dir: genuinely different directories compare UNEQUAL (negative cont
   "real=$real other=$other"
 
 same_dir_rc "" "$real" && ok=no || ok=yes
-report "same_dir: fails closed on an empty path" "$ok"
+report "same_dir: fails closed on one empty path" "$ok"
+
+# THE fail-open the emptiness guard exists for, and the only line in the diff that changes a reachable
+# outcome: `[ "" = "" ]` is TRUE, so without the guard two empty paths compare as "the same directory"
+# and an unverifiable worktree is reported isolated. The one-empty case above passes either way
+# (`[ -e "" ]` catches it), so it does NOT cover this.
+same_dir_rc "" "" && ok=no || ok=yes
+report "same_dir: fails closed when BOTH paths are empty (the pre-existing fail-open)" "$ok"
 
 same_dir_rc "$real" "$tmp/c6-does-not-exist" && ok=no || ok=yes
 report "same_dir: fails closed on a non-existent path" "$ok"
@@ -193,6 +202,13 @@ if [[ -d "$tmp/c6-caseprobe" ]]; then
 else
   echo "SKIP: case-only comparison — filesystem is case-sensitive (covered by the symlink case above)"
 fi
+
+# NOTE — the emptiness guard above is deliberately covered at the HELPER level only. Driving it through
+# `--check` end-to-end does not work today, and not because the guard is wrong: `probe` runs
+# `git worktree prune` before `check_existing_worktrees`, so an unverifiable worktree's admin entry is
+# deleted before the sweep meant to flag it, and `--check` reports the submodule isolated. That is a
+# separate fail-open tracked in monorepo#2460 — asserting the end-to-end behaviour here would pin the
+# bug rather than the fix.
 
 if [[ $fail -ne 0 ]]; then
   echo "submodule-init self-test: FAILURES above" >&2


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The pre-flight isolation check every agent run depends on was raising a false alarm: it declared one
submodule unsafe to edit when it was perfectly fine. That blocked legitimate work for a phantom
reason — and worse, a warning that fires routinely teaches the reader to ignore the one that flags a
genuine collision, which is the failure this check exists to catch.

## What

The check now decides whether two paths are the same directory by asking the filesystem instead of
comparing the text, so two spellings of one directory no longer read as a conflict. A real collision
is still reported exactly as before, and the guard covering that case is unchanged.

Fixes #2457
