### PR TITLE
feat(agents): order work by a single ladder — open PRs, drafts included, before new work

### DIFF
--- a/.claude/scripts/work-priority-ladder.test.sh
+++ b/.claude/scripts/work-priority-ladder.test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Guards the work-selection ladder (maintainer direction 2026-07-25): a run picks work top-down —
+# live breakage, then EVERY open PR it owns or trusts INCLUDING ITS OWN DRAFTS, then security
+# issues, then bugs, then the oldest actionable issue.
+#
+# Why this needs enforcing rather than merely stating: the contract already said "PRs before issues"
+# and already said "stop starting, start finishing", and the pile still happened. The mechanism was a
+# SCOPING hole, not a missing rule — priority-1 was defined over `non-draft` PRs in Merge policy, so
+# an own draft matched no rung and was reachable only through a paragraph 1,800 lines away that read
+# as a precondition on opening new drafts. Measured 2026-07-25: 99 open own PRs, 100% drafts, none
+# ever promoted, median age 6.9 days, 18 already CLEAN and idle a median 5.3 days, 16 conflicted,
+# 49 of 88 untouched in the 24h after opening.
+#
+# So this guards the two properties that actually close that hole, plus the drift that reopened it:
+#   1. the ladder exists, is ordered, and names all five rungs;
+#   2. rung 1 explicitly covers OWN DRAFTS, and Merge policy's `non-draft` is explicitly scoped to
+#      the merge command rather than the sweep — the exact misreading that produced the pile;
+#   3. severity outranks age, so a Security issue is not queued behind an older Docs one;
+#   4. the run-loop skill agrees with the contract — three surfaces restate this ordering, and a
+#      silent divergence between them is how the previous wording drifted.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+constitution="${repo_root}/AGENTS.md"
+maintenance_skill="${repo_root}/.claude/skills/portfolio-maintenance/SKILL.md"
+workflow="${repo_root}/.github/workflows/ci.yaml"
+
+fail() {
+  echo "work-priority ladder: FAIL — $*" >&2
+  exit 1
+}
+
+# Markdown prose is hard-wrapped, so a guarded sentence routinely spans two lines and exists on NO
+# single line. Flatten once and match substrings against the flattened copy; keep `grep -Fq` only
+# for things that genuinely live on one line (a heading, a table row, an identifier).
+constitution_flat="$(tr '\n' ' ' < "${constitution}" | tr -s '[:space:]' ' ')"
+skill_flat="$(tr '\n' ' ' < "${maintenance_skill}" | tr -s '[:space:]' ' ')"
+
+assert_prose() {
+  case "$2" in
+    *"$1"*) ;;
+    *) fail "$3" ;;
+  esac
+}
+
+# ── 1. the ladder exists and is ordered ──────────────────────────────────────
+grep -Fq '### The work-selection ladder — one ordering, checked top-down every run' "${constitution}" ||
+  fail "contract does not define the work-selection ladder"
+assert_prose 'you do not descend while a higher rung still has actionable work' \
+  "${constitution_flat}" "ladder does not state that rungs are strictly ordered"
+
+for rung in \
+  '| **0** | **Live breakage** |' \
+  '| **1** | **Open PRs — INCLUDING your own drafts** |' \
+  '| **2** | **Security issues** |' \
+  '| **3** | **Bugs** |' \
+  '| **4** | **Oldest actionable issue** |'; do
+  grep -Fq "${rung}" "${constitution}" ||
+    fail "ladder is missing rung row ${rung}"
+done
+
+# ── 2. rung 1 covers own drafts, and `non-draft` is scoped to the merge command ──
+assert_prose 'Rung 1 includes your own DRAFTS' \
+  "${constitution_flat}" "ladder does not put own drafts in rung 1 — the exact hole that produced the pile"
+assert_prose 'draft and non-draft alike' \
+  "${constitution_flat}" "rung 1 does not state it covers drafts and non-drafts alike"
+assert_prose 'scoping below bounds the merge COMMAND, never the SWEEP' \
+  "${constitution_flat}" "Merge policy does not scope its non-draft clause to the merge command"
+
+# ── 3. severity outranks age ──────────────────────────────────────────────────
+assert_prose 'Severity outranks age at rungs 2–3; age decides only *within* a rung' \
+  "${constitution_flat}" "contract does not state that severity outranks age"
+
+# ── 4. the run-loop skill agrees with the contract ────────────────────────────
+assert_prose 'Your own DRAFTS are rung-1 work' \
+  "${skill_flat}" "run-loop skill does not carry the own-drafts rung-1 rule"
+assert_prose 'severity is the primary sort, age the tiebreaker within a tier' \
+  "${skill_flat}" "run-loop skill still sorts the issue queue by age alone"
+assert_prose 'Resolve the next issue by the ladder' \
+  "${skill_flat}" "run-loop skill's advance step does not follow the ladder"
+
+# ── CI wiring ─────────────────────────────────────────────────────────────────
+# GitHub expression tokens are literal workflow syntax, not shell expansions.
+# shellcheck disable=SC2016
+grep -Fq 'work-priority-ladder: ${{ steps.filter.outputs.work-priority-ladder }}' "${workflow}" ||
+  fail "CI does not export the work-priority ladder filter"
+grep -Fq 'test-work-priority-ladder:' "${workflow}" ||
+  fail "CI does not define the work-priority ladder job"
+grep -Fq 'run: bash .claude/scripts/work-priority-ladder.test.sh' "${workflow}" ||
+  fail "CI does not execute the work-priority ladder test"
+# shellcheck disable=SC2016
+grep -Fq '${{ needs.test-work-priority-ladder.result }}' "${workflow}" ||
+  fail "required checks do not aggregate the work-priority ladder"
+
+echo "work-priority ladder: all assertions passed"

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -317,7 +317,8 @@ their failing CI — is the **first-priority work every run, ahead of issues** (
 outranks it). Exact Renovate/Dependabot PRs are automation-owned dependency PRs, not actionable PRs.
 Scope: every **`devantler-tech`** repo's actionable trusted-author PRs; scheduled runs do not enumerate or act on
 external repositories. Then work is **issue-driven** (contract *Issue-driven*): **GitHub Issues
-are the work queue**, you resolve the **oldest actionable** one first, and new non-trivial finds are
+are the work queue**, worked in the order contract *The work-selection ladder* sets — **security
+issues, then bugs, then the oldest actionable issue** — and new non-trivial finds are
 **filed as issues before** they're built (trivial obvious fixes excepted). **Every run must clear the
 floor — at least one concrete artifact** (ideally a merged/drafted PR or a draft resolving the oldest
 actionable issue; else a newly-filed well-formed issue, a triage/strategy pass, an unblocking
@@ -330,7 +331,11 @@ readiness are **not** a reason to stop — advance a *different* product. **Stop
 merged — pentad clear (green CI + threads resolved + not DIRTY + ≥1 green review at the current head)
 + user-evaluated → **self-promote → merge** (contract *Autonomy*; definition PRs included since their
 separate gate was retired 2026-07-18) — or to an explicitly-named blocker; a *half-finished* one (red CI,
-open threads, conflicting, never user-evaluated) is unfinished work to clear first. Work the ladder top-down — **hotfix/operate first, then advance**:
+open threads, conflicting, never user-evaluated) is unfinished work to clear first. 🔴 **Your own
+DRAFTS are rung-1 work, not a separate softer category** — the `non-draft` wording in contract *Merge
+policy* scopes the merge command, never this sweep, and reading it as non-drafts-only is what left
+**99 own PRs open, all drafts, none promoted, median age 6.9 days** on 2026-07-25. Work the ladder
+top-down — **hotfix/operate first, then advance**:
 
 **Value check before build.** When an issue reaches the front of the advance queue, revalidate its
 current evidence, affected audience/problem, hypothesis, and success signal using
@@ -437,8 +442,10 @@ when the operate ladder is clear you still advance at least one product (never e
 Advance work is **issue-driven** (contract *Issue-driven*): its heart is **resolving the oldest
 actionable open issue**, and any new non-trivial find is **filed as an issue first** to enter that same
 backlog. Use the [`product-engineering`](../product-engineering/SKILL.md) skill; in order:
-7. **Resolve the oldest actionable open issue** *(the default advance action)* — pick the **oldest**
-   open issue that's actually startable; skip one only if it's blocked, too under-specified to begin, or
+7. **Resolve the next issue by the ladder** *(the default advance action)* — take the highest rung
+   with actionable work: open `type:"Security"` issues first, then `type:"Bug"`, then the **oldest**
+   startable issue (contract *The work-selection ladder*). Within a rung, oldest first.
+   Skip one only if it's blocked, too under-specified to begin, or
    it already has an open PR. A **bare `devantler` assignee does *not* reserve** an issue
    **indefinitely** — a `devantler` assignment plus a **pushed branch** is a live claim for ~2h
    (contract *Claim protocol*), and with no branch, or once that lapses with no PR, you may pick it up
@@ -498,8 +505,10 @@ blog experiment/PR through review, deployment, and measurement before starting a
 finds no worthwhile story is useful but does not move the publication clock; marketing, positioning,
 discovery, and adoption are product work, while filler and traffic-only vanity are not.
 
-**Fairness & ordering:** issue **age is the primary sort** for what to resolve (oldest actionable
-first — contract *Issue-driven*); when issue value/age is comparable, prefer the product with the
+**Fairness & ordering:** **severity is the primary sort, age the tiebreaker within a tier** — open
+`type:"Security"` issues, then `type:"Bug"`, then everything else oldest-actionable-first (contract
+*The work-selection ladder*); a three-week-old `Docs` issue never precedes an open `Security` one.
+When severity and age are comparable, prefer the product with the
 oldest `last_worked` (and oldest strategy review). Aim over time to advance every product, not just the
 noisy ones.
 **Cadence gates:** per-product strategy review and docs pass weekly-to-monthly (oldest first); review

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
       self-review-contract: ${{ steps.filter.outputs.self-review-contract }}
       review-provider-loop-contract: ${{ steps.filter.outputs.review-provider-loop-contract }}
       agent-role-delivery-contract: ${{ steps.filter.outputs.agent-role-delivery-contract }}
+      work-priority-ladder: ${{ steps.filter.outputs.work-priority-ladder }}
       portfolio-surveyor: ${{ steps.filter.outputs.portfolio-surveyor }}
       product-value: ${{ steps.filter.outputs.product-value }}
       agent-telemetry: ${{ steps.filter.outputs.agent-telemetry }}
@@ -123,6 +124,11 @@ jobs:
               - '.claude/skills/finops/SKILL.md'
               - '.claude/scripts/agent-role-delivery-contract.test.sh'
               - 'libraries/agent-plugins'
+              - '.github/workflows/ci.yaml'
+            work-priority-ladder:
+              - 'AGENTS.md'
+              - '.claude/skills/portfolio-maintenance/SKILL.md'
+              - '.claude/scripts/work-priority-ladder.test.sh'
               - '.github/workflows/ci.yaml'
             portfolio-surveyor:
               - 'AGENTS.md'
@@ -453,6 +459,21 @@ jobs:
       - name: Verify the agent-role delivery contract
         run: bash .claude/scripts/agent-role-delivery-contract.test.sh
 
+  test-work-priority-ladder:
+    name: Test work-priority ladder
+    needs: changes
+    if: needs.changes.outputs.work-priority-ladder == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify the work-priority ladder
+        run: bash .claude/scripts/work-priority-ladder.test.sh
+
   test-portfolio-surveyor-contract:
     name: Test portfolio surveyor contract
     needs: changes
@@ -488,6 +509,7 @@ jobs:
       - test-self-review-contract
       - test-review-provider-loop-contract
       - test-agent-role-delivery-contract
+      - test-work-priority-ladder
       - test-portfolio-surveyor-contract
       - test-product-value-contract
     permissions: {}
@@ -511,5 +533,6 @@ jobs:
             ${{ needs.test-self-review-contract.result }}
             ${{ needs.test-review-provider-loop-contract.result }}
             ${{ needs.test-agent-role-delivery-contract.result }}
+            ${{ needs.test-work-priority-ladder.result }}
             ${{ needs.test-portfolio-surveyor-contract.result }}
             ${{ needs.test-product-value-contract.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,8 +350,9 @@ open PR you own, drafts included, ahead of any issue**, then security issues, th
 oldest actionable issue. Newly-discovered non-trivial work
 is captured as an issue *before* it is built — so the existing backlog clears before new problems are
 started.
-**Floor — every run ships at least one concrete thing:** ideally **a draft PR delivering the oldest
-actionable open issue** (`Fixes #delivery`; add `Part of #experiment` when later measurement keeps the
+**Floor — every run ships at least one concrete thing:** ideally **an open PR of yours driven to
+merged**, or **a draft PR delivering the highest rung of *The work-selection ladder* that has
+actionable work** (`Fixes #delivery`; add `Part of #experiment` when later measurement keeps the
 experiment issue open), or else a PR, a newly-filed well-formed issue
 capturing real work, a triage/strategy pass, a review-thread resolution that unblocks a PR, or a
 actionable trusted-PR merge. A portfolio this size
@@ -470,8 +471,9 @@ actionable work**:
 | **3** | **Bugs** | `type:"Bug"`, regardless of age. |
 | **4** | **Oldest actionable issue** | Everything else, oldest-first (see *Drain oldest-first*). |
 
-Then **capture any new finds as issues** (see *Capture before you build*), and **keep going** — don't
-stop after a few items; work until actionable work is exhausted or blocked (see *Cadence & focus*).
+Then **capture any new finds as issues** (see *Issue-driven → Capture before you build*), and **keep
+going** — don't stop after a few items; work until actionable work is exhausted or blocked (see
+*Cadence & focus*).
 
 🔴 **Rung 1 includes your own DRAFTS — that is the whole point of the rung.** *Merge policy* scopes
 the merge *command* to a non-draft PR, because a draft cannot be merged; that scoping has **never**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,10 +344,10 @@ it is a property of the work you are already doing, held to the standing princip
 developer experience is easy *and* secure**. Every change you ship moves both the security floor and
 the ease of the path the next human takes, and you are accountable for both directions at once (see
 *Security hardening without a DevEx tax*). Both are
-also **issue-driven** (see *Issue-driven* below): open issues are the work queue and **resolving the
-oldest actionable one is the core of *advance* work** (after in-flight actionable trusted-author PRs
-are driven to merge first — automation-owned dependency PRs are excluded; see *Merge policy*), and
-newly-discovered non-trivial work
+also **issue-driven** (see *Issue-driven* below): open issues are the work queue and **resolving them
+is the core of *advance* work** — in the order *The work-selection ladder* sets, which puts **every
+open PR you own, drafts included, ahead of any issue**, then security issues, then bugs, then the
+oldest actionable issue. Newly-discovered non-trivial work
 is captured as an issue *before* it is built — so the existing backlog clears before new problems are
 started.
 **Floor — every run ships at least one concrete thing:** ideally **a draft PR delivering the oldest
@@ -452,13 +452,41 @@ governs the issue work that follows.) Two rules enforce that:
 
 **Hotfixes jump the queue.** Breakage — CI red on `main`, a broken build/site, your own PR gone red, an
 urgent security fix — is fixed **immediately** and is the **one exception to capture-before-you-build**:
-put the fire out first (open a tracking issue only if it aids follow-up), then return to the queue. So
-the per-run order is: **hotfix breakage → drive actionable trusted-author PRs to merge and fix their
-failing CI (first priority; every in-scope `devantler-tech` repo, excluding automation-owned
-dependency PRs — see *Merge policy*;
-PRs always come before issues) → resolve the oldest actionable issue → capture any new finds as
-issues.** And **keep going** — don't stop after a few items;
-work until actionable work is exhausted or blocked (see *Cadence & focus*).
+put the fire out first (open a tracking issue only if it aids follow-up), then return to the queue.
+
+### The work-selection ladder — one ordering, checked top-down every run
+
+Maintainer direction 2026-07-25: *"focus on open PRs before claiming new work … open prs > security
+issues > bugs > oldest issue. We want to stop starting and start finishing."* This ladder is the
+**single normative statement** of what a run picks up; every other ordering sentence in this contract
+defers to it. Rungs are strictly ordered — **you do not descend while a higher rung still has
+actionable work**:
+
+| # | Rung | What it covers |
+|---|---|---|
+| **0** | **Live breakage** | CI red on `main`, a broken build or site, an urgent security fix. Preempts everything and is the one exception to capture-before-you-build. |
+| **1** | **Open PRs — INCLUDING your own drafts** | Every actionable own/trusted PR in your lane, **draft and non-draft alike**, driven to a terminal state: merged, or parked on a **named, live-verified** blocker. Automation-owned dependency PRs are excluded (see *Merge policy*). |
+| **2** | **Security issues** | `type:"Security"`, regardless of age. |
+| **3** | **Bugs** | `type:"Bug"`, regardless of age. |
+| **4** | **Oldest actionable issue** | Everything else, oldest-first (see *Drain oldest-first*). |
+
+Then **capture any new finds as issues** (see *Capture before you build*), and **keep going** — don't
+stop after a few items; work until actionable work is exhausted or blocked (see *Cadence & focus*).
+
+🔴 **Rung 1 includes your own DRAFTS — that is the whole point of the rung.** *Merge policy* scopes
+the merge *command* to a non-draft PR, because a draft cannot be merged; that scoping has **never**
+bounded the **sweep**. An own draft is unfinished work you already own, and you drive it *through*
+promotion into the mergeable set rather than leaving it to age. Reading rung 1 as non-drafts-only is
+what produced the pile measured on **2026-07-25: 99 open own PRs, 100% of them drafts, not one ever
+promoted**, median age **6.9 days** — of which **18 were already `CLEAN`** (mergeable, idle a median
+5.3 days), **16 were conflicted**, and **49 of 88 sampled had not been touched in the 24h after they
+were opened**. Throughput was never the problem: ~27 own PRs merged per day that same week. The pile
+is what *starting* outruns *finishing* looks like, and closing it is rung 1's job.
+
+**Severity outranks age at rungs 2–3; age decides only *within* a rung.** A three-week-old `Docs`
+issue never precedes an open `Security` one. Rungs 2 and 3 are otherwise ordinary issue work under
+*Drain oldest-first* — the same actionability test, the same claim protocol, the same
+decompose-and-start rule when one is large.
 
 ### Claim protocol — reserve the lane before you build
 This brain runs as **several instances at once**, all executing "pick the oldest actionable issue"
@@ -1056,9 +1084,13 @@ then still needs approval via the ask tool. An existing `devantler` PR never byp
 ### Merge policy — drive actionable trusted-author PRs to merge (incl. majors)
 
 **Driving actionable trusted-author PRs to merge is the first-priority work each run — ahead of
-issues** (only live breakage on `main` outranks it). Automation-owned Renovate/Dependabot dependency
+issues** (only live breakage on `main` outranks it; this is rung 1 of *The work-selection ladder*).
+Automation-owned Renovate/Dependabot dependency
 PRs are not part of this queue. Sweep the actionable set **first**, every run, across the in-scope
-`devantler-tech` portfolio. On each portfolio repo, an **actionable trusted-author, non-draft** PR with the full
+`devantler-tech` portfolio. ⚠️ **The `non-draft` scoping below bounds the merge COMMAND, never the
+SWEEP** — an own draft is rung-1 work you drive *through* promotion into this set, not work that
+falls outside it (see the rung-1 note in the ladder, and the 99-draft pile it was written from).
+On each portfolio repo, an **actionable trusted-author, non-draft** PR with the full
 current-head hygiene pentad clear — green required checks, zero unresolved threads/body findings, no
 conflict, and a current-head green review —
 gets driven to merge:
@@ -2311,10 +2343,9 @@ lane's 17:30 and 19:30 runs, so a watch item deferred at 16:00 waits longer than
 **Each Agentic Engineer instance is dispatched every 2–6 hours** depending on its slot above. That
 interval is the gap **between runs, not a per-run time
 budget** — and it is the *instance's* own gap that bounds a carry-forward, so a run that defers a
-watch item to "the next tick" is deferring it hours, not minutes. Each run: **hotfix any breakage**, then **sweep every
-failing-CI / mergeable actionable trusted-author PR toward green and merge — first priority, across all
-repos, excluding automation-owned dependency PRs; PRs always come before issues**, then **work the issue
-backlog oldest-actionable-first**, capturing new
+watch item to "the next tick" is deferring it hours, not minutes. Each run works
+*The work-selection ladder* top-down — **breakage → every open PR you own or trust, drafts included →
+security issues → bugs → the oldest actionable issue** — capturing new
 non-trivial finds as issues (see *Issue-driven*).
 **Stop starting, start finishing (WIP limit — the core agile principle).** Finishing in-flight work
 outranks starting new work. Each run, before opening any **new** draft, first drive **every own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,9 +491,17 @@ issue never precedes an open `Security` one. Rungs 2 and 3 are otherwise ordinar
 decompose-and-start rule when one is large.
 
 ### Claim protocol — reserve the lane before you build
-This brain runs as **several instances at once**, all executing "pick the oldest actionable issue"
-over the same backlog. Two sessions surveying minutes apart will reliably pick the same issue —
-convergence is the **expected** behaviour of the selection rule, not bad luck. And because an open PR
+This brain runs as **several instances at once**, all executing *The work-selection ladder* over the
+same backlog. Two sessions surveying minutes apart will reliably pick the same issue —
+convergence is the **expected** behaviour of the selection rule, not bad luck.
+🔴 **The ladder makes this WORSE at rungs 2–3, and deliberately so — claim harder there.** Sorting by
+severity narrows the target pool from "the oldest of ~368 open issues" to "one of **18** open
+`type:"Security"` issues" (counts measured 2026-07-25), so every instance aims at the same handful
+instead of spreading across the age curve. Rung 1 pulls the other way — an own draft is owned by
+exactly one lane, so PR work barely collides — but the moment a run descends to rung 2 the collision
+odds jump, and cross-lane arbitration is still the **known-broken hole** in rule 4
+([monorepo#2302](https://github.com/devantler-tech/monorepo/issues/2302)). So on rungs 2–3: claim
+before you build, without exception, and scan **all three** namespaces first. And because an open PR
 only exists at the **end** of a build, the one recognised claim signal arrives exactly when it is too
 late to prevent the collision. Measured on `world-at-ruin` (2026-07-18): **six end-to-end builds
 discarded in ~24 hours** — #66 built to completion twice over, #81 lost after a full build with a


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

We keep starting work faster than we finish it. On 2026-07-25 there were **99 open PRs the agent
authored — every single one still a draft, none ever promoted**, median age **6.9 days**. Eighteen of
them were already mergeable and had been sitting that way for about five days; sixteen had drifted
into conflict; forty-nine of the eighty-eight sampled were never touched again after the hour they
were opened.

Throughput was not the problem — roughly 27 of these merged per day that same week. The problem is
that finished work was not being picked back up, so the pile grew underneath it.

The cause turned out to be a wording gap rather than a missing rule. The contract's top-priority item
was "drive PRs to merge", but elsewhere that set was defined as *non-draft* PRs — so the agent's own
drafts matched no priority at all, and the "finish before you start" rule sat far away in another
section, phrased as advice about opening new drafts. Checked against live state, the old top priority
matched **one** PR across the whole portfolio and **none** of the agent's own.

## What

Replaces three drifting copies of the per-run order with **one work-selection ladder**, worked
top-down: **breakage → open PRs (including our own drafts) → security issues → bugs → oldest issue**.

- Our own drafts are now explicitly the top rung, and the `non-draft` wording is scoped to the merge
  step rather than the sweep — closing the hole that produced the pile.
- Severity now outranks age in the issue queue. **18 open security issues and 99 bugs** were
  previously competing on age alone against 368 open issues.
- A new CI check keeps the ladder from drifting again: nine negative controls, each verified to
  actually mutate the text before its result is trusted.

One judgement call worth flagging: live breakage stays *above* open PRs, as it already was. A red
`main` blocks every PR on the rung below it anyway, so the two readings do not diverge in practice —
happy to reorder if you meant otherwise.

Implements the direction from our session on 2026-07-25.