### PR TITLE
fix(agents): bound draft intake by review capacity, not only by ordering

### DIFF
--- a/.claude/scripts/work-priority-ladder.test.sh
+++ b/.claude/scripts/work-priority-ladder.test.sh
@@ -109,6 +109,10 @@ assert_prose 'filing an issue is not opening a draft' \
 # Autonomy must no longer bless an unreviewable burst as "not sprawl".
 assert_prose 'What IS sprawl is a burst that outruns your own review capacity' \
   "${constitution_flat}" "Autonomy still licenses an unbounded draft set as 'not sprawl'"
+# A cap bounds STARTING, never the run itself — without this the cap reads as permission to idle,
+# which would trade the floor and "work as long as there is work" for the pile fix.
+assert_prose 'A cap is NOT licence to stop early, and it never blocks the floor' \
+  "${constitution_flat}" "intake cap does not say it bounds starting rather than the run — it reads as licence to idle"
 
 # ── CI wiring ─────────────────────────────────────────────────────────────────
 # GitHub expression tokens are literal workflow syntax, not shell expansions.

--- a/.claude/scripts/work-priority-ladder.test.sh
+++ b/.claude/scripts/work-priority-ladder.test.sh
@@ -98,7 +98,9 @@ assert_prose 'a run that opens its whole batch in one pass satisfies it **vacuou
   "${constitution_flat}" "contract does not explain why the ordering rule is satisfiable vacuously"
 grep -Fq '| **Per run** | Open at most **5** new own drafts. |' "${constitution}" ||
   fail "contract does not state the per-run draft intake cap"
-grep -Fq '| **Per lane** | While your own lane holds **more than 20** open drafts' "${constitution}" ||
+# Assert the WHOLE row, not just the threshold: a prefix match would still pass with the actual
+# instruction ("open no new ones") deleted, leaving a number that binds nothing.
+grep -Fq '| **Per lane** | While your own lane holds **more than 20** open drafts, open **no** new ones — spend the whole run finishing. |' "${constitution}" ||
   fail "contract does not state the per-lane draft ceiling"
 # The carve-outs are load-bearing: without them the cap would block a hotfix or stop the backlog
 # being captured, which is a guard firing on correct mandated work.
@@ -113,6 +115,10 @@ assert_prose 'What IS sprawl is a burst that outruns your own review capacity' \
 # which would trade the floor and "work as long as there is work" for the pile fix.
 assert_prose 'A cap is NOT licence to stop early, and it never blocks the floor' \
   "${constitution_flat}" "intake cap does not say it bounds starting rather than the run — it reads as licence to idle"
+# ...and that it says what a capped run should do INSTEAD. Without this, "don't stop early" states
+# only the prohibition, leaving the redirection to finishing implicit.
+assert_prose 'the cap redirects a run **from starting toward finishing**, and finishing is unbounded' \
+  "${constitution_flat}" "contract does not redirect a capped run toward finishing"
 
 # ── CI wiring ─────────────────────────────────────────────────────────────────
 # GitHub expression tokens are literal workflow syntax, not shell expansions.

--- a/.claude/scripts/work-priority-ladder.test.sh
+++ b/.claude/scripts/work-priority-ladder.test.sh
@@ -18,7 +18,9 @@
 #      the merge command rather than the sweep — the exact misreading that produced the pile;
 #   3. severity outranks age, so a Security issue is not queued behind an older Docs one;
 #   4. the run-loop skill agrees with the contract — three surfaces restate this ordering, and a
-#      silent divergence between them is how the previous wording drifted.
+#      silent divergence between them is how the previous wording drifted;
+#   5. intake is CAPPED and not merely ordered — because fixing (2) still did not drain the pile, and
+#      the re-measurement showed why: ordering is not the binding constraint, review capacity is.
 
 set -euo pipefail
 
@@ -80,6 +82,33 @@ assert_prose 'severity is the primary sort, age the tiebreaker within a tier' \
   "${skill_flat}" "run-loop skill still sorts the issue queue by age alone"
 assert_prose 'Resolve the next issue by the ladder' \
   "${skill_flat}" "run-loop skill's advance step does not follow the ladder"
+
+# ── 5. intake is CAPPED, not merely ordered ──────────────────────────────────
+# Re-measured 2026-07-26, after §2's fix landed: the pile did NOT drain. 99 → 91 open own PRs, still
+# 100% drafts, and median age ROSE 6.9d → 8.0d. Per lane it was 88/91 `codex/*` — and 63 of those 88
+# (72%) were opened on ONE day, all on one repo, all one theme, every sampled one NEVER reviewed and
+# by then BLOCKED or DIRTY. So §2's diagnosis was incomplete: ordering cannot drain a pile, because
+# promotion needs a green review at the current head and the review lanes are metered and shared. A
+# run that opens its whole batch in one pass satisfies "finish before you start more" VACUOUSLY — it
+# had nothing in flight when it started. These guard the cap that closes that, and the carve-outs
+# that keep it from blocking mandated work.
+assert_prose 'The WIP limit is also a CAP ON INTAKE, not only an ordering' \
+  "${constitution_flat}" "contract does not bound draft intake — ordering alone cannot drain a pile"
+assert_prose 'a run that opens its whole batch in one pass satisfies it **vacuously**' \
+  "${constitution_flat}" "contract does not explain why the ordering rule is satisfiable vacuously"
+grep -Fq '| **Per run** | Open at most **5** new own drafts. |' "${constitution}" ||
+  fail "contract does not state the per-run draft intake cap"
+grep -Fq '| **Per lane** | While your own lane holds **more than 20** open drafts' "${constitution}" ||
+  fail "contract does not state the per-lane draft ceiling"
+# The carve-outs are load-bearing: without them the cap would block a hotfix or stop the backlog
+# being captured, which is a guard firing on correct mandated work.
+assert_prose 'Rung-0 live breakage is exempt from both' \
+  "${constitution_flat}" "intake cap does not exempt live breakage — it would block a hotfix"
+assert_prose 'filing an issue is not opening a draft' \
+  "${constitution_flat}" "intake cap does not exempt issue capture — the backlog would stop being capturable"
+# Autonomy must no longer bless an unreviewable burst as "not sprawl".
+assert_prose 'What IS sprawl is a burst that outruns your own review capacity' \
+  "${constitution_flat}" "Autonomy still licenses an unbounded draft set as 'not sprawl'"
 
 # ── CI wiring ─────────────────────────────────────────────────────────────────
 # GitHub expression tokens are literal workflow syntax, not shell expansions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2551,6 +2551,11 @@ stay capturable while the caps bite. Both numbers are a deliberately permissive 
 than a measured optimum — 5/run is ~2.5× observed daily drainage, and 20 sits above the 18
 already-CLEAN drafts counted 2026-07-25. **Treat a cap you hit as the signal it is**: your lane's
 finishing capacity is the binding constraint, and the work to do is finishing.
+⚠️ **A cap is NOT licence to stop early, and it never blocks the floor.** *Work as long as there is
+work* below is unchanged: the cap redirects a run **from starting toward finishing**, and finishing is
+unbounded — a run that hits the cap and then idles has stopped too soon. The floor is unaffected for
+the same reason, because its first and preferred option is **an open PR of yours driven to merged**,
+which is exactly what a capped run should be doing.
 **Work as long as there is work — don't stop early.** The floor (≥1 artifact) is a **minimum and a
 backstop, not a target or a stopping point**: keep going while actionable work remains, and **prefer
 long, continuous sessions** over stopping after a handful of items. End a run only when actionable work

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1186,9 +1186,11 @@ Prefer acting — a draft PR on an issue, or filing the issue for a new find —
 report-only note for things that genuinely aren't a diff or an issue (environment/infra/repo-config/
 external blockers). Restraint applies to *noise* (don't stack
 duplicate PRs or filler comments on the **same** concern), not to work you've already identified.
-**A set of in-flight drafts still maturing toward readiness is NOT sprawl and NOT a reason to stop** —
-distinct, substantive work across products is exactly what's wanted; only duplicate/filler PRs on one
-concern are bounded. A maintainer-sequenced queue on **one** product (e.g. a recovery sprint) holds
+**Distinct, substantive work ACROSS PRODUCTS is NOT sprawl and NOT a reason to stop** — breadth is
+exactly what's wanted; duplicate/filler PRs on one concern are what's bounded. **What IS sprawl is a
+burst that outruns your own review capacity**: drafts you cannot carry to a green review are not work
+in progress, they are work that cannot finish — see the intake cap in *Cadence & focus*, which bounds
+how many you may open. A maintainer-sequenced queue on **one** product (e.g. a recovery sprint) holds
 back only *that* product's lane — it never gates advance work on the **other** products. **That said,
 finish before you start more** (*stop starting, start finishing* — see *Cadence & focus*): the
 deliverable is now the **merged, readiness-proven PR**, so each run drive your existing in-flight own
@@ -2525,6 +2527,30 @@ nothing while they sit. Concretely: a pentad-clear own PR left un-promoted/un-me
 blocked on a **fixable** check/thread, is unfinished work — clear it **before** you start more. (This
 sharpens *PRs-before-issues* and the every-run own-draft review-thread sweep into an explicit
 finish-before-start ordering.)
+**The WIP limit is also a CAP ON INTAKE, not only an ordering — a run cannot finish what it cannot get
+reviewed.** The paragraph above orders work *within* a run, so a run that opens its whole batch in one
+pass satisfies it **vacuously**: it had nothing in flight when it started. That is precisely what
+happened. Measured 2026-07-26: **63 of 88 open `codex/*` drafts — 72% — were opened on a single day
+(2026-07-18)**, all on one repo, all one theme; **every sampled one had never been reviewed at all**,
+was last touched 2026-07-21, and had since gone `BLOCKED` or `DIRTY`. Net drainage was ~2/day across
+the lane, so the cohort was conflicting faster than it drained. **Ordering could not have helped**:
+promotion needs **≥1 green review at the current head**, every push re-stales it, and the review lanes
+are **metered and shared** — CodeRabbit per-review, Codex weekly, Bugbot monthly (which returned
+`Error` for every request after 25 in one batch). A 63-draft burst is **structurally unreviewable**,
+and it spends a scarce resource every other lane also needs. So intake is bounded by finishing
+capacity:
+
+| Bound | Rule |
+|---|---|
+| **Per run** | Open at most **5** new own drafts. |
+| **Per lane** | While your own lane holds **more than 20** open drafts, open **no** new ones — spend the whole run finishing. |
+
+**Rung-0 live breakage is exempt from both** — a hotfix is never blocked by a cap. So is the
+issue-capture *Issue-driven* mandates: **filing an issue is not opening a draft**, and the backlog must
+stay capturable while the caps bite. Both numbers are a deliberately permissive starting point rather
+than a measured optimum — 5/run is ~2.5× observed daily drainage, and 20 sits above the 18
+already-CLEAN drafts counted 2026-07-25. **Treat a cap you hit as the signal it is**: your lane's
+finishing capacity is the binding constraint, and the work to do is finishing.
 **Work as long as there is work — don't stop early.** The floor (≥1 artifact) is a **minimum and a
 backstop, not a target or a stopping point**: keep going while actionable work remains, and **prefer
 long, continuous sessions** over stopping after a handful of items. End a run only when actionable work

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2529,16 +2529,12 @@ sharpens *PRs-before-issues* and the every-run own-draft review-thread sweep int
 finish-before-start ordering.)
 **The WIP limit is also a CAP ON INTAKE, not only an ordering — a run cannot finish what it cannot get
 reviewed.** The paragraph above orders work *within* a run, so a run that opens its whole batch in one
-pass satisfies it **vacuously**: it had nothing in flight when it started. That is precisely what
-happened. Measured 2026-07-26: **63 of 88 open `codex/*` drafts — 72% — were opened on a single day
-(2026-07-18)**, all on one repo, all one theme; **every sampled one had never been reviewed at all**,
-was last touched 2026-07-21, and had since gone `BLOCKED` or `DIRTY`. Net drainage was ~2/day across
-the lane, so the cohort was conflicting faster than it drained. **Ordering could not have helped**:
-promotion needs **≥1 green review at the current head**, every push re-stales it, and the review lanes
-are **metered and shared** — CodeRabbit per-review, Codex weekly, Bugbot monthly (which returned
-`Error` for every request after 25 in one batch). A 63-draft burst is **structurally unreviewable**,
-and it spends a scarce resource every other lane also needs. So intake is bounded by finishing
-capacity:
+pass satisfies it **vacuously**: it had nothing in flight when it started. **Ordering alone cannot
+drain a pile**, because promotion needs **≥1 green review at the current head**, every push re-stales
+it, and the review lanes are **metered and shared** — CodeRabbit per-review, Codex weekly, Bugbot
+monthly. A burst larger than that capacity is **structurally unreviewable**: it cannot finish, it ages
+into conflicts, and it spends a scarce resource every other lane also needs. So intake is bounded by
+finishing capacity:
 
 | Bound | Rule |
 |---|---|
@@ -2548,8 +2544,9 @@ capacity:
 **Rung-0 live breakage is exempt from both** — a hotfix is never blocked by a cap. So is the
 issue-capture *Issue-driven* mandates: **filing an issue is not opening a draft**, and the backlog must
 stay capturable while the caps bite. Both numbers are a deliberately permissive starting point rather
-than a measured optimum — 5/run is ~2.5× observed daily drainage, and 20 sits above the 18
-already-CLEAN drafts counted 2026-07-25. **Treat a cap you hit as the signal it is**: your lane's
+than a measured optimum — each sits above the lane's observed drainage and idle-clean counts, so the
+caps bite only on a burst ([#2490](https://github.com/devantler-tech/monorepo/issues/2490) holds the
+measurement they were set from). **Treat a cap you hit as the signal it is**: your lane's
 finishing capacity is the binding constraint, and the work to do is finishing.
 ⚠️ **A cap is NOT licence to stop early, and it never blocks the floor.** *Work as long as there is
 work* below is unchanged: the cap redirects a run **from starting toward finishing**, and finishing is


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Two previous fixes tried to drain the pile of unfinished own draft PRs by changing **which work a run picks first**. Re-measuring this week shows it did not work: the pile is barely smaller (99 → 91) and the drafts in it are now **older**, not newer (median 6.9 → 8.0 days).

The reason is that draining was never a question of ordering. **63 of the 88 drafts in the largest lane were opened on a single day**, all against one product — and not one of them has ever been reviewed. Every draft needs a review before it can ship, and our review services are rate-limited and shared across the whole portfolio. A batch that size simply cannot be finished, so it sits, ages, and starts conflicting — while consuming review capacity every other lane also needs.

The rule meant to prevent this ("finish before you start more") only orders work *inside* a run, so a run that opens its entire batch at once satisfies it without breaking it. And a separate sentence elsewhere explicitly described an unbounded set of drafts as acceptable.

## What

Puts a ceiling on how much new work a run may **start**, matched to how much it can actually **finish**: at most 5 new drafts per run, and none at all while a lane is already carrying more than 20. Live breakage and filing issues are exempt, so neither a hotfix nor keeping the backlog captured is ever blocked.

Fixes #2490
