### PR TITLE
docs(agents): drop the completed plugin-rescope in-progress claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,8 +65,7 @@ view is proposed precisely and applied by the maintainer.
 `product-engineering` skill): the CI building block `devantler-tech/actions` (which
 absorbed the archived `reusable-workflows` repo), the agent extensions `devantler-tech/agent-skills` (generic,
 cross-tool agent skills) + `devantler-tech/agent-plugins` (a tool-neutral marketplace bundling those skills
-for VS Code / Copilot CLI / Claude Code; rescope in progress —
-[plugins#7](https://github.com/devantler-tech/agent-plugins/issues/7)), and the cluster-guardrail
+for VS Code / Copilot CLI / Claude Code), and the cluster-guardrail
 catalog `devantler-tech/kyverno-policies` (shared, tested Kyverno policies the platform and
 platform-template consume instead of vendoring copies). A generic pattern proven in one
 product belongs in a shared library so *every* product inherits it — keep them **industry-standard and


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

**Why:** The contract has told every agent for the past month that the plugin marketplace rescope is still "in progress". It finished on 2026-06-26. A stale instruction file quietly misleads every future agent and reviewer, and this one was already spreading — an open draft copies the same wording into a product card, which would have put the false claim in a second place.

**What:** Removes the outdated in-progress clause. The sentence already describes the marketplace as tool-neutral, so it now simply says what is true today.

No behaviour changes; all seven contract test suites pass.