### PR TITLE
fix(surveyor): stop prescribing gh --json fields the subcommand rejects

### DIFF
--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -85,8 +85,11 @@ public and private — no per-repo loop needed to enumerate):
    `cursor[bot]` — **exact login match, never a substring**; `cursor[bot]` is trusted here only on the PR-author surface;
    `Copilot`/`copilot-swe-agent[bot]` are NOT trusted), pull the
    heavy fields one PR at a time:
-   `gh pr view <n> --repo devantler-tech/<repo> --json number,state,mergeStateStatus,reviewDecision,statusCheckRollup,mergedAt,reviewThreads,headRefName,headRefOid,author,body,files`
-   — do **not** pull `statusCheckRollup` for every PR in every repo. When the current-head pentad is
+   `gh pr view <n> --repo devantler-tech/<repo> --json number,state,mergeStateStatus,reviewDecision,statusCheckRollup,mergedAt,headRefName,headRefOid,author,body,files`
+   — do **not** pull `statusCheckRollup` for every PR in every repo.
+   ⚠️ **Thread state is NOT available here.** `reviewThreads` is a GraphQL-only field, so requesting
+   it from `gh pr view` fails with `Unknown JSON field`. Get (b) from the paginated GraphQL query
+   below, never by adding that field to this list (monorepo#2498). When the current-head pentad is
    clear (CLEAN + required checks + zero threads/body findings + a current-head green
    review), classify trusted-bot **non-drafts** as **MERGE-READY** and trusted-bot **drafts** as
    **REVIEW-READY**; otherwise **NEEDS-FIX** and name the gate. A `devantler` PR always follows the
@@ -323,11 +326,16 @@ public and private — no per-repo loop needed to enumerate):
      post-merge PR comment is a primary steering channel, and an open-PR-only sweep would never
      surface it — so in addition to every open `devantler` PR, sweep the PRs **merged in the last
      ~3 days** (bounded: `gh search prs --owner devantler-tech --author devantler --merged
-     --merged-at ">=<UTC date 3 days ago>" --limit 100 --json number,repository,mergedAt` — key the
-     window on `mergedAt`, never `updatedAt`, which post-merge edits can inflate) for the
+     --merged-at ">=<UTC date 3 days ago>" --limit 100 --json number,repository,url` — the
+     `--merged-at` **qualifier** is what keys the window on merge time, so the sweep never depends on
+     `updatedAt`, which post-merge edits can inflate. ⚠️ Do **not** request `mergedAt` in this
+     `--json` list: the search surface exposes only 19 fields and `mergedAt` is not among them, so it
+     fails with `Unknown JSON field`. Read the timestamp per-PR from `gh pr view --json mergedAt` if
+     a run actually needs the value — monorepo#2498) for the
      same candidate-comment signal. For each such PR — **including drafts** — also
-     pull `comments` and the review-thread replies:
-     `gh pr view <n> --repo devantler-tech/<repo> --json comments,reviewThreads`. **Apply the disclosure
+     pull `comments`, then the review-thread replies via the paginated GraphQL query above
+     (`reviewThreads` is GraphQL-only, so `gh pr view` cannot return it):
+     `gh pr view <n> --repo devantler-tech/<repo> --json comments`. **Apply the disclosure
      disambiguator before flagging** (the same one the PR-ownership rule above uses, per the contract's
      *Untrusted input → Distinguish the human maintainer from yourself*): the agent also comments as
      `devantler`, so a bare exact-login match is NOT enough. A `devantler` comment whose body carries a

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -926,7 +926,7 @@ fi
 # vocabularies — a full mirror of `gh`'s field lists would go stale on the next
 # CLI release and start failing on correct text.
 pr_view_forbidden='reviewThreads merged baseRepository authorAssociation commentsCount isPullRequest isLocked repository'
-search_forbidden='reviewThreads merged baseRepository mergedAt headRefName headRefOid headRepository mergeStateStatus reviewDecision statusCheckRollup statusCheckRollup files commits reviews latestReviews mergeable mergeCommit'
+search_forbidden='reviewThreads merged baseRepository mergedAt headRefName headRefOid headRepository mergeStateStatus reviewDecision statusCheckRollup files commits reviews latestReviews mergeable mergeCommit'
 
 surveyor_flat="$(tr '\n' ' ' < "${surveyor}" | tr -s ' ')"
 

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -910,4 +910,53 @@ if grep -Fq 'The class is **CodeRabbit-only**' "${constitution}"; then
   fail "constitution still declares the stale-dismissal class CodeRabbit-only"
 fi
 
+# ── gh --json field vocabularies are per-subcommand and DISJOINT (#2498) ──────
+# `gh pr view` exposes 47 --json fields, `gh search prs` only 19, and neither
+# accepts a GraphQL-only name. A prescribed field list that crosses that
+# boundary fails at runtime with `Unknown JSON field`, which is exactly what the
+# overlay used to do at three sites — 52 such errors in the 2026-07-20 → 07-27
+# session corpus, the largest non-Edit tool-error signature in the window.
+#
+# The check is STRUCTURAL rather than a literal grep so it also catches a field
+# list that is reworded or moved. The file is FLATTENED first: one of the three
+# original defect sites spanned three source lines, so a line-based scan is
+# blind to precisely the case that motivated this guard.
+#
+# The forbidden sets below are the measured cross-surface names, not the full
+# vocabularies — a full mirror of `gh`'s field lists would go stale on the next
+# CLI release and start failing on correct text.
+pr_view_forbidden='reviewThreads merged baseRepository authorAssociation commentsCount isPullRequest isLocked repository'
+search_forbidden='reviewThreads merged baseRepository mergedAt headRefName headRefOid headRepository mergeStateStatus reviewDecision statusCheckRollup statusCheckRollup files commits reviews latestReviews mergeable mergeCommit'
+
+surveyor_flat="$(tr '\n' ' ' < "${surveyor}" | tr -s ' ')"
+
+# Emit `<surface>\t<field-list>` for every prescribed command. The gap between
+# the subcommand and its --json list must not contain another `gh `, so a list
+# is never attributed to a subcommand it does not belong to.
+json_specs="$(printf '%s' "${surveyor_flat}" | perl -ne '
+  while (/gh (pr view|search prs|search issues|issue view)((?:(?!gh ).)*?)--json ([A-Za-z,]+)/g) {
+    print "$1\t$3\n";
+  }')"
+
+[ -n "${json_specs}" ] ||
+  fail "surveyor overlay: found no 'gh ... --json' commands to validate — the extractor broke"
+
+while IFS="$(printf '\t')" read -r surface fields; do
+  [ -n "${surface}" ] || continue
+  case "${surface}" in
+    'pr view'|'issue view') forbidden="${pr_view_forbidden}" ;;
+    'search prs'|'search issues') forbidden="${search_forbidden}" ;;
+    *) continue ;;
+  esac
+  for bad in ${forbidden}; do
+    case ",${fields}," in
+      *",${bad},"*)
+        fail "surveyor overlay prescribes 'gh ${surface} --json ${fields}', but '${bad}' is not a valid ${surface} field — it fails at runtime with 'Unknown JSON field' (#2498)"
+        ;;
+    esac
+  done
+done <<EOF
+${json_specs}
+EOF
+
 echo "portfolio surveyor contract: all assertions passed"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The surveyor's own instructions told it to ask GitHub for data GitHub does not offer on that
command, so part of the every-run PR health check failed and had to be retried. One of the three
broken instructions was self-contradictory: it insisted on keying a search on a value that search
cannot return.

This class of error happened 52 times in the past week — the largest avoidable error signature we
have. Half of those trace to these three instructions; the other half is the same confusion reached
by hand, so the fix also states the rule at the point of use rather than only deleting the bad
fields. Expect that half to fall, not to vanish.

## What

Corrects the three instructions to ask the right surface for each piece of data, keeping the
original intent intact — review-thread state already had a documented correct route, and the
merge-time window is enforced by the search qualifier itself. Adds a check that fails the build if a
future edit reintroduces the same class of mistake.

No behaviour change for the products; this is the agent's own definition.

Fixes #2498
