### PR TITLE
fix(surveyor): exclude dependency-automation issues from oldest-actionable

### DIFF
--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -41,8 +41,9 @@ public and private — no per-repo loop needed to enumerate):
 
 1. **Open PRs (org-wide, one call):**
    `gh search prs --owner devantler-tech --archived=false --state open --limit 300 --json number,repository,title,author,isDraft,labels,updatedAt,url`
-2. **Open issues (org-wide, one call) — include `assignees`, they are a CLAIM signal:**
-   `gh search issues --owner devantler-tech --archived=false --state open --limit 300 --json number,repository,title,labels,updatedAt,url,assignees`
+2. **Open issues (org-wide, one call) — include `assignees` (claim signal) and `author`
+   (automation-owned filter):**
+   `gh search issues --owner devantler-tech --archived=false --state open --limit 300 --json number,repository,title,author,labels,updatedAt,url,assignees`
    (`--archived=false` keeps archived repos' stale PRs/issues — e.g. `data-product`'s 2025 bot PRs —
    out of every survey; archived repos are read-only and carry no actionable signal.)
    (`gh search issues` returns issues only — not PRs; treat label-less issues as untriaged.)
@@ -55,6 +56,16 @@ public and private — no per-repo loop needed to enumerate):
    ordinary open issues, noting the assignee so the orchestrator can respect a human's in-progress work
    on its own merits. Without these logins the orchestrator selects the oldest issue blind to live
    claims and re-opens the duplicate-build race the protocol exists to close.
+   **Short-circuit dependency-automation ISSUES the same way as their PRs** (live miss 2026-07-21,
+   #2349): an issue whose author is the exact `renovate[bot]` or `dependabot[bot]` identity
+   (org-search/REST; deeper surfaces may show `app/renovate` / `app/dependabot`) is
+   **AUTOMATION-OWNED (NO-ACTION)** — Renovate's Dependency Dashboard is the standing example
+   (`platform#313`, open since 2023-08-24 by design). Match **author login only** — never the title,
+   labels, or age. **Exclude them from every oldest-actionable / Advance ranking**; at most emit one
+   compact Operate `AUTOMATION-OWNED (NO-ACTION)` line. **Never select, triage-as-work, or close
+   them** — closing a Dependency Dashboard changes Renovate's behaviour. Without this filter the
+   dashboard heads a repo's oldest-first queue forever and every run re-derives that it is not real
+   work.
 2b. **Claim branches (one call per repo that has PR-less open issues):**
    `gh api repos/<o>/<r>/branches --paginate --jq '.[].name' | grep -E '^(claude|cursor|codex)/'` —
    report any `claude/*`, `cursor/*`, or `codex/*` branch that ends in `-<issue>`, ends in a
@@ -412,6 +423,7 @@ public and private — no per-repo loop needed to enumerate):
    the complete and canonical partition; labels are legacy and **provably incomplete** — 8 of 63 open
    Epics carried no `roadmap` label on 2026-07-18, and `Spike`/`Kata`/`Chore` have no label at all, so
    a label sweep silently drops them. Sweep each type once:
+
    ```sh
    # VERIFIED WORKING 2026-07-18 — run it, don't retype it from memory:
    #  · the search QUALIFIER type: works; there is NO issueType JSON field (gh search issues --json
@@ -424,16 +436,24 @@ public and private — no per-repo loop needed to enumerate):
    for T in Epic Feature Bug Security Performance Refactor Docs Spike Kata Chore; do
      gh api "search/issues?q=org:devantler-tech+is:issue+is:open+type:$T&per_page=100" --paginate \
        --jq '.items[] | [((.repository_url|split("/")|last)+"#"+(.number|tostring)), .created_at[0:10],
-              .title, ((.body//"")|gsub("[\\n\\r\\t]";" ")|.[0:300])] | @tsv' | sed "s/^/$T\t/"
+              .user.login, .title, ((.body//"")|gsub("[\\n\\r\\t]";" ")|.[0:300])] | @tsv' | sed "s/^/$T\t/"
    done
    ```
+
    ⚠️ **Type sweeps alone are NOT complete — 65 open issues were untyped on 2026-07-18.** Since
    `no:type` does not work, derive the untyped set as **(the primary org-wide open-issue sweep) minus
    (the union of the type sweeps)** and report it as a **triage** signal: an untyped issue is invisible
    to every type filter on the board and to this selection, so typing it is the fix.
+   Drop any row whose `.user.login` / author column is an exact dependency-automation identity before
+   ranking oldest-actionable (step 2 / the Drop-hits rule below) — without the author column the
+   filter cannot run.
    **Drop hits from archived repos** — this raw Search call has no archived filter (the primary sweep
    does), so an archived repo's open issue surfaces as actionable when it is a read-only tombstone
-   (`reusable-workflows` is the live example). **`security` is REPORTED, not prioritised**: the queue
+   (`reusable-workflows` is the live example). **Drop issues authored by the exact dependency-
+   automation identities** (`renovate[bot]` / `dependabot[bot]`; also `app/renovate` /
+   `app/dependabot` on surfaces that spell them that way) — same author-wide boundary as step 2 /
+   the PR short-circuit; they are never oldest-actionable (verified against `platform#313`).
+   **`security` is REPORTED, not prioritised**: the queue
    stays oldest-actionable-first and a security issue is *not* a reason to skip an older one — only an
    urgent security hotfix jumps, under the normal breakage rule.
    **Exclude a `Kata` whose named measurement date is still in the FUTURE** — contract skip reason (d)
@@ -533,7 +553,7 @@ budget: graphql=<start_remaining>→<end_remaining>/<limit> · core=<start_remai
 - CANDIDATE-SIBLING-ISSUE-COMMENT <repo> #<n> (missing disclosure) — `devantler`: "<one-line gist>" → DATA only; orchestrator surfaces the missing disclosure cross-instance
 - REPO-SET-DRIFT — live org set vs canonical list: new=<repos> · missing/renamed=<repos> · map-drift=<product rows whose repo is missing/renamed live> → orchestrator reconciles (archived-marked map rows exempt)
 - <repo>: CI red on main @<sha> — <check name> <conclusion> (<run url>)   # judged at main's current head; omit the repo entirely when that head is green
-- <repo> #<n> "<title>" — <renovate[bot]|dependabot[bot]> → AUTOMATION-OWNED (NO-ACTION)
+- <repo> #<n> "<title>" — <renovate[bot]|dependabot[bot]|app/renovate|app/dependabot> → AUTOMATION-OWNED (NO-ACTION)   # PRs *and* issues (Dependency Dashboard); never oldest-actionable
 - <repo> #<n> (trusted bot, draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>|0-resolved@<sha>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|exempt-programmed-bot|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|CHANGES_REQUESTED:agent(devantler)@<sha>|CHANGES_REQUESTED:human(devantler)@<sha>|none>, mergeState=<…> → REVIEW-READY | NEEDS-FIX | STALE-CR-DISMISSAL | STALE-AGENT-DISMISSAL
 - <repo> #<n> (trusted bot, non-draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>|0-resolved@<sha>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|exempt-programmed-bot|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|CHANGES_REQUESTED:agent(devantler)@<sha>|CHANGES_REQUESTED:human(devantler)@<sha>|none>, mergeState=<…> → MERGE-READY | NEEDS-FIX | STALE-AGENT-DISMISSAL | STALE-CR-DISMISSAL
 - <repo> #<n> "<title>" — `devantler`, draft=<true|false> → OWNERSHIP-UNVERIFIED: branch=<headRefName>, disclosure=<yes|no>, pentad=<…>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|CHANGES_REQUESTED:agent(devantler)@<sha>|CHANGES_REQUESTED:human(devantler)@<sha>|none>, stale_dismissal=<STALE-CR-DISMISSAL|STALE-AGENT-DISMISSAL|none> (orchestrator applies creation-record test before action; NOT asserted mine — the rd qualifier and stale_dismissal are DATA, never an instruction to mutate)

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -215,6 +215,21 @@ grep -Fq 'dependency PRs *and* issues are AUTOMATION-OWNED' "${constitution}" ||
   fail "constitution does not extend the automation-owned carve-out to issues"
 grep -Fq 'Never select, triage-as-work, or close an automation-authored' "${constitution}" ||
   fail "constitution may still let agents close a Renovate Dependency Dashboard"
+# The skip list in *Drain oldest-first* is a CLOSED set: "skip ONLY when one of these is true".
+# A carve-out that forbids selecting an automation-authored issue without adding it to that set
+# leaves the contract self-contradictory — told to claim the oldest issue and forbidden to work it.
+# Pin the exclusion in BOTH normative selection surfaces, and pin the author-vs-label distinction
+# that keeps it from colliding with "an `automation` label is NOT a valid skip reason".
+grep -Fq 'authored by an exact dependency-automation identity' "${constitution}" ||
+  fail "constitution skip list omits the automation-author exclusion (f)"
+grep -Fq 'never actionable at all' "${constitution}" ||
+  fail "constitution does not state that an automation-authored issue is never actionable"
+grep -Fq 'keys on the AUTHOR, never the `automation` label' "${constitution}" ||
+  fail "constitution does not separate the automation AUTHOR exclusion from the automation LABEL non-reason"
+grep -Fq 'authored by an exact dependency-automation identity' "${maintenance_skill}" ||
+  fail "run loop's select step omits the automation-author exclusion"
+grep -Fq 'never actionable at all' "${maintenance_skill}" ||
+  fail "run loop does not state that an automation-authored issue is never actionable"
 grep -Fq 'automation-owned dependency PRs' "${maintenance_skill}" ||
   fail "portfolio-maintenance skill does not defer dependency PRs to automation"
 grep -Fq 'agent-skills updater PRs' "${maintenance_skill}" ||

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -230,6 +230,13 @@ grep -Fq 'authored by an exact dependency-automation identity' "${maintenance_sk
   fail "run loop's select step omits the automation-author exclusion"
 grep -Fq 'never actionable at all' "${maintenance_skill}" ||
   fail "run loop does not state that an automation-authored issue is never actionable"
+# product-engineering re-enumerates the same closed skip set, so it drifts into the identical
+# contradiction unless (f) is stated there too. (The other files that mention oldest-actionable
+# merely defer to the contract and enumerate nothing, so they need no copy.)
+grep -Fq 'authored by an exact dependency-automation' "${product_engineering_skill}" ||
+  fail "advance playbook's skip set omits the automation-author exclusion (f)"
+grep -Fq 'never actionable at all' "${product_engineering_skill}" ||
+  fail "advance playbook does not state that an automation-authored issue is never actionable"
 grep -Fq 'automation-owned dependency PRs' "${maintenance_skill}" ||
   fail "portfolio-maintenance skill does not defer dependency PRs to automation"
 grep -Fq 'agent-skills updater PRs' "${maintenance_skill}" ||

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -181,6 +181,40 @@ grep -Fq 'do **not** call' "${surveyor}" ||
   fail "surveyor still permits heavy dependency-PR deepening"
 grep -Fq 'count it against' "${surveyor}" ||
   fail "surveyor may still turn dependency automation into operate work"
+# Issue-side automation ownership (#2349): Renovate's Dependency Dashboard is an open issue by
+# design and will head oldest-first forever unless the surveyor excludes exact author identities
+# the same way it already does for dependency PRs. Match author only — never title/labels/age.
+grep -Fq 'Short-circuit dependency-automation ISSUES' "${surveyor}" ||
+  fail "surveyor does not short-circuit dependency-automation issues as no-action"
+grep -Fq 'Exclude them from every oldest-actionable' "${surveyor}" ||
+  fail "surveyor may still rank a Renovate Dependency Dashboard as oldest-actionable"
+grep -Fq 'platform#313' "${surveyor}" ||
+  fail "surveyor does not pin the live Dependency Dashboard counter-example"
+grep -Fq 'Never select, triage-as-work, or close' "${surveyor}" ||
+  fail "surveyor may still close or triage an automation-authored issue"
+grep -Fq 'author,labels,updatedAt,url,assignees' "${surveyor}" ||
+  fail "surveyor open-issue search omits author, so the issue-side filter cannot run"
+grep -Fq 'Drop issues authored by the exact dependency-' "${surveyor}" ||
+  fail "surveyor type sweeps may still rank automation-authored issues"
+grep -Fq '.user.login, .title,' "${surveyor}" ||
+  fail "surveyor type-sweep jq omits the author column the issue-side filter needs"
+# Pin every spelling of the identity on BOTH surfaces, and pin the author-only prohibition itself:
+# without these a later edit could drop one identity, or re-admit title/label/age matching, while
+# the descriptive prose still reads correct and every other assertion still passes.
+for identity in 'renovate[bot]' 'dependabot[bot]' 'app/renovate' 'app/dependabot'; do
+  grep -Fq "${identity}" "${surveyor}" ||
+    fail "surveyor omits automation identity: ${identity}"
+  grep -Fq "${identity}" "${constitution}" ||
+    fail "constitution omits automation identity: ${identity}"
+done
+grep -Fq 'Match **author login only** — never the title' "${surveyor}" ||
+  fail "surveyor does not enforce exact author-only matching"
+grep -Fq 'labels, or age' "${surveyor}" ||
+  fail "surveyor does not prohibit label/age matching"
+grep -Fq 'dependency PRs *and* issues are AUTOMATION-OWNED' "${constitution}" ||
+  fail "constitution does not extend the automation-owned carve-out to issues"
+grep -Fq 'Never select, triage-as-work, or close an automation-authored' "${constitution}" ||
+  fail "constitution may still let agents close a Renovate Dependency Dashboard"
 grep -Fq 'automation-owned dependency PRs' "${maintenance_skill}" ||
   fail "portfolio-maintenance skill does not defer dependency PRs to automation"
 grep -Fq 'agent-skills updater PRs' "${maintenance_skill}" ||

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -463,7 +463,10 @@ backlog. Use the [`product-engineering`](../product-engineering/SKILL.md) skill;
    stand down rather than force over them. Check open PRs, remote
    `claude/*` branches AND assignees by **issue number, never literal branch name**. A live claim
    (assigned + branched, in-window, no PR) is skip reason **(e)** — the only one that expires by
-   itself. If it **already has an
+   itself. An issue **authored by an exact dependency-automation identity** (`renovate[bot]` /
+   `dependabot[bot]`, `app/renovate` / `app/dependabot`) is skip reason **(f)**: it is
+   automation-owned, **never actionable at all**, and is never selected, worked, or closed — match the
+   author only, never the `automation` label. If it **already has an
    actionable trusted-author, non-draft PR**, drive *that* to merge instead of duplicating; leave
    automation-owned dependency PRs to repository automation, **draft** PRs for the maintainer, and
    **external** PRs static-review-only (trust gate). Otherwise ship it: tests +

--- a/.claude/skills/product-engineering/SKILL.md
+++ b/.claude/skills/product-engineering/SKILL.md
@@ -126,7 +126,12 @@ Issues are the unit of work (contract *Issue-driven*) — this is where new work
    under-specified to begin, (d) a delivered experiment is waiting for its named future measurement
    date — once that date arrives, measuring it is actionable — or (e) another instance holds a **live
    claim** (assigned **and** branched, within ~2h, no PR yet; contract *Claim protocol*), the only
-   skip reason that expires on its own. **Size, difficulty, a `roadmap`/`enhancement`/
+   skip reason that expires on its own, or (f) it is **authored by an exact dependency-automation
+   identity** (`renovate[bot]` / `dependabot[bot]`, `app/renovate` / `app/dependabot`) — unlike the
+   others that is not a deferral: such an issue is **never actionable at all**, never becomes so, and
+   is never selected, worked, or closed (Renovate's Dependency Dashboard is the standing example).
+   ⚠️ (f) matches the **author**, never the `automation` **label** — see the next sentence.
+   **Size, difficulty, a `roadmap`/`enhancement`/
    `security`/`repo-assist`/`automation` label, or a "maintainer-hot" feeling are NOT skip reasons** —
    when the oldest issue is large, **decompose it into a small first child and ship that increment**
    (`Fixes #child`; add `Part of #experiment` when the parent stays open) so the big thing advances

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -950,23 +950,28 @@ never collapsed to "no review" followed by another review request. A **fourth sa
 when no lane will deliver at that head** — unavailable, or rate/billing limited — the agent's own posted
 local review round (see *Local review round* in the request discipline below); it is never a way
 around requesting a reviewer that is actually serving.
-**Carve-out — Renovate/Dependabot dependency PRs are AUTOMATION-OWNED and need NO agent action**
-(maintainer direction 2026-07-16). Match only the exact app identities: org-search/REST surfaces expose
-`renovate[bot]` and `dependabot[bot]`; deeper GraphQL surfaces may expose `app/renovate` and
-`app/dependabot`. Do not key this classification on the unreliable search `is_bot` field, titles,
-branch names, or dependency labels. This is an author-wide ownership boundary. Do not inspect commit provenance
+**Carve-out — Renovate/Dependabot dependency PRs *and* issues are AUTOMATION-OWNED and need NO agent action**
+(maintainer direction 2026-07-16; issue side confirmed 2026-07-21 via #2349). Match
+only the exact app identities: org-search/REST surfaces expose `renovate[bot]` and `dependabot[bot]`;
+deeper GraphQL / `gh issue view` surfaces may expose `app/renovate` and `app/dependabot`. Do not key
+this classification on the unreliable search `is_bot` field, titles, branch names, or dependency
+labels. This is an author-wide ownership boundary covering **both** their pull requests **and** their
+issues (Renovate's Dependency Dashboard is an open issue by design — e.g. `platform#313` since
+2023-08-24 — and must never head an oldest-actionable queue). Do not inspect commit provenance
 or reclassify the PR because a human/agent adaptation commit exists. Repository automation
 and the human who chose to edit that bot branch remain responsible; agents never add such commits going
 forward. Repository checks and dependency automation own these PRs' entire lifecycle, including updates
 and merging. **Never request a review from any lane (CodeRabbit, Codex, Cursor Bugbot), inspect
 ancillary CodeRabbit output, comment, rebase/recreate, rerun checks, push adaptation commits,
-arm auto-merge, or merge them.** Red, stale, DIRTY/conflicting, major-version, missing-review, and
-other reviewer-output states are not routine-agent work and never make one of these PRs a hygiene gap or
-fire. The survey may report one compact `AUTOMATION-OWNED (NO-ACTION)` line from the exact author
-identity, but does not deepen its pentad or count it against `nothing_on_fire`. If a merged dependency
-bump breaks `main`, repair that resulting `main` breakage normally on an agent-owned branch; never
-touch the bot PR branch. This actor-wide no-action rule is stronger than the trusted-author permissions
-below and is separate from the narrower programmed-bot review exemption.
+arm auto-merge, or merge them.** **Never select, triage-as-work, or close an automation-authored
+issue** — closing a Dependency Dashboard changes Renovate's behaviour. Red, stale, DIRTY/conflicting,
+major-version, missing-review, and other reviewer-output states are not routine-agent work and never
+make one of these PRs a hygiene gap or fire. The survey may report one compact `AUTOMATION-OWNED
+(NO-ACTION)` line from the exact author identity, but does not deepen a PR's pentad, rank an
+automation issue as oldest-actionable, or count either against `nothing_on_fire`. If a merged
+dependency bump breaks `main`, repair that resulting `main` breakage normally on an agent-owned
+branch; never touch the bot PR branch. This actor-wide no-action rule is stronger than the
+trusted-author permissions below and is separate from the narrower programmed-bot review exemption.
 
 **Carve-out — trusted programmed bot PRs need NO review.** Two suite-owned paths are intentionally
 gated by required CI and auto-merge rather than an AI review:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,7 +500,15 @@ governs the issue work that follows.) Two rules enforce that:
    is recorded on the issue and has not elapsed. Once that date arrives, measuring and recording the
    decision is actionable work; or (e) another instance holds a **live claim** on it — assigned **and**
    branched, within the ~2h window, no PR yet (see *Claim protocol*). (e) is the only skip reason that
-   expires on its own: once the window lapses with no PR, the issue is fair game again.
+   expires on its own: once the window lapses with no PR, the issue is fair game again; or (f) it is
+   **authored by an exact dependency-automation identity** (`renovate[bot]` / `dependabot[bot]`, or
+   `app/renovate` / `app/dependabot`) — see the automation-owned carve-out under *Merge policy*.
+   (f) is not a deferral like the others: such an issue is **never actionable at all** and never
+   becomes so, because it is a live control surface the bot owns (Renovate's Dependency Dashboard is
+   the standing example). It is never selected, never worked, and never closed by an agent.
+   ⚠️ **(f) keys on the AUTHOR, never the `automation` label** — the two are unrelated, and the very
+   next sentence keeps the label a non-reason. A `devantler`-authored issue *labelled* `automation` is
+   ordinary actionable work.
    **Size, difficulty, architectural weight, a
    `roadmap`/`enhancement`/`security`/`performance`/`repo-assist`/`automation` label, or a vague
    "maintainer-hot" feel are NOT valid skip reasons.** A large or hard issue **is the work, not an excuse


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Renovate keeps a permanently-open "Dependency Dashboard" issue in each repo it manages — `platform#313` has been open since August 2023 **by design**. Because the backlog is worked oldest-first, that issue headed platform's queue forever: every run met it first, spent effort establishing it was not real work, and moved on. The existing "leave dependency automation alone" rule was written for pull requests only, so the same bot's *issues* still flowed into the ordinary work queue.

## What

Extends that ownership boundary to cover the bots' issues as well as their PRs: they are never ranked as available work, never selected, and never closed by an agent (closing a Dependency Dashboard changes Renovate's own behaviour). The survey now carries the author information it needs to apply the filter, and a guard pins the behaviour so it cannot quietly regress.

Matching stays on the exact bot identity only — never on a title, label, or age heuristic — the same way the pull-request side is already bound.

Supersedes #2449 (same fix, stranded on a branch in another instance's namespace and conflicting with main).

Fixes #2349