### PR TITLE
fix(telemetry): give the credential detector provenance and blob separation

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1538,8 +1538,39 @@ if want safety; then
     printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | while IFS= read -r f; do
       cred_sess=$(basename "$f" | tr -cd 'A-Za-z0-9._-' | cut -c1-120)
       [ -n "$cred_sess" ] || cred_sess=unknown
+      # Redact the basename BEFORE it reaches the scratch file. redact() runs at
+      # the OUTPUT boundary, so a credential-shaped session name would otherwise
+      # sit unmasked in $CREDCONC for the length of the run — and that file
+      # survives a SIGKILL, which the EXIT/HUP/INT/TERM trap cannot cover. The
+      # report would still print it masked, so this buys value minimisation at
+      # rest, not a change in what is displayed. Ordered AFTER the `tr -cd` on
+      # purpose: the mask introduces `…` and `<>`, which that filter strips.
+      # Two distinct real sessions stay distinct (UUID basenames carry no
+      # credential shape and pass through untouched); two DIFFERENT names of the
+      # same shape can merge, which under-counts sessions in a case that cannot
+      # occur outside a fixture and fails safe. (Codex P2 on #2520.)
+      cred_sess=$(printf '%s\n' "$cred_sess" | redact)
+      [ -n "$cred_sess" ] || cred_sess=unknown
+      # Split compound matches on `;&|` exactly as the TABLE does. The generic
+      # alternative's value class admits those separators, so grep's
+      # leftmost-longest rule hands back a whole run of assignments as ONE
+      # match and `grep -o` emits ONE line — reporting `largest single record:
+      # 1` for a record the table counts as three credentials. That is the
+      # amplified record the metric exists to surface, so the count has to
+      # agree with the table. The line locator is carried onto every fragment;
+      # a match consisting only of separators still emits its one row, so a
+      # locator can never be lost. records/sessions reduce through `sort -u`
+      # and are unchanged by construction. (Codex P2 on #2520.)
       grep -naoEi "$CRED_TABLE_RE" "$f" 2>/dev/null \
-        | awk -F: -v s="$cred_sess" '$1 ~ /^[0-9]+$/ {print s "\t" substr($1,1,12)}'
+        | awk -F: -v s="$cred_sess" '
+            $1 ~ /^[0-9]+$/ {
+              ln = substr($1, 1, 12)
+              rest = substr($0, index($0, ":") + 1)
+              n = split(rest, frag, /[;&|]/)
+              emitted = 0
+              for (i = 1; i <= n; i++) if (frag[i] != "") { print s "\t" ln; emitted = 1 }
+              if (!emitted) print s "\t" ln
+            }'
     done > "$CREDCONC"
     cred_records=$(sort -u "$CREDCONC" | grep -c . || true)
     cred_sessions=$(cut -f1 "$CREDCONC" | sort -u | grep -c . || true)

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -272,6 +272,18 @@ emit_credential_hits() {
               elif [[ $m == -----begin* ]];                       then shape="private-key-block"
               else shape="generic-assignment"
               fi
+              # Carry the table's [masked-display] qualifier through. Without
+              # it the table shows `github-pat (fine-grained) [masked-display]`
+              # (a tool's own masked rendering, do NOT rotate) while the
+              # locator says plain `shape=github-pat`, so an operator holding
+              # both a masked display and a real token of the same shape cannot
+              # tell which record belongs to the lower-risk row — and may rotate
+              # on the wrong one. Same rule as the wrapper/length agreement
+              # above: a locator that disagrees with the row it annotates is
+              # worse than no locator.
+              case $m in
+                [a-z0-9_-]*\*\*\**) [ "$shape" = generic-assignment ] || shape="$shape [masked-display]" ;;
+              esac
               printf '%s\t%s\t%s\t%s\n' "$session" "$line" "$record" "$shape"
             done
       done
@@ -338,25 +350,6 @@ CRED_RE='(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{1
 # for the leak TABLE; redact() keeps the broad unanchored CRED_RE, so
 # over-redaction is preserved even where the table refuses to count.
 CRED_TABLE_RE='((^|[^A-Za-z0-9_-])(github_pat_[A-Za-z0-9_]{20,}\**|gh[pousr]_[A-Za-z0-9]{16,}\**|AKIA[0-9A-Z]{12,}\**|xox[baprs]-[A-Za-z0-9-]{10,}\**|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})|-----BEGIN [A-Z ]*PRIVATE KEY-----|(secret|token|password|passwd|api[_-]?key)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?[^"'"'"'[:space:],}]{8,})'
-
-# Sentinel marking a match whose boundary character was `+` or `/`. Those are
-# the ONLY two characters that can satisfy the boundary anchor *inside* a
-# base64 run — every other base64 character is in [A-Za-z0-9_-], which the
-# anchor rejects — so they are the signature of a mid-blob chance match rather
-# than a pasted credential. `=` is deliberately EXCLUDED: it is base64 padding
-# but also the commonest assignment delimiter, so treating it as blob noise
-# would hide a real `TOKEN=ghp_…` leak. Ambiguity fails closed into the plain
-# high-signal row, exactly as [masked-display] does.
-#
-# A control byte is used because it cannot occur in any credential alphabet nor
-# in the generic value class, so it can only ever have been written by the sed
-# below — a printable sentinel could be forged by corpus content.
-# Only the ANCHORED token alternatives can carry a `+`/`/` first character (the
-# generic alternative's match begins with its key name), and no token alphabet
-# contains `:` or `=`, so the assignment-stripping sed downstream cannot fire on
-# a marked value and the mark survives to the classifier intact.
-B64MARK=$(printf '\001')
-
 # Portable mtime listing. GNU `stat -f` means --file-system (it SUCCEEDS and
 # prints filesystem status), so a `stat -f … || stat -c …` fallback never fires
 # on Linux and its output pollutes the file list — six phantom paths for one
@@ -1441,7 +1434,7 @@ if want safety; then
         | sed -E "s/$(printf '\033')\[[0-9;:]*[A-Za-z]//g" \
         | grep -ahoEi "$CRED_TABLE_RE" 2>/dev/null \
         | tr ';&|' '\n' | grep -v '^$' \
-        | sed -E -e "s|^[+/]|$B64MARK|" -e "s/^[^A-Za-z0-9_${B64MARK}-]//" \
+        | sed -E -e 's/^[^A-Za-z0-9_-]//' -e "s/^[^:=]*[:=][[:space:]]*[\"']?//" \
         -e "s/^[^:=]*[:=][[:space:]]*[\"']?//" \
         -e 's/^([A-Za-z0-9_-]+)\*\*\*+.*$/\1***/' \
         | grep -E . | sort -u
@@ -1461,13 +1454,6 @@ if want safety; then
       }
       {
         x = tolower($0)
-        # Mid-blob chance match: strip the sentinel before classifying, so the
-        # shape is derived from the value itself and the label is additive.
-        # The count is SUBDIVIDED, never dropped — a suppressing classifier is
-        # what got PR #2364 closed, because a record can hold a real hit and
-        # noise at once.
-        blob = 0
-        if (substr(x, 1, 1) == sprintf("%c", 1)) { blob = 1; x = substr(x, 2) }
         s = shape_of(x)
         # NB: the label itself passes through the output-boundary redactor, so
         # it must not be credential-SHAPED ("token=…" would come out mangled
@@ -1483,10 +1469,6 @@ if want safety; then
         # prefix+mask form under these regexes, and the weak generic bucket
         # keeps its own label.
         else if (x ~ /^[a-z0-9_-]+\*\*\*/) s = s " [masked-display]"
-        # Applied only to a shape that CLASSIFIED: the weak generic bucket is
-        # already triage-first, and labelling it would imply a precision the
-        # boundary character does not carry there.
-        if (blob && shape_of(x) != "") s = s " [in-base64-run]"
         print s
       }' | sort | uniq -c | sort -rn | sed 's/^/    /'
     # Concentration, mirroring the injection detector and placed directly under
@@ -1506,20 +1488,22 @@ if want safety; then
     cred_sessions=$(cut -f1 "$CREDCONC" | sort -u | grep -c . || true)
     cred_top=$(sort "$CREDCONC" | uniq -c | sort -rn | head -1 | awk '{print $1+0}')
     echo "      across ${cred_records:-0} transcript records in ${cred_sessions:-0} sessions; largest single record: ${cred_top:-0}"
-    echo "      (raw-line locator: the TABLE scans DECODED strings, so an"
-    echo "       escaped-quote match can be counted there yet have no locator"
-    echo "       line here. Concentration is CONTEXT, never a verdict.)"
+    echo "      (raw-line locator — it can DIVERGE FROM THE TABLE IN BOTH"
+    echo "       DIRECTIONS, so read it as a pointer, never as a second count."
+    echo "       UNDER: the table scans DECODED strings, so an escaped-quote"
+    echo "       match is counted there with no locator line here. OVER: the"
+    echo "       table structurally excludes complete base64 image payloads"
+    echo "       (encoded binary manufactures token shapes at random '+'/'/'"
+    echo "       boundaries); this raw scan does not, so a record inside such"
+    echo "       an image can appear here while the table stays empty."
+    echo "       Concentration is CONTEXT, never a verdict.)"
     : > "$CREDCONC"
     echo "    (empty = clean. A HIGH-SIGNAL shape count means rotate the credential AND"
     echo "     fix the path that logged it — see the cross-system rotation rule; triage"
     echo "     the weak-signal generic bucket before treating it as a leak."
     echo "     [masked-display] = a tool's own prefix+mask token rendering, e.g."
     echo "     gh auth status — the secret segment never reached the transcript;"
-    echo "     verify the mask is the tool's own display, don't rotate."
-    echo "     [in-base64-run] = the match's boundary character was '+' or '/',"
-    echo "     the only two that can satisfy the anchor INSIDE a base64 run, so"
-    echo "     it is very likely a chance substring of an encoded blob. Nothing"
-    echo "     is suppressed — verify before dismissing.)"
+    echo "     verify the mask is the tool's own display, don't rotate)"
     if [ "$CREDENTIAL_PROVENANCE" -eq 1 ]; then
       printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | while IFS= read -r f; do
         emit_credential_hits "$f"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -227,14 +227,24 @@ emit_credential_hits() {
   session=$(basename "$f" | tr -cd 'A-Za-z0-9._-' | cut -c1-120)
   [ -n "$session" ] || session=unknown
 
-  grep -niE "$CRED_TABLE_RE" "$f" 2>/dev/null \
+  # -a is LOAD-BEARING: a single NUL byte anywhere in the file makes grep treat
+  # it as binary and emit nothing at all. The table and concentration scans both
+  # pass -a, so without it here the row is counted while its locator silently
+  # vanishes — provenance disappearing exactly on the odd record most worth
+  # inspecting. Reproduced, not assumed (CodeRabbit finding).
+  # `tr -d '\000'` is the second half of the same fix: bash's `read` TRUNCATES a
+  # line at the first NUL, so -a alone gets the line out of grep and then the
+  # match is silently lost from $raw before the inner scan ever sees it.
+  # (Verified under bash specifically — zsh's read does not truncate, so an
+  # interactive spot-check in the wrong shell reports this as working.)
+  grep -naiE "$CRED_TABLE_RE" "$f" 2>/dev/null | tr -d '\000' \
     | while IFS=: read -r line raw; do
         case "$line" in ''|*[!0-9]*) continue ;; esac
         line=$(printf '%s' "$line" | cut -c1-12)
         record=$(printf '%s' "$raw" | jq -r '.type // "malformed"' 2>/dev/null \
                  | tr -cd 'A-Za-z0-9_-' | cut -c1-32)
         [ -n "$record" ] || record=malformed
-        printf '%s' "$raw" | grep -hoiE "$CRED_TABLE_RE" \
+        printf '%s' "$raw" | grep -haoiE "$CRED_TABLE_RE" \
           | while IFS= read -r match || [ -n "$match" ]; do
               # Classify to a SHAPE NAME and discard the value immediately.
               # These mirror the TABLE's shape_of() including its LENGTH bounds,

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -244,7 +244,13 @@ emit_credential_hits() {
         record=$(printf '%s' "$raw" | jq -r '.type // "malformed"' 2>/dev/null \
                  | tr -cd 'A-Za-z0-9_-' | cut -c1-32)
         [ -n "$record" ] || record=malformed
+        # Split on `;&|` exactly as the TABLE does before classifying. One raw
+        # field can carry several assignments, and grep's leftmost-longest rule
+        # returns the whole run as a single match — so without this the locator
+        # strips only the first wrapper and reports `generic-assignment` for a
+        # field the table counts as a high-signal key.
         printf '%s' "$raw" | grep -haoiE "$CRED_TABLE_RE" \
+          | tr ';&|' '\n' | grep -v '^$' \
           | while IFS= read -r match || [ -n "$match" ]; do
               # Classify to a SHAPE NAME and discard the value immediately.
               # These mirror the TABLE's shape_of() including its LENGTH bounds,
@@ -1434,8 +1440,9 @@ if want safety; then
         | sed -E "s/$(printf '\033')\[[0-9;:]*[A-Za-z]//g" \
         | grep -ahoEi "$CRED_TABLE_RE" 2>/dev/null \
         | tr ';&|' '\n' | grep -v '^$' \
-        | sed -E -e 's/^[^A-Za-z0-9_-]//' -e "s/^[^:=]*[:=][[:space:]]*[\"']?//" \
-        -e "s/^[^:=]*[:=][[:space:]]*[\"']?//" \
+        | sed -E -e 's/^[^A-Za-z0-9_-]//' \
+        -e "s/^[^:=]*[:=][[:space:]]*[\"']?(.+)$/\1/" \
+        -e "s/^[^:=]*[:=][[:space:]]*[\"']?(.+)$/\1/" \
         -e 's/^([A-Za-z0-9_-]+)\*\*\*+.*$/\1***/' \
         | grep -E . | sort -u
     done | sort -u | awk '

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -223,7 +223,7 @@ emit_injection_hits() {
 # rather than shared because the table consumes normalised values and this
 # consumes raw matches; keep the two prefix sets in step.
 emit_credential_hits() {
-  local f="$1" session line raw record match shape
+  local f="$1" session line raw record match shape m
   session=$(basename "$f" | tr -cd 'A-Za-z0-9._-' | cut -c1-120)
   [ -n "$session" ] || session=unknown
 
@@ -237,17 +237,31 @@ emit_credential_hits() {
         printf '%s' "$raw" | grep -hoiE "$CRED_TABLE_RE" \
           | while IFS= read -r match || [ -n "$match" ]; do
               # Classify to a SHAPE NAME and discard the value immediately.
-              # Anything unclassified reports as the weak generic bucket, so an
-              # unrecognised shape is never silently dropped from the locator.
-              case "$(printf '%s' "$match" | tr '[:upper:]' '[:lower:]')" in
-                *github_pat_*)  shape="github-pat" ;;
-                *ghp_*|*gho_*|*ghu_*|*ghs_*|*ghr_*) shape="github-token" ;;
-                *akia*)         shape="aws-access-key-id" ;;
-                *xox*)          shape="slack-token" ;;
-                *eyj*)          shape="jwt-like" ;;
-                *-----begin*)   shape="private-key-block" ;;
-                *)              shape="generic-assignment" ;;
-              esac
+              # These mirror the TABLE's shape_of() including its LENGTH bounds,
+              # not just the prefix: a prefix-only test would report
+              # `shape=github-token` for `token=ghp_short`, which the table
+              # correctly counts as weak generic — a locator disagreeing with
+              # the table it annotates is worse than no locator. Anything
+              # unclassified reports as the weak generic bucket, so an
+              # unrecognised shape is never silently dropped.
+              m=$(printf '%s' "$match" | tr '[:upper:]' '[:lower:]')
+              m=${m#[^a-z0-9_-]}
+              # Strip a `KEY=`/`key: ` wrapper exactly as the table does before
+              # classifying. grep's LEFTMOST-match rule hands `token=ghp_…` to
+              # the generic alternative, so the match begins at the KEY — and
+              # that wrapped form is the commonest real-leak shape. Without
+              # this, every wrapped leak would be located as
+              # `shape=generic-assignment` while the table counted it as a
+              # high-signal token.
+              case $m in *[:=]*) m=${m#*[:=]}; m=${m#"${m%%[![:space:]]*}"}; m=${m#[\"\']} ;; esac
+              if   [[ $m =~ ^github_pat_[a-z0-9_]{20,} ]];        then shape="github-pat"
+              elif [[ $m =~ ^gh[pousr]_[a-z0-9]{16,} ]];          then shape="github-token"
+              elif [[ $m =~ ^akia[0-9a-z]{12,} ]];                then shape="aws-access-key-id"
+              elif [[ $m =~ ^xox[baprs]-[a-z0-9-]{10,} ]];        then shape="slack-token"
+              elif [[ $m =~ ^eyj[a-z0-9_-]{10,}\.[a-z0-9_-]{10,} ]]; then shape="jwt-like"
+              elif [[ $m == -----begin* ]];                       then shape="private-key-block"
+              else shape="generic-assignment"
+              fi
               printf '%s\t%s\t%s\t%s\n' "$session" "$line" "$record" "$shape"
             done
       done

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -307,9 +307,21 @@ emit_credential_hits() {
               # on the wrong one. Same rule as the wrapper/length agreement
               # above: a locator that disagrees with the row it annotates is
               # worse than no locator.
-              case $m in
-                [a-z0-9_-]*\*\*\**) [ "$shape" = generic-assignment ] || shape="$shape [masked-display]" ;;
-              esac
+              # ANCHORED, mirroring the table's `x ~ /^[a-z0-9_-]+\*\*\*/`. A
+              # bash glob cannot express "one-or-more of this class": in
+              # `[a-z0-9_-]*\*\*\**` the middle `*` is an unrestricted wildcard,
+              # so it only required ONE leading class character and `***`
+              # SOMEWHERE later. The shape regexes above are anchored at `^`
+              # only, so `ghp_<16 class chars>.junk***tail` classifies as
+              # github-token and that glob then tagged it `[masked-display]`
+              # while the table — whose regex fails at the `.` — did not.
+              # Wrong in the DANGEROUS direction: `[masked-display]` is
+              # documented as "do NOT rotate", so a live credential was labelled
+              # not-worth-rotating. (CodeRabbit Major on #2520; reproduced
+              # before fixing.)
+              if [ "$shape" != generic-assignment ] && [[ $m =~ $MASK_TAIL_RE ]]; then
+                shape="$shape [masked-display]"
+              fi
               printf '%s\t%s\t%s\t%s\n' "$session" "$line" "$record" "$shape"
             done
       done
@@ -376,6 +388,12 @@ CRED_RE='(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{1
 # for the leak TABLE; redact() keeps the broad unanchored CRED_RE, so
 # over-redaction is preserved even where the table refuses to count.
 CRED_TABLE_RE='((^|[^A-Za-z0-9_-])(github_pat_[A-Za-z0-9_]{20,}\**|gh[pousr]_[A-Za-z0-9]{16,}\**|AKIA[0-9A-Z]{12,}\**|xox[baprs]-[A-Za-z0-9-]{10,}\**|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})|-----BEGIN [A-Z ]*PRIVATE KEY-----|(secret|token|password|passwd|api[_-]?key)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?[^"'"'"'[:space:],}]{8,})'
+# The locator's masked-display test, kept as a REGEX rather than a glob and kept
+# byte-for-byte equivalent to the table's own `x ~ /^[a-z0-9_-]+\*\*\*/`. It must
+# stay anchored and must require the WHOLE run before `***` to be class
+# characters: a glob cannot express that (its `*` is an unrestricted wildcard),
+# and the loose form mislabels a real credential as a tool's masked rendering.
+MASK_TAIL_RE='^[a-z0-9_-]+\*\*\*'
 # Portable mtime listing. GNU `stat -f` means --file-system (it SUCCEEDS and
 # prints filesystem status), so a `stat -f … || stat -c …` fallback never fires
 # on Linux and its output pollutes the file list — six phantom paths for one

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -249,7 +249,9 @@ emit_credential_hits() {
   # weld and cannot itself be mistaken for value content; it also keeps `$raw`
   # parseable for the `jq` call below, which a literal NUL would not.
   # (Codex P2 on #2520; reproduced before fixing.)
-  grep -naiE "$CRED_TABLE_RE" "$f" 2>/dev/null | tr '\000' ' ' \
+  # `strip_ansi` runs BEFORE the scan so a styled credential is locatable at all;
+  # it is line-for-line, so grep's `-n` numbering still names the real record.
+  strip_ansi < "$f" 2>/dev/null | grep -naiE "$CRED_TABLE_RE" 2>/dev/null | tr '\000' ' ' \
     | while IFS=: read -r line raw; do
         case "$line" in ''|*[!0-9]*) continue ;; esac
         line=$(printf '%s' "$line" | cut -c1-12)
@@ -292,12 +294,25 @@ emit_credential_hits() {
               # separator that would leave nothing behind — that is what keeps a
               # value whose own last character is `=` (base64 padding) from being
               # eaten as a further wrapper and dropped from the report entirely.
+              # That guard only covers a SINGLE trailing `=`. Base64 pads with up
+              # to TWO, and `secret=<b64>==` leaves `=` behind — non-empty, so the
+              # guard passes it, and the whole value collapses to `=`. Distinct
+              # secrets then share one identity and `sort -u` counts them as one
+              # credential: an UNDER-count in a leak detector. So pass 2 also
+              # refuses a remainder that itself begins with `=`, which is padding
+              # rather than a nested wrapper. Kept byte-equivalent to the table's
+              # `([^=].*)` second pass — a locator that disagreed with the table
+              # here would reintroduce exactly the divergence this work removes.
+              # (Codex P2 on #2520; reproduced before fixing.)
               for _pass in 1 2; do
                 case $m in
                   *[:=]*)
                     _c=${m#*[:=]}
                     _c=${_c#"${_c%%[![:space:]]*}"}
                     _c=${_c#[\"\']}
+                    if [ "$_pass" = 2 ]; then
+                      case $_c in '='*) _c= ;; esac
+                    fi
                     [ -n "$_c" ] && m=$_c
                     ;;
                 esac
@@ -406,6 +421,27 @@ CRED_TABLE_RE='((^|[^A-Za-z0-9_-])(github_pat_[A-Za-z0-9_]{20,}\**|gh[pousr]_[A-
 # characters: a glob cannot express that (its `*` is an unrestricted wildcard),
 # and the loose form mislabels a real credential as a tool's masked rendering.
 MASK_TAIL_RE='^[a-z0-9_-]+\*\*\*'
+# ANSI normalization for the RAW scans (the locator and the concentration
+# metric), which read the transcript VERBATIM.
+#
+# 🔴 BOTH forms are load-bearing, and the encoded one is the form that actually
+# occurs. The TABLE decodes with `jq` first, so by the time it normalizes it can
+# only ever see a literal ESC byte. A raw scan never decodes — and a JSON string
+# cannot carry a literal ESC, so a transcript stores it ENCODED as ``.
+# Mirroring only the table's literal-ESC strip here is therefore a NO-OP on real
+# transcript bytes: measured on a realistic fixture, the styled token stayed
+# invisible under the literal-only strip and matched only once both forms went.
+#
+# Without this, a styled credential is counted by the table while the locator
+# cannot find it: the boundary-anchored regex needs a non-`[A-Za-z0-9_-]` char
+# before the prefix, and the CSI terminator `m` sits directly against it. The
+# reported shape is "one high-signal token across 0 transcript records", which
+# reads as a detector fault rather than the leak it is. (Codex P2 on #2520;
+# reproduced before fixing.)
+_ESC=$(printf '\033')
+strip_ansi() {
+  sed -E -e "s/${_ESC}\[[0-9;:]*[A-Za-z]//g" -e 's/\\u001[bB]\[[0-9;:]*[A-Za-z]//g'
+}
 # Portable mtime listing. GNU `stat -f` means --file-system (it SUCCEEDS and
 # prints filesystem status), so a `stat -f … || stat -c …` fallback never fires
 # on Linux and its output pollutes the file list — six phantom paths for one
@@ -1492,7 +1528,7 @@ if want safety; then
         | tr ';&|' '\n' | grep -v '^$' \
         | sed -E -e 's/^[^A-Za-z0-9_-]//' \
         -e "s/^[^:=]*[:=][[:space:]]*[\"']?(.+)$/\1/" \
-        -e "s/^[^:=]*[:=][[:space:]]*[\"']?(.+)$/\1/" \
+        -e "s/^[^:=]*[:=][[:space:]]*[\"']?([^=].*)$/\1/" \
         -e 's/^([A-Za-z0-9_-]+)\*\*\*+.*$/\1***/' \
         | grep -E . | sort -u
     done | sort -u | awk '
@@ -1561,7 +1597,10 @@ if want safety; then
       # a match consisting only of separators still emits its one row, so a
       # locator can never be lost. records/sessions reduce through `sort -u`
       # and are unchanged by construction. (Codex P2 on #2520.)
-      grep -naoEi "$CRED_TABLE_RE" "$f" 2>/dev/null \
+      # Normalized exactly as the locator is, and for the same reason: an
+      # unnormalized scan reports a styled leak as `across 0 transcript records`,
+      # which is the metric contradicting the table it qualifies.
+      strip_ansi < "$f" 2>/dev/null | grep -naoEi "$CRED_TABLE_RE" 2>/dev/null \
         | awk -F: -v s="$cred_sess" '
             $1 ~ /^[0-9]+$/ {
               ln = substr($1, 1, 12)

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1515,7 +1515,23 @@ if want safety; then
         emit_credential_hits "$f"
       done | redact > "$CREDPROV"
       echo "    occurrence provenance (locator + SHAPE only — never the value):"
-      awk -F'\t' '{printf "      session=%s line=%s record=%s shape=%s\n", $1, $2, $3, $4}' "$CREDPROV"
+      # Collapse identical locators to `Nx`. One record legitimately holds
+      # several matches, so the raw list repeats a location once per match —
+      # measured 171 lines for 100 distinct locations on a 1-day corpus, which
+      # buries the few high-signal rows this exists to surface. The count is
+      # PRINTED, not dropped, so nothing is silently truncated.
+      # NB: do NOT rebuild $0 to drop uniq's count — assigning to a field
+      # re-joins with OFS and turns the TABS into spaces, after which the
+      # split() below finds one field and every value prints empty.
+      sort "$CREDPROV" | uniq -c | sort -rn \
+        | awk '{
+            line = $0
+            sub(/^[[:space:]]*/, "", line)
+            n = line; sub(/[^0-9].*$/, "", n)
+            rest = line; sub(/^[0-9]+[[:space:]]+/, "", rest)
+            split(rest, p, "\t")
+            printf "      %4dx session=%s line=%s record=%s shape=%s\n", n, p[1], p[2], p[3], p[4]
+          }'
       : > "$CREDPROV"
     else
       echo "    provenance: rerun with --section safety --credential-provenance"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -12,13 +12,15 @@
 #   of this output and acts on it has been injected. See the installed
 #   `agentic-engineering` plugin's `agent-improver` → "Ingestion boundary".
 #
-# Usage: agent-telemetry.sh [--since-days N] [--max-files N] [--section NAME] [--injection-provenance]
+# Usage: agent-telemetry.sh [--since-days N] [--max-files N] [--section NAME]
+#                           [--injection-provenance] [--credential-provenance]
 set -uo pipefail
 
 SINCE_DAYS=1
 MAX_FILES=400
 SECTION=all
 INJECTION_PROVENANCE=0
+CREDENTIAL_PROVENANCE=0
 
 # Require a value before shifting past it. `shift 2` with only one arg left is a
 # no-op error under `set +e`, which spins the loop on the same $1 forever — a
@@ -36,6 +38,7 @@ while [ $# -gt 0 ]; do
     --max-files)  need_val "$@"; MAX_FILES="$2";  shift 2 ;;
     --section)    need_val "$@"; SECTION="$2";    shift 2 ;;
     --injection-provenance) INJECTION_PROVENANCE=1; shift ;;
+    --credential-provenance) CREDENTIAL_PROVENANCE=1; shift ;;
     -h|--help)    sed -n '2,16p' "$0"; exit 0 ;;
     *) echo "unknown argument (value not echoed)" >&2; exit 2 ;;
   esac
@@ -174,10 +177,12 @@ PROVTMP=$(mktemp "${TMPDIR:-/tmp}/.agtel_prov.XXXXXXXX") || { echo "cannot creat
 # Distinct prefix from .agtel_inj so the aggregate-identity width instrumentation
 # in the test suite keeps measuring only the phrase scratch it targets.
 CONCTMP=$(mktemp "${TMPDIR:-/tmp}/.agtel_conc.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
+CREDCONC=$(mktemp "${TMPDIR:-/tmp}/.agtel_credconc.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
+CREDPROV=$(mktemp "${TMPDIR:-/tmp}/.agtel_credprov.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
 # Remove on normal exit; on a SIGNAL also terminate, since a trap that only
 # cleans up leaves the script running after the scheduler asked it to stop.
-trap 'rm -f "$ERRTMP" "$INJTMP" "$PROVTMP" "$CONCTMP"' EXIT
-trap 'rm -f "$ERRTMP" "$INJTMP" "$PROVTMP" "$CONCTMP"; trap - HUP INT TERM; kill -s INT $$' HUP INT TERM
+trap 'rm -f "$ERRTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV"' EXIT
+trap 'rm -f "$ERRTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV"; trap - HUP INT TERM; kill -s INT $$' HUP INT TERM
 
 INJ_PHRASE_RE='(ignore (all )?(prior|previous) (rules|instructions)|disregard (your|all) (instructions|rules)|the maintainer (approved|authorised|authorized)|add [^ ]+ to the trust gate|update your instructions|you are now [a-z ]{0,20}mode)'
 
@@ -207,6 +212,43 @@ emit_injection_hits() {
                        | tr -cd 'a-z0-9 ._:/@+-' | cut -c1-80)
               [ -n "$phrase" ] || continue
               printf '%s\t%s\t%s\t%s\n' "$session" "$line" "$record" "$phrase"
+            done
+      done
+}
+
+# Locator for a credential-shaped match: session, line, record type and SHAPE.
+# Deliberately weaker than emit_injection_hits, which prints the matched phrase:
+# a phrase is evidence, a credential is the secret itself, so the value NEVER
+# leaves this function. Shape classification is duplicated from the table's awk
+# rather than shared because the table consumes normalised values and this
+# consumes raw matches; keep the two prefix sets in step.
+emit_credential_hits() {
+  local f="$1" session line raw record match shape
+  session=$(basename "$f" | tr -cd 'A-Za-z0-9._-' | cut -c1-120)
+  [ -n "$session" ] || session=unknown
+
+  grep -niE "$CRED_TABLE_RE" "$f" 2>/dev/null \
+    | while IFS=: read -r line raw; do
+        case "$line" in ''|*[!0-9]*) continue ;; esac
+        line=$(printf '%s' "$line" | cut -c1-12)
+        record=$(printf '%s' "$raw" | jq -r '.type // "malformed"' 2>/dev/null \
+                 | tr -cd 'A-Za-z0-9_-' | cut -c1-32)
+        [ -n "$record" ] || record=malformed
+        printf '%s' "$raw" | grep -hoiE "$CRED_TABLE_RE" \
+          | while IFS= read -r match || [ -n "$match" ]; do
+              # Classify to a SHAPE NAME and discard the value immediately.
+              # Anything unclassified reports as the weak generic bucket, so an
+              # unrecognised shape is never silently dropped from the locator.
+              case "$(printf '%s' "$match" | tr '[:upper:]' '[:lower:]')" in
+                *github_pat_*)  shape="github-pat" ;;
+                *ghp_*|*gho_*|*ghu_*|*ghs_*|*ghr_*) shape="github-token" ;;
+                *akia*)         shape="aws-access-key-id" ;;
+                *xox*)          shape="slack-token" ;;
+                *eyj*)          shape="jwt-like" ;;
+                *-----begin*)   shape="private-key-block" ;;
+                *)              shape="generic-assignment" ;;
+              esac
+              printf '%s\t%s\t%s\t%s\n' "$session" "$line" "$record" "$shape"
             done
       done
 }
@@ -272,6 +314,24 @@ CRED_RE='(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{1
 # for the leak TABLE; redact() keeps the broad unanchored CRED_RE, so
 # over-redaction is preserved even where the table refuses to count.
 CRED_TABLE_RE='((^|[^A-Za-z0-9_-])(github_pat_[A-Za-z0-9_]{20,}\**|gh[pousr]_[A-Za-z0-9]{16,}\**|AKIA[0-9A-Z]{12,}\**|xox[baprs]-[A-Za-z0-9-]{10,}\**|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})|-----BEGIN [A-Z ]*PRIVATE KEY-----|(secret|token|password|passwd|api[_-]?key)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?[^"'"'"'[:space:],}]{8,})'
+
+# Sentinel marking a match whose boundary character was `+` or `/`. Those are
+# the ONLY two characters that can satisfy the boundary anchor *inside* a
+# base64 run — every other base64 character is in [A-Za-z0-9_-], which the
+# anchor rejects — so they are the signature of a mid-blob chance match rather
+# than a pasted credential. `=` is deliberately EXCLUDED: it is base64 padding
+# but also the commonest assignment delimiter, so treating it as blob noise
+# would hide a real `TOKEN=ghp_…` leak. Ambiguity fails closed into the plain
+# high-signal row, exactly as [masked-display] does.
+#
+# A control byte is used because it cannot occur in any credential alphabet nor
+# in the generic value class, so it can only ever have been written by the sed
+# below — a printable sentinel could be forged by corpus content.
+# Only the ANCHORED token alternatives can carry a `+`/`/` first character (the
+# generic alternative's match begins with its key name), and no token alphabet
+# contains `:` or `=`, so the assignment-stripping sed downstream cannot fire on
+# a marked value and the mark survives to the classifier intact.
+B64MARK=$(printf '\001')
 
 # Portable mtime listing. GNU `stat -f` means --file-system (it SUCCEEDS and
 # prints filesystem status), so a `stat -f … || stat -c …` fallback never fires
@@ -1357,7 +1417,8 @@ if want safety; then
         | sed -E "s/$(printf '\033')\[[0-9;:]*[A-Za-z]//g" \
         | grep -ahoEi "$CRED_TABLE_RE" 2>/dev/null \
         | tr ';&|' '\n' | grep -v '^$' \
-        | sed -E -e 's/^[^A-Za-z0-9_-]//' -e "s/^[^:=]*[:=][[:space:]]*[\"']?//" \
+        | sed -E -e "s|^[+/]|$B64MARK|" -e "s/^[^A-Za-z0-9_${B64MARK}-]//" \
+        -e "s/^[^:=]*[:=][[:space:]]*[\"']?//" \
         -e 's/^([A-Za-z0-9_-]+)\*\*\*+.*$/\1***/' \
         | grep -E . | sort -u
     done | sort -u | awk '
@@ -1376,6 +1437,13 @@ if want safety; then
       }
       {
         x = tolower($0)
+        # Mid-blob chance match: strip the sentinel before classifying, so the
+        # shape is derived from the value itself and the label is additive.
+        # The count is SUBDIVIDED, never dropped — a suppressing classifier is
+        # what got PR #2364 closed, because a record can hold a real hit and
+        # noise at once.
+        blob = 0
+        if (substr(x, 1, 1) == sprintf("%c", 1)) { blob = 1; x = substr(x, 2) }
         s = shape_of(x)
         # NB: the label itself passes through the output-boundary redactor, so
         # it must not be credential-SHAPED ("token=…" would come out mangled
@@ -1391,14 +1459,53 @@ if want safety; then
         # prefix+mask form under these regexes, and the weak generic bucket
         # keeps its own label.
         else if (x ~ /^[a-z0-9_-]+\*\*\*/) s = s " [masked-display]"
+        # Applied only to a shape that CLASSIFIED: the weak generic bucket is
+        # already triage-first, and labelling it would imply a precision the
+        # boundary character does not carry there.
+        if (blob && shape_of(x) != "") s = s " [in-base64-run]"
         print s
       }' | sort | uniq -c | sort -rn | sed 's/^/    /'
+    # Concentration, mirroring the injection detector and placed directly under
+    # the table it qualifies. The TABLE counts distinct VALUES on purpose (one
+    # leak pasted into fifty transcripts is one credential to rotate); this
+    # answers the different question the table cannot — WHERE to look — without
+    # printing any value. Triaging the 2026-07-25 report needed four manual
+    # queries precisely because a documentation example, a test constant and a
+    # real leak render as the same integer.
+    printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | while IFS= read -r f; do
+      cred_sess=$(basename "$f" | tr -cd 'A-Za-z0-9._-' | cut -c1-120)
+      [ -n "$cred_sess" ] || cred_sess=unknown
+      grep -naoEi "$CRED_TABLE_RE" "$f" 2>/dev/null \
+        | awk -F: -v s="$cred_sess" '$1 ~ /^[0-9]+$/ {print s "\t" substr($1,1,12)}'
+    done > "$CREDCONC"
+    cred_records=$(sort -u "$CREDCONC" | grep -c . || true)
+    cred_sessions=$(cut -f1 "$CREDCONC" | sort -u | grep -c . || true)
+    cred_top=$(sort "$CREDCONC" | uniq -c | sort -rn | head -1 | awk '{print $1+0}')
+    echo "      across ${cred_records:-0} transcript records in ${cred_sessions:-0} sessions; largest single record: ${cred_top:-0}"
+    echo "      (raw-line locator: the TABLE scans DECODED strings, so an"
+    echo "       escaped-quote match can be counted there yet have no locator"
+    echo "       line here. Concentration is CONTEXT, never a verdict.)"
+    : > "$CREDCONC"
     echo "    (empty = clean. A HIGH-SIGNAL shape count means rotate the credential AND"
     echo "     fix the path that logged it — see the cross-system rotation rule; triage"
     echo "     the weak-signal generic bucket before treating it as a leak."
     echo "     [masked-display] = a tool's own prefix+mask token rendering, e.g."
     echo "     gh auth status — the secret segment never reached the transcript;"
-    echo "     verify the mask is the tool's own display, don't rotate)"
+    echo "     verify the mask is the tool's own display, don't rotate."
+    echo "     [in-base64-run] = the match's boundary character was '+' or '/',"
+    echo "     the only two that can satisfy the anchor INSIDE a base64 run, so"
+    echo "     it is very likely a chance substring of an encoded blob. Nothing"
+    echo "     is suppressed — verify before dismissing.)"
+    if [ "$CREDENTIAL_PROVENANCE" -eq 1 ]; then
+      printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | while IFS= read -r f; do
+        emit_credential_hits "$f"
+      done | redact > "$CREDPROV"
+      echo "    occurrence provenance (locator + SHAPE only — never the value):"
+      awk -F'\t' '{printf "      session=%s line=%s record=%s shape=%s\n", $1, $2, $3, $4}' "$CREDPROV"
+      : > "$CREDPROV"
+    else
+      echo "    provenance: rerun with --section safety --credential-provenance"
+    fi
     echo
     echo "  build/codegen commands run in a session that ALSO checked out a"
     echo "  non-own branch (candidates for untrusted-code execution):"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -232,12 +232,24 @@ emit_credential_hits() {
   # pass -a, so without it here the row is counted while its locator silently
   # vanishes — provenance disappearing exactly on the odd record most worth
   # inspecting. Reproduced, not assumed (CodeRabbit finding).
-  # `tr -d '\000'` is the second half of the same fix: bash's `read` TRUNCATES a
+  # Translating NUL is the second half of the same fix: bash's `read` TRUNCATES a
   # line at the first NUL, so -a alone gets the line out of grep and then the
   # match is silently lost from $raw before the inner scan ever sees it.
   # (Verified under bash specifically — zsh's read does not truncate, so an
   # interactive spot-check in the wrong shell reports this as working.)
-  grep -naiE "$CRED_TABLE_RE" "$f" 2>/dev/null | tr -d '\000' \
+  # 🔴 It must be `tr '\000' ' '`, NOT `tr -d '\000'`. DELETING the byte welds the
+  # fragments on either side of it into one string, so two short, harmless
+  # token-shaped pieces become a full-length credential that never existed:
+  # `ghp_<8 chars>\0<12 chars>` is correctly NOT counted by the table, but the
+  # deleting form emitted `shape=github-token` for it — a PHANTOM high-signal
+  # locator pointing at a credential nobody ever leaked, which is a false
+  # positive in a leak detector and the exact locator/table disagreement this
+  # provenance work exists to remove. A space is the right replacement because it
+  # appears in no token alphabet and in none of the shape regexes, so it cannot
+  # weld and cannot itself be mistaken for value content; it also keeps `$raw`
+  # parseable for the `jq` call below, which a literal NUL would not.
+  # (Codex P2 on #2520; reproduced before fixing.)
+  grep -naiE "$CRED_TABLE_RE" "$f" 2>/dev/null | tr '\000' ' ' \
     | while IFS=: read -r line raw; do
         case "$line" in ''|*[!0-9]*) continue ;; esac
         line=$(printf '%s' "$line" | cut -c1-12)

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -223,7 +223,7 @@ emit_injection_hits() {
 # rather than shared because the table consumes normalised values and this
 # consumes raw matches; keep the two prefix sets in step.
 emit_credential_hits() {
-  local f="$1" session line raw record match shape m
+  local f="$1" session line raw record match shape m _pass _c
   session=$(basename "$f" | tr -cd 'A-Za-z0-9._-' | cut -c1-120)
   [ -n "$session" ] || session=unknown
 
@@ -269,7 +269,27 @@ emit_credential_hits() {
               # this, every wrapped leak would be located as
               # `shape=generic-assignment` while the table counted it as a
               # high-signal token.
-              case $m in *[:=]*) m=${m#*[:=]}; m=${m#"${m%%[![:space:]]*}"}; m=${m#[\"\']} ;; esac
+              # TWICE, because the table strips twice. Its sed's `[^:=]*` cannot
+              # cross a separator, so one pass removes exactly ONE wrapper — and
+              # a token stored under a credential-NAMED record field arrives as
+              # two (`secret":"token=ghp_…`). A single strip left `token=ghp_…`
+              # here and reported `generic-assignment` while the table counted a
+              # live github-token, sending the operator to a weak-signal record.
+              # (Codex P2 on #2520.)
+              # The `-n` guard mirrors the sed's `(.+)`, which refuses a
+              # separator that would leave nothing behind — that is what keeps a
+              # value whose own last character is `=` (base64 padding) from being
+              # eaten as a further wrapper and dropped from the report entirely.
+              for _pass in 1 2; do
+                case $m in
+                  *[:=]*)
+                    _c=${m#*[:=]}
+                    _c=${_c#"${_c%%[![:space:]]*}"}
+                    _c=${_c#[\"\']}
+                    [ -n "$_c" ] && m=$_c
+                    ;;
+                esac
+              done
               if   [[ $m =~ ^github_pat_[a-z0-9_]{20,} ]];        then shape="github-pat"
               elif [[ $m =~ ^gh[pousr]_[a-z0-9]{16,} ]];          then shape="github-token"
               elif [[ $m =~ ^akia[0-9a-z]{12,} ]];                then shape="aws-access-key-id"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1945,56 +1945,24 @@ OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credbin" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR=
       bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
 check "NUL-bearing record still produces a locator" "$OUT" "session=s.jsonl"
 
-# A mid-blob chance match: base64 alphabet includes `+` and `/`, which are the
-# only characters that can satisfy the boundary anchor INSIDE a blob. The image
-# path is already excluded structurally; this covers the remaining blob shapes
-# (Codex `encrypted_content`). It is LABELLED, never dropped.
-mkdir -p "$FIX/credb64"
-B64_BLOB="TWFueSBoYW5kcyBtYWtlIGxpZ2h0IHdvcmsu+__GHPC__/QUJDREVGRw"
-cat > "$FIX/credb64/s.jsonl" <<EOF
-{"type":"user","message":{"content":[{"type":"text","text":"$B64_BLOB"}]}}
+# The locator must carry the table's [masked-display] qualifier. Without it the
+# table says "do NOT rotate, it's a tool's own mask" while the locator names a
+# bare high-signal shape — so an operator holding both a masked display and a
+# real token of that shape cannot tell which record is the lower-risk one
+# (Codex finding on #2520).
+mkdir -p "$FIX/credmaskloc"
+cat > "$FIX/credmaskloc/s.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"Token: __PATA__*** (masked)"}]}}
 EOF
-subst "$FIX/credb64/s.jsonl"
-TABLE=$(CLAUDE_PROJECTS_DIR="$FIX/credb64" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
-      bash "$TARGET" --since-days 3650 --section safety 2>&1 \
-      | sed -n '/credential-shaped/,/rotate the credential/p')
-check "mid-blob chance match is labelled, not dropped" "$TABLE" "[in-base64-run]"
+subst "$FIX/credmaskloc/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credmaskloc" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+if printf '%s' "$OUT" | grep -q 'masked-display' \
+   && printf '%s' "$OUT" | grep -qE 'shape=github-pat \[masked-display\]'; then
+  ok "locator carries the table's [masked-display] qualifier"
+else bad "locator carries the table's [masked-display] qualifier" \
+  "$(printf '%s' "$OUT" | grep -E 'github-pat|session=' | head -3)"; fi
 
-# Fail closed: `=` is base64 PADDING but also the commonest assignment
-# delimiter, so it must stay in the plain high-signal row. Getting this wrong
-# would hide a real `…=ghp_…` leak behind a noise label.
-# NB: the fixture deliberately carries NO secret/token/password/api_key keyword.
-# With one (`GITHUB_TOKEN=…`) the generic alternative wins the leftmost match,
-# the extracted match starts at the KEY, and `=` is never the boundary
-# character — so that fixture asserts nothing about `=` at all. Ablating the
-# boundary class to `[+/=]` left it green, which is how the vacuity was caught.
-mkdir -p "$FIX/credeq"
-cat > "$FIX/credeq/s.jsonl" <<'EOF'
-{"type":"user","message":{"content":[{"type":"text","text":"blob QUJDREVG=__GHPD__ end"}]}}
-EOF
-subst "$FIX/credeq/s.jsonl"
-TABLE=$(CLAUDE_PROJECTS_DIR="$FIX/credeq" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
-      bash "$TARGET" --since-days 3650 --section safety 2>&1 \
-      | sed -n '/credential-shaped/,/rotate the credential/p')
-if printf '%s' "$TABLE" | grep -q 'in-base64-run'; then
-  bad "'=' delimiter fails closed to the plain high-signal row" "labelled as blob noise: $TABLE"
-else ok "'=' delimiter fails closed to the plain high-signal row"; fi
-
-# A quote-anchored real token stays high-signal and unlabelled. This is the
-# shape 100% of the live corpus's matches actually had when measured
-# 2026-07-28, so mislabelling it would blind the detector on real data.
-mkdir -p "$FIX/credquote"
-cat > "$FIX/credquote/s.jsonl" <<'EOF'
-{"type":"user","message":{"content":[{"type":"text","text":"value is \"__GHPA__\" here"}]}}
-EOF
-subst "$FIX/credquote/s.jsonl"
-TABLE=$(CLAUDE_PROJECTS_DIR="$FIX/credquote" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
-      bash "$TARGET" --since-days 3650 --section safety 2>&1 \
-      | sed -n '/credential-shaped/,/rotate the credential/p')
-if printf '%s' "$TABLE" | grep -q 'github-token (classic/app)' \
-   && ! printf '%s' "$TABLE" | grep -q 'in-base64-run'; then
-  ok "quote-anchored real token stays unlabelled high-signal"
-else bad "quote-anchored real token stays unlabelled high-signal" "$TABLE"; fi
 
 echo
 echo "──────────────────────────────"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1933,6 +1933,18 @@ if printf '%s' "$OUT" | grep -qE '^[[:space:]]+1 github-token'; then
 else bad "table still counts ONE distinct value for the repeated token" \
   "$(printf '%s' "$OUT" | grep 'github-token' | head -2)"; fi
 
+# A NUL byte anywhere in the file makes grep treat it as binary and emit
+# NOTHING without -a. The table and concentration scans both pass -a, so
+# omitting it in the locator counts the row while its provenance silently
+# vanishes — on exactly the odd record most worth inspecting. Reproduced
+# against real grep before fixing (CodeRabbit finding on #2520).
+mkdir -p "$FIX/credbin"
+printf 'prefix \000 token "__GHPA__" here\n' > "$FIX/credbin/s.jsonl"
+subst "$FIX/credbin/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credbin" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+check "NUL-bearing record still produces a locator" "$OUT" "session=s.jsonl"
+
 # A mid-blob chance match: base64 alphabet includes `+` and `/`, which are the
 # only characters that can satisfy the boundary anchor INSIDE a blob. The image
 # path is already excluded structurally; this covers the remaining blob shapes

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1977,18 +1977,12 @@ else bad "nested wrappers locate as the underlying token shape" \
 # A value whose OWN trailing character is a separator must still produce a
 # locator row after nested stripping — base64 padding is the everyday case.
 #
-# ⚠️ ABLATION-MEASURED SCOPE, stated because the obvious reading is wrong: this
-# asserts the ROW SURVIVES, not that the stripper stopped at the right place.
-# Measured three variants against it — two passes with the non-empty guard, two
-# passes WITHOUT the guard, and longest-match `${m##*[:=]}` — and all three pass,
-# because a value stripped down to nothing fails every shape regex and lands in
-# the same `generic-assignment` bucket the correct value lands in. The locator
-# prints only the shape, so no assertion on its output can separate them.
-# The `-n` guard in the stripper is therefore defence-in-depth for parity with
-# the table's own value (its sed's `(.+)` refuses to leave nothing), NOT a
-# property this suite pins — the same honest scoping as the output-boundary
-# assertion above. What IS pinned here: dropping the row entirely, which is the
-# false negative this PR's head commit fixed and a real regression risk.
+# ⚠️ SCOPE: this asserts the ROW SURVIVES, not that the stripper stopped at the
+# right separator. All three stripper variants (two passes with the non-empty
+# guard, two passes without it, and longest-match `${m##*[:=]}`) pass THIS case,
+# because a GENERIC value stripped to nothing lands in the same
+# `generic-assignment` bucket the correctly-stripped generic value lands in.
+# The stop-at-the-right-separator half is pinned by the high-signal case below.
 mkdir -p "$FIX/crednestpad"
 cat > "$FIX/crednestpad/s.jsonl" <<'EOF'
 {"type":"user","secret":"token=__GENPAD__","message":{"content":[{"type":"text","text":"see config"}]}}
@@ -1998,6 +1992,32 @@ OUT=$(CLAUDE_PROJECTS_DIR="$FIX/crednestpad" CODEX_HOME="$FIX/nocodex" MONOREPO_
       bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
 check "nested wrapper around a '='-terminated value still emits a locator" \
       "$OUT" "shape=generic-assignment"
+
+# The other half: a padded HIGH-SIGNAL value. This is where stopping at the WRONG
+# separator becomes visible, because collapsing the value loses its SHAPE — and
+# the shape is the only thing the locator prints. A JWT ending in base64 padding
+# has no interior `:`/`=`, so the trailing `=` is the first separator the second
+# pass sees; without the non-empty guard that pass empties the value and the row
+# degrades to the weak generic bucket.
+# Measured, three arms against this fixture:
+#   two passes + `-n` guard (as implemented) → jwt-like   ✓
+#   two passes, guard removed               → generic    ✗
+#   longest-match `${m##*[:=]}`             → generic    ✗
+# Both failing arms leave the REST of the suite green, so this case is the only
+# thing standing between the stripper and a silent revert to the pre-fix
+# behaviour. It matters specifically because collapsing the two-pass loop into
+# one longest-match strip is the obvious "simplify this" edit.
+# (Found by a sibling instance's differential pass on this PR's head — it built
+# the same fix independently, lost the push race, and diffed the two suites.)
+mkdir -p "$FIX/crednestpadjwt"
+cat > "$FIX/crednestpadjwt/s.jsonl" <<'EOF'
+{"type":"user","secret":"__JWT__=","message":{"content":[{"type":"text","text":"see config"}]}}
+EOF
+subst "$FIX/crednestpadjwt/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/crednestpadjwt" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+check "a padded HIGH-SIGNAL value keeps its shape through nested stripping" \
+      "$OUT" "shape=jwt-like"
 
 # Repeated matches at ONE location collapse to `Nx` with the count printed, not
 # dropped. Measured 171 locator lines for 100 distinct locations on a 1-day

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -2121,6 +2121,56 @@ else bad "locator withholds [masked-display] when the pre-mask run is not class 
   "$(printf '%s' "$OUT" | grep -E 'github-token|session=' | head -3)"; fi
 
 
+# The concentration line must SPLIT compound matches, exactly as the table does.
+# The generic alternative's value class admits `;`, `&` and `|`, so grep's
+# leftmost-longest rule returns a whole run of assignments as ONE match — and
+# `grep -o` then emits ONE line for it. Counting lines therefore reported
+# `largest single record: 1` for a record the table and the provenance locator
+# both split into three credentials, which defeats the entire purpose of a
+# concentration metric: an amplified record is exactly what it exists to find.
+# Splitting here restores agreement with the table (the same rule the locator
+# already follows) and moves ONLY the top-record figure — records and sessions
+# both reduce through `sort -u`, so they are unchanged by construction.
+# (Codex P2 on #2520; reproduced against the real detector before fixing.)
+mkdir -p "$FIX/credcompound"
+cat > "$FIX/credcompound/s.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"token=__GHPA__;key=__AWS__;password=abcdefghijkl"}]}}
+EOF
+subst "$FIX/credcompound/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credcompound" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+CREDSEC=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$CREDSEC" | grep -qE 'largest single record: 3'; then
+  ok "concentration splits compound matches like the table"
+else bad "concentration splits compound matches like the table" \
+  "$(printf '%s' "$CREDSEC" | grep -E 'across .* records')"; fi
+
+# Guard the REGRESSION the source-side session redaction could introduce.
+# Redacting the basename before it reaches the scratch file must not collapse
+# distinct sessions into one bucket — a redactor that mapped every name to a
+# constant would still pass every "no secret is printed" assertion while
+# silently destroying the session count the concentration line reports.
+# ⚠️ SCOPE, stated because the obvious assertion is VACUOUS: the property the
+# redaction actually buys — that a credential-shaped basename never lands in
+# the temp file — is NOT observable from the output, because redact() masks the
+# value at the output boundary either way. The same limitation is documented
+# above for the emitter test. This assertion pins the part that IS observable.
+mkdir -p "$FIX/credsesscount"
+cat > "$FIX/credsesscount/alpha.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"token=__GHPA__"}]}}
+EOF
+cat > "$FIX/credsesscount/beta.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"key=__AWS__"}]}}
+EOF
+subst "$FIX/credsesscount/alpha.jsonl" "$FIX/credsesscount/beta.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credsesscount" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+CREDSEC=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$CREDSEC" | grep -qE 'in 2 sessions'; then
+  ok "session redaction keeps distinct sessions distinct"
+else bad "session redaction keeps distinct sessions distinct" \
+  "$(printf '%s' "$CREDSEC" | grep -E 'across .* records')"; fi
+
 echo
 echo "──────────────────────────────"
 echo "  passed: $PASS   failed: $FAIL"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -2052,6 +2052,29 @@ OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credbin" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR=
       bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
 check "NUL-bearing record still produces a locator" "$OUT" "session=s.jsonl"
 
+# ...and the NUL must be TRANSLATED, not DELETED. Deleting it welds the fragments
+# on either side into one string, so two short token-shaped pieces — neither a
+# credential on its own — become a full-length one that never existed in the
+# transcript. The table (which scans decoded strings with the NUL intact)
+# correctly counts only the real AWS key here; the deleting form ADDITIONALLY
+# emitted `shape=github-token`, a PHANTOM high-signal locator sending an operator
+# to rotate something nobody leaked. That is a false positive in a leak detector,
+# and the same locator-disagrees-with-its-own-table failure this provenance work
+# exists to remove. The AWS key on the same line is load-bearing: it is what makes
+# the OUTER grep select the line at all, so the welded fragments reach the inner
+# scan. (Codex P2 on #2520; reproduced against the real detector before fixing.)
+mkdir -p "$FIX/crednulweld"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"k=%s x %s\000%s y"}]}}\n' \
+  "$S_AWS" "$(_j 'gh' 'p_AAAAAAAA')" 'AAAAAAAAAAAA' > "$FIX/crednulweld/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/crednulweld" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+# Assert BOTH sides: the real credential is still located, and no phantom appears.
+if printf '%s' "$OUT" | grep -q 'shape=aws-access-key-id' \
+   && ! printf '%s' "$OUT" | grep -q 'shape=github-token'; then
+  ok "NUL is translated, not deleted, so fragments cannot weld into a phantom token"
+else bad "NUL is translated, not deleted, so fragments cannot weld into a phantom token" \
+  "$(printf '%s' "$OUT" | grep -E 'shape=' | head -3)"; fi
+
 # The locator must carry the table's [masked-display] qualifier. Without it the
 # table says "do NOT rotate, it's a tool's own mask" while the locator names a
 # bare high-signal shape — so an operator holding both a masked display and a

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1878,6 +1878,40 @@ if printf '%s' "$OUT" | grep -q "$S_GHPB"; then
   bad "output boundary never prints the credential value" "raw token appeared in output"
 else ok "output boundary never prints the credential value"; fi
 
+# The locator must AGREE with the table row it annotates: a locator naming a
+# different shape than the count it explains is worse than no locator. Asserted
+# as agreement on both sides, not as a guess about which shape is right —
+# an earlier version of this test asserted __PATP__ was weak-generic, which the
+# table disproves (21 chars after the prefix satisfies its {20,} bound).
+mkdir -p "$FIX/credshort"
+cat > "$FIX/credshort/s.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"token=__PATP__ here"}]}}
+EOF
+subst "$FIX/credshort/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credshort" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+if printf '%s' "$OUT" | grep -q 'github-pat (fine-grained)' \
+   && printf '%s' "$OUT" | grep -q 'shape=github-pat'; then
+  ok "locator shape agrees with the table row it annotates"
+else bad "locator shape agrees with the table row it annotates" \
+  "$(printf '%s' "$OUT" | grep -E 'github-|session=' | head -3)"; fi
+
+# The converse, and the one that actually matters: a LONG token behind a
+# `token=` wrapper is the commonest real-leak shape, and grep's leftmost rule
+# hands it to the generic alternative — so the match begins at the KEY. The
+# locator must strip that wrapper exactly as the table does, or every real
+# wrapped leak is located as `generic-assignment` while the table counts it
+# high-signal. The short-value test above CANNOT catch this (it is generic
+# either way), which an ablation proved.
+mkdir -p "$FIX/credwrap"
+cat > "$FIX/credwrap/s.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"token=__GHPD__ here"}]}}
+EOF
+subst "$FIX/credwrap/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credwrap" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+check "wrapped real token locates as its true shape" "$OUT" "shape=github-token"
+
 # A mid-blob chance match: base64 alphabet includes `+` and `/`, which are the
 # only characters that can satisfy the boundary anchor INSIDE a blob. The image
 # path is already excluded structurally; this covers the remaining blob shapes

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -48,6 +48,22 @@ S_GEN='s3cr3t''value0123456789abcdef'
 # the credential disappeared from the table entirely, which is a false negative
 # in a leak detector rather than a cosmetic bug.
 S_GENPAD='c3ZhbHVl''MDEyMzQ1Njc4OWFiY2R='
+# Base64 pads with up to TWO '=', and the single-pad case above does not cover
+# it: the second strip pass left exactly '=' behind, which is non-empty, so the
+# emptiness guard passed it and the whole value collapsed to '='. Distinct
+# secrets then shared one identity and `sort -u` counted them as ONE — an
+# under-count in a leak detector. Two DIFFERENT values are needed to see it: a
+# single padded value looks fine on its own, which is why it survived.
+S_GENPAD2A='c3ZhbHVl''MDEyMzQ1Njc4OWFiY2Rl''=='
+S_GENPAD2B='cXV4cXV1''eGNvcmdlZGdyYXVsdHk''=='
+# A HIGH-SIGNAL token carrying the same double padding. A collapsed GENERIC
+# value is unobservable — '=' and the intact value both classify as
+# generic-assignment — so a generic fixture cannot pin the locator's copy of the
+# strip at all. Padding a token makes the collapse change the reported CLASS
+# (github-token -> generic-assignment), which is precisely the locator/table
+# divergence this work exists to remove, and it is what makes the guard testable
+# on both sides.
+S_GHPPAD2="${S_GHPB}=="
 
 # Replace placeholders in a fixture file with the assembled samples.
 subst() {
@@ -62,6 +78,8 @@ subst() {
       -e "s|__JWTHEAD__|$S_JWTHEAD|g" -e "s|__JWT__|$S_JWT|g" \
       -e "s|__AWS__|$S_AWS|g"     -e "s|__SLACK__|$S_SLACK|g" \
       -e "s|__GENPAD__|$S_GENPAD|g" \
+      -e "s|__GENPAD2A__|$S_GENPAD2A|g" -e "s|__GENPAD2B__|$S_GENPAD2B|g" \
+      -e "s|__GHPPAD2__|$S_GHPPAD2|g" \
       -e "s|__GEN__|$S_GEN|g" "$_f" && rm -f "$_f.bak"
   done
 }
@@ -75,6 +93,8 @@ ex() { printf '%s' "$1" | sed \
       -e "s|__JWTHEAD__|$S_JWTHEAD|g" -e "s|__JWT__|$S_JWT|g" \
       -e "s|__AWS__|$S_AWS|g"     -e "s|__SLACK__|$S_SLACK|g" \
       -e "s|__GENPAD__|$S_GENPAD|g" \
+      -e "s|__GENPAD2A__|$S_GENPAD2A|g" -e "s|__GENPAD2B__|$S_GENPAD2B|g" \
+      -e "s|__GHPPAD2__|$S_GHPPAD2|g" \
       -e "s|__GEN__|$S_GEN|g"; }
 
 # ── fixtures ──────────────────────────────────────────────────────────────────
@@ -2188,6 +2208,77 @@ if printf '%s' "$CREDSEC" | grep -qE 'in 2 sessions'; then
   ok "session redaction keeps distinct sessions distinct"
 else bad "session redaction keeps distinct sessions distinct" \
   "$(printf '%s' "$CREDSEC" | grep -E 'across .* records')"; fi
+
+# Base64 pads with up to TWO '='. The single-pad guard above does not reach that
+# case: the second strip pass left exactly '=' behind, which is non-empty, so
+# every double-padded value collapsed to the SAME '=' identity and `sort -u`
+# reported unrelated secrets as one credential. Two DIFFERENT values are what
+# makes it visible — one padded value alone looks correct, which is why the
+# existing single-pad fixture never caught it. (Codex P2 on #2520.)
+mkdir -p "$FIX/credpad2"
+cat > "$FIX/credpad2/a.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"password=__GENPAD2A__"}]}}
+EOF
+cat > "$FIX/credpad2/b.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"password=__GENPAD2B__"}]}}
+EOF
+subst "$FIX/credpad2/a.jsonl" "$FIX/credpad2/b.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credpad2" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+CREDSEC=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+check "two distinct double-padded secrets stay two credentials" "$CREDSEC" \
+      "2 generic-assignment"
+# The value must survive stripping intact, not merely be counted: a collapsed
+# identity is what merged them, so pin that no row is the bare padding.
+nocheck "a double-padded value never collapses to bare padding" "$CREDSEC" " 1 ="
+
+# The locator keeps its OWN copy of the two-pass strip, so the table-side fix
+# above does not cover it — and a generic fixture cannot: '=' and an intact
+# generic value both classify as generic-assignment, so the collapse is
+# invisible. Pad a HIGH-SIGNAL token instead and the collapse changes the
+# reported class, which is observable on both surfaces at once: unguarded, the
+# locator says generic-assignment about a row the table counts as a github-token
+# — the exact locator/table disagreement this work removes.
+mkdir -p "$FIX/credpadhi"
+cat > "$FIX/credpadhi/s.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"password=__GHPPAD2__"}]}}
+EOF
+subst "$FIX/credpadhi/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credpadhi" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+CREDSEC=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+check "a double-padded HIGH-SIGNAL token keeps its shape in the table" "$CREDSEC" \
+      "1 github-token (classic/app)"
+if printf '%s' "$OUT" | grep -qE 'shape=github-token'; then
+  ok "the locator agrees: double padding does not demote a token to generic"
+else bad "the locator agrees: double padding does not demote a token to generic" \
+  "$(printf '%s' "$OUT" | grep 'session=' | head -3)"; fi
+
+# A styled credential must stay LOCATABLE, not just counted. The table decodes
+# with jq before normalizing, so it only ever meets a literal ESC byte; the raw
+# locator/concentration scans read the transcript verbatim, where a JSON string
+# stores ESC ENCODED. Unnormalized, the boundary-anchored regex sees the CSI
+# terminator 'm' against the prefix and rejects it — the table then reports a
+# high-signal token "across 0 transcript records", which reads as a broken
+# detector rather than a real leak. (Codex P2 on #2520.)
+mkdir -p "$FIX/credansi"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"styled \\u001b[31m__GHPB__\\u001b[0m"}]}}\n' \
+  > "$FIX/credansi/s.jsonl"
+subst "$FIX/credansi/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credansi" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+CREDSEC=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+check "an ANSI-styled token is still counted by the table" "$CREDSEC" \
+      "1 github-token (classic/app)"
+# THE assertion this pair exists for: the locator must AGREE with that count.
+# Scoped to the credential section — the injection detector prints an identical
+# concentration line, and an unscoped grep passes on that one instead.
+nocheck "a styled credential is not reported across 0 records" "$CREDSEC" \
+      "across 0 transcript records"
+if printf '%s' "$OUT" | grep -qE 'session=s\.jsonl line=[0-9]+ record=user shape=github-token'; then
+  ok "a styled credential still emits a full provenance locator"
+else bad "a styled credential still emits a full provenance locator" \
+  "$(printf '%s' "$OUT" | grep 'session=' | head -3)"; fi
 
 echo
 echo "──────────────────────────────"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1826,6 +1826,109 @@ check "handles a missing corpus" "$OUT" "no sessions in window"
 OUT=$(run --since-days notanumber); RC=$?
 if [ $RC -ne 0 ]; then ok "rejects non-numeric --since-days"; else bad "rejects non-numeric --since-days" "exited 0"; fi
 
+# ── 8. credential provenance (#2471) ──────────────────────────────────────────
+# The table counts DISTINCT VALUES by shape and says nothing about where a match
+# came from, so a documentation example, a test constant and a real leak are one
+# undifferentiated number. Triaging the 2026-07-25 report took four manual
+# queries. Provenance is an ADDITIONAL surface, exactly like
+# --injection-provenance: the table's counts and the redactor are unchanged, and
+# nothing is suppressed (that is why PR #2364, which classified records away,
+# was closed).
+echo
+echo "credential provenance"
+
+mkdir -p "$FIX/credprov"
+cat > "$FIX/credprov/s.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"example response shows __GHPB__ in docs"}]}}
+EOF
+subst "$FIX/credprov/s.jsonl"
+
+# Default run must NOT dump provenance — it is opt-in, so the routine scorecard
+# stays the same size and no locator is printed unless asked for.
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credprov" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+check "default run advertises the credential-provenance flag" "$OUT" \
+  "rerun with --section safety --credential-provenance"
+
+# Concentration: records/sessions/top-record, mirroring the injection detector.
+# SCOPE THIS TO THE CREDENTIAL SECTION. An unscoped grep matches the INJECTION
+# detector's identical concentration line and passes before anything is built —
+# caught here as a false pass during the RED run.
+CREDSEC=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$CREDSEC" | grep -qE 'across [0-9]+ transcript records in [0-9]+ sessions'; then
+  ok "credential table carries a concentration line"
+else bad "credential table carries a concentration line" "$CREDSEC"; fi
+
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credprov" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+check "provenance emits a session locator" "$OUT" "session=s.jsonl"
+if printf '%s' "$OUT" | grep -qE 'session=s\.jsonl line=[0-9]+ record=user shape=github-token'; then
+  ok "provenance locator carries line, record type and shape"
+else bad "provenance locator carries line, record type and shape" \
+  "$(printf '%s' "$OUT" | grep 'session=' | head -3)"; fi
+
+# THE load-bearing safety property: a locator must never print the secret.
+# ⚠️ ABLATION-MEASURED SCOPE: this asserts the OUTPUT BOUNDARY, not the emitter.
+# Making emit_credential_hits print the raw match instead of the shape leaves it
+# GREEN, because redact() masks the value on the way out. It is kept as a
+# defence-in-depth assertion that would catch a redactor regression; the
+# EMITTER-level property is pinned by the `shape=` assertion above, which does
+# go RED under exactly that ablation.
+if printf '%s' "$OUT" | grep -q "$S_GHPB"; then
+  bad "output boundary never prints the credential value" "raw token appeared in output"
+else ok "output boundary never prints the credential value"; fi
+
+# A mid-blob chance match: base64 alphabet includes `+` and `/`, which are the
+# only characters that can satisfy the boundary anchor INSIDE a blob. The image
+# path is already excluded structurally; this covers the remaining blob shapes
+# (Codex `encrypted_content`). It is LABELLED, never dropped.
+mkdir -p "$FIX/credb64"
+B64_BLOB="TWFueSBoYW5kcyBtYWtlIGxpZ2h0IHdvcmsu+__GHPC__/QUJDREVGRw"
+cat > "$FIX/credb64/s.jsonl" <<EOF
+{"type":"user","message":{"content":[{"type":"text","text":"$B64_BLOB"}]}}
+EOF
+subst "$FIX/credb64/s.jsonl"
+TABLE=$(CLAUDE_PROJECTS_DIR="$FIX/credb64" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1 \
+      | sed -n '/credential-shaped/,/rotate the credential/p')
+check "mid-blob chance match is labelled, not dropped" "$TABLE" "[in-base64-run]"
+
+# Fail closed: `=` is base64 PADDING but also the commonest assignment
+# delimiter, so it must stay in the plain high-signal row. Getting this wrong
+# would hide a real `…=ghp_…` leak behind a noise label.
+# NB: the fixture deliberately carries NO secret/token/password/api_key keyword.
+# With one (`GITHUB_TOKEN=…`) the generic alternative wins the leftmost match,
+# the extracted match starts at the KEY, and `=` is never the boundary
+# character — so that fixture asserts nothing about `=` at all. Ablating the
+# boundary class to `[+/=]` left it green, which is how the vacuity was caught.
+mkdir -p "$FIX/credeq"
+cat > "$FIX/credeq/s.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"blob QUJDREVG=__GHPD__ end"}]}}
+EOF
+subst "$FIX/credeq/s.jsonl"
+TABLE=$(CLAUDE_PROJECTS_DIR="$FIX/credeq" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1 \
+      | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -q 'in-base64-run'; then
+  bad "'=' delimiter fails closed to the plain high-signal row" "labelled as blob noise: $TABLE"
+else ok "'=' delimiter fails closed to the plain high-signal row"; fi
+
+# A quote-anchored real token stays high-signal and unlabelled. This is the
+# shape 100% of the live corpus's matches actually had when measured
+# 2026-07-28, so mislabelling it would blind the detector on real data.
+mkdir -p "$FIX/credquote"
+cat > "$FIX/credquote/s.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"value is \"__GHPA__\" here"}]}}
+EOF
+subst "$FIX/credquote/s.jsonl"
+TABLE=$(CLAUDE_PROJECTS_DIR="$FIX/credquote" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1 \
+      | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$TABLE" | grep -q 'github-token (classic/app)' \
+   && ! printf '%s' "$TABLE" | grep -q 'in-base64-run'; then
+  ok "quote-anchored real token stays unlabelled high-signal"
+else bad "quote-anchored real token stays unlabelled high-signal" "$TABLE"; fi
+
 echo
 echo "──────────────────────────────"
 echo "  passed: $PASS   failed: $FAIL"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1941,6 +1941,64 @@ OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credcompound" CODEX_HOME="$FIX/nocodex" MONOREPO
 check "compound assignment locates the high-signal key, not just generic" \
       "$OUT" "shape=aws-access-key-id"
 
+# NESTED wrappers: a token assignment stored under a credential-NAMED record
+# field (`{"secret":"token=ghp_…"}`) carries TWO wrappers in one match, because
+# the generic alternative matches from the outer `secret` and its value class
+# runs straight through the inner `token=`. The TABLE strips with a greedy
+# `[^:=]*[:=]` sed, which reaches the LAST separator in one pass, so it
+# classifies the underlying token. The locator stripped with `${m#*[:=]}` —
+# bash's SHORTEST match — which reaches only the FIRST separator, leaving
+# `token=ghp_…` and reporting `generic-assignment`. Same
+# locator-disagrees-with-its-own-table failure as the compound case above,
+# reached through a different door: the operator is sent to a weak-signal record
+# while the table reports a live token. (Codex P2 on #2520.)
+#
+# ⚠️ The nesting must be a REAL record field, not a JSON blob inside a text
+# value. The locator greps the RAW transcript line, where a nested blob's quotes
+# are backslash-escaped (`{\"secret\":\"token=…`) — and `\` breaks the outer
+# wrapper's `["']?[[:space:]]*[:=]`, so only one wrapper survives and the two
+# surfaces agree. That fixture passes without any fix and was measured doing so.
+mkdir -p "$FIX/crednested"
+cat > "$FIX/crednested/s.jsonl" <<'EOF'
+{"type":"user","secret":"token=__GHPD__","message":{"content":[{"type":"text","text":"see config"}]}}
+EOF
+subst "$FIX/crednested/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/crednested" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+# Assert AGREEMENT on both sides, as the sibling parity tests do — the table's
+# verdict is the reference, so a regression that broke the table instead of the
+# locator cannot pass by making the two agree on the wrong answer.
+if printf '%s' "$OUT" | grep -q 'github-token (classic/app)' \
+   && printf '%s' "$OUT" | grep -q 'shape=github-token'; then
+  ok "nested wrappers locate as the underlying token shape"
+else bad "nested wrappers locate as the underlying token shape" \
+  "$(printf '%s' "$OUT" | grep -E 'github-token|generic-assignment|session=' | head -4)"; fi
+
+# A value whose OWN trailing character is a separator must still produce a
+# locator row after nested stripping — base64 padding is the everyday case.
+#
+# ⚠️ ABLATION-MEASURED SCOPE, stated because the obvious reading is wrong: this
+# asserts the ROW SURVIVES, not that the stripper stopped at the right place.
+# Measured three variants against it — two passes with the non-empty guard, two
+# passes WITHOUT the guard, and longest-match `${m##*[:=]}` — and all three pass,
+# because a value stripped down to nothing fails every shape regex and lands in
+# the same `generic-assignment` bucket the correct value lands in. The locator
+# prints only the shape, so no assertion on its output can separate them.
+# The `-n` guard in the stripper is therefore defence-in-depth for parity with
+# the table's own value (its sed's `(.+)` refuses to leave nothing), NOT a
+# property this suite pins — the same honest scoping as the output-boundary
+# assertion above. What IS pinned here: dropping the row entirely, which is the
+# false negative this PR's head commit fixed and a real regression risk.
+mkdir -p "$FIX/crednestpad"
+cat > "$FIX/crednestpad/s.jsonl" <<'EOF'
+{"type":"user","secret":"token=__GENPAD__","message":{"content":[{"type":"text","text":"see config"}]}}
+EOF
+subst "$FIX/crednestpad/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/crednestpad" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+check "nested wrapper around a '='-terminated value still emits a locator" \
+      "$OUT" "shape=generic-assignment"
+
 # Repeated matches at ONE location collapse to `Nx` with the count printed, not
 # dropped. Measured 171 locator lines for 100 distinct locations on a 1-day
 # corpus, which buries the few high-signal rows. The TABLE still counts ONE

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -2074,6 +2074,22 @@ if printf '%s' "$OUT" | grep -q 'shape=aws-access-key-id' \
   ok "NUL is translated, not deleted, so fragments cannot weld into a phantom token"
 else bad "NUL is translated, not deleted, so fragments cannot weld into a phantom token" \
   "$(printf '%s' "$OUT" | grep -E 'shape=' | head -3)"; fi
+# Pin the CONCENTRATION figure for the same record, so the third surface cannot
+# drift away from the table and the locator (CodeRabbit on #2520). Only the AWS
+# key is a credential here: the github fragment is 8 chars after its prefix,
+# below the 16 the shape requires, and the fragment after the NUL is not a token
+# at all — so exactly one match, on one record.
+# ⚠️ MEASURED SCOPE, stated because the obvious reading overclaims: this pins the
+# figure, it does NOT re-prove the NUL translation. The concentration scan runs
+# its own `grep` over the raw file and never passes through the `tr` in
+# emit_credential_hits, so flipping that back to the deleting form leaves this
+# assertion GREEN — verified by ablation, not assumed. The weld itself stays
+# pinned by the phantom-shape assertion directly above.
+CREDSEC=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if printf '%s' "$CREDSEC" | grep -qE 'largest single record: 1$'; then
+  ok "NUL-weld record pins the concentration figure too"
+else bad "NUL-weld record pins the concentration figure too" \
+  "$(printf '%s' "$CREDSEC" | grep -E 'across .* records')"; fi
 
 # The locator must carry the table's [masked-display] qualifier. Without it the
 # table says "do NOT rotate, it's a tool's own mask" while the locator names a
@@ -2115,6 +2131,8 @@ OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credmasknotclass" CODEX_HOME="$FIX/nocodex" MONO
 # high-signal shape, and the locator must agree with it rather than adding the
 # lower-risk qualifier.
 if printf '%s' "$OUT" | grep -qE 'shape=github-token$|shape=github-token[^[]' \
+   && printf '%s' "$OUT" | grep -q 'github-token (classic/app)' \
+   && ! printf '%s' "$OUT" | grep -qE 'github-token \(classic/app\) \[masked-display\]' \
    && ! printf '%s' "$OUT" | grep -qE 'shape=github-token \[masked-display\]'; then
   ok "locator withholds [masked-display] when the pre-mask run is not class chars"
 else bad "locator withholds [masked-display] when the pre-mask run is not class chars" \

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -2070,6 +2070,33 @@ if printf '%s' "$OUT" | grep -q 'masked-display' \
 else bad "locator carries the table's [masked-display] qualifier" \
   "$(printf '%s' "$OUT" | grep -E 'github-pat|session=' | head -3)"; fi
 
+# ...and must NOT carry it when the table would not. The fixture above cannot
+# catch an over-loose test, because its mask run immediately follows class
+# characters, so a strict and a loose check agree there. Here the run before
+# `***` contains a `.`, which is NOT in the class: the table's anchored
+# `^[a-z0-9_-]+\*\*\*` therefore does not fire, while a bash glob
+# (`[a-z0-9_-]*\*\*\**`, whose middle `*` is an unrestricted wildcard) did.
+# The shape regexes are anchored at `^` only, so the value still classifies
+# github-token — meaning a LIVE credential was tagged `[masked-display]`, which
+# the report documents as "do NOT rotate". Wrong in the dangerous direction, so
+# the negative side is pinned as tightly as the positive one.
+# (CodeRabbit Major on #2520; reproduced against the real detector first.)
+mkdir -p "$FIX/credmasknotclass"
+cat > "$FIX/credmasknotclass/s.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"token=__GHPA__.junk***tail here"}]}}
+EOF
+subst "$FIX/credmasknotclass/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credmasknotclass" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+# Assert BOTH sides, so the table stays the reference: the row must be the plain
+# high-signal shape, and the locator must agree with it rather than adding the
+# lower-risk qualifier.
+if printf '%s' "$OUT" | grep -qE 'shape=github-token$|shape=github-token[^[]' \
+   && ! printf '%s' "$OUT" | grep -qE 'shape=github-token \[masked-display\]'; then
+  ok "locator withholds [masked-display] when the pre-mask run is not class chars"
+else bad "locator withholds [masked-display] when the pre-mask run is not class chars" \
+  "$(printf '%s' "$OUT" | grep -E 'github-token|session=' | head -3)"; fi
+
 
 echo
 echo "──────────────────────────────"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -42,6 +42,12 @@ S_JWT="${S_JWTHEAD}NiJ9.${S_JWTTAIL}"
 S_AWS=$(_j 'AKI' 'AIOSFODNN7EXAMPLE')
 S_SLACK=$(_j 'xox' 'b-1234567890-abcdefghijklmno')
 S_GEN='s3cr3t''value0123456789abcdef'
+# A value that itself ends in '=' — base64 padding is the everyday case. The
+# assignment-stripping sed ran twice, so the value's own trailing '=' was eaten
+# as a second wrapper, leaving an empty string that `grep -E .` then dropped:
+# the credential disappeared from the table entirely, which is a false negative
+# in a leak detector rather than a cosmetic bug.
+S_GENPAD='c3ZhbHVl''MDEyMzQ1Njc4OWFiY2R='
 
 # Replace placeholders in a fixture file with the assembled samples.
 subst() {
@@ -55,6 +61,7 @@ subst() {
       -e "s|__JWTTAIL__|$S_JWTTAIL|g" \
       -e "s|__JWTHEAD__|$S_JWTHEAD|g" -e "s|__JWT__|$S_JWT|g" \
       -e "s|__AWS__|$S_AWS|g"     -e "s|__SLACK__|$S_SLACK|g" \
+      -e "s|__GENPAD__|$S_GENPAD|g" \
       -e "s|__GEN__|$S_GEN|g" "$_f" && rm -f "$_f.bak"
   done
 }
@@ -67,6 +74,7 @@ ex() { printf '%s' "$1" | sed \
       -e "s|__JWTTAIL__|$S_JWTTAIL|g" \
       -e "s|__JWTHEAD__|$S_JWTHEAD|g" -e "s|__JWT__|$S_JWT|g" \
       -e "s|__AWS__|$S_AWS|g"     -e "s|__SLACK__|$S_SLACK|g" \
+      -e "s|__GENPAD__|$S_GENPAD|g" \
       -e "s|__GEN__|$S_GEN|g"; }
 
 # ── fixtures ──────────────────────────────────────────────────────────────────
@@ -393,6 +401,10 @@ parity_case "aws"        "leak __AWS__" "__AWS__"
 parity_case "slack"      "leak __SLACK__" "__SLACK__"
 parity_case "jwt"        "leak __JWT__" "__JWTTAIL__"
 parity_case "generic"    "config token=__GEN__" "__GEN__"
+# A value ending in '=' must survive assignment-stripping. Stripping the wrapper
+# twice consumed the value's own padding and emptied the line, so the leak was
+# reported as clean.
+parity_case "generic_padded" "config secret=__GENPAD__" "__GENPAD__"
 
 # Codex image tools persist rendered images as very large `data:` strings in
 # custom tool outputs. Those strings are encoded binary, not transcript text;
@@ -1911,6 +1923,23 @@ subst "$FIX/credwrap/s.jsonl"
 OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credwrap" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
       bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
 check "wrapped real token locates as its true shape" "$OUT" "shape=github-token"
+
+# One raw field can carry SEVERAL assignments, and grep's leftmost-longest rule
+# returns the whole run as a single match. The table splits on `;&|` before
+# classifying, so it counts the high-signal key; the locator did not, so it
+# stripped only the first wrapper and reported the remainder as
+# `generic-assignment`. That is the locator-disagrees-with-its-own-table failure
+# the classifier comment calls worse than no locator: the operator is told to
+# look for a weak generic where an AWS key is sitting.
+mkdir -p "$FIX/credcompound"
+cat > "$FIX/credcompound/s.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"env token=abcdefghijk;AWS_ACCESS_KEY=__AWS__ tail"}]}}
+EOF
+subst "$FIX/credcompound/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credcompound" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+check "compound assignment locates the high-signal key, not just generic" \
+      "$OUT" "shape=aws-access-key-id"
 
 # Repeated matches at ONE location collapse to `Nx` with the count printed, not
 # dropped. Measured 171 locator lines for 100 distinct locations on a 1-day

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1912,6 +1912,27 @@ OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credwrap" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR
       bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
 check "wrapped real token locates as its true shape" "$OUT" "shape=github-token"
 
+# Repeated matches at ONE location collapse to `Nx` with the count printed, not
+# dropped. Measured 171 locator lines for 100 distinct locations on a 1-day
+# corpus, which buries the few high-signal rows. The TABLE still counts ONE
+# distinct value here — the two surfaces answer different questions, and this
+# pins that they disagree in the RIGHT direction.
+mkdir -p "$FIX/creddup"
+DUPTOK="__GHPD__"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"a \\"%s\\" b \\"%s\\" c \\"%s\\""}]}}\n' \
+  "$DUPTOK" "$DUPTOK" "$DUPTOK" > "$FIX/creddup/s.jsonl"
+subst "$FIX/creddup/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/creddup" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
+if printf '%s' "$OUT" | grep -qE '3x session=s\.jsonl line=1 .*shape=github-token'; then
+  ok "repeated matches at one location collapse with a printed count"
+else bad "repeated matches at one location collapse with a printed count" \
+  "$(printf '%s' "$OUT" | grep 'session=' | head -3)"; fi
+if printf '%s' "$OUT" | grep -qE '^[[:space:]]+1 github-token'; then
+  ok "table still counts ONE distinct value for the repeated token"
+else bad "table still counts ONE distinct value for the repeated token" \
+  "$(printf '%s' "$OUT" | grep 'github-token' | head -2)"; fi
+
 # A mid-blob chance match: base64 alphabet includes `+` and `/`, which are the
 # only characters that can satisfy the boundary anchor INSIDE a blob. The image
 # path is already excluded structurally; this covers the remaining blob shapes


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The credential-leak detector reports a count per credential shape and nothing else. A documentation example, a test constant and a genuine leaked key all render as the same integer, so the one thing the detector exists to surface cannot be told apart from noise. Triaging the 2026-07-25 report took four manual queries and found zero real leaks.

That matters because the contract says a high-signal shape means **rotate the credential**. Today’s 7-day scan shows three such rows — so the current state invites a portfolio-wide rotation on what is probably a docs example, while a real leak would arrive as merely one more entry in the same list.

## What

The table now says **where** to look, without ever printing a secret:

- a concentration line (records / sessions / largest single record) under the table, matching what the injection detector already does;
- an opt-in `--credential-provenance` locator giving session, line, record type and the credential **shape** — never the value;
- matches that sit inside an encoded blob rather than at a real value boundary are **labelled** as such.

Nothing is filtered or suppressed — every match is still counted and still reported. That is deliberate: the previous attempt to classify records away was closed for exactly that reason, because one record can hold both noise and a real hit. Ambiguous cases stay in the high-signal row.

Fixes #2471