### PR TITLE
feat(cadence): densify the engineer schedule and split lanes by hour parity

### DIFF
--- a/.claude/loaders/cursor-daily-ai-engineer.md
+++ b/.claude/loaders/cursor-daily-ai-engineer.md
@@ -26,8 +26,8 @@ this file and the deployed automation is a defect to fix here first.
 **Why that cron.** The machine-local lanes split by parity — **Claude on even hours, Codex on uneven
 hours** (see the *Cadence & focus* table) — so `:30` past **uneven** hours drops Cursor into the one
 remaining gap: 30 minutes after the Codex dispatch it follows, and ~38 minutes before the next Claude
-one. The three lanes end up 30–50 minutes apart all day, and Cursor is **never simultaneous with a
-sibling**. The 30-minute trail behind Codex is deliberate and sufficient: the claim protocol requires a
+one. No two consecutive dispatches land less than 30 minutes apart, and Cursor is **never simultaneous
+with a sibling**. The 30-minute trail behind Codex is deliberate and sufficient: the claim protocol requires a
 claim to be pushed *before* building, within the first minutes of a run, so a claim Codex just took is
 already visible when Cursor selects its issue.
 

--- a/.claude/loaders/cursor-daily-ai-engineer.md
+++ b/.claude/loaders/cursor-daily-ai-engineer.md
@@ -23,14 +23,20 @@ this file and the deployed automation is a defect to fix here first.
 | Tools | `prComment` — add others only when a run demonstrably needs them |
 | Scope | **Private** automation (not team-scoped) — see *Identity* below |
 
-**Why that cron.** Both machine-local Agentic Engineer lanes now dispatch on **even** hours (see the
-*Cadence & focus* table), so `:30` past **uneven** hours puts Cursor squarely between them — never
-simultaneous with a sibling, and always ~90 minutes after the last local run, so a claim either sibling
-just pushed is already visible when Cursor selects its issue. It also covers the schedule's one local
-gap: with no local Agentic Engineer at 18:00, the 17:30 and 19:30 Cursor runs are what keep the
-16:00 → 20:00 stretch swept. Changing this is a one-field edit in the Automations UI — but keep the
-offset, since a third instance selecting simultaneously with a sibling is exactly what the claim
-protocol cannot arbitrate across lanes.
+**Why that cron.** The machine-local lanes split by parity — **Claude on even hours, Codex on uneven
+hours** (see the *Cadence & focus* table) — so `:30` past **uneven** hours drops Cursor into the one
+remaining gap: 30 minutes after the Codex dispatch it follows, and ~38 minutes before the next Claude
+one. The three lanes end up 30–50 minutes apart all day, and Cursor is **never simultaneous with a
+sibling**. The 30-minute trail behind Codex is deliberate and sufficient: the claim protocol requires a
+claim to be pushed *before* building, within the first minutes of a run, so a claim Codex just took is
+already visible when Cursor selects its issue.
+
+**This cron did not change when the local lanes densified — do not re-paste the automation for it.**
+The value is still `30 1-23/2 * * *` and the prompt below still describes it correctly; only the
+*rationale* above was rewritten, because the premise it used to give ("both local lanes dispatch on
+even hours", and a local gap at 18:00) is no longer true. Changing the cron is a one-field edit in the
+Automations UI — but keep the offset, since a third instance selecting simultaneously with a sibling is
+exactly what the claim protocol cannot arbitrate across lanes.
 
 ## Instructions (paste this into the automation's prompt)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2509,39 +2509,42 @@ schedule; see *Agentic engineering plugin contract*). Times are the agent host's
 runtime-local scheduler entries are **thin pointers that must match this table**; when the two
 disagree, the scheduler is the defect — reconcile it there, per *Agent definition locations*.
 
-| Hour | Codex — `codex/*` | Claude — `claude/*` |
+**The parity invariant IS the schedule: Claude takes EVEN hours, Codex takes UNEVEN hours, and no two
+local instances ever share a dispatch hour.** Read your lane's row for your own slots; read the
+invariant to know that whatever else is running, it did not start when you did.
+
+| Lane | Agentic Engineer | Agent Improver |
 |---|---|---|
-| 00:00 | Agentic Engineer | Agent Improver |
-| 02:00 | — | Agentic Engineer |
-| 04:00 | Agentic Engineer | — |
-| 06:00 | Agent Improver | Agentic Engineer |
-| 08:00 | Agentic Engineer | — |
-| 10:00 | — | Agentic Engineer |
-| 12:00 | Agentic Engineer | Agent Improver |
-| 14:00 | **Agentic Engineer** | **Agentic Engineer** |
-| 16:00 | — | Agentic Engineer |
-| 18:00 | Agent Improver | — |
-| 20:00 | Agentic Engineer | — |
-| 22:00 | — | Agentic Engineer |
+| **Claude** — `claude/*`, even hours | 02, 04, 06, 08, 10, 14, 16, 18, 20, 22 | 00, 12 |
+| **Codex** — `codex/*`, uneven hours | 01, 03, 05, 09, 11, 13, 15, 17, 21, 23 | 07, 19 |
+| **Cursor** — `cursor/*`, uneven hours at `:30` | 01:30 … 23:30 | — |
 
-The **Cursor cloud instance** (`cursor/*`) is unchanged: Agentic Engineer at `:30` past uneven hours,
-scheduled server-side. The Agent Improver lands on a clean 6-hourly rotation across the two local
-lanes (00, 06, 12, 18). This table covers the two scheduled engineering roles only — spend
-stewardship has no dispatch slot of its own (see *The FinOps engineer*).
+Each lane dispatches **every 2 hours**, uniformly, and the three lanes interleave 30–50 minutes apart
+(the Claude runtime adds a few minutes of dispatch jitter, which only widens the gaps). The Agent
+Improver keeps its 4×/day rotation, alternating lanes (00 Claude, 07 Codex, 12 Claude, 19 Codex).
+This table covers the two scheduled engineering roles only — spend stewardship has no dispatch slot
+of its own (see *Spend contract*).
 
-**Two properties of this table change how you plan a run.**
-⚠️ **14:00 dispatches BOTH local Agentic Engineer lanes simultaneously.** *Claim protocol* rule 4
-records that claim arbitration does **not** work across lanes — each instance writes its own
-namespace, so both pushes succeed and both believe they won. A simultaneous start is therefore the
-portfolio's highest duplicate-work risk. On a 14:00 run, scan `codex/*` **and** `claude/*` branches
-and open PRs before claiming, not just your own namespace.
-**18:00 is the longest Agentic Engineer gap:** 16:00 → 20:00 is four hours covered only by the Cursor
-lane's 17:30 and 19:30 runs, so a watch item deferred at 16:00 waits longer than a usual tick.
+**Two properties of this schedule change how you plan a run.**
+⚠️ **A sibling being mid-run is the NORMAL case — scan cross-lane on EVERY run, never at one special
+hour.** The parity invariant removes simultaneous *starts*, which is the window where two instances
+select the same issue; it does **not** remove overlap, because runs outlive their hour. Measured over
+the 7 days to 2026-07-28 (n=26 completed Claude dispatches): **median 51 min, p75 79 min, 46% ran
+longer than 60 minutes, max 377**. So a sibling lane is very often still working when you start.
+*Claim protocol* rule 4 records that claim arbitration does **not** work across lanes — each instance
+writes its own namespace, so both pushes succeed and both believe they won. Scan `codex/*`,
+`claude/*` **and** `cursor/*` branches and open PRs before claiming, always. (The previous schedule
+put two local instances on the same hour **four** times a day — 00, 06, 12 and 14 — while this
+paragraph warned about only one of them; the invariant above is what retires that whole class.)
+**Same-lane overlap is expected, and it IS arbitrated.** With 2-hour spacing and ~12% of runs
+exceeding 120 minutes, your own lane's next dispatch can start before you finish. That case is safe
+by construction — same namespace, same deterministic branch name, and a non-forced push is refused
+(see *Claim protocol* rule 4) — so it needs no handling beyond never force-pushing a claim branch.
 
-**Each Agentic Engineer instance is dispatched every 2–6 hours** depending on its slot above. That
-interval is the gap **between runs, not a per-run time
+**Each Agentic Engineer instance is dispatched every 2 hours.** That interval is the gap **between
+runs, not a per-run time
 budget** — and it is the *instance's* own gap that bounds a carry-forward, so a run that defers a
-watch item to "the next tick" is deferring it hours, not minutes. Each run works
+watch item to "the next tick" is deferring it two hours, not minutes. Each run works
 *The work-selection ladder* top-down — **breakage → every open PR you own or trust, drafts included →
 security issues → bugs → the oldest actionable issue** — capturing new
 non-trivial finds as issues (see *Issue-driven*).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2519,8 +2519,9 @@ invariant to know that whatever else is running, it did not start when you did.
 | **Codex** — `codex/*`, uneven hours | 01, 03, 05, 09, 11, 13, 15, 17, 21, 23 | 07, 19 |
 | **Cursor** — `cursor/*`, uneven hours at `:30` | 01:30 … 23:30 | — |
 
-Each lane dispatches **every 2 hours**, uniformly, and the three lanes interleave 30–50 minutes apart
-(the Claude runtime adds a few minutes of dispatch jitter, which only widens the gaps). The Agent
+Each lane dispatches **every 2 hours**, uniformly, and the three lanes interleave so that consecutive
+dispatches are **never less than 30 minutes apart** (the Claude runtime adds a few minutes of dispatch
+jitter, which only widens the gaps). The Agent
 Improver keeps its 4×/day rotation, alternating lanes (00 Claude, 07 Codex, 12 Claude, 19 Codex).
 This table covers the two scheduled engineering roles only — spend stewardship has no dispatch slot
 of its own (see *Spend contract*).
@@ -2533,9 +2534,7 @@ the 7 days to 2026-07-28 (n=26 completed Claude dispatches): **median 51 min, p7
 longer than 60 minutes, max 377**. So a sibling lane is very often still working when you start.
 *Claim protocol* rule 4 records that claim arbitration does **not** work across lanes — each instance
 writes its own namespace, so both pushes succeed and both believe they won. Scan `codex/*`,
-`claude/*` **and** `cursor/*` branches and open PRs before claiming, always. (The previous schedule
-put two local instances on the same hour **four** times a day — 00, 06, 12 and 14 — while this
-paragraph warned about only one of them; the invariant above is what retires that whole class.)
+`claude/*` **and** `cursor/*` branches and open PRs before claiming, always.
 **Same-lane overlap is expected, and it IS arbitrated.** With 2-hour spacing and ~12% of runs
 exceeding 120 minutes, your own lane's next dispatch can start before you finish. That case is safe
 by construction — same namespace, same deterministic branch name, and a non-forced push is refused

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2540,10 +2540,14 @@ exceeding 120 minutes, your own lane's next dispatch can start before you finish
 by construction — same namespace, same deterministic branch name, and a non-forced push is refused
 (see *Claim protocol* rule 4) — so it needs no handling beyond never force-pushing a claim branch.
 
-**Each Agentic Engineer instance is dispatched every 2 hours.** That interval is the gap **between
+**Your LANE fires every 2 hours; your own ROLE's next slot is sometimes 4.** Two of each lane's twelve
+slots belong to the Agent Improver, so an Agentic Engineer's own next tick is **2 hours away eight
+times a day and 4 hours away twice** — Claude across its 12:00 and 00:00 improver slots (10→14, 22→02),
+Codex across its 07:00 and 19:00 ones (05→09, 17→21). That interval is the gap **between
 runs, not a per-run time
-budget** — and it is the *instance's* own gap that bounds a carry-forward, so a run that defers a
-watch item to "the next tick" is deferring it two hours, not minutes. Each run works
+budget** — and it is the *instance's* own gap that bounds a carry-forward, so **check which slot you
+are in before deferring**: a watch item handed to "the next tick" from a Claude **10:00/22:00** or a
+Codex **05:00/17:00** run waits four hours, not two. Each run works
 *The work-selection ladder* top-down — **breakage → every open PR you own or trust, drafts included →
 security issues → bugs → the oldest actionable issue** — capturing new
 non-trivial finds as issues (see *Issue-driven*).


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The engineer is not running often enough to use the Claude and Codex usage limits before they reset — capacity we are paying for and leaving on the table. The obvious fix, running more often, pushes the two local lanes closer together, and the claim protocol cannot arbitrate a collision *across* lanes. So the schedule had to get denser and safer at the same time.

It turns out the old schedule was already less safe than it claimed. It warned about one hour where both lanes start together; the live schedule actually did that **four** times a day — half of all local dispatches began at the exact same moment as a sibling.

## What

Claude now takes **even** hours, Codex takes **uneven** hours. No two local instances ever share a dispatch hour again.

- Agentic Engineer dispatches: **12/day → 20/day** across the two local lanes.
- Simultaneous local starts: **8 per day → 0**, despite 50% more dispatches.
- Every lane now runs uniformly every 2 hours; the three lanes interleave 30–50 minutes apart.
- The Agent Improver keeps 4/day, alternating lanes.

Because runs routinely outlive their hour (46% exceed 60 minutes), a sibling being mid-run is now the normal case — so the cross-lane check is mandated on every run rather than at one special hour.

The Cursor lane is untouched and needs no re-paste; only the stale explanation of why its timing works was corrected.

Maintainer direction, interactive session 2026-07-28.