### PR TITLE
fix(exemption): re-gate a hand-amended World at Ruin cask commit

### DIFF
--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -193,8 +193,13 @@ public and private — no per-repo loop needed to enumerate):
      with `gh api --paginate --slurp ... | jq -c 'add | map(...)'` (this `gh` version does not allow
      `--slurp` together with its own `--jq` flag), then normalize every commit into `commits_json` as an ordered compact
      JSON array whose objects contain exactly `sha`, `author_login`, `author_name`, `author_email`,
-     `committer_login`, `committer_name`, `committer_email`, and `message` (use an empty string for a
-     null login). Do not substitute `gh pr view --json commits`: it omits raw committer provenance.
+     `author_date`, `committer_login`, `committer_name`, `committer_email`, `committer_date`, and
+     `message` (use an empty string for a null login). Take both dates from the raw commit object
+     (`.commit.author.date` / `.commit.committer.date`) and pass them through verbatim in the
+     API's `YYYY-MM-DDTHH:MM:SSZ` form — the classifier compares them to each other to tell a
+     freshly-produced release commit from a rewritten one, so a reformatted or omitted date fails
+     the payload closed. Do not substitute `gh pr view --json commits`: it omits raw committer
+     provenance and both dates.
      The list's last SHA must equal `headRefOid`; an agent/maintainer adaptation commit therefore
      revokes the exemption even when the branch, title, and files still look generated. Exit 1 means
      the normal review gate applies; exit 2 or any query/classifier failure is a survey error

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -683,11 +683,18 @@ expect_classifier_error \
   "$(jq -c 'map(del(.author_date, .committer_date))' <<<"${war_cask_commits}")"
 
 # The surveyor must be told to carry the pair, or a correct classifier is fed a payload that can
-# never exercise it.
+# never exercise it. Naming the output fields is not enough on its own: the discriminator only works
+# if both values come from the raw commit object, so the source paths are asserted too. Taking
+# either date from the PR-level view instead would still satisfy a field-name-only assertion while
+# silently supplying a value the amend does not move.
 grep -Fq 'author_date' "${surveyor}" ||
   fail "surveyor commit normalization does not carry author_date"
 grep -Fq 'committer_date' "${surveyor}" ||
   fail "surveyor commit normalization does not carry committer_date"
+grep -Fq '.commit.author.date' "${surveyor}" ||
+  fail "surveyor does not source author_date from the raw commit object"
+grep -Fq '.commit.committer.date' "${surveyor}" ||
+  fail "surveyor does not source committer_date from the raw commit object"
 
 expect_exempt \
   "GoReleaser cask carrying several release cycles" \

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -309,6 +309,17 @@ expect_classifier_error() {
   [[ "${rc}" -eq 2 ]] || fail "classifier did not fail closed for invalid fixture: ${name}"
 }
 
+# Every commit the surveyor normalizes carries the author/committer date pair, and the schema
+# requires both (#2291). A commit created in one operation has the same timestamp in each, so that
+# is the default here; only the World at Ruin amend fixtures state a diverging pair, which keeps the
+# date discriminator visible in exactly the tests that exercise it instead of in all nineteen.
+with_commit_dates() {
+  jq -c 'map(
+    .author_date = (.author_date // "2026-07-18T09:14:22Z")
+    | .committer_date = (.committer_date // .author_date)
+  )'
+}
+
 homebrew_commits_json() {
   local component="$1"
   local version="$2"
@@ -341,18 +352,26 @@ homebrew_commits_json() {
         committer_email: "generator-bot@users.noreply.github.com",
         message: "style: autocorrect Casks (brew style --fix)"
       }
-    ]'
+    ]' | with_commit_dates
 }
 
 # Measured from homebrew-tap #1238/#1241/#1242: World at Ruin's cask PRs come from its own CD
 # workflow rather than GoReleaser, so they are a single tap-token commit.
+#
+# The optional third argument sets the committer date independently of the author date. The CD
+# workflow creates the commit in one operation, so the real path leaves it unset and both dates
+# match (verified against homebrew-tap #1324-#1332, 8/8 equal on 2026-07-28). Passing a later
+# committer date reproduces `git commit --amend`, which is what a hand-edited cask body looks like
+# on this arm — every identity field survives the rewrite, so the date pair is the only signal.
 war_cask_commits_json() {
   local version="$1"
   local head_sha="$2"
+  local committer_date="${3:-}"
 
   jq -cn \
     --arg version "${version}" \
     --arg head_sha "${head_sha}" \
+    --arg committer_date "${committer_date}" \
     '[{
       sha: $head_sha,
       author_login: "devantler",
@@ -362,7 +381,9 @@ war_cask_commits_json() {
       committer_name: "Nikolai Emil Damm",
       committer_email: "ned@devantler.tech",
       message: "chore(cask): update world-at-ruin to \($version)"
-    }]'
+    }
+    | if $committer_date == "" then . else .committer_date = $committer_date end]' \
+    | with_commit_dates
 }
 
 ksail_head="8fdc117e5892a57a82781fc3a4806ef1f21873af"
@@ -376,7 +397,7 @@ ksail_commits="$(jq -cn --arg head "${ksail_head}" '[{
   committer_name: "devantler-tech-bot[bot]",
   committer_email: "devantler-tech-bot[bot]@users.noreply.github.com",
   message: "chore(copilot-plugin): release v7.172.2"
-}]')"
+}]' | with_commit_dates)"
 
 ksail_cask_head="c58256924878560caff669a7c05df0d84c458b38"
 ksail_cask_commits="$(homebrew_commits_json \
@@ -415,7 +436,7 @@ multi_cycle_cask_commits="$(jq -cn \
      author_login: "", author_name: "generator-bot", author_email: "generator-bot@users.noreply.github.com",
      committer_login: "", committer_name: "generator-bot", committer_email: "generator-bot@users.noreply.github.com",
      message: "style: autocorrect Casks (brew style --fix)"}
-  ]')"
+  ]' | with_commit_dates)"
 
 # An agent adaptation commit takes a cask PR off its programmed path and makes it review-bearing.
 adapted_cask_head="7f6e5d4c3b2a19087f6e5d4c3b2a19087f6e5d4c"
@@ -430,7 +451,7 @@ adapted_cask_commits="$(jq -cn \
      author_login: "devantler", author_name: "Nikolai Emil Damm", author_email: "ned@devantler.tech",
      committer_login: "devantler", committer_name: "Nikolai Emil Damm", committer_email: "ned@devantler.tech",
      message: "fix(cask): correct the sha256 by hand"}
-  ]')"
+  ]' | with_commit_dates)"
 
 default_title_cask_head="5a5792bb83bd6b8469f10cd7e00abfe75c7f36be"
 default_title_cask_commits="$(homebrew_commits_json \
@@ -449,7 +470,7 @@ platform_commits="$(jq -cn --arg head "${platform_head}" '[{
   committer_name: "GitHub",
   committer_email: "noreply@github.com",
   message: "chore(deps): update dependency devantler-tech/ksail to v7.172.1"
-}]')"
+}]' | with_commit_dates)"
 
 agent_plugins_skills_head="e9cf0d8f34ef5e235d11b5141d71bb067d96538d"
 agent_plugins_skills_files='["plugins/github/skills/gh-stack/SKILL.md","plugins/gitops-kubernetes/skills/gitops-knowledge/SKILL.md"]'
@@ -462,7 +483,7 @@ agent_plugins_skills_commits="$(jq -cn --arg head "${agent_plugins_skills_head}"
   committer_name: "github-actions[bot]",
   committer_email: "41898282+github-actions[bot]@users.noreply.github.com",
   message: "chore(deps): update agent skills"
-}]')"
+}]' | with_commit_dates)"
 
 multi_agent_skills_head="6666666666666666666666666666666666666666"
 multi_agent_skills_commits="$(jq -cn --arg head "${multi_agent_skills_head}" '[
@@ -486,7 +507,7 @@ multi_agent_skills_commits="$(jq -cn --arg head "${multi_agent_skills_head}" '[
     committer_email: "41898282+github-actions[bot]@users.noreply.github.com",
     message: "chore(deps): update agent skills"
   }
-]')"
+]' | with_commit_dates)"
 
 platform_skills_head="d668b9d0f52c22473abc75a7d7457505e3624cc6"
 platform_skills_files='[".agents/skills/gitops-cluster-debug/SKILL.md",".agents/skills/gitops-knowledge/SKILL.md"]'
@@ -499,7 +520,7 @@ platform_skills_commits="$(jq -cn --arg head "${platform_skills_head}" '[{
   committer_name: "github-actions[bot]",
   committer_email: "41898282+github-actions[bot]@users.noreply.github.com",
   message: "chore(deps): update agent skills"
-}]')"
+}]' | with_commit_dates)"
 
 ksail_skills_head="fdffbf83c8c0c1cc01050dc3d5c79ab18c3a45b4"
 ksail_skills_files='[".agents/skills/gh-stack/SKILL.md"]'
@@ -512,7 +533,7 @@ ksail_skills_commits="$(jq -cn --arg head "${ksail_skills_head}" '[{
   committer_name: "github-actions[bot]",
   committer_email: "41898282+github-actions[bot]@users.noreply.github.com",
   message: "chore(deps): update agent skills"
-}]')"
+}]' | with_commit_dates)"
 
 adapted_agent_skills_head="5555555555555555555555555555555555555555"
 adapted_agent_skills_commits="$(jq -c --arg head "${adapted_agent_skills_head}" '. + [{
@@ -524,7 +545,7 @@ adapted_agent_skills_commits="$(jq -c --arg head "${adapted_agent_skills_head}" 
   committer_name: "Nikolai Emil Damm",
   committer_email: "26203420+devantler@users.noreply.github.com",
   message: "fix: adapt generated skill update"
-}]' <<<"${agent_plugins_skills_commits}")"
+}]' <<<"${agent_plugins_skills_commits}" | with_commit_dates)"
 
 adapted_ksail_head="2222222222222222222222222222222222222222"
 adapted_ksail_commits="$(jq -c --arg head "${adapted_ksail_head}" '. + [{
@@ -536,7 +557,7 @@ adapted_ksail_commits="$(jq -c --arg head "${adapted_ksail_head}" '. + [{
   committer_name: "Nikolai Emil Damm",
   committer_email: "26203420+devantler@users.noreply.github.com",
   message: "fix: adapt generated release"
-}]' <<<"${ksail_commits}")"
+}]' <<<"${ksail_commits}" | with_commit_dates)"
 
 adapted_cask_head="3333333333333333333333333333333333333333"
 adapted_cask_commits="$(jq -c --arg head "${adapted_cask_head}" '. + [{
@@ -548,7 +569,7 @@ adapted_cask_commits="$(jq -c --arg head "${adapted_cask_head}" '. + [{
   committer_name: "Nikolai Emil Damm",
   committer_email: "26203420+devantler@users.noreply.github.com",
   message: "fix: adapt generated cask"
-}]' <<<"${ksail_cask_commits}")"
+}]' <<<"${ksail_cask_commits}" | with_commit_dates)"
 
 expect_exempt \
   "KSail programmed plugin release" \
@@ -629,6 +650,44 @@ expect_exempt \
   "${war_cask_head}" \
   '["Casks/world-at-ruin.rb"]' \
   "${war_cask_commits}"
+
+# #2291. The tap token commits under the maintainer's own identity, so a `git commit --amend` that
+# rewrites the cask body leaves every login, name, email, message, branch and path identical to a
+# genuine release — the exemption used to survive it. The author/committer date pair is what an
+# amend cannot preserve, so it is what re-gates the PR here.
+war_amended_cask_commits="$(war_cask_commits_json \
+  "v0.36.0" \
+  "${war_cask_head}" \
+  "2026-07-18T09:17:05Z")"
+
+expect_review_gated \
+  "World at Ruin cask whose commit was amended by hand" \
+  "homebrew-tap" \
+  "devantler" \
+  "goreleaser/world-at-ruin" \
+  "chore(cask): update world-at-ruin to v0.36.0" \
+  "${war_cask_head}" \
+  '["Casks/world-at-ruin.rb"]' \
+  "${war_amended_cask_commits}"
+
+# A surveyor that has not been updated to send both dates must fail closed rather than silently
+# skipping the discriminator: without this the exemption would quietly widen back to what it was.
+expect_classifier_error \
+  "World at Ruin cask payload missing the commit date pair" \
+  "homebrew-tap" \
+  "devantler" \
+  "goreleaser/world-at-ruin" \
+  "chore(cask): update world-at-ruin to v0.36.0" \
+  "${war_cask_head}" \
+  '["Casks/world-at-ruin.rb"]' \
+  "$(jq -c 'map(del(.author_date, .committer_date))' <<<"${war_cask_commits}")"
+
+# The surveyor must be told to carry the pair, or a correct classifier is fed a payload that can
+# never exercise it.
+grep -Fq 'author_date' "${surveyor}" ||
+  fail "surveyor commit normalization does not carry author_date"
+grep -Fq 'committer_date' "${surveyor}" ||
+  fail "surveyor commit normalization does not carry committer_date"
 
 expect_exempt \
   "GoReleaser cask carrying several release cycles" \

--- a/.claude/scripts/programmed-bot-review-exemption.sh
+++ b/.claude/scripts/programmed-bot-review-exemption.sh
@@ -17,9 +17,11 @@ commits_json="$7"
 commit_schema='type == "array" and length > 0 and all(.[];
   type == "object" and
   keys == [
+    "author_date",
     "author_email",
     "author_login",
     "author_name",
+    "committer_date",
     "committer_email",
     "committer_login",
     "committer_name",
@@ -27,7 +29,9 @@ commit_schema='type == "array" and length > 0 and all(.[];
     "sha"
   ] and
   all(.[]; type == "string") and
-  (.sha | test("^[0-9a-f]{40}$"))
+  (.sha | test("^[0-9a-f]{40}$")) and
+  (.author_date | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+  (.committer_date | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
 )'
 
 if [[ ! "${head}" =~ ^[0-9a-f]{40}$ ]] ||
@@ -97,12 +101,15 @@ is_semver() {
   [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]
 }
 
+# The date pair is dropped before the identity comparison: this arm is authored by a bot account
+# that a rewrite would replace, so it already detects an adaptation commit the way the World at Ruin
+# arm cannot, and pinning timestamps here would only make the fixture brittle.
 matches_ksail_provenance() {
   local version="$1"
   jq -e \
     --arg head "${head}" \
     --arg version "${version}" \
-    '. == [{
+    'map(del(.author_date, .committer_date)) == [{
       sha: $head,
       author_login: "",
       author_name: "devantler-tech-bot[bot]",
@@ -163,18 +170,34 @@ matches_homebrew_provenance() {
 # single tap-token commit whose message is the normalized title. Named explicitly by maintainer
 # direction 2026-07-18 as a programmed release path.
 #
-# KNOWN LIMIT (#2291): this arm cannot detect a hand-amended commit. The tap token commits under the
-# maintainer's own Git identity, so `git commit --amend --no-edit` preserves every field checked
-# here while the cask body changes, and the PR stays exempt. The GoReleaser arm above is not
-# exposed to this, because an amend there replaces the `goreleaserbot` identity and breaks the
-# match. Closing it needs commit-signature provenance, which this schema does not carry.
+# This arm carries an identity check that the GoReleaser arm gets for free. The tap token commits
+# under the maintainer's own Git identity, so every login/name/email/message field is the same
+# whether the workflow produced the commit or a person rewrote it — an adaptation commit cannot be
+# detected by identity here the way `goreleaserbot` detects it above.
+#
+# The author/committer date pair supplies the missing signal. A commit created in one operation
+# carries one timestamp in both fields; `git commit --amend` preserves the author date and moves the
+# committer date, which is exactly the maneuver that edits a cask body while leaving every identity
+# field intact. Requiring the pair to be equal therefore revokes the exemption for a rewritten
+# commit and keeps it for a freshly-produced one (#2291).
+#
+# Measured 2026-07-28 on the real path: the CD workflow pushes with the tap token rather than
+# committing through the API, so its commits are `verified=false`/`unsigned`. A signature predicate
+# would reject every genuine release, which is why the date pair — not commit signing — is the
+# discriminator here.
+#
+# Residual, deliberately accepted: `git commit --amend --reset-author`, or an explicit `--date`,
+# realigns the pair and is not detected. Both are deliberate evasions by an actor who already holds
+# tap write access, whereas the plain `--amend` this catches is the maneuver reachable by accident.
 matches_war_cask_provenance() {
   local version="$1"
 
   jq -e \
     --arg head "${head}" \
     --arg version "${version}" \
-    '. == [{
+    'length == 1 and
+     (.[0].author_date == .[0].committer_date) and
+     (map(del(.author_date, .committer_date)) == [{
       sha: $head,
       author_login: "devantler",
       author_name: "Nikolai Emil Damm",
@@ -183,7 +206,7 @@ matches_war_cask_provenance() {
       committer_name: "Nikolai Emil Damm",
       committer_email: "ned@devantler.tech",
       message: "chore(cask): update world-at-ruin to \($version)"
-    }]' <<<"${commits_json}" >/dev/null
+    }])' <<<"${commits_json}" >/dev/null
 }
 
 if [[ "${branch}" == "deps/agent-skills-update" &&

--- a/.claude/scripts/programmed-bot-review-exemption.sh
+++ b/.claude/scripts/programmed-bot-review-exemption.sh
@@ -170,10 +170,10 @@ matches_homebrew_provenance() {
 # single tap-token commit whose message is the normalized title. Named explicitly by maintainer
 # direction 2026-07-18 as a programmed release path.
 #
-# This arm carries an identity check that the GoReleaser arm gets for free. The tap token commits
-# under the maintainer's own Git identity, so every login/name/email/message field is the same
-# whether the workflow produced the commit or a person rewrote it — an adaptation commit cannot be
-# detected by identity here the way `goreleaserbot` detects it above.
+# This arm has to earn a property the GoReleaser arm gets for free. The tap token commits under the
+# maintainer's own Git identity, so every login/name/email/message field is the same whether the
+# workflow produced the commit or a person rewrote it — an adaptation commit cannot be detected by
+# identity here the way `goreleaserbot` detects it above.
 #
 # The author/committer date pair supplies the missing signal. A commit created in one operation
 # carries one timestamp in both fields; `git commit --amend` preserves the author date and moves the


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The release-bot review exemption lets a Homebrew cask release PR skip review because it is provably machine-generated. On the World at Ruin release path that proof did not hold: its CD workflow commits under the maintainer's own Git identity, so amending the commit by hand kept every signal the check looks at while the cask contents changed — and the PR stayed exempt from review.

Low severity (it needs tap write access, so only the maintainer can reach it), but the World at Ruin path was weaker than the equivalent KSail one, and that asymmetry was undocumented.

## What

The check now also compares the commit's two timestamps. A commit made in one go carries the same time in both; amending one moves only the second. That tells a freshly-produced release apart from a rewritten one, so an amended cask PR needs review again while genuine releases are untouched.

**The fix in the issue would have broken every release.** It proposed requiring the commit to be signed by GitHub. Measured against the real path, the release workflow pushes rather than committing through the API, so its commits are unsigned — that rule would have rejected all of them. Verified against the last eight real releases before choosing the timestamp signal instead.

One residual is deliberate and noted in the code: a more elaborate amend can realign the timestamps. That takes a deliberate effort by someone who already has release access, whereas the plain amend now caught is the one reachable by accident.

Fixes #2291