### PR TITLE
fix(scripts): refuse a branch sweep whose path and slug are different repos

### DIFF
--- a/.claude/scripts/branch-cleanup.sh
+++ b/.claude/scripts/branch-cleanup.sh
@@ -86,17 +86,34 @@ fi
 #     The URL itself is never echoed — it can carry credentials.
 origin_url=$(git remote get-url origin 2>/dev/null) || origin_url=""
 origin_nwo=""
-case "$origin_url" in
-  *github.com[:/]*)
-    origin_nwo=${origin_url#*github.com}
-    origin_nwo=${origin_nwo#[:/]}
+# Hostnames are case-insensitive, so normalise before matching: an "GitHub.com"
+# origin must not slip past the host test and silently skip this whole check.
+# Owner/repo are compared case-insensitively too, on the same normalised copy.
+origin_lc=$(printf '%s' "$origin_url" | tr '[:upper:]' '[:lower:]')
+case "$origin_lc" in
+  *github.com:*|*github.com/*)
+    origin_nwo=${origin_lc#*github.com}
+    case "$origin_nwo" in
+      :*)
+        origin_nwo=${origin_nwo#:}
+        # After ':' this is EITHER an explicit port ("443/owner/repo") or the
+        # scp-style path ("owner/repo"). Only an all-digit first segment is a
+        # port; anything else is the owner and must be kept.
+        case "${origin_nwo%%/*}" in
+          ''|*[!0-9]*) ;;
+          *) origin_nwo=${origin_nwo#*/} ;;
+        esac
+        ;;
+      /*) origin_nwo=${origin_nwo#/} ;;
+    esac
     # Trailing slash BEFORE the .git suffix: ".../ksail.git/" must reduce to
     # "devantler-tech/ksail", and stripping ".git" first would leave the slash.
     origin_nwo=${origin_nwo%/}
     origin_nwo=${origin_nwo%.git}
     ;;
 esac
-if [ -n "$origin_nwo" ] && [ "$origin_nwo" != "devantler-tech/$SLUG" ]; then
+slug_lc=$(printf 'devantler-tech/%s' "$SLUG" | tr '[:upper:]' '[:lower:]')
+if [ -n "$origin_nwo" ] && [ "$origin_nwo" != "$slug_lc" ]; then
   echo "$SLUG: ABORT — slug '$SLUG' does not match the checkout at '$REPO_PATH', whose origin" >&2
   echo "  is '$origin_nwo'. The keep-set would be fetched for the wrong repository." >&2
   exit 2

--- a/.claude/scripts/branch-cleanup.sh
+++ b/.claude/scripts/branch-cleanup.sh
@@ -90,8 +90,10 @@ case "$origin_url" in
   *github.com[:/]*)
     origin_nwo=${origin_url#*github.com}
     origin_nwo=${origin_nwo#[:/]}
-    origin_nwo=${origin_nwo%.git}
+    # Trailing slash BEFORE the .git suffix: ".../ksail.git/" must reduce to
+    # "devantler-tech/ksail", and stripping ".git" first would leave the slash.
     origin_nwo=${origin_nwo%/}
+    origin_nwo=${origin_nwo%.git}
     ;;
 esac
 if [ -n "$origin_nwo" ] && [ "$origin_nwo" != "devantler-tech/$SLUG" ]; then

--- a/.claude/scripts/branch-cleanup.sh
+++ b/.claude/scripts/branch-cleanup.sh
@@ -53,6 +53,53 @@ DO_LOCAL=0
 
 cd "$REPO_PATH" || exit 1
 
+# --- <repo_path> and <slug> must describe the SAME repository -------------
+# The tree that gets deleted from comes from <repo_path>; the keep-set that
+# decides what survives is fetched for devantler-tech/<slug>. When they
+# disagree, branches are deleted from repository A against repository B's
+# open-PR evidence — the safety contract's central promise evaluated against
+# the wrong repository. Both checks run BEFORE the checkout is moved and before
+# anything is fetched, so a mismatch costs nothing.
+
+# (a) The path must be that repository's own root. An UNINITIALISED SUBMODULE
+#     directory is empty, so `cd` succeeds and git resolves UPWARD to the
+#     parent — silently, with no error and a zero exit (monorepo#2531).
+if ! toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || [ -z "$toplevel" ]; then
+  echo "$SLUG: ABORT — '$REPO_PATH' is not inside a git repository" >&2
+  exit 2
+fi
+# Compare physical paths: git may report an unresolved path where `pwd -P` has
+# followed symlinks (macOS /tmp -> /private/tmp), and that difference alone must
+# not read as a mismatch.
+here_phys=$(pwd -P)
+top_phys=$(cd "$toplevel" 2>/dev/null && pwd -P)
+if [ "$here_phys" != "$top_phys" ]; then
+  echo "$SLUG: ABORT — '$REPO_PATH' is not the repository root; git resolved upward to a" >&2
+  echo "  parent repository, so this sweep would delete from the wrong tree. An" >&2
+  echo "  uninitialised submodule is the usual cause — run .claude/scripts/submodule-init.sh" >&2
+  exit 2
+fi
+
+# (b) That repository must be the one the keep-set is fetched for. Only
+#     comparable when origin parses as a GitHub owner/repo; a local or
+#     non-GitHub origin (hermetic test clones) is left to check (a) alone.
+#     The URL itself is never echoed — it can carry credentials.
+origin_url=$(git remote get-url origin 2>/dev/null) || origin_url=""
+origin_nwo=""
+case "$origin_url" in
+  *github.com[:/]*)
+    origin_nwo=${origin_url#*github.com}
+    origin_nwo=${origin_nwo#[:/]}
+    origin_nwo=${origin_nwo%.git}
+    origin_nwo=${origin_nwo%/}
+    ;;
+esac
+if [ -n "$origin_nwo" ] && [ "$origin_nwo" != "devantler-tech/$SLUG" ]; then
+  echo "$SLUG: ABORT — slug '$SLUG' does not match the checkout at '$REPO_PATH', whose origin" >&2
+  echo "  is '$origin_nwo'. The keep-set would be fetched for the wrong repository." >&2
+  exit 2
+fi
+
 # DEFAULT reads the LOCAL origin/HEAD (set at clone) and needs no fresh fetch,
 # so the checkout-restoration path can be armed BEFORE fetching.
 DEFAULT=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')

--- a/.claude/scripts/branch-cleanup.sh
+++ b/.claude/scripts/branch-cleanup.sh
@@ -80,77 +80,103 @@ if [ "$here_phys" != "$top_phys" ]; then
   exit 2
 fi
 
-# (b) That repository must be the one the keep-set is fetched for, and when it
-#     cannot be tied to the slug a DESTRUCTIVE sweep refuses to run.
-#     The URL itself is never echoed — it can carry credentials.
-origin_url=$(git remote get-url origin 2>/dev/null) || origin_url=""
-origin_nwo=""
-# Hostnames are case-insensitive, so normalise before matching: an "GitHub.com"
-# origin must not slip past the host test and silently skip this whole check.
-# Owner/repo are compared case-insensitively too, on the same normalised copy.
-origin_lc=$(printf '%s' "$origin_url" | tr '[:upper:]' '[:lower:]')
+# (b) Every repository this sweep can reach must be the one the keep-set is
+#     fetched for, and when one cannot be tied to the slug a DESTRUCTIVE sweep
+#     refuses to run. The URL itself is never echoed — it can carry credentials.
+#
+# Reduce a remote URL to "owner/repo", or to the empty string when it is not a
+# GitHub URL at all.
+github_nwo() {
+  url_lc=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
 
-# Drop any userinfo BEFORE looking for the host. In "scheme://user:token@host/path"
-# the credential itself may contain "github.com", and a search for the first
-# occurrence would latch onto THAT — leaving the token inside the value this
-# script goes on to print in its mismatch message.
-origin_scan=$origin_lc
-case "$origin_scan" in
-  *://*) origin_scan=${origin_scan#*://} ;;
-esac
-origin_auth=${origin_scan%%/*}            # authority: up to the first path slash
-origin_rest=${origin_scan#"$origin_auth"}
-case "$origin_auth" in
-  *@*) origin_auth=${origin_auth##*@} ;;  # keep only what follows the LAST '@'
-esac
-origin_scan=$origin_auth$origin_rest
+  # Drop any userinfo BEFORE looking for the host. In "scheme://user:token@host/path"
+  # the credential itself may contain "github.com", and a search for the first
+  # occurrence would latch onto THAT — leaving the token inside the value this
+  # script goes on to print in its mismatch message.
+  scan=$url_lc
+  case "$scan" in
+    *://*) scan=${scan#*://} ;;
+  esac
+  auth=${scan%%/*}                  # authority: up to the first path slash
+  rest=${scan#"$auth"}
+  case "$auth" in
+    *@*) auth=${auth##*@} ;;        # keep only what follows the LAST '@'
+  esac
+  scan=$auth$rest
 
-# Match the host at the START of what remains, never as a substring: a
-# "mygithub.com/owner/repo" origin is a different host and must not be read as
-# GitHub's, which a substring test would do.
-case "$origin_scan" in
-  github.com:*|github.com/*)
-    origin_nwo=${origin_scan#github.com}
-    case "$origin_nwo" in
-      :*)
-        origin_nwo=${origin_nwo#:}
-        # After ':' this is EITHER an explicit port ("443/owner/repo") or the
-        # scp-style path ("owner/repo"). Only an all-digit first segment is a
-        # port; anything else is the owner and must be kept.
-        case "${origin_nwo%%/*}" in
-          ''|*[!0-9]*) ;;
-          *) origin_nwo=${origin_nwo#*/} ;;
-        esac
-        ;;
-      /*) origin_nwo=${origin_nwo#/} ;;
-    esac
-    # Trailing slash BEFORE the .git suffix: ".../ksail.git/" must reduce to
-    # "devantler-tech/ksail", and stripping ".git" first would leave the slash.
-    origin_nwo=${origin_nwo%/}
-    origin_nwo=${origin_nwo%.git}
-    ;;
-esac
+  # Match the host at the START of what remains, never as a substring: a
+  # "mygithub.com/owner/repo" origin is a different host and must not be read as
+  # GitHub's, which a substring test would do.
+  nwo=""
+  case "$scan" in
+    github.com:*|github.com/*)
+      nwo=${scan#github.com}
+      case "$nwo" in
+        :*)
+          nwo=${nwo#:}
+          # After ':' this is EITHER an explicit port ("443/owner/repo") or the
+          # scp-style path ("owner/repo"). Only an all-digit first segment is a
+          # port; anything else is the owner and must be kept.
+          case "${nwo%%/*}" in
+            ''|*[!0-9]*) ;;
+            *) nwo=${nwo#*/} ;;
+          esac
+          ;;
+        /*) nwo=${nwo#/} ;;
+      esac
+      # Trailing slash BEFORE the .git suffix: ".../ksail.git/" must reduce to
+      # "devantler-tech/ksail", and stripping ".git" first would leave the slash.
+      nwo=${nwo%/}
+      nwo=${nwo%.git}
+      ;;
+  esac
+  printf '%s' "$nwo"
+}
+
 slug_lc=$(printf 'devantler-tech/%s' "$SLUG" | tr '[:upper:]' '[:lower:]')
-if [ -n "$origin_nwo" ]; then
-  if [ "$origin_nwo" != "$slug_lc" ]; then
-    echo "$SLUG: ABORT — slug '$SLUG' does not match the checkout at '$REPO_PATH', whose origin" >&2
-    echo "  is '$origin_nwo'. The keep-set would be fetched for the wrong repository." >&2
+
+# Check the FETCH url and every PUSH url. The keep-set is fetched from the first,
+# but `git push origin --delete` writes to the second, and they diverge whenever
+# `remote.origin.pushurl` or a `pushInsteadOf` rewrite is configured — both of
+# which `get-url --push --all` resolves. Validating only the fetch url would let
+# a sweep delete branches from a repository the keep-set never described.
+# With neither configured, git returns the fetch url here, so this degrades to
+# the same single check.
+check_remote_identity() {
+  _kind="$1"; _url="$2"
+  _nwo=$(github_nwo "$_url")
+  if [ -n "$_nwo" ]; then
+    if [ "$_nwo" != "$slug_lc" ]; then
+      echo "$SLUG: ABORT — slug '$SLUG' does not match the checkout at '$REPO_PATH', whose" >&2
+      echo "  $_kind is '$_nwo'. The keep-set would be fetched for the wrong repository." >&2
+      exit 2
+    fi
+  elif [ "$MODE" = "apply" ] && [ "${BRANCH_CLEANUP_ALLOW_UNVERIFIABLE_ORIGIN:-}" != "1" ]; then
+    # Check (a) proved the tree is SOME repository's root, but nothing ties this
+    # remote to <slug> while the keep-set is still fetched for
+    # devantler-tech/<slug>. A wrong slug here deletes real branches against
+    # another repository's open-PR evidence — irreversible for an unpushed local
+    # branch, and it CLOSES the PR for a remote one — so the unverifiable case
+    # fails CLOSED rather than proceeding on an unchecked assumption.
+    # dry-run is exempt: it deletes nothing.
+    echo "$SLUG: ABORT — the $_kind of the checkout at '$REPO_PATH' has no GitHub origin," >&2
+    echo "  so it cannot be tied to slug '$SLUG' and a destructive sweep would run against" >&2
+    echo "  unverified evidence. Point it at devantler-tech/$SLUG, or re-run with 'dry-run'." >&2
+    echo "  A hermetic fixture declares itself with BRANCH_CLEANUP_ALLOW_UNVERIFIABLE_ORIGIN=1." >&2
     exit 2
   fi
-elif [ "$MODE" = "apply" ] && [ "${BRANCH_CLEANUP_ALLOW_UNVERIFIABLE_ORIGIN:-}" != "1" ]; then
-  # Origin does not parse as a GitHub owner/repo, so check (a) proved the tree is
-  # SOME repository's root but nothing ties it to <slug>. The keep-set is still
-  # fetched for devantler-tech/<slug>, so a wrong slug here deletes real branches
-  # against another repository's open-PR evidence. Deletion is irreversible for
-  # an unpushed local branch and CLOSES the PR for a remote one, so the
-  # unverifiable case fails CLOSED rather than proceeding on an unchecked
-  # assumption. dry-run is exempt: it deletes nothing.
-  echo "$SLUG: ABORT — the checkout at '$REPO_PATH' has no GitHub origin, so it cannot be" >&2
-  echo "  tied to slug '$SLUG' and a destructive sweep would run against unverified" >&2
-  echo "  evidence. Point origin at devantler-tech/$SLUG, or re-run with 'dry-run'." >&2
-  echo "  A hermetic fixture declares itself with BRANCH_CLEANUP_ALLOW_UNVERIFIABLE_ORIGIN=1." >&2
-  exit 2
-fi
+}
+
+origin_url=$(git remote get-url origin 2>/dev/null) || origin_url=""
+check_remote_identity "origin" "$origin_url"
+
+push_urls=$(git remote get-url --push --all origin 2>/dev/null) || push_urls=""
+while IFS= read -r _push_url; do
+  [ -n "$_push_url" ] || continue
+  check_remote_identity "push destination" "$_push_url"
+done <<EOF
+$push_urls
+EOF
 
 # DEFAULT reads the LOCAL origin/HEAD (set at clone) and needs no fresh fetch,
 # so the checkout-restoration path can be armed BEFORE fetching.

--- a/.claude/scripts/branch-cleanup.sh
+++ b/.claude/scripts/branch-cleanup.sh
@@ -80,9 +80,8 @@ if [ "$here_phys" != "$top_phys" ]; then
   exit 2
 fi
 
-# (b) That repository must be the one the keep-set is fetched for. Only
-#     comparable when origin parses as a GitHub owner/repo; a local or
-#     non-GitHub origin (hermetic test clones) is left to check (a) alone.
+# (b) That repository must be the one the keep-set is fetched for, and when it
+#     cannot be tied to the slug a DESTRUCTIVE sweep refuses to run.
 #     The URL itself is never echoed — it can carry credentials.
 origin_url=$(git remote get-url origin 2>/dev/null) || origin_url=""
 origin_nwo=""
@@ -90,9 +89,28 @@ origin_nwo=""
 # origin must not slip past the host test and silently skip this whole check.
 # Owner/repo are compared case-insensitively too, on the same normalised copy.
 origin_lc=$(printf '%s' "$origin_url" | tr '[:upper:]' '[:lower:]')
-case "$origin_lc" in
-  *github.com:*|*github.com/*)
-    origin_nwo=${origin_lc#*github.com}
+
+# Drop any userinfo BEFORE looking for the host. In "scheme://user:token@host/path"
+# the credential itself may contain "github.com", and a search for the first
+# occurrence would latch onto THAT — leaving the token inside the value this
+# script goes on to print in its mismatch message.
+origin_scan=$origin_lc
+case "$origin_scan" in
+  *://*) origin_scan=${origin_scan#*://} ;;
+esac
+origin_auth=${origin_scan%%/*}            # authority: up to the first path slash
+origin_rest=${origin_scan#"$origin_auth"}
+case "$origin_auth" in
+  *@*) origin_auth=${origin_auth##*@} ;;  # keep only what follows the LAST '@'
+esac
+origin_scan=$origin_auth$origin_rest
+
+# Match the host at the START of what remains, never as a substring: a
+# "mygithub.com/owner/repo" origin is a different host and must not be read as
+# GitHub's, which a substring test would do.
+case "$origin_scan" in
+  github.com:*|github.com/*)
+    origin_nwo=${origin_scan#github.com}
     case "$origin_nwo" in
       :*)
         origin_nwo=${origin_nwo#:}
@@ -113,9 +131,24 @@ case "$origin_lc" in
     ;;
 esac
 slug_lc=$(printf 'devantler-tech/%s' "$SLUG" | tr '[:upper:]' '[:lower:]')
-if [ -n "$origin_nwo" ] && [ "$origin_nwo" != "$slug_lc" ]; then
-  echo "$SLUG: ABORT — slug '$SLUG' does not match the checkout at '$REPO_PATH', whose origin" >&2
-  echo "  is '$origin_nwo'. The keep-set would be fetched for the wrong repository." >&2
+if [ -n "$origin_nwo" ]; then
+  if [ "$origin_nwo" != "$slug_lc" ]; then
+    echo "$SLUG: ABORT — slug '$SLUG' does not match the checkout at '$REPO_PATH', whose origin" >&2
+    echo "  is '$origin_nwo'. The keep-set would be fetched for the wrong repository." >&2
+    exit 2
+  fi
+elif [ "$MODE" = "apply" ] && [ "${BRANCH_CLEANUP_ALLOW_UNVERIFIABLE_ORIGIN:-}" != "1" ]; then
+  # Origin does not parse as a GitHub owner/repo, so check (a) proved the tree is
+  # SOME repository's root but nothing ties it to <slug>. The keep-set is still
+  # fetched for devantler-tech/<slug>, so a wrong slug here deletes real branches
+  # against another repository's open-PR evidence. Deletion is irreversible for
+  # an unpushed local branch and CLOSES the PR for a remote one, so the
+  # unverifiable case fails CLOSED rather than proceeding on an unchecked
+  # assumption. dry-run is exempt: it deletes nothing.
+  echo "$SLUG: ABORT — the checkout at '$REPO_PATH' has no GitHub origin, so it cannot be" >&2
+  echo "  tied to slug '$SLUG' and a destructive sweep would run against unverified" >&2
+  echo "  evidence. Point origin at devantler-tech/$SLUG, or re-run with 'dry-run'." >&2
+  echo "  A hermetic fixture declares itself with BRANCH_CLEANUP_ALLOW_UNVERIFIABLE_ORIGIN=1." >&2
   exit 2
 fi
 

--- a/.claude/scripts/branch-cleanup.sh
+++ b/.claude/scripts/branch-cleanup.sh
@@ -68,12 +68,15 @@ if ! toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || [ -z "$toplevel" ]
   echo "$SLUG: ABORT — '$REPO_PATH' is not inside a git repository" >&2
   exit 2
 fi
-# Compare physical paths: git may report an unresolved path where `pwd -P` has
-# followed symlinks (macOS /tmp -> /private/tmp), and that difference alone must
-# not read as a mismatch.
+# Compare by FILESYSTEM IDENTITY, not by string. Two spellings of one directory
+# are routine here: git may report an unresolved path where `pwd -P` has followed
+# symlinks (macOS /tmp -> /private/tmp), and on a case-insensitive volume (APFS)
+# the caller's casing survives in `pwd -P` while git reports its own — so a valid
+# sweep reached through a differently-cased path would abort on a string compare.
+# `-ef` compares device+inode and is what submodule-init.sh already uses.
 here_phys=$(pwd -P)
 top_phys=$(cd "$toplevel" 2>/dev/null && pwd -P)
-if [ "$here_phys" != "$top_phys" ]; then
+if [ -z "$top_phys" ] || ! [ "$here_phys" -ef "$top_phys" ]; then
   echo "$SLUG: ABORT — '$REPO_PATH' is not the repository root; git resolved upward to a" >&2
   echo "  parent repository, so this sweep would delete from the wrong tree. An" >&2
   echo "  uninitialised submodule is the usual cause — run .claude/scripts/submodule-init.sh" >&2
@@ -89,14 +92,26 @@ fi
 github_nwo() {
   url_lc=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
 
+  # The SCHEME decides whether the host means anything. Discarding everything
+  # through "://" without checking it accepts `file://github.com/owner/repo`,
+  # which git resolves as a LOCAL path (/owner/repo) while this script would go
+  # on to fetch its keep-set from GitHub — deleting branches in one repository
+  # against another's evidence. Only GitHub-capable network transports qualify;
+  # every other scheme is left unverifiable, which apply mode already refuses.
+  scan=$url_lc
+  case "$scan" in
+    *://*)
+      case "${scan%%://*}" in
+        https|http|ssh|git) scan=${scan#*://} ;;
+        *) printf '%s' ""; return ;;
+      esac
+      ;;
+  esac
+
   # Drop any userinfo BEFORE looking for the host. In "scheme://user:token@host/path"
   # the credential itself may contain "github.com", and a search for the first
   # occurrence would latch onto THAT — leaving the token inside the value this
   # script goes on to print in its mismatch message.
-  scan=$url_lc
-  case "$scan" in
-    *://*) scan=${scan#*://} ;;
-  esac
   auth=${scan%%/*}                  # authority: up to the first path slash
   rest=${scan#"$auth"}
   case "$auth" in
@@ -124,10 +139,23 @@ github_nwo() {
           ;;
         /*) nwo=${nwo#/} ;;
       esac
+      # A query or fragment can carry a CREDENTIAL (".../ksail.git?access_token=…").
+      # Left attached it also defeats the .git strip below, so the comparison fails
+      # and the mismatch message prints the token. Cut both before anything else.
+      nwo=${nwo%%\?*}
+      nwo=${nwo%%#*}
       # Trailing slash BEFORE the .git suffix: ".../ksail.git/" must reduce to
       # "devantler-tech/ksail", and stripping ".git" first would leave the slash.
       nwo=${nwo%/}
       nwo=${nwo%.git}
+      # A GitHub repository is exactly two path components. Anything else is a
+      # URL shape this parser does not understand, and guessing at it is how a
+      # stray suffix reaches the log — leave it unverifiable instead.
+      case "$nwo" in
+        */*/*|*/) nwo="" ;;
+        */*) ;;
+        *) nwo="" ;;
+      esac
       ;;
   esac
   printf '%s' "$nwo"

--- a/.claude/scripts/branch-cleanup.test.sh
+++ b/.claude/scripts/branch-cleanup.test.sh
@@ -148,6 +148,52 @@ report "default (claude) dry-run exits 0" "$([[ $rc -eq 0 ]] && echo yes || echo
 report "default dry-run reports ns=claude" \
   "$(grep -q 'ns=claude' <<<"$out" && echo yes || echo no)"
 
+# --- 6. repo_path that is not its own git toplevel is REFUSED -------------
+# monorepo#2531: an uninitialised submodule directory is empty, so `cd` succeeds
+# and git resolves UPWARD to the parent repository. The sweep then deletes from
+# the parent's tree while the keep-set is fetched for <slug> — the safety
+# contract's central promise evaluated against the wrong repository.
+mkdir -p "$work/applications/uninitialised-submodule"
+: >"$OPEN_HEADS_FILE"
+: >"$PR_EVIDENCE_FILE"
+manifest="$tmp/manifest6"
+: >"$manifest"
+out="$("$helper" "$work/applications/uninitialised-submodule" "ksail" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+report "path that resolves upward to a parent repo is refused (exit 2)" \
+  "$([[ ${rc:-0} -eq 2 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
+report "refusal names the repository-root mismatch" \
+  "$(grep -qi 'repository root' <<<"$out" && echo yes || echo no)" "out=$out"
+report "refusal happened before any sweep output" \
+  "$(grep -q 'ns=claude' <<<"$out" && echo no || echo yes)" "out=$out"
+
+# --- 7. slug that disagrees with the checkout's origin is REFUSED ---------
+# Same defect class, caught by the other half: the tree IS its own toplevel, but
+# it is not the repository the keep-set will be fetched for. Origin is a
+# non-existent GitHub repo so that a REGRESSION fails fast at the fetch instead
+# of pulling a real repository over the network.
+slugwork="$tmp/slugwork"
+git clone --quiet "$bare" "$slugwork"
+git -C "$slugwork" remote set-url origin "https://github.com/devantler-tech/does-not-exist-2531.git"
+manifest="$tmp/manifest7"
+: >"$manifest"
+out="$("$helper" "$slugwork" "ksail" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+report "slug that disagrees with origin is refused (exit 2)" \
+  "$([[ ${rc:-0} -eq 2 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
+report "slug refusal names both the slug and the origin repo" \
+  "$(grep -q 'ksail' <<<"$out" && grep -q 'does-not-exist-2531' <<<"$out" && echo yes || echo no)" "out=$out"
+
+# --- 8. a non-GitHub origin still runs (hermetic clones must keep working) -
+# The origin-vs-slug half can only compare when origin parses as a GitHub
+# owner/repo. A local bare origin cannot, so it is skipped there — the
+# toplevel half above still covers the silent walk-upward class.
+: >"$OPEN_HEADS_FILE"
+: >"$PR_EVIDENCE_FILE"
+manifest="$tmp/manifest8"
+: >"$manifest"
+out="$("$helper" "$work" "monorepo" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+report "non-GitHub origin does not trip the slug guard" \
+  "$([[ ${rc:-0} -eq 0 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
+
 # Silence unused-var lint for the open_sha we only needed for push tip creation.
 : "$open_sha" "$local_sha"
 

--- a/.claude/scripts/branch-cleanup.test.sh
+++ b/.claude/scripts/branch-cleanup.test.sh
@@ -224,6 +224,50 @@ report "credentialed origin is parsed to owner/repo, not the userinfo" \
 report "credentialed origin never echoes the secret" \
   "$(grep -qF 's3kr3t-fixture-token' <<<"$out" && echo no || echo yes)"
 
+# --- 7g. a credential in the QUERY never reaches the log -------------------
+# A query/fragment can carry a token, and left attached it also defeats the .git
+# strip — so the comparison fails and the mismatch message prints the token.
+git -C "$slugwork" remote set-url origin \
+  "https://github.com/devantler-tech/does-not-exist-2531.git?access_token=s3kr3t-query-token"
+manifest="$tmp/manifest7g"
+: >"$manifest"
+out="$("$helper" "$slugwork" "ksail" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+report "a query-string credential never reaches the output" \
+  "$(grep -qF 's3kr3t-query-token' <<<"$out" && echo no || echo yes)" "out=$out"
+report "the query is stripped, leaving a clean owner/repo" \
+  "$(grep -qF "is 'devantler-tech/does-not-exist-2531'" <<<"$out" && echo yes || echo no)" "out=$out"
+
+# --- 7h. file:// is NOT a GitHub origin ------------------------------------
+# git treats file:// as a LOCAL transport, so `file://github.com/devantler-tech/x`
+# resolves to /devantler-tech/x on disk. Accepting it as GitHub would sweep a
+# local repository against GitHub's PR evidence. It must read as unverifiable —
+# which dry-run tolerates and apply refuses.
+git -C "$slugwork" remote set-url origin "file://github.com/devantler-tech/does-not-exist-2531"
+manifest="$tmp/manifest7h"
+: >"$manifest"
+out="$(env -u BRANCH_CLEANUP_ALLOW_UNVERIFIABLE_ORIGIN \
+        "$helper" "$slugwork" "does-not-exist-2531" "$manifest" apply claude 2>&1)" && rc=0 || rc=$?
+report "a file:// origin is not accepted as GitHub (apply refused)" \
+  "$([[ ${rc:-0} -eq 2 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
+report "the file:// refusal is the unverifiable-origin one, not a slug match" \
+  "$(grep -qF 'no GitHub origin' <<<"$out" && echo yes || echo no)" "out=$out"
+
+# --- 7i. a differently-cased path is still the same repository -------------
+# On a case-insensitive volume `pwd -P` keeps the caller's casing while git
+# reports its own, so a string compare would abort a perfectly valid sweep.
+git -C "$slugwork" remote set-url origin "https://github.com/devantler-tech/does-not-exist-2531.git"
+cased="$(dirname "$slugwork")/$(basename "$slugwork" | tr '[:lower:]' '[:upper:]')"
+manifest="$tmp/manifest7i"
+: >"$manifest"
+if [ -d "$cased" ]; then
+  out="$("$helper" "$cased" "ksail" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+  report "a differently-cased path reaches the ORIGIN check, not the root abort" \
+    "$(grep -qF 'does not match the checkout' <<<"$out" && echo yes || echo no)" "out=$out"
+else
+  report "a differently-cased path reaches the ORIGIN check, not the root abort" "yes" \
+    "skipped — case-sensitive volume, the string compare cannot diverge here"
+fi
+
 # --- 7e. a diverging PUSH destination is refused ---------------------------
 # The keep-set is fetched from the fetch url, but `git push origin --delete`
 # writes to the push url. With `remote.origin.pushurl` set they are different

--- a/.claude/scripts/branch-cleanup.test.sh
+++ b/.claude/scripts/branch-cleanup.test.sh
@@ -224,6 +224,37 @@ report "credentialed origin is parsed to owner/repo, not the userinfo" \
 report "credentialed origin never echoes the secret" \
   "$(grep -qF 's3kr3t-fixture-token' <<<"$out" && echo no || echo yes)"
 
+# --- 7e. a diverging PUSH destination is refused ---------------------------
+# The keep-set is fetched from the fetch url, but `git push origin --delete`
+# writes to the push url. With `remote.origin.pushurl` set they are different
+# repositories, so a fetch-url-only check would authorise deletions in a repo the
+# evidence never described. Fetch url matches the slug here, so ONLY the push url
+# can trigger the refusal.
+git -C "$slugwork" remote set-url origin "https://github.com/devantler-tech/does-not-exist-2531.git"
+git -C "$slugwork" remote set-url --push origin "https://github.com/devantler-tech/some-other-repo.git"
+manifest="$tmp/manifest7e"
+: >"$manifest"
+out="$("$helper" "$slugwork" "does-not-exist-2531" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+report "a diverging push destination is refused (exit 2)" \
+  "$([[ ${rc:-0} -eq 2 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
+report "the refusal names the push destination, not the fetch origin" \
+  "$(grep -qF 'push destination' <<<"$out" && grep -qF 'some-other-repo' <<<"$out" && echo yes || echo no)" "out=$out"
+
+# --- 7f. a pushInsteadOf rewrite is refused too ----------------------------
+# `pushInsteadOf` redirects the push without touching either configured url, and
+# `get-url --push --all` is what resolves it — so the same check must catch it.
+git -C "$slugwork" remote set-url --push --delete "https://github.com/devantler-tech/some-other-repo.git" 2>/dev/null \
+  || git -C "$slugwork" config --unset-all remote.origin.pushurl 2>/dev/null || true
+git -C "$slugwork" config url."https://github.com/somewhere-else/".pushInsteadOf "https://github.com/devantler-tech/"
+manifest="$tmp/manifest7f"
+: >"$manifest"
+out="$("$helper" "$slugwork" "does-not-exist-2531" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+report "a pushInsteadOf rewrite is refused (exit 2)" \
+  "$([[ ${rc:-0} -eq 2 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
+report "the pushInsteadOf refusal names the rewritten destination" \
+  "$(grep -qF 'somewhere-else' <<<"$out" && echo yes || echo no)" "out=$out"
+git -C "$slugwork" config --unset url."https://github.com/somewhere-else/".pushInsteadOf
+
 # --- 8. a non-GitHub origin still runs (hermetic clones must keep working) -
 # The origin-vs-slug half can only compare when origin parses as a GitHub
 # owner/repo. A local bare origin cannot, so it is skipped there — the

--- a/.claude/scripts/branch-cleanup.test.sh
+++ b/.claude/scripts/branch-cleanup.test.sh
@@ -182,6 +182,28 @@ report "slug that disagrees with origin is refused (exit 2)" \
 report "slug refusal names both the slug and the origin repo" \
   "$(grep -q 'ksail' <<<"$out" && grep -q 'does-not-exist-2531' <<<"$out" && echo yes || echo no)" "out=$out"
 
+# --- 7b. an UPPERCASE GitHub host must not slip past the identity check ---
+# Hostnames are case-insensitive, so a case-sensitive host match would leave
+# origin unparsed and skip the slug comparison entirely — a silent bypass.
+git -C "$slugwork" remote set-url origin "https://GitHub.com/devantler-tech/does-not-exist-2531.git"
+manifest="$tmp/manifest7b"
+: >"$manifest"
+out="$("$helper" "$slugwork" "ksail" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+report "uppercase-host origin is still identity-checked (exit 2)" \
+  "$([[ ${rc:-0} -eq 2 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
+
+# --- 7c. an explicit port must NOT be read as part of the owner -----------
+# ":443/owner/repo" must reduce to "owner/repo". If the port leaked into the
+# comparison the guard would REJECT a correct repository. Slug matches the
+# origin here, so a correct parse passes the guard and fails later at the fetch
+# (exit 1) — proving the guard let it through without needing the network.
+git -C "$slugwork" remote set-url origin "https://github.com:443/devantler-tech/does-not-exist-2531.git"
+manifest="$tmp/manifest7c"
+: >"$manifest"
+out="$("$helper" "$slugwork" "does-not-exist-2531" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+report "explicit port does not falsely reject a matching repo (not exit 2)" \
+  "$([[ ${rc:-0} -ne 2 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
+
 # --- 8. a non-GitHub origin still runs (hermetic clones must keep working) -
 # The origin-vs-slug half can only compare when origin parses as a GitHub
 # owner/repo. A local bare origin cannot, so it is skipped there — the

--- a/.claude/scripts/branch-cleanup.test.sh
+++ b/.claude/scripts/branch-cleanup.test.sh
@@ -62,6 +62,12 @@ STUB
 chmod +x "$tmp/bin/gh"
 export PATH="$tmp/bin:$PATH"
 
+# These fixtures use a local bare "origin", which cannot be tied to a slug, so an
+# apply-mode sweep refuses to run against them. Declaring the fixture explicitly
+# is what keeps that refusal fail-closed in production while the offline tests
+# still exercise the real deletion paths. Test 9 unsets it to prove the refusal.
+export BRANCH_CLEANUP_ALLOW_UNVERIFIABLE_ORIGIN=1
+
 # Build a clone with a local bare origin so `git fetch` / `git push` stay offline.
 # CI runners have no default git identity — set one on the work clone before any commit.
 bare="$tmp/origin.git"
@@ -193,16 +199,30 @@ report "uppercase-host origin is still identity-checked (exit 2)" \
   "$([[ ${rc:-0} -eq 2 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
 
 # --- 7c. an explicit port must NOT be read as part of the owner -----------
-# ":443/owner/repo" must reduce to "owner/repo". If the port leaked into the
-# comparison the guard would REJECT a correct repository. Slug matches the
-# origin here, so a correct parse passes the guard and fails later at the fetch
-# (exit 1) — proving the guard let it through without needing the network.
+# ":443/owner/repo" must reduce to "owner/repo"; a leaked port would make the
+# parsed owner "443/devantler-tech", so a correct repository would be rejected.
+# The slug is deliberately WRONG so the guard aborts and prints what it parsed:
+# that asserts the port was stripped without letting the sweep reach the network.
 git -C "$slugwork" remote set-url origin "https://github.com:443/devantler-tech/does-not-exist-2531.git"
 manifest="$tmp/manifest7c"
 : >"$manifest"
-out="$("$helper" "$slugwork" "does-not-exist-2531" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
-report "explicit port does not falsely reject a matching repo (not exit 2)" \
-  "$([[ ${rc:-0} -ne 2 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
+out="$("$helper" "$slugwork" "ksail" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+report "explicit port is stripped from the parsed origin" \
+  "$(grep -qF "is 'devantler-tech/does-not-exist-2531'" <<<"$out" && echo yes || echo no)" "out=$out"
+
+# --- 7d. credentials in the origin URL never reach the message -----------
+# Userinfo can itself contain the host ("https://github.com:TOKEN@github.com/..."),
+# so a parser that searched for the FIRST "github.com" would keep the token in
+# the value it prints. The guard must report owner/repo only.
+git -C "$slugwork" remote set-url origin \
+  "https://github.com:s3kr3t-fixture-token@github.com/devantler-tech/does-not-exist-2531.git"
+manifest="$tmp/manifest7d"
+: >"$manifest"
+out="$("$helper" "$slugwork" "ksail" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+report "credentialed origin is parsed to owner/repo, not the userinfo" \
+  "$(grep -qF "is 'devantler-tech/does-not-exist-2531'" <<<"$out" && echo yes || echo no)" "out=$out"
+report "credentialed origin never echoes the secret" \
+  "$(grep -qF 's3kr3t-fixture-token' <<<"$out" && echo no || echo yes)"
 
 # --- 8. a non-GitHub origin still runs (hermetic clones must keep working) -
 # The origin-vs-slug half can only compare when origin parses as a GitHub
@@ -214,6 +234,34 @@ manifest="$tmp/manifest8"
 : >"$manifest"
 out="$("$helper" "$work" "monorepo" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
 report "non-GitHub origin does not trip the slug guard" \
+  "$([[ ${rc:-0} -eq 0 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
+
+# --- 9. an unverifiable origin FAILS CLOSED for a destructive sweep -------
+# Check (a) proves the tree is a repository root, but a non-GitHub origin ties it
+# to no slug — while the keep-set is still fetched for devantler-tech/<slug>. A
+# wrong slug there deletes local branches outright and CLOSES the PR of any
+# remote one, so apply mode must refuse unless a fixture declares itself.
+# Every other test exports the fixture variable, so this one drops it.
+: >"$OPEN_HEADS_FILE"
+: >"$PR_EVIDENCE_FILE"
+manifest="$tmp/manifest9"
+: >"$manifest"
+out="$(env -u BRANCH_CLEANUP_ALLOW_UNVERIFIABLE_ORIGIN \
+        "$helper" "$work" "monorepo" "$manifest" apply claude 2>&1)" && rc=0 || rc=$?
+report "apply against an unverifiable origin is refused (exit 2)" \
+  "$([[ ${rc:-0} -eq 2 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
+report "the refusal names the unverifiable origin, not a slug mismatch" \
+  "$(grep -qF 'no GitHub origin' <<<"$out" && echo yes || echo no)" "out=$out"
+report "the refusal happened before any sweep output" \
+  "$(grep -q 'ns=claude' <<<"$out" && echo no || echo yes)" "out=$out"
+
+# dry-run over the SAME unverifiable origin still runs — the refusal is scoped to
+# destruction, so the guard cannot be satisfied merely by the variable existing.
+manifest="$tmp/manifest9b"
+: >"$manifest"
+out="$(env -u BRANCH_CLEANUP_ALLOW_UNVERIFIABLE_ORIGIN \
+        "$helper" "$work" "monorepo" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+report "dry-run over the same unverifiable origin is unaffected" \
   "$([[ ${rc:-0} -eq 0 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
 
 # Silence unused-var lint for the open_sha we only needed for push tip creation.

--- a/.claude/scripts/branch-cleanup.test.sh
+++ b/.claude/scripts/branch-cleanup.test.sh
@@ -252,21 +252,14 @@ report "a file:// origin is not accepted as GitHub (apply refused)" \
 report "the file:// refusal is the unverifiable-origin one, not a slug match" \
   "$(grep -qF 'no GitHub origin' <<<"$out" && echo yes || echo no)" "out=$out"
 
-# --- 7i. a differently-cased path is still the same repository -------------
-# On a case-insensitive volume `pwd -P` keeps the caller's casing while git
-# reports its own, so a string compare would abort a perfectly valid sweep.
+# NOTE — the repository-root check compares filesystem identity (`-ef`) rather
+# than strings, so two spellings of one directory cannot abort a valid sweep.
+# There is deliberately NO assertion for it: on this host `cd "$cased" && pwd -P`
+# returns the canonical on-disk casing, so the caller's casing never survives to
+# diverge from git's, and every candidate test passed against the OLD string
+# compare too. An assertion that cannot fail is worse than none — it reads as
+# proof. `-ef` ships as a correctness improvement, unproven by test.
 git -C "$slugwork" remote set-url origin "https://github.com/devantler-tech/does-not-exist-2531.git"
-cased="$(dirname "$slugwork")/$(basename "$slugwork" | tr '[:lower:]' '[:upper:]')"
-manifest="$tmp/manifest7i"
-: >"$manifest"
-if [ -d "$cased" ]; then
-  out="$("$helper" "$cased" "ksail" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
-  report "a differently-cased path reaches the ORIGIN check, not the root abort" \
-    "$(grep -qF 'does not match the checkout' <<<"$out" && echo yes || echo no)" "out=$out"
-else
-  report "a differently-cased path reaches the ORIGIN check, not the root abort" "yes" \
-    "skipped — case-sensitive volume, the string compare cannot diverge here"
-fi
 
 # --- 7e. a diverging PUSH destination is refused ---------------------------
 # The keep-set is fetched from the fetch url, but `git push origin --delete`


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The end-of-tick branch sweep decides what to delete from one repository using the list of
open pull requests fetched for **another**. Nothing checked that the two were the same
repository, and the easy way to get them apart is completely silent: an uninitialised
submodule folder is empty, so the sweep steps into it, lands in the parent repository
instead, and carries on — reporting under the submodule's name and finishing successfully.

That happened for real: a sweep announced itself as `ksail` while enumerating the
monorepo's 383 branches, and exited 0. The safety promise everything else rests on —
never delete a branch that has an open pull request — was being checked against the
wrong repository's pull requests.

Branch cleanup has been skipped for two runs because of it.

## What

The sweep now refuses to start when the folder it was pointed at and the repository name
it was given disagree. It checks that the folder really is that repository's own root,
and that the repository is the one whose pull requests it is about to fetch. Both checks
run before anything is deleted, moved, or downloaded, so a mismatch costs nothing and a
correct run is unaffected.

Fixes #2531
