### PR TITLE
fix(telemetry): verify schedule persistence

### DIFF
--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -187,6 +187,12 @@ for writer_namespace in '`claude/*`' '`codex/*`' '`cursor/*`'; do
 done
 grep -Fq 'remain undeployed and read-only' "${constitution}" ||
   fail "consumer does not fail closed for unmapped Cursor role schedules"
+assert_prose 'the in-session read-back is necessary but not sufficient' \
+  "runtime-local delivery incorrectly treats an in-session read-back as persistence proof"
+assert_prose 're-read after at least one dispatch of that schedule' \
+  "runtime-local delivery does not require a post-dispatch persistence check"
+assert_prose 'a reverted value with an advanced marker means the runtime overwrote the file' \
+  "runtime-local delivery does not recognise the dispatch-time rewrite failure mode"
 
 # --- The merged spend mandate -------------------------------------------------
 # Spend is a dimension of the Agentic Engineer. The consumer must supply the Spend

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -193,6 +193,16 @@ assert_prose 're-read after at least one dispatch of that schedule' \
   "runtime-local delivery does not require a post-dispatch persistence check"
 assert_prose 'a reverted value with an advanced marker means the runtime overwrote the file' \
   "runtime-local delivery does not recognise the dispatch-time rewrite failure mode"
+for marker_baseline in \
+  '`CLAUDE_ENGINEER_MARKER_BASELINE`' \
+  '`CLAUDE_IMPROVER_MARKER_BASELINE`' \
+  '`CODEX_ENGINEER_MARKER_BASELINE`' \
+  '`CODEX_IMPROVER_MARKER_BASELINE`'; do
+  assert_prose "${marker_baseline}" \
+    "runtime-local delivery does not name ${marker_baseline} for persistence verification"
+done
+assert_prose 'A missing baseline, a marker that did not advance, or an incomplete recurrence rule is `UNKNOWN`, never `MATCH`.' \
+  "runtime-local delivery does not fail closed on incomplete persistence evidence"
 
 # --- The merged spend mandate -------------------------------------------------
 # Spend is a dimension of the Agentic Engineer. The consumer must supply the Spend

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -201,7 +201,11 @@ for marker_baseline in \
   assert_prose "${marker_baseline}" \
     "runtime-local delivery does not name ${marker_baseline} for persistence verification"
 done
-assert_prose 'A missing baseline, a marker that did not advance, or an incomplete recurrence rule is `UNKNOWN`, never `MATCH`.' \
+assert_prose 'authoritative `scheduled-tasks.json` record selected by exact task id plus pointer path' \
+  "runtime-local delivery does not require the authoritative Claude scheduler record"
+assert_prose '`lastRunAt` as its marker; the `SKILL.md` description is not scheduler state' \
+  "runtime-local delivery can mistake Claude loader prose for deployed cadence"
+assert_prose 'A missing or ambiguous store, missing baseline, marker that did not advance, or incomplete recurrence rule is `UNKNOWN`, never `MATCH`.' \
   "runtime-local delivery does not fail closed on incomplete persistence evidence"
 
 # --- The merged spend mandate -------------------------------------------------

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1755,16 +1755,21 @@ if want drift; then
   normalise_hours() {
     awk -F',' '
       {
-        out = ""
         for (i = 1; i <= NF; i++) {
           gsub(/^[[:space:]]+|[[:space:]]+$/, "", $i)
           if ($i !~ /^[0-9][0-9]?$/) continue
           h = $i + 0
-          if (h < 0 || h > 23 || seen[h]++) continue
-          out = out (out == "" ? "" : ",") h
+          if (h >= 0 && h <= 23) seen[h] = 1
         }
       }
-      END { print out }
+      END {
+        out = ""
+        for (h = 0; h <= 23; h++) {
+          if (!seen[h]) continue
+          out = out (out == "" ? "" : ",") h
+        }
+        print out
+      }
     '
   }
 
@@ -1778,9 +1783,34 @@ if want drift; then
   }
 
   codex_pointer_hours() {
+    local rule
     [ -f "$1" ] || return 0
-    sed -nE 's/^rrule[[:space:]]*=[[:space:]]*".*BYHOUR=([0-9,]+).*/\1/p' "$1" \
-      | head -1 | normalise_hours
+    rule=$(sed -nE 's/^rrule[[:space:]]*=[[:space:]]*"RRULE:([^"]+)".*/\1/p' "$1" \
+      | head -1)
+    [ -n "$rule" ] || return 0
+    printf '%s\n' "$rule" | awk -F';' '
+      {
+        for (i = 1; i <= NF; i++) {
+          split($i, pair, "=")
+          key = pair[1]
+          value = substr($i, length(key) + 2)
+          if (seen[key]++) invalid = 1
+          if (key == "FREQ") freq = value
+          else if (key == "INTERVAL") interval = value
+          else if (key == "BYHOUR") hours = value
+          else if (key == "BYMINUTE") minute = value
+          else if (key == "BYSECOND") second = value
+          else invalid = 1
+        }
+      }
+      END {
+        if (invalid || (freq != "DAILY" && freq != "HOURLY") ||
+            (interval != "" && interval != "1") ||
+            hours !~ /^[0-9][0-9]?(,[0-9][0-9]?)*$/ ||
+            minute != "0" || second != "0") exit 1
+        print hours
+      }
+    ' | normalise_hours
   }
 
   # Claude's native schedule pointer is a thin SKILL.md rather than a TOML
@@ -1824,28 +1854,52 @@ if want drift; then
     awk -F'=' '
       /^updated_at[[:space:]]*=/ {
         gsub(/[[:space:]]/, "", $2)
-        print " updated_at=" $2
+        print $2
         exit
       }
     ' "$1" 2>/dev/null
   }
 
+  file_change_marker() {
+    [ -f "$1" ] || return 0
+    stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1" 2>/dev/null || true
+  }
+
+  marker_advanced() {
+    local current="$1" baseline="$2"
+    [[ "$current" =~ ^[0-9]+$ ]] && [[ "$baseline" =~ ^[0-9]+$ ]] \
+      && [ "$current" -gt "$baseline" ]
+  }
+
   compare_schedule() {
-    local label="$1" expected="$2" actual="$3" file="$4" marker="${5:-}" marker_required="${6:-0}"
+    local label="$1" expected="$2" actual="$3" file="$4"
+    local marker="${5:-}" baseline="${6:-}" pointer_kind="${7:-pointer}"
     if [ ! -f "$file" ]; then
       echo "    UNKNOWN: $label schedule pointer missing"
-    elif [ "$marker_required" -eq 1 ] && [ -z "$marker" ]; then
-      echo "    UNKNOWN: $label change marker missing"
-    elif [ -z "$expected" ]; then
-      echo "    UNKNOWN: $label schedule absent from AGENTS.md cadence table"
+    elif [ -z "$actual" ] && [ "$pointer_kind" = recurrence ]; then
+      echo "    UNKNOWN: $label recurrence rule is incomplete or unsupported"
     elif [ -z "$actual" ]; then
       echo "    UNKNOWN: $label schedule could not be parsed from its pointer"
-    elif [ "$expected" = "$actual" ]; then
-      printf '    %-16s expected=%s actual=%s MATCH%s\n' \
-        "${label}:" "$expected" "$actual" "$marker"
+    elif [ -z "$expected" ]; then
+      echo "    UNKNOWN: $label schedule absent from AGENTS.md cadence table"
+    elif [ "$expected" != "$actual" ]; then
+      echo "    ⚠️  DRIFT: $label schedule expected=$expected actual=$actual marker=${marker:-missing} baseline=${baseline:-missing}"
+    elif [ -z "$marker" ]; then
+      echo "    UNKNOWN: $label change marker missing"
+    elif [ -z "$baseline" ]; then
+      echo "    UNKNOWN: $label change marker baseline missing"
+    elif ! marker_advanced "$marker" "$baseline"; then
+      echo "    UNKNOWN: $label change marker did not advance (marker=$marker baseline=$baseline)"
     else
-      echo "    ⚠️  DRIFT: $label schedule expected=$expected actual=$actual$marker"
+      printf '    %-16s expected=%s actual=%s MATCH marker=%s baseline=%s\n' \
+        "${label}:" "$expected" "$actual" "$marker" "$baseline"
     fi
+  }
+
+  schedule_measured() {
+    local file="$1" expected="$2" actual="$3" marker="$4" baseline="$5"
+    [ -f "$file" ] && [ -n "$expected" ] && [ -n "$actual" ] \
+      && marker_advanced "$marker" "$baseline"
   }
 
   CLAUDE_ENGINEER_EXPECTED=$(cadence_expected Claude 3)
@@ -1856,23 +1910,41 @@ if want drift; then
   CLAUDE_IMPROVER_ACTUAL=$(claude_pointer_hours "$CLAUDE_IMPROVER_LOADER" improver)
   CODEX_ENGINEER_ACTUAL=$(codex_pointer_hours "$CODEX_LOADER")
   CODEX_IMPROVER_ACTUAL=$(codex_pointer_hours "$CODEX_IMPROVER_LOADER")
+  CLAUDE_ENGINEER_MARKER=$(file_change_marker "$CLAUDE_LOADER")
+  CLAUDE_IMPROVER_MARKER=$(file_change_marker "$CLAUDE_IMPROVER_LOADER")
+  CODEX_ENGINEER_MARKER=$(codex_change_marker "$CODEX_LOADER")
+  CODEX_IMPROVER_MARKER=$(codex_change_marker "$CODEX_IMPROVER_LOADER")
+  CLAUDE_ENGINEER_BASELINE="${CLAUDE_ENGINEER_MARKER_BASELINE:-}"
+  CLAUDE_IMPROVER_BASELINE="${CLAUDE_IMPROVER_MARKER_BASELINE:-}"
+  CODEX_ENGINEER_BASELINE="${CODEX_ENGINEER_MARKER_BASELINE:-}"
+  CODEX_IMPROVER_BASELINE="${CODEX_IMPROVER_MARKER_BASELINE:-}"
 
-  compare_schedule "claude engineer" "$CLAUDE_ENGINEER_EXPECTED" "$CLAUDE_ENGINEER_ACTUAL" "$CLAUDE_LOADER"
-  compare_schedule "claude improver" "$CLAUDE_IMPROVER_EXPECTED" "$CLAUDE_IMPROVER_ACTUAL" "$CLAUDE_IMPROVER_LOADER"
+  compare_schedule "claude engineer" "$CLAUDE_ENGINEER_EXPECTED" "$CLAUDE_ENGINEER_ACTUAL" \
+    "$CLAUDE_LOADER" "$CLAUDE_ENGINEER_MARKER" "$CLAUDE_ENGINEER_BASELINE"
+  compare_schedule "claude improver" "$CLAUDE_IMPROVER_EXPECTED" "$CLAUDE_IMPROVER_ACTUAL" \
+    "$CLAUDE_IMPROVER_LOADER" "$CLAUDE_IMPROVER_MARKER" "$CLAUDE_IMPROVER_BASELINE"
   compare_schedule "codex engineer" "$CODEX_ENGINEER_EXPECTED" "$CODEX_ENGINEER_ACTUAL" \
-    "$CODEX_LOADER" "$(codex_change_marker "$CODEX_LOADER")" 1
+    "$CODEX_LOADER" "$CODEX_ENGINEER_MARKER" "$CODEX_ENGINEER_BASELINE" recurrence
   compare_schedule "codex improver" "$CODEX_IMPROVER_EXPECTED" "$CODEX_IMPROVER_ACTUAL" \
-    "$CODEX_IMPROVER_LOADER" "$(codex_change_marker "$CODEX_IMPROVER_LOADER")" 1
+    "$CODEX_IMPROVER_LOADER" "$CODEX_IMPROVER_MARKER" "$CODEX_IMPROVER_BASELINE" recurrence
 
-  if [ -n "$CLAUDE_ENGINEER_ACTUAL" ] && [ -n "$CLAUDE_IMPROVER_ACTUAL" ] \
-     && [ -n "$CODEX_ENGINEER_ACTUAL" ] && [ -n "$CODEX_IMPROVER_ACTUAL" ]; then
-    COLLISIONS=$(awk -v a="$CLAUDE_ENGINEER_ACTUAL,$CLAUDE_IMPROVER_ACTUAL" \
-                     -v b="$CODEX_ENGINEER_ACTUAL,$CODEX_IMPROVER_ACTUAL" '
+  if schedule_measured "$CLAUDE_LOADER" "$CLAUDE_ENGINEER_EXPECTED" "$CLAUDE_ENGINEER_ACTUAL" \
+       "$CLAUDE_ENGINEER_MARKER" "$CLAUDE_ENGINEER_BASELINE" \
+     && schedule_measured "$CLAUDE_IMPROVER_LOADER" "$CLAUDE_IMPROVER_EXPECTED" "$CLAUDE_IMPROVER_ACTUAL" \
+       "$CLAUDE_IMPROVER_MARKER" "$CLAUDE_IMPROVER_BASELINE" \
+     && schedule_measured "$CODEX_LOADER" "$CODEX_ENGINEER_EXPECTED" "$CODEX_ENGINEER_ACTUAL" \
+       "$CODEX_ENGINEER_MARKER" "$CODEX_ENGINEER_BASELINE" \
+     && schedule_measured "$CODEX_IMPROVER_LOADER" "$CODEX_IMPROVER_EXPECTED" "$CODEX_IMPROVER_ACTUAL" \
+       "$CODEX_IMPROVER_MARKER" "$CODEX_IMPROVER_BASELINE"; then
+    COLLISIONS=$(awk -v schedules="$CLAUDE_ENGINEER_ACTUAL,$CLAUDE_IMPROVER_ACTUAL,$CODEX_ENGINEER_ACTUAL,$CODEX_IMPROVER_ACTUAL" '
       BEGIN {
-        split(a, aa, ",")
-        split(b, bb, ",")
-        for (i in aa) if (aa[i] != "") left[aa[i]] = 1
-        for (i in bb) if (bb[i] != "" && left[bb[i]]) collisions++
+        count = split(schedules, slots, ",")
+        for (i = 1; i <= count; i++) {
+          if (slots[i] != "") starts[slots[i]]++
+        }
+        for (hour in starts) {
+          if (starts[hour] > 1) collisions += starts[hour] - 1
+        }
         print collisions + 0
       }
     ')

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1736,49 +1736,162 @@ if want drift; then
   echo
   echo "── DRIFT (loader ↔ constitution ↔ memory) ───────────────────────"
   CLAUDE_LOADER="${CLAUDE_LOADER_PATH:-$HOME/.claude/scheduled-tasks/daily-ai-assistant/SKILL.md}"
+  CLAUDE_IMPROVER_LOADER="${CLAUDE_IMPROVER_LOADER_PATH:-$HOME/.claude/scheduled-tasks/agent-improver/SKILL.md}"
   CODEX_LOADER="${CODEX_LOADER_PATH:-$CODEX_HOME/automations/daily-ai-engineer/automation.toml}"
+  CODEX_IMPROVER_LOADER="${CODEX_IMPROVER_LOADER_PATH:-$CODEX_HOME/automations/agent-improver/automation.toml}"
   AGENTS_MD="$MONOREPO/AGENTS.md"
 
-  for f in "$CLAUDE_LOADER" "$CODEX_LOADER" "$AGENTS_MD"; do
+  for f in "$CLAUDE_LOADER" "$CLAUDE_IMPROVER_LOADER" \
+           "$CODEX_LOADER" "$CODEX_IMPROVER_LOADER" "$AGENTS_MD"; do
     [ -f "$f" ] && echo "  present: $f" || echo "  MISSING: $f"
   done
 
   echo
-  echo "  declared cadence vs actual schedule:"
-  # Extract the loader's SELF-description only. Both loaders also describe the
-  # SIBLING's cadence ("You run in parallel with ... dispatched every second hour"),
-  # so an unanchored match reads the wrong agent's schedule back — anchor on the
-  # self-identifying clause instead.
-  # Portable awk rather than a regex: the Codex loader packs the whole prompt onto
-  # ONE line containing both cadences, so a greedy `.*dispatched` picks the sibling's.
-  # index() finds the FIRST "dispatched" after the self-identifying clause. awk also
-  # sidesteps bounded/lazy quantifiers, which differ across grep implementations
-  # (BSD grep vs GNU grep vs ugrep) and would make this pass locally and fail in CI.
-  self_cadence() {
-    awk '
+  echo "  cadence table vs all four runtime schedule pointers:"
+
+  # Canonicalise an hour set for exact comparison. The contract prints zero-
+  # padded hours while RRULE uses integers; comparing the raw strings would
+  # report false drift for equivalent schedules.
+  normalise_hours() {
+    awk -F',' '
       {
-        i = index($0, "You are the devantler-tech")
-        if (i > 0) {
-          rest = substr($0, i)
-          j = index(rest, "dispatched")
-          if (j > 0) { print substr(rest, j, 70); exit }
+        out = ""
+        for (i = 1; i <= NF; i++) {
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", $i)
+          if ($i !~ /^[0-9][0-9]?$/) continue
+          h = $i + 0
+          if (h < 0 || h > 23 || seen[h]++) continue
+          out = out (out == "" ? "" : ",") h
         }
-      }' "$1" 2>/dev/null
+      }
+      END { print out }
+    '
   }
-  if [ -f "$CODEX_LOADER" ]; then
-    echo "    codex rrule:  $(grep -o 'BYHOUR=[0-9,]*' "$CODEX_LOADER" 2>/dev/null | head -1)"
-    echo "    codex prose:  $(self_cadence "$CODEX_LOADER")"
+
+  cadence_expected() {
+    local provider="$1" column="$2" lane
+    [ -f "$AGENTS_MD" ] || return 0
+    lane=$(printf '%s' "$provider" | tr '[:upper:]' '[:lower:]')
+    awk -F'|' -v p="$provider" -v lane="$lane/*" -v c="$column" '
+      index($2, "**" p "**") && index($2, lane) { print $c; exit }
+    ' "$AGENTS_MD" 2>/dev/null | tr -cd '0-9, \n' | normalise_hours
+  }
+
+  codex_pointer_hours() {
+    [ -f "$1" ] || return 0
+    sed -nE 's/^rrule[[:space:]]*=[[:space:]]*".*BYHOUR=([0-9,]+).*/\1/p' "$1" \
+      | head -1 | normalise_hours
+  }
+
+  # Claude's native schedule pointer is a thin SKILL.md rather than a TOML
+  # record. Its machine-readable surface is the pointer's bounded lane clause:
+  # the engineer declares an even range and exclusions; the improver declares
+  # its two hours. Parse only those clauses, never unrelated numbers elsewhere
+  # in the prompt.
+  claude_pointer_hours() {
+    local file="$1" role="$2" flat bounds exclusions start end ex1 ex2
+    [ -f "$file" ] || return 0
+    flat=$(tr '\n' ' ' < "$file")
+    if [ "$role" = engineer ]; then
+      bounds=$(printf '%s\n' "$flat" \
+        | sed -nE 's/.*EVEN hours ([0-9][0-9])[^0-9]+([0-9][0-9]).*/\1,\2/p')
+      exclusions=$(printf '%s\n' "$flat" \
+        | sed -nE 's/.*minus the ([0-9][0-9])\/([0-9][0-9]).*/\1,\2/p')
+      [ -n "$bounds" ] || return 0
+      start=${bounds%%,*}
+      end=${bounds##*,}
+      ex1=${exclusions%%,*}
+      ex2=${exclusions##*,}
+      awk -v first="$start" -v last="$end" -v skip1="$ex1" -v skip2="$ex2" '
+        BEGIN {
+          out = ""
+          for (h = first + 0; h <= last + 0; h++) {
+            if (h % 2 != 0 || h == skip1 + 0 || h == skip2 + 0) continue
+            out = out (out == "" ? "" : ",") h
+          }
+          print out
+        }
+      '
+    else
+      printf '%s\n' "$flat" \
+        | sed -nE 's/.*lane:[^0-9]*([0-9][0-9])[[:space:]]+and[[:space:]]+([0-9][0-9])[[:space:]]+local.*/\1,\2/p' \
+        | normalise_hours
+    fi
+  }
+
+  codex_change_marker() {
+    [ -f "$1" ] || return 0
+    awk -F'=' '
+      /^updated_at[[:space:]]*=/ {
+        gsub(/[[:space:]]/, "", $2)
+        print " updated_at=" $2
+        exit
+      }
+    ' "$1" 2>/dev/null
+  }
+
+  compare_schedule() {
+    local label="$1" expected="$2" actual="$3" file="$4" marker="${5:-}"
+    if [ ! -f "$file" ]; then
+      echo "    UNKNOWN: $label schedule pointer missing"
+    elif [ -z "$expected" ]; then
+      echo "    UNKNOWN: $label schedule absent from AGENTS.md cadence table"
+    elif [ -z "$actual" ]; then
+      echo "    UNKNOWN: $label schedule could not be parsed from its pointer"
+    elif [ "$expected" = "$actual" ]; then
+      printf '    %-16s expected=%s actual=%s MATCH%s\n' \
+        "${label}:" "$expected" "$actual" "$marker"
+    else
+      echo "    ⚠️  DRIFT: $label schedule expected=$expected actual=$actual$marker"
+    fi
+  }
+
+  CLAUDE_ENGINEER_EXPECTED=$(cadence_expected Claude 3)
+  CLAUDE_IMPROVER_EXPECTED=$(cadence_expected Claude 4)
+  CODEX_ENGINEER_EXPECTED=$(cadence_expected Codex 3)
+  CODEX_IMPROVER_EXPECTED=$(cadence_expected Codex 4)
+  CLAUDE_ENGINEER_ACTUAL=$(claude_pointer_hours "$CLAUDE_LOADER" engineer)
+  CLAUDE_IMPROVER_ACTUAL=$(claude_pointer_hours "$CLAUDE_IMPROVER_LOADER" improver)
+  CODEX_ENGINEER_ACTUAL=$(codex_pointer_hours "$CODEX_LOADER")
+  CODEX_IMPROVER_ACTUAL=$(codex_pointer_hours "$CODEX_IMPROVER_LOADER")
+
+  compare_schedule "claude engineer" "$CLAUDE_ENGINEER_EXPECTED" "$CLAUDE_ENGINEER_ACTUAL" "$CLAUDE_LOADER"
+  compare_schedule "claude improver" "$CLAUDE_IMPROVER_EXPECTED" "$CLAUDE_IMPROVER_ACTUAL" "$CLAUDE_IMPROVER_LOADER"
+  compare_schedule "codex engineer" "$CODEX_ENGINEER_EXPECTED" "$CODEX_ENGINEER_ACTUAL" \
+    "$CODEX_LOADER" "$(codex_change_marker "$CODEX_LOADER")"
+  compare_schedule "codex improver" "$CODEX_IMPROVER_EXPECTED" "$CODEX_IMPROVER_ACTUAL" \
+    "$CODEX_IMPROVER_LOADER" "$(codex_change_marker "$CODEX_IMPROVER_LOADER")"
+
+  if [ -n "$CLAUDE_ENGINEER_ACTUAL" ] && [ -n "$CLAUDE_IMPROVER_ACTUAL" ] \
+     && [ -n "$CODEX_ENGINEER_ACTUAL" ] && [ -n "$CODEX_IMPROVER_ACTUAL" ]; then
+    COLLISIONS=$(awk -v a="$CLAUDE_ENGINEER_ACTUAL,$CLAUDE_IMPROVER_ACTUAL" \
+                     -v b="$CODEX_ENGINEER_ACTUAL,$CODEX_IMPROVER_ACTUAL" '
+      BEGIN {
+        split(a, aa, ",")
+        split(b, bb, ",")
+        for (i in aa) if (aa[i] != "") left[aa[i]] = 1
+        for (i in bb) if (bb[i] != "" && left[bb[i]]) collisions++
+        print collisions + 0
+      }
+    ')
+    ENGINEER_DISPATCHES=$(awk -v a="$CLAUDE_ENGINEER_ACTUAL" -v b="$CODEX_ENGINEER_ACTUAL" '
+      BEGIN {
+        na = split(a, aa, ",")
+        nb = split(b, bb, ",")
+        print (a == "" ? 0 : na) + (b == "" ? 0 : nb)
+      }
+    ')
+    echo "    local simultaneous starts/day: $COLLISIONS"
+    echo "    local engineer dispatches/day: $ENGINEER_DISPATCHES"
+  else
+    echo "    local simultaneous starts/day: UNKNOWN (one or more pointers unmeasured)"
+    echo "    local engineer dispatches/day: UNKNOWN (one or more engineer pointers unmeasured)"
   fi
-  if [ -f "$CLAUDE_LOADER" ]; then
-    echo "    claude prose: $(self_cadence "$CLAUDE_LOADER")"
-    echo "    claude cron:  (loader file holds no cron — cross-check the scheduled-tasks store)"
-  fi
-  echo "    ⇒ compare prose against the ACTUAL schedule; a mismatch means the agent"
-  echo "      is told a cadence it does not run on (affects its own pacing decisions)."
 
   echo
   echo "  retired-rule residue (loader asserts something the constitution dropped):"
-  for L in "$CLAUDE_LOADER" "$CODEX_LOADER"; do
+  for L in "$CLAUDE_LOADER" "$CLAUDE_IMPROVER_LOADER" \
+           "$CODEX_LOADER" "$CODEX_IMPROVER_LOADER"; do
     [ -f "$L" ] || continue
     if grep -qiE 'NEVER self-promote those|promotion stays the maintainer' "$L" 2>/dev/null; then
       if [ -f "$AGENTS_MD" ] && grep -qiE 'promotion gate .{0,40}retired|retired by maintainer direction' "$AGENTS_MD" 2>/dev/null; then

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1741,10 +1741,42 @@ if want drift; then
   CODEX_IMPROVER_LOADER="${CODEX_IMPROVER_LOADER_PATH:-$CODEX_HOME/automations/agent-improver/automation.toml}"
   AGENTS_MD="$MONOREPO/AGENTS.md"
 
+  discover_claude_schedule_store() {
+    local root candidate selected="" matches=0
+    if [ -n "${CLAUDE_SCHEDULE_STORE_PATH:-}" ]; then
+      [ -f "$CLAUDE_SCHEDULE_STORE_PATH" ] && printf '%s\n' "$CLAUDE_SCHEDULE_STORE_PATH"
+      return 0
+    fi
+    root="${CLAUDE_SCHEDULE_STORE_ROOT:-$HOME/Library/Application Support/Claude/claude-code-sessions}"
+    for candidate in "$root"/*/*/scheduled-tasks.json; do
+      [ -f "$candidate" ] || continue
+      jq -e --arg engineer "$CLAUDE_LOADER" --arg improver "$CLAUDE_IMPROVER_LOADER" '
+        [.scheduledTasks[]? |
+          select(.enabled == true) |
+          select(
+            (.id == "daily-ai-assistant" and .filePath == $engineer) or
+            (.id == "agent-improver" and .filePath == $improver)
+          ) |
+          .id
+        ] | sort | unique == ["agent-improver", "daily-ai-assistant"]
+      ' "$candidate" >/dev/null 2>&1 || continue
+      selected="$candidate"
+      matches=$((matches + 1))
+    done
+    [ "$matches" -eq 1 ] && printf '%s\n' "$selected"
+  }
+
+  CLAUDE_SCHEDULE_STORE=$(discover_claude_schedule_store)
+
   for f in "$CLAUDE_LOADER" "$CLAUDE_IMPROVER_LOADER" \
            "$CODEX_LOADER" "$CODEX_IMPROVER_LOADER" "$AGENTS_MD"; do
     [ -f "$f" ] && echo "  present: $f" || echo "  MISSING: $f"
   done
+  if [ -n "$CLAUDE_SCHEDULE_STORE" ] && [ -f "$CLAUDE_SCHEDULE_STORE" ]; then
+    echo "  present: $CLAUDE_SCHEDULE_STORE"
+  else
+    echo "  MISSING: authoritative Claude scheduled-tasks store"
+  fi
 
   echo
   echo "  cadence table vs all four runtime schedule pointers:"
@@ -1771,6 +1803,18 @@ if want drift; then
         print out
       }
     '
+  }
+
+  validated_hours() {
+    awk -F',' '
+      {
+        if (NF < 1) exit 1
+        for (i = 1; i <= NF; i++) {
+          if ($i !~ /^[0-9][0-9]?$/ || $i + 0 < 0 || $i + 0 > 23) exit 1
+        }
+        print
+      }
+    ' | normalise_hours
   }
 
   cadence_expected() {
@@ -1810,43 +1854,36 @@ if want drift; then
             minute != "0" || second != "0") exit 1
         print hours
       }
-    ' | normalise_hours
+    ' | validated_hours
   }
 
-  # Claude's native schedule pointer is a thin SKILL.md rather than a TOML
-  # record. Its machine-readable surface is the pointer's bounded lane clause:
-  # the engineer declares an even range and exclusions; the improver declares
-  # its two hours. Parse only those clauses, never unrelated numbers elsewhere
-  # in the prompt.
-  claude_pointer_hours() {
-    local file="$1" role="$2" flat bounds exclusions start end ex1 ex2
-    [ -f "$file" ] || return 0
-    flat=$(tr '\n' ' ' < "$file")
-    if [ "$role" = engineer ]; then
-      bounds=$(printf '%s\n' "$flat" \
-        | sed -nE 's/.*EVEN hours ([0-9][0-9])[^0-9]+([0-9][0-9]).*/\1,\2/p')
-      exclusions=$(printf '%s\n' "$flat" \
-        | sed -nE 's/.*minus the ([0-9][0-9])\/([0-9][0-9]).*/\1,\2/p')
-      [ -n "$bounds" ] || return 0
-      start=${bounds%%,*}
-      end=${bounds##*,}
-      ex1=${exclusions%%,*}
-      ex2=${exclusions##*,}
-      awk -v first="$start" -v last="$end" -v skip1="$ex1" -v skip2="$ex2" '
-        BEGIN {
-          out = ""
-          for (h = first + 0; h <= last + 0; h++) {
-            if (h % 2 != 0 || h == skip1 + 0 || h == skip2 + 0) continue
-            out = out (out == "" ? "" : ",") h
-          }
-          print out
-        }
-      '
-    else
-      printf '%s\n' "$flat" \
-        | sed -nE 's/.*lane:[^0-9]*([0-9][0-9])[[:space:]]+and[[:space:]]+([0-9][0-9])[[:space:]]+local.*/\1,\2/p' \
-        | normalise_hours
-    fi
+  claude_store_field() {
+    local store="$1" id="$2" pointer="$3" field="$4"
+    [ -f "$store" ] || return 0
+    jq -r --arg id "$id" --arg pointer "$pointer" --arg field "$field" '
+      [.scheduledTasks[]? |
+        select(.enabled == true and .id == $id and .filePath == $pointer)
+      ] |
+      if length == 1 then (.[0][$field] // empty) else empty end
+    ' "$store" 2>/dev/null
+  }
+
+  claude_store_hours() {
+    local store="$1" id="$2" pointer="$3" cron
+    cron=$(claude_store_field "$store" "$id" "$pointer" cronExpression)
+    [ -n "$cron" ] || return 0
+    printf '%s\n' "$cron" | awk '
+      NF == 5 && $1 == "0" && $3 == "*" && $4 == "*" && $5 == "*" { print $2 }
+    ' | validated_hours
+  }
+
+  claude_store_marker() {
+    local store="$1" id="$2" pointer="$3" last_run
+    last_run=$(claude_store_field "$store" "$id" "$pointer" lastRunAt)
+    [ -n "$last_run" ] || return 0
+    jq -nr --arg value "$last_run" '
+      $value | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601 | floor
+    ' 2>/dev/null
   }
 
   codex_change_marker() {
@@ -1858,11 +1895,6 @@ if want drift; then
         exit
       }
     ' "$1" 2>/dev/null
-  }
-
-  file_change_marker() {
-    [ -f "$1" ] || return 0
-    stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1" 2>/dev/null || true
   }
 
   marker_advanced() {
@@ -1878,6 +1910,8 @@ if want drift; then
       echo "    UNKNOWN: $label schedule pointer missing"
     elif [ -z "$actual" ] && [ "$pointer_kind" = recurrence ]; then
       echo "    UNKNOWN: $label recurrence rule is incomplete or unsupported"
+    elif [ -z "$actual" ] && [ "$pointer_kind" = cron ]; then
+      echo "    UNKNOWN: $label authoritative scheduler record is missing or unsupported"
     elif [ -z "$actual" ]; then
       echo "    UNKNOWN: $label schedule could not be parsed from its pointer"
     elif [ -z "$expected" ]; then
@@ -1906,12 +1940,12 @@ if want drift; then
   CLAUDE_IMPROVER_EXPECTED=$(cadence_expected Claude 4)
   CODEX_ENGINEER_EXPECTED=$(cadence_expected Codex 3)
   CODEX_IMPROVER_EXPECTED=$(cadence_expected Codex 4)
-  CLAUDE_ENGINEER_ACTUAL=$(claude_pointer_hours "$CLAUDE_LOADER" engineer)
-  CLAUDE_IMPROVER_ACTUAL=$(claude_pointer_hours "$CLAUDE_IMPROVER_LOADER" improver)
+  CLAUDE_ENGINEER_ACTUAL=$(claude_store_hours "$CLAUDE_SCHEDULE_STORE" daily-ai-assistant "$CLAUDE_LOADER")
+  CLAUDE_IMPROVER_ACTUAL=$(claude_store_hours "$CLAUDE_SCHEDULE_STORE" agent-improver "$CLAUDE_IMPROVER_LOADER")
   CODEX_ENGINEER_ACTUAL=$(codex_pointer_hours "$CODEX_LOADER")
   CODEX_IMPROVER_ACTUAL=$(codex_pointer_hours "$CODEX_IMPROVER_LOADER")
-  CLAUDE_ENGINEER_MARKER=$(file_change_marker "$CLAUDE_LOADER")
-  CLAUDE_IMPROVER_MARKER=$(file_change_marker "$CLAUDE_IMPROVER_LOADER")
+  CLAUDE_ENGINEER_MARKER=$(claude_store_marker "$CLAUDE_SCHEDULE_STORE" daily-ai-assistant "$CLAUDE_LOADER")
+  CLAUDE_IMPROVER_MARKER=$(claude_store_marker "$CLAUDE_SCHEDULE_STORE" agent-improver "$CLAUDE_IMPROVER_LOADER")
   CODEX_ENGINEER_MARKER=$(codex_change_marker "$CODEX_LOADER")
   CODEX_IMPROVER_MARKER=$(codex_change_marker "$CODEX_IMPROVER_LOADER")
   CLAUDE_ENGINEER_BASELINE="${CLAUDE_ENGINEER_MARKER_BASELINE:-}"
@@ -1920,9 +1954,9 @@ if want drift; then
   CODEX_IMPROVER_BASELINE="${CODEX_IMPROVER_MARKER_BASELINE:-}"
 
   compare_schedule "claude engineer" "$CLAUDE_ENGINEER_EXPECTED" "$CLAUDE_ENGINEER_ACTUAL" \
-    "$CLAUDE_LOADER" "$CLAUDE_ENGINEER_MARKER" "$CLAUDE_ENGINEER_BASELINE"
+    "$CLAUDE_LOADER" "$CLAUDE_ENGINEER_MARKER" "$CLAUDE_ENGINEER_BASELINE" cron
   compare_schedule "claude improver" "$CLAUDE_IMPROVER_EXPECTED" "$CLAUDE_IMPROVER_ACTUAL" \
-    "$CLAUDE_IMPROVER_LOADER" "$CLAUDE_IMPROVER_MARKER" "$CLAUDE_IMPROVER_BASELINE"
+    "$CLAUDE_IMPROVER_LOADER" "$CLAUDE_IMPROVER_MARKER" "$CLAUDE_IMPROVER_BASELINE" cron
   compare_schedule "codex engineer" "$CODEX_ENGINEER_EXPECTED" "$CODEX_ENGINEER_ACTUAL" \
     "$CODEX_LOADER" "$CODEX_ENGINEER_MARKER" "$CODEX_ENGINEER_BASELINE" recurrence
   compare_schedule "codex improver" "$CODEX_IMPROVER_EXPECTED" "$CODEX_IMPROVER_ACTUAL" \

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1834,6 +1834,8 @@ if want drift; then
     local label="$1" expected="$2" actual="$3" file="$4" marker="${5:-}" marker_required="${6:-0}"
     if [ ! -f "$file" ]; then
       echo "    UNKNOWN: $label schedule pointer missing"
+    elif [ "$marker_required" -eq 1 ] && [ -z "$marker" ]; then
+      echo "    UNKNOWN: $label change marker missing"
     elif [ -z "$expected" ]; then
       echo "    UNKNOWN: $label schedule absent from AGENTS.md cadence table"
     elif [ -z "$actual" ]; then
@@ -1843,9 +1845,6 @@ if want drift; then
         "${label}:" "$expected" "$actual" "$marker"
     else
       echo "    ⚠️  DRIFT: $label schedule expected=$expected actual=$actual$marker"
-    fi
-    if [ "$marker_required" -eq 1 ] && [ -z "$marker" ] && [ -f "$file" ]; then
-      echo "    UNKNOWN: $label change marker missing"
     fi
   }
 

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1831,7 +1831,7 @@ if want drift; then
   }
 
   compare_schedule() {
-    local label="$1" expected="$2" actual="$3" file="$4" marker="${5:-}"
+    local label="$1" expected="$2" actual="$3" file="$4" marker="${5:-}" marker_required="${6:-0}"
     if [ ! -f "$file" ]; then
       echo "    UNKNOWN: $label schedule pointer missing"
     elif [ -z "$expected" ]; then
@@ -1843,6 +1843,9 @@ if want drift; then
         "${label}:" "$expected" "$actual" "$marker"
     else
       echo "    ⚠️  DRIFT: $label schedule expected=$expected actual=$actual$marker"
+    fi
+    if [ "$marker_required" -eq 1 ] && [ -z "$marker" ] && [ -f "$file" ]; then
+      echo "    UNKNOWN: $label change marker missing"
     fi
   }
 
@@ -1858,9 +1861,9 @@ if want drift; then
   compare_schedule "claude engineer" "$CLAUDE_ENGINEER_EXPECTED" "$CLAUDE_ENGINEER_ACTUAL" "$CLAUDE_LOADER"
   compare_schedule "claude improver" "$CLAUDE_IMPROVER_EXPECTED" "$CLAUDE_IMPROVER_ACTUAL" "$CLAUDE_IMPROVER_LOADER"
   compare_schedule "codex engineer" "$CODEX_ENGINEER_EXPECTED" "$CODEX_ENGINEER_ACTUAL" \
-    "$CODEX_LOADER" "$(codex_change_marker "$CODEX_LOADER")"
+    "$CODEX_LOADER" "$(codex_change_marker "$CODEX_LOADER")" 1
   compare_schedule "codex improver" "$CODEX_IMPROVER_EXPECTED" "$CODEX_IMPROVER_ACTUAL" \
-    "$CODEX_IMPROVER_LOADER" "$(codex_change_marker "$CODEX_IMPROVER_LOADER")"
+    "$CODEX_IMPROVER_LOADER" "$(codex_change_marker "$CODEX_IMPROVER_LOADER")" 1
 
   if [ -n "$CLAUDE_ENGINEER_ACTUAL" ] && [ -n "$CLAUDE_IMPROVER_ACTUAL" ] \
      && [ -n "$CODEX_ENGINEER_ACTUAL" ] && [ -n "$CODEX_IMPROVER_ACTUAL" ]; then

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -126,11 +126,11 @@ description: Thin scheduler pointer for the Agent Improver (claude/* lane: 00 an
 EOF
 cat > "$FIX/codex/automations/daily-ai-engineer/automation.toml" <<'EOF'
 prompt = "definition/self-improvement PRs are the one exception: NEVER self-promote those"
-rrule = "RRULE:FREQ=HOURLY;BYHOUR=1,3,5,9,11,13,15,17,21,23;BYMINUTE=0"
+rrule = "RRULE:FREQ=HOURLY;INTERVAL=1;BYHOUR=1,3,5,9,11,13,15,17,21,23;BYMINUTE=0;BYSECOND=0"
 updated_at = 1785238559676
 EOF
 cat > "$FIX/codex/automations/agent-improver/automation.toml" <<'EOF'
-rrule = "RRULE:FREQ=DAILY;BYHOUR=7,19;BYMINUTE=0"
+rrule = "RRULE:FREQ=DAILY;BYHOUR=7,19;BYMINUTE=0;BYSECOND=0"
 updated_at = 1785222863850
 EOF
 cat > "$FIX/monorepo/AGENTS.md" <<'EOF'
@@ -155,6 +155,10 @@ run() {
   CLAUDE_IMPROVER_LOADER_PATH="$FIX/claude-sched/agent-improver/SKILL.md" \
   CODEX_LOADER_PATH="$FIX/codex/automations/daily-ai-engineer/automation.toml" \
   CODEX_IMPROVER_LOADER_PATH="$FIX/codex/automations/agent-improver/automation.toml" \
+  CLAUDE_ENGINEER_MARKER_BASELINE="${CLAUDE_ENGINEER_MARKER_BASELINE:-1}" \
+  CLAUDE_IMPROVER_MARKER_BASELINE="${CLAUDE_IMPROVER_MARKER_BASELINE:-1}" \
+  CODEX_ENGINEER_MARKER_BASELINE="${CODEX_ENGINEER_MARKER_BASELINE:-1785238559000}" \
+  CODEX_IMPROVER_MARKER_BASELINE="${CODEX_IMPROVER_MARKER_BASELINE:-1785222863000}" \
   bash "$TARGET" --since-days 3650 --max-files 50 "$@" 2>&1
 }
 
@@ -204,8 +208,8 @@ check "compares Claude engineer schedule" "$OUT" "claude engineer: expected=2,4,
 check "compares Claude improver schedule" "$OUT" "claude improver: expected=0,12 actual=0,12 MATCH"
 check "compares Codex engineer schedule"  "$OUT" "codex engineer:  expected=1,3,5,9,11,13,15,17,21,23 actual=1,3,5,9,11,13,15,17,21,23 MATCH"
 check "compares Codex improver schedule"  "$OUT" "codex improver:  expected=7,19 actual=7,19 MATCH"
-check "reports Codex engineer change marker" "$OUT" "MATCH updated_at=1785238559676"
-check "reports Codex improver change marker" "$OUT" "MATCH updated_at=1785222863850"
+check "reports Codex engineer marker advance" "$OUT" "MATCH marker=1785238559676 baseline=1785238559000"
+check "reports Codex improver marker advance" "$OUT" "MATCH marker=1785222863850 baseline=1785222863000"
 check "proves local start parity"         "$OUT" "local simultaneous starts/day: 0"
 check "proves engineer dispatch volume"   "$OUT" "local engineer dispatches/day: 20"
 
@@ -226,8 +230,41 @@ sed -i.bak '/^updated_at = /d' \
 OUT=$(run --section drift)
 check "missing runtime marker is explicit" "$OUT" "UNKNOWN: codex improver change marker missing"
 nocheck "missing runtime marker never claims persistence" "$OUT" "codex improver:  expected=7,19 actual=7,19 MATCH"
+check "missing runtime marker invalidates parity total" "$OUT" "local simultaneous starts/day: UNKNOWN"
+check "missing runtime marker invalidates dispatch total" "$OUT" "local engineer dispatches/day: UNKNOWN"
 mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
    "$FIX/codex/automations/agent-improver/automation.toml"
+
+# An unchanged marker is the in-session read-back, not persistence proof.
+OUT=$(CODEX_IMPROVER_MARKER_BASELINE=1785222863850 run --section drift)
+check "unchanged marker is not persistence proof" "$OUT" "UNKNOWN: codex improver change marker did not advance"
+nocheck "unchanged marker never claims persistence" "$OUT" "codex improver:  expected=7,19 actual=7,19 MATCH"
+
+# RRULE parity includes minute, second, frequency, interval, and filters, not
+# merely the set of hours.
+sed -i.bak 's/BYMINUTE=0/BYMINUTE=30/' \
+  "$FIX/codex/automations/agent-improver/automation.toml"
+OUT=$(run --section drift)
+check "minute drift invalidates recurrence" "$OUT" "UNKNOWN: codex improver recurrence rule is incomplete or unsupported"
+check "minute drift invalidates aggregate parity" "$OUT" "local simultaneous starts/day: UNKNOWN"
+mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
+   "$FIX/codex/automations/agent-improver/automation.toml"
+
+# BYHOUR is a set; harmless serialization order must not create false drift.
+sed -i.bak 's/BYHOUR=7,19/BYHOUR=19,7/' \
+  "$FIX/codex/automations/agent-improver/automation.toml"
+OUT=$(run --section drift)
+check "hour sets are sorted before comparison" "$OUT" "codex improver:  expected=7,19 actual=7,19 MATCH"
+mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
+   "$FIX/codex/automations/agent-improver/automation.toml"
+
+# Same-provider overlaps are collisions too.
+sed -i.bak 's/lane: 00 and 12 local/lane: 00 and 10 local/' \
+  "$FIX/claude-sched/agent-improver/SKILL.md"
+OUT=$(run --section drift)
+check "same-provider overlap is counted" "$OUT" "local simultaneous starts/day: 1"
+mv "$FIX/claude-sched/agent-improver/SKILL.md.bak" \
+   "$FIX/claude-sched/agent-improver/SKILL.md"
 
 # A persisted runtime rewrite must report the concrete expected/actual delta.
 sed -i.bak 's/BYHOUR=7,19/BYHOUR=6,18/' \

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -219,6 +219,15 @@ check "missing improver pointer is explicit" "$OUT" "UNKNOWN: codex improver sch
 mv "$FIX/codex/automations/agent-improver/automation.toml.missing" \
    "$FIX/codex/automations/agent-improver/automation.toml"
 
+# A matching value without the runtime's own write marker cannot prove that a
+# dispatch occurred after the edit, so persistence remains explicitly unknown.
+sed -i.bak '/^updated_at = /d' \
+  "$FIX/codex/automations/agent-improver/automation.toml"
+OUT=$(run --section drift)
+check "missing runtime marker is explicit" "$OUT" "UNKNOWN: codex improver change marker missing"
+mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
+   "$FIX/codex/automations/agent-improver/automation.toml"
+
 # A persisted runtime rewrite must report the concrete expected/actual delta.
 sed -i.bak 's/BYHOUR=7,19/BYHOUR=6,18/' \
   "$FIX/codex/automations/agent-improver/automation.toml"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -225,6 +225,7 @@ sed -i.bak '/^updated_at = /d' \
   "$FIX/codex/automations/agent-improver/automation.toml"
 OUT=$(run --section drift)
 check "missing runtime marker is explicit" "$OUT" "UNKNOWN: codex improver change marker missing"
+nocheck "missing runtime marker never claims persistence" "$OUT" "codex improver:  expected=7,19 actual=7,19 MATCH"
 mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
    "$FIX/codex/automations/agent-improver/automation.toml"
 

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -99,8 +99,10 @@ ex() { printf '%s' "$1" | sed \
 
 # ── fixtures ──────────────────────────────────────────────────────────────────
 mkdir -p "$FIX/projects/proj-a" "$FIX/codex/automations/daily-ai-engineer" \
+         "$FIX/codex/automations/agent-improver" \
          "$FIX/codex/sessions" "$FIX/monorepo/.claude" \
-         "$FIX/claude-sched/daily-ai-assistant"
+         "$FIX/claude-sched/daily-ai-assistant" \
+         "$FIX/claude-sched/agent-improver"
 
 # A session with: one failing Bash call, one credential-shaped string, one blocked
 # action, and — critically — a line of PROSE that tries to issue an instruction.
@@ -117,15 +119,32 @@ subst "$FIX/projects/proj-a/s1.jsonl"
 
 # Loader fixtures: Codex asserts the RETIRED gate; the constitution records it retired.
 cat > "$FIX/claude-sched/daily-ai-assistant/SKILL.md" <<'EOF'
-You are the devantler-tech AI Engineer, dispatched **every 4 hours** (00/04 local).
-You run in parallel with a sibling agent dispatched every second **hour** (uneven).
+description: Thin scheduler pointer for the Agentic Engineer (claude/* lane: EVEN hours 02–22, minus the 00/12 Agent Improver slots).
+EOF
+cat > "$FIX/claude-sched/agent-improver/SKILL.md" <<'EOF'
+description: Thin scheduler pointer for the Agent Improver (claude/* lane: 00 and 12 local).
 EOF
 cat > "$FIX/codex/automations/daily-ai-engineer/automation.toml" <<'EOF'
-prompt = "You are the devantler-tech AI Engineer, dispatched every second **hour** (uneven). definition/self-improvement PRs are the one exception: NEVER self-promote those"
-rrule = "RRULE:FREQ=HOURLY;BYHOUR=1,3,5;BYMINUTE=0"
+prompt = "definition/self-improvement PRs are the one exception: NEVER self-promote those"
+rrule = "RRULE:FREQ=HOURLY;BYHOUR=1,3,5,9,11,13,15,17,21,23;BYMINUTE=0"
+updated_at = 1785238559676
+EOF
+cat > "$FIX/codex/automations/agent-improver/automation.toml" <<'EOF'
+rrule = "RRULE:FREQ=DAILY;BYHOUR=7,19;BYMINUTE=0"
+updated_at = 1785222863850
 EOF
 cat > "$FIX/monorepo/AGENTS.md" <<'EOF'
 Definition PRs: their separate human promotion gate was retired by maintainer direction 2026-07-18.
+
+| Lane | Clean artifact | Findings artifact |
+|---|---|---|
+| **Codex** (`chatgpt-codex-connector[bot]`) | comment carries a 10-char SHA | review object |
+
+### Cadence & focus
+| Lane | Agentic Engineer | Agent Improver |
+|---|---|---|
+| **Claude** — `claude/*`, even hours | 02, 04, 06, 08, 10, 14, 16, 18, 20, 22 | 00, 12 |
+| **Codex** — `codex/*`, uneven hours | 01, 03, 05, 09, 11, 13, 15, 17, 21, 23 | 07, 19 |
 EOF
 mkdir -p "$FIX/monorepo/.claude"
 
@@ -133,7 +152,9 @@ run() {
   CLAUDE_PROJECTS_DIR="$FIX/projects" CODEX_HOME="$FIX/codex" \
   MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
   CLAUDE_LOADER_PATH="$FIX/claude-sched/daily-ai-assistant/SKILL.md" \
+  CLAUDE_IMPROVER_LOADER_PATH="$FIX/claude-sched/agent-improver/SKILL.md" \
   CODEX_LOADER_PATH="$FIX/codex/automations/daily-ai-engineer/automation.toml" \
+  CODEX_IMPROVER_LOADER_PATH="$FIX/codex/automations/agent-improver/automation.toml" \
   bash "$TARGET" --since-days 3650 --max-files 50 "$@" 2>&1
 }
 
@@ -179,16 +200,38 @@ echo
 echo "drift"
 OUT=$(run --section drift)
 check "detects retired-rule residue"   "$OUT" "DRIFT"
-check "reads codex self-cadence"       "$OUT" "codex prose:  dispatched every second"
-check "reads claude self-cadence"      "$OUT" "claude prose: dispatched **every 4 hours**"
-# Regression guard: the claude loader also mentions the SIBLING's "(uneven)" cadence.
-# An unanchored match reads the wrong agent's schedule back as the claude one.
-nocheck "does not misread sibling cadence as claude's" "$OUT" "claude prose: dispatched every second"
+check "compares Claude engineer schedule" "$OUT" "claude engineer: expected=2,4,6,8,10,14,16,18,20,22 actual=2,4,6,8,10,14,16,18,20,22 MATCH"
+check "compares Claude improver schedule" "$OUT" "claude improver: expected=0,12 actual=0,12 MATCH"
+check "compares Codex engineer schedule"  "$OUT" "codex engineer:  expected=1,3,5,9,11,13,15,17,21,23 actual=1,3,5,9,11,13,15,17,21,23 MATCH"
+check "compares Codex improver schedule"  "$OUT" "codex improver:  expected=7,19 actual=7,19 MATCH"
+check "reports Codex engineer change marker" "$OUT" "MATCH updated_at=1785238559676"
+check "reports Codex improver change marker" "$OUT" "MATCH updated_at=1785222863850"
+check "proves local start parity"         "$OUT" "local simultaneous starts/day: 0"
+check "proves engineer dispatch volume"   "$OUT" "local engineer dispatches/day: 20"
+
+# Removing one pointer must fail closed rather than leaving the schedule surface
+# silently unmeasured. This is the exact blind spot that hid the reverted Codex
+# schedule after the applying run had recorded an in-session success.
+mv "$FIX/codex/automations/agent-improver/automation.toml" \
+   "$FIX/codex/automations/agent-improver/automation.toml.missing"
+OUT=$(run --section drift)
+check "missing improver pointer is explicit" "$OUT" "UNKNOWN: codex improver schedule pointer missing"
+mv "$FIX/codex/automations/agent-improver/automation.toml.missing" \
+   "$FIX/codex/automations/agent-improver/automation.toml"
+
+# A persisted runtime rewrite must report the concrete expected/actual delta.
+sed -i.bak 's/BYHOUR=7,19/BYHOUR=6,18/' \
+  "$FIX/codex/automations/agent-improver/automation.toml"
+OUT=$(run --section drift)
+check "runtime schedule rewrite is detected" "$OUT" "DRIFT: codex improver schedule expected=7,19 actual=6,18"
+check "runtime rewrite exposes collisions"   "$OUT" "local simultaneous starts/day: 2"
+mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
+   "$FIX/codex/automations/agent-improver/automation.toml"
 
 # ── 6. clean-state: no false positives when nothing is wrong ──────────────────
 echo
 echo "clean state"
-sed -i.bak 's/ definition\/self-improvement PRs are the one exception: NEVER self-promote those//' \
+sed -i.bak 's/definition\/self-improvement PRs are the one exception: NEVER self-promote those//' \
   "$FIX/codex/automations/daily-ai-engineer/automation.toml"
 OUT=$(run --section drift)
 nocheck "no drift reported once loaders agree" "$OUT" "⚠️  DRIFT"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -101,6 +101,7 @@ ex() { printf '%s' "$1" | sed \
 mkdir -p "$FIX/projects/proj-a" "$FIX/codex/automations/daily-ai-engineer" \
          "$FIX/codex/automations/agent-improver" \
          "$FIX/codex/sessions" "$FIX/monorepo/.claude" \
+         "$FIX/claude-store" \
          "$FIX/claude-sched/daily-ai-assistant" \
          "$FIX/claude-sched/agent-improver"
 
@@ -123,6 +124,26 @@ description: Thin scheduler pointer for the Agentic Engineer (claude/* lane: EVE
 EOF
 cat > "$FIX/claude-sched/agent-improver/SKILL.md" <<'EOF'
 description: Thin scheduler pointer for the Agent Improver (claude/* lane: 00 and 12 local).
+EOF
+cat > "$FIX/claude-store/scheduled-tasks.json" <<EOF
+{
+  "scheduledTasks": [
+    {
+      "id": "daily-ai-assistant",
+      "enabled": true,
+      "filePath": "$FIX/claude-sched/daily-ai-assistant/SKILL.md",
+      "cronExpression": "0 2,4,6,8,10,14,16,18,20,22 * * *",
+      "lastRunAt": "2026-07-25T20:00:00.000Z"
+    },
+    {
+      "id": "agent-improver",
+      "enabled": true,
+      "filePath": "$FIX/claude-sched/agent-improver/SKILL.md",
+      "cronExpression": "0 0,12 * * *",
+      "lastRunAt": "2026-07-25T12:00:00.000Z"
+    }
+  ]
+}
 EOF
 cat > "$FIX/codex/automations/daily-ai-engineer/automation.toml" <<'EOF'
 prompt = "definition/self-improvement PRs are the one exception: NEVER self-promote those"
@@ -151,12 +172,13 @@ mkdir -p "$FIX/monorepo/.claude"
 run() {
   CLAUDE_PROJECTS_DIR="$FIX/projects" CODEX_HOME="$FIX/codex" \
   MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+  CLAUDE_SCHEDULE_STORE_PATH="$FIX/claude-store/scheduled-tasks.json" \
   CLAUDE_LOADER_PATH="$FIX/claude-sched/daily-ai-assistant/SKILL.md" \
   CLAUDE_IMPROVER_LOADER_PATH="$FIX/claude-sched/agent-improver/SKILL.md" \
   CODEX_LOADER_PATH="$FIX/codex/automations/daily-ai-engineer/automation.toml" \
   CODEX_IMPROVER_LOADER_PATH="$FIX/codex/automations/agent-improver/automation.toml" \
-  CLAUDE_ENGINEER_MARKER_BASELINE="${CLAUDE_ENGINEER_MARKER_BASELINE:-1}" \
-  CLAUDE_IMPROVER_MARKER_BASELINE="${CLAUDE_IMPROVER_MARKER_BASELINE:-1}" \
+  CLAUDE_ENGINEER_MARKER_BASELINE="${CLAUDE_ENGINEER_MARKER_BASELINE:-1750000000}" \
+  CLAUDE_IMPROVER_MARKER_BASELINE="${CLAUDE_IMPROVER_MARKER_BASELINE:-1750000000}" \
   CODEX_ENGINEER_MARKER_BASELINE="${CODEX_ENGINEER_MARKER_BASELINE:-1785238559000}" \
   CODEX_IMPROVER_MARKER_BASELINE="${CODEX_IMPROVER_MARKER_BASELINE:-1785222863000}" \
   bash "$TARGET" --since-days 3650 --max-files 50 "$@" 2>&1
@@ -250,6 +272,15 @@ check "minute drift invalidates aggregate parity" "$OUT" "local simultaneous sta
 mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
    "$FIX/codex/automations/agent-improver/automation.toml"
 
+# Invalid values must not be silently dropped while the remaining set matches.
+sed -i.bak 's/BYHOUR=7,19/BYHOUR=7,19,24/' \
+  "$FIX/codex/automations/agent-improver/automation.toml"
+OUT=$(run --section drift)
+check "out-of-range hour invalidates recurrence" "$OUT" "UNKNOWN: codex improver recurrence rule is incomplete or unsupported"
+nocheck "out-of-range hour never normalizes to MATCH" "$OUT" "codex improver:  expected=7,19 actual=7,19 MATCH"
+mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
+   "$FIX/codex/automations/agent-improver/automation.toml"
+
 # BYHOUR is a set; harmless serialization order must not create false drift.
 sed -i.bak 's/BYHOUR=7,19/BYHOUR=19,7/' \
   "$FIX/codex/automations/agent-improver/automation.toml"
@@ -258,13 +289,22 @@ check "hour sets are sorted before comparison" "$OUT" "codex improver:  expected
 mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
    "$FIX/codex/automations/agent-improver/automation.toml"
 
-# Same-provider overlaps are collisions too.
-sed -i.bak 's/lane: 00 and 12 local/lane: 00 and 10 local/' \
-  "$FIX/claude-sched/agent-improver/SKILL.md"
+# Loader prose is not scheduler state. A stale description must not override the
+# authoritative cron record.
+sed -i.bak -e 's/02–22/00–22/' -e 's|00/12|02/04|' \
+  "$FIX/claude-sched/daily-ai-assistant/SKILL.md"
+OUT=$(run --section drift)
+check "Claude cadence comes from scheduler store" "$OUT" "claude engineer: expected=2,4,6,8,10,14,16,18,20,22 actual=2,4,6,8,10,14,16,18,20,22 MATCH"
+mv "$FIX/claude-sched/daily-ai-assistant/SKILL.md.bak" \
+   "$FIX/claude-sched/daily-ai-assistant/SKILL.md"
+
+# Same-provider overlaps in the authoritative store are collisions too.
+sed -i.bak 's/"cronExpression": "0 0,12/"cronExpression": "0 0,10/' \
+  "$FIX/claude-store/scheduled-tasks.json"
 OUT=$(run --section drift)
 check "same-provider overlap is counted" "$OUT" "local simultaneous starts/day: 1"
-mv "$FIX/claude-sched/agent-improver/SKILL.md.bak" \
-   "$FIX/claude-sched/agent-improver/SKILL.md"
+mv "$FIX/claude-store/scheduled-tasks.json.bak" \
+   "$FIX/claude-store/scheduled-tasks.json"
 
 # A persisted runtime rewrite must report the concrete expected/actual delta.
 sed -i.bak 's/BYHOUR=7,19/BYHOUR=6,18/' \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,9 +344,12 @@ reverted value with an advanced marker means the runtime overwrote the file**, s
 supported control path rather than treating the file as authoritative. Keep the backup until this
 post-dispatch check passes. Supply that post-apply baseline to the drift check as
 `CLAUDE_ENGINEER_MARKER_BASELINE`, `CLAUDE_IMPROVER_MARKER_BASELINE`,
-`CODEX_ENGINEER_MARKER_BASELINE`, or `CODEX_IMPROVER_MARKER_BASELINE`; the Claude pointers use their
-file modification time and the Codex pointers use `updated_at`. A missing baseline, a marker that did
-not advance, or an incomplete recurrence rule is `UNKNOWN`, never `MATCH`.
+`CODEX_ENGINEER_MARKER_BASELINE`, or `CODEX_IMPROVER_MARKER_BASELINE`. Claude cadence comes from the
+authoritative `scheduled-tasks.json` record selected by exact task id plus pointer path, with
+`lastRunAt` as its marker; the `SKILL.md` description is not scheduler state. Codex cadence and
+markers come from `automation.toml`'s complete RRULE and `updated_at`. A missing or ambiguous store,
+missing baseline, marker that did not advance, or incomplete recurrence rule is `UNKNOWN`, never
+`MATCH`.
 
 The deployed Cursor Automation has no supported local write surface. Its reviewed source is
 `.claude/loaders/cursor-daily-ai-engineer.md`; after that source merges, use a declared Maintainer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,13 @@ memory and the run report:**
   `/Users/homelab-mac-mini/.claude/hooks/`, and
   `/Users/homelab-mac-mini/.codex/config.toml`.
 
+For runtime-managed schedule pointers, **the in-session read-back is necessary but not sufficient**.
+Record the applied schedule and the surface's own change marker, then **re-read after at least one
+dispatch of that schedule**. Completion requires the value to persist while the marker advances; **a
+reverted value with an advanced marker means the runtime overwrote the file**, so use the runtime's
+supported control path rather than treating the file as authoritative. Keep the backup until this
+post-dispatch check passes.
+
 The deployed Cursor Automation has no supported local write surface. Its reviewed source is
 `.claude/loaders/cursor-daily-ai-engineer.md`; after that source merges, use a declared Maintainer
 channel for the UI paste rather than claiming the server-side prompt changed. Marketplace/plugin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,7 +342,11 @@ Record the applied schedule and the surface's own change marker, then **re-read 
 dispatch of that schedule**. Completion requires the value to persist while the marker advances; **a
 reverted value with an advanced marker means the runtime overwrote the file**, so use the runtime's
 supported control path rather than treating the file as authoritative. Keep the backup until this
-post-dispatch check passes.
+post-dispatch check passes. Supply that post-apply baseline to the drift check as
+`CLAUDE_ENGINEER_MARKER_BASELINE`, `CLAUDE_IMPROVER_MARKER_BASELINE`,
+`CODEX_ENGINEER_MARKER_BASELINE`, or `CODEX_IMPROVER_MARKER_BASELINE`; the Claude pointers use their
+file modification time and the Codex pointers use `updated_at`. A missing baseline, a marker that did
+not advance, or an incomplete recurrence rule is `UNKNOWN`, never `MATCH`.
 
 The deployed Cursor Automation has no supported local write surface. Its reviewed source is
 `.claude/loaders/cursor-daily-ai-engineer.md`; after that source merges, use a declared Maintainer


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- require runtime-local schedule changes to survive a real dispatch before completion
- compare authoritative Claude cron records and complete Codex RRULEs for both engineer and improver lanes
- fail closed on missing baselines, ambiguous stores, invalid recurrence data, and unmeasured aggregate safety

## Evidence

A Codex schedule reverted at dispatch after an in-session read-back reported success, producing six simultaneous local starts per day until corrected. The prior drift miner omitted both improver schedules and read Claude loader prose instead of the scheduler store.

## Validation

- `agent-telemetry.test.sh`: 226 passed, 0 failed
- `agent-role-delivery-contract.test.sh`: all assertions passed
- hosted CI: all required checks green on `65070fa947`
- live drift scan found the unique Claude scheduler store and proved Codex-engineer persistence from an advanced recorded marker; three schedules without historical post-apply baselines and their aggregate totals remain explicitly `UNKNOWN`
- current-head Codex review: no major issues; zero unresolved threads

Fixes #2525