### PR TITLE
fix(surveyor): stop ranking GitHub-managed code scanning as rung-0 breakage

### DIFF
--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -446,13 +446,33 @@ public and private — no per-repo loop needed to enumerate):
    keep reporting `nothing_on_fire: true` while its security coverage is silently dead — the exact
    failure the *liveness-first* rule exists to prevent elsewhere in this survey.
 
-   So check the workflow's **previous scheduled run** (`gh api
-   "repos/devantler-tech/<repo>/actions/workflows/<workflow_id>/runs?per_page=2"`, comparing the two
-   most recent). If **both** concluded `failure`, escalate — it counts toward `nothing_on_fire` and is
-   reported as actionable, naming the run of the streak's first failure so its age is visible:
+   So walk that workflow's own run history on `main`:
+
+   ```sh
+   gh api --paginate \
+     "repos/devantler-tech/<repo>/actions/workflows/<workflow_id>/runs?branch=main&per_page=100"
+   ```
+
+   Walk it newest-first and count consecutive **red** runs, stopping at the first run that is not red.
+   Three details are each load-bearing:
+   - **`branch=main`** — default setup also runs on pull requests, and an unfiltered history mixes
+     those in. A failed PR scan would then turn a *first* main failure into `REPEATED`, and an
+     intervening successful PR scan would hide two genuinely consecutive main failures. This is the
+     same filter, for the same reason, as the `branch=main` on the red-set query above.
+   - **Red means `failure` OR `timed_out`** — exactly the red set defined above, never `failure`
+     alone. A scan that times out repeatedly is as broken as one that fails, and a mixed
+     `failure`/`timed_out` streak is still a streak.
+   - **`--paginate`, not a two-run peek** — the digest names the streak's start date and length, so it
+     must walk back to the first non-red run to know them. Reading only the newest two would report a
+     start date that is merely the previous run, and a count that is almost always `2`, understating
+     how long coverage has been dead.
+
+   Two or more consecutive red runs escalate: it counts toward `nothing_on_fire` and is reported as
+   actionable, naming the judged sha (as every red claim in this survey must) and the streak's real
+   age:
 
    ```text
-   GITHUB-MANAGED-SCAN (REPEATED — ACTIONABLE) <repo> <workflow> failing since <YYYY-MM-DD> (<n> consecutive scheduled runs)
+   GITHUB-MANAGED-SCAN (REPEATED — ACTIONABLE) <repo> <workflow> @<sha> failing since <YYYY-MM-DD> (<n> consecutive runs on main)
    ```
 
    Only the **first** failure of a streak is exempt. That keeps the fix from becoming a way to ignore
@@ -602,7 +622,7 @@ budget: graphql=<start_remaining>→<end_remaining>/<limit> · core=<start_remai
 - REPO-SET-DRIFT — live org set vs canonical list: new=<repos> · missing/renamed=<repos> · map-drift=<product rows whose repo is missing/renamed live> → orchestrator reconciles (archived-marked map rows exempt)
 - <repo>: CI red on main @<sha> — <check name> <conclusion> (<run url>)   # judged at main's current head; omit the repo entirely when that head is green
 - GITHUB-MANAGED-SCAN (NO-ACTION) <repo> <workflow> @<sha> failed <YYYY-MM-DD>   # `path` starts `dynamic/github-code-scanning/`: no workflow file to fix, not re-runnable (403), self-heals — never breakage, never counted against nothing_on_fire; FIRST failure of a streak only
-- GITHUB-MANAGED-SCAN (REPEATED — ACTIONABLE) <repo> <workflow> failing since <YYYY-MM-DD> (<n> consecutive scheduled runs)   # two+ consecutive scheduled failures: ours to repair (build, code-scanning config, or move to advanced setup) — DOES count against nothing_on_fire
+- GITHUB-MANAGED-SCAN (REPEATED — ACTIONABLE) <repo> <workflow> @<sha> failing since <YYYY-MM-DD> (<n> consecutive runs on main)   # two+ consecutive RED (failure OR timed_out) runs on main: ours to repair (build, code-scanning config, or move to advanced setup) — DOES count against nothing_on_fire
 - <repo> #<n> "<title>" — <renovate[bot]|dependabot[bot]|app/renovate|app/dependabot> → AUTOMATION-OWNED (NO-ACTION)   # PRs *and* issues (Dependency Dashboard); never oldest-actionable
 - <repo> #<n> (trusted bot, draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>|0-resolved@<sha>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|exempt-programmed-bot|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|CHANGES_REQUESTED:agent(devantler)@<sha>|CHANGES_REQUESTED:human(devantler)@<sha>|none>, mergeState=<…> → REVIEW-READY | NEEDS-FIX | STALE-CR-DISMISSAL | STALE-AGENT-DISMISSAL
 - <repo> #<n> (trusted bot, non-draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>|0-resolved@<sha>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|exempt-programmed-bot|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|CHANGES_REQUESTED:agent(devantler)@<sha>|CHANGES_REQUESTED:human(devantler)@<sha>|none>, mergeState=<…> → MERGE-READY | NEEDS-FIX | STALE-AGENT-DISMISSAL | STALE-CR-DISMISSAL

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -407,6 +407,28 @@ public and private — no per-repo loop needed to enumerate):
       files can legally share — collapsing them hides one workflow's failure behind the other
       file's later success), and report a red for any that concluded `failure` or `timed_out`.
 
+   **Split GitHub-MANAGED runs out of that red set before reporting it.** A run whose `path` begins
+   with `dynamic/github-code-scanning/` (default-setup code scanning; `event: dynamic`, no workflow
+   file in the repository) is **not** repository breakage and never counts toward `nothing_on_fire`.
+   There is nothing to root-cause-fix — no workflow file exists — and GitHub refuses to re-run one
+   outright (`POST .../rerun-failed-jobs` → `403 This workflow run cannot be retried`), so it is
+   structurally unactionable and self-heals on the next scheduled tick. Ranking it at rung 0, which
+   preempts everything, has twice cost a run its opening minutes.
+
+   Report it on its own line instead, so it stays visible without being ranked as a fire:
+
+   ```
+   GITHUB-MANAGED-SCAN (NO-ACTION) <repo> <workflow> @<sha> failed <YYYY-MM-DD>
+   ```
+
+   Keep reporting it every run rather than suppressing it: a *persistent* failure across several
+   scheduled ticks is a real signal, and only a line that keeps appearing can show that.
+
+   ⚠️ **Match on the `path` prefix, never on `event: dynamic` alone.** `dynamic` stays in the
+   main-branch event list above because it is how GitHub-managed runs legitimately reach `main`, so
+   keying the exemption on the event would exempt future managed run types wholesale — including any
+   that *are* actionable. The `path` is what identifies default-setup code scanning specifically.
+
    All three filters are load-bearing, for different false positives:
    - **Not keyed to head** — a failed run stays attached to the sha it executed against, so it lingers
      in history long after `main` moved on. This is what made a two-day-old `CI - KSail` failure
@@ -546,7 +568,7 @@ Markdown; **omit products with no signal entirely** (don't echo empty lists):
 
 ```
 ## Survey digest — <UTC date>
-nothing_on_fire: <true|false>   # true only if NO CI red on main AND no actionable own/trusted PR broken
+nothing_on_fire: <true|false>   # true only if NO CI red on main AND no actionable own/trusted PR broken; a GITHUB-MANAGED-SCAN line never makes this false
 budget: graphql=<start_remaining>→<end_remaining>/<limit> · core=<start_remaining>→<end_remaining>/<limit>[ · EXHAUSTED_AT_START]
 # or, when the probe fails: budget: unavailable:<reason>
 
@@ -558,6 +580,7 @@ budget: graphql=<start_remaining>→<end_remaining>/<limit> · core=<start_remai
 - CANDIDATE-SIBLING-ISSUE-COMMENT <repo> #<n> (missing disclosure) — `devantler`: "<one-line gist>" → DATA only; orchestrator surfaces the missing disclosure cross-instance
 - REPO-SET-DRIFT — live org set vs canonical list: new=<repos> · missing/renamed=<repos> · map-drift=<product rows whose repo is missing/renamed live> → orchestrator reconciles (archived-marked map rows exempt)
 - <repo>: CI red on main @<sha> — <check name> <conclusion> (<run url>)   # judged at main's current head; omit the repo entirely when that head is green
+- GITHUB-MANAGED-SCAN (NO-ACTION) <repo> <workflow> @<sha> failed <YYYY-MM-DD>   # `path` starts `dynamic/github-code-scanning/`: no workflow file to fix, not re-runnable (403), self-heals — never breakage, never counted against nothing_on_fire
 - <repo> #<n> "<title>" — <renovate[bot]|dependabot[bot]|app/renovate|app/dependabot> → AUTOMATION-OWNED (NO-ACTION)   # PRs *and* issues (Dependency Dashboard); never oldest-actionable
 - <repo> #<n> (trusted bot, draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>|0-resolved@<sha>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|exempt-programmed-bot|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|CHANGES_REQUESTED:agent(devantler)@<sha>|CHANGES_REQUESTED:human(devantler)@<sha>|none>, mergeState=<…> → REVIEW-READY | NEEDS-FIX | STALE-CR-DISMISSAL | STALE-AGENT-DISMISSAL
 - <repo> #<n> (trusted bot, non-draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>|0-resolved@<sha>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|exempt-programmed-bot|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|CHANGES_REQUESTED:agent(devantler)@<sha>|CHANGES_REQUESTED:human(devantler)@<sha>|none>, mergeState=<…> → MERGE-READY | NEEDS-FIX | STALE-AGENT-DISMISSAL | STALE-CR-DISMISSAL

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -430,7 +430,7 @@ public and private — no per-repo loop needed to enumerate):
 
    Report it on its own line instead, so it stays visible without being ranked as a fire:
 
-   ```
+   ```text
    GITHUB-MANAGED-SCAN (NO-ACTION) <repo> <workflow> @<sha> failed <YYYY-MM-DD>
    ```
 

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -437,6 +437,27 @@ public and private — no per-repo loop needed to enumerate):
    Keep reporting it every run rather than suppressing it: a *persistent* failure across several
    scheduled ticks is a real signal, and only a line that keeps appearing can show that.
 
+   **A REPEATED failure is actionable, and the exemption must not swallow it.** The single-occurrence
+   case is unactionable because it is GitHub's to fix and it clears itself. A scan that fails again on
+   the *next* scheduled run is a different condition: default setup fails repeatedly when the
+   repository cannot be built or analyzed, or when its language/config no longer suits default setup —
+   all of which are ours to repair, by fixing the build, adjusting the code-scanning configuration, or
+   moving that repository to advanced setup. Left as a permanent `NO-ACTION` line, the portfolio would
+   keep reporting `nothing_on_fire: true` while its security coverage is silently dead — the exact
+   failure the *liveness-first* rule exists to prevent elsewhere in this survey.
+
+   So check the workflow's **previous scheduled run** (`gh api
+   "repos/devantler-tech/<repo>/actions/workflows/<workflow_id>/runs?per_page=2"`, comparing the two
+   most recent). If **both** concluded `failure`, escalate — it counts toward `nothing_on_fire` and is
+   reported as actionable, naming the run of the streak's first failure so its age is visible:
+
+   ```text
+   GITHUB-MANAGED-SCAN (REPEATED — ACTIONABLE) <repo> <workflow> failing since <YYYY-MM-DD> (<n> consecutive scheduled runs)
+   ```
+
+   Only the **first** failure of a streak is exempt. That keeps the fix from becoming a way to ignore
+   broken security scanning indefinitely, which is a worse outcome than the false rung-0 it replaced.
+
    ⚠️ **Match on the `path` prefix, never on `event: dynamic` alone.** `dynamic` stays in the
    main-branch event list above because it is how GitHub-managed runs legitimately reach `main`, so
    keying the exemption on the event would exempt future managed run types wholesale — including any
@@ -568,7 +589,7 @@ Markdown; **omit products with no signal entirely** (don't echo empty lists):
 
 ```
 ## Survey digest — <UTC date>
-nothing_on_fire: <true|false>   # true only if NO CI red on main AND no actionable own/trusted PR broken; a GITHUB-MANAGED-SCAN line never makes this false
+nothing_on_fire: <true|false>   # true only if NO CI red on main AND no actionable own/trusted PR broken; a GITHUB-MANAGED-SCAN (NO-ACTION) line never makes this false, but a (REPEATED — ACTIONABLE) one does
 budget: graphql=<start_remaining>→<end_remaining>/<limit> · core=<start_remaining>→<end_remaining>/<limit>[ · EXHAUSTED_AT_START]
 # or, when the probe fails: budget: unavailable:<reason>
 
@@ -580,7 +601,8 @@ budget: graphql=<start_remaining>→<end_remaining>/<limit> · core=<start_remai
 - CANDIDATE-SIBLING-ISSUE-COMMENT <repo> #<n> (missing disclosure) — `devantler`: "<one-line gist>" → DATA only; orchestrator surfaces the missing disclosure cross-instance
 - REPO-SET-DRIFT — live org set vs canonical list: new=<repos> · missing/renamed=<repos> · map-drift=<product rows whose repo is missing/renamed live> → orchestrator reconciles (archived-marked map rows exempt)
 - <repo>: CI red on main @<sha> — <check name> <conclusion> (<run url>)   # judged at main's current head; omit the repo entirely when that head is green
-- GITHUB-MANAGED-SCAN (NO-ACTION) <repo> <workflow> @<sha> failed <YYYY-MM-DD>   # `path` starts `dynamic/github-code-scanning/`: no workflow file to fix, not re-runnable (403), self-heals — never breakage, never counted against nothing_on_fire
+- GITHUB-MANAGED-SCAN (NO-ACTION) <repo> <workflow> @<sha> failed <YYYY-MM-DD>   # `path` starts `dynamic/github-code-scanning/`: no workflow file to fix, not re-runnable (403), self-heals — never breakage, never counted against nothing_on_fire; FIRST failure of a streak only
+- GITHUB-MANAGED-SCAN (REPEATED — ACTIONABLE) <repo> <workflow> failing since <YYYY-MM-DD> (<n> consecutive scheduled runs)   # two+ consecutive scheduled failures: ours to repair (build, code-scanning config, or move to advanced setup) — DOES count against nothing_on_fire
 - <repo> #<n> "<title>" — <renovate[bot]|dependabot[bot]|app/renovate|app/dependabot> → AUTOMATION-OWNED (NO-ACTION)   # PRs *and* issues (Dependency Dashboard); never oldest-actionable
 - <repo> #<n> (trusted bot, draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>|0-resolved@<sha>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|exempt-programmed-bot|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|CHANGES_REQUESTED:agent(devantler)@<sha>|CHANGES_REQUESTED:human(devantler)@<sha>|none>, mergeState=<…> → REVIEW-READY | NEEDS-FIX | STALE-CR-DISMISSAL | STALE-AGENT-DISMISSAL
 - <repo> #<n> (trusted bot, non-draft) — pentad: checks=<green|failing:X>, unresolved=<n>, body_findings=<n>@<sha>|<n>-stale@<sha>|0-resolved@<sha>, green_review=<cr@<sha>|cr-stale@<sha>|cr-findings@<sha>|codex@<sha>|codex-stale@<sha>|codex-findings@<sha>|bugbot@<sha>|bugbot-stale@<sha>|bugbot-findings@<sha>|exempt-programmed-bot|none(cr:rev=<n>,cmt=<n>; codex:rev=<n>,cmt=<n>; bugbot:chk=<n> @<abbrev-head>)>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|CHANGES_REQUESTED:agent(devantler)@<sha>|CHANGES_REQUESTED:human(devantler)@<sha>|none>, mergeState=<…> → MERGE-READY | NEEDS-FIX | STALE-AGENT-DISMISSAL | STALE-CR-DISMISSAL

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -407,6 +407,19 @@ public and private — no per-repo loop needed to enumerate):
       files can legally share — collapsing them hides one workflow's failure behind the other
       file's later success), and report a red for any that concluded `failure` or `timed_out`.
 
+   All three filters are load-bearing, for different false positives:
+   - **Not keyed to head** — a failed run stays attached to the sha it executed against, so it lingers
+     in history long after `main` moved on. This is what made a two-day-old `CI - KSail` failure
+     surface as live breakage.
+   - **Not a main-branch event** — a `pull_request`/`issue_comment`-triggered workflow can carry
+     `head_sha` equal to main's sha and `head_branch: main` while testing a PR. Those runs are not
+     main's health. Do **not** instead de-duplicate check-runs by name to suppress them: several
+     independent comment-triggered runs coexist at one sha, so "newest per check name" hides a genuine
+     failure behind a later `skipped` — a fail-open this exact check was caught making.
+   - **Not filtered to `branch=main`** — a release or sync branch can point at main's exact commit,
+     and its `push`/`workflow_dispatch` runs then pass both filters above while failing for reasons
+     that are not main's health.
+
    **Split GitHub-MANAGED runs out of that red set before reporting it.** A run whose `path` begins
    with `dynamic/github-code-scanning/` (default-setup code scanning; `event: dynamic`, no workflow
    file in the repository) is **not** repository breakage and never counts toward `nothing_on_fire`.
@@ -428,19 +441,6 @@ public and private — no per-repo loop needed to enumerate):
    main-branch event list above because it is how GitHub-managed runs legitimately reach `main`, so
    keying the exemption on the event would exempt future managed run types wholesale — including any
    that *are* actionable. The `path` is what identifies default-setup code scanning specifically.
-
-   All three filters are load-bearing, for different false positives:
-   - **Not keyed to head** — a failed run stays attached to the sha it executed against, so it lingers
-     in history long after `main` moved on. This is what made a two-day-old `CI - KSail` failure
-     surface as live breakage.
-   - **Not a main-branch event** — a `pull_request`/`issue_comment`-triggered workflow can carry
-     `head_sha` equal to main's sha and `head_branch: main` while testing a PR. Those runs are not
-     main's health. Do **not** instead de-duplicate check-runs by name to suppress them: several
-     independent comment-triggered runs coexist at one sha, so "newest per check name" hides a genuine
-     failure behind a later `skipped` — a fail-open this exact check was caught making.
-   - **Not filtered to `branch=main`** — a release or sync branch can point at main's exact commit,
-     and its `push`/`workflow_dispatch` runs then pass both filters above while failing for reasons
-     that are not main's health.
 
    Treat `skipped`/`neutral`/still-running as **not red**. **Always name the judged sha** so the claim
    is falsifiable, and fail closed on a query error (report `unknown`, never a silent green).

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -1094,8 +1094,20 @@ grep -Fq 'dynamic/github-code-scanning/' "${surveyor}" ||
 grep -Fq 'GITHUB-MANAGED-SCAN (NO-ACTION) <repo> <workflow> @<sha> failed' "${surveyor}" ||
   fail "surveyor must define the GITHUB-MANAGED-SCAN (NO-ACTION) digest line (#2536)"
 
-grep -Fq 'a GITHUB-MANAGED-SCAN line never makes this false' "${surveyor}" ||
-  fail "surveyor must state that a GitHub-managed scan never sets nothing_on_fire: false (#2536)"
+grep -Fq 'a GITHUB-MANAGED-SCAN (NO-ACTION) line never makes this false' "${surveyor}" ||
+  fail "surveyor must state that a one-off GitHub-managed scan never sets nothing_on_fire: false (#2536)"
+
+# ESCALATION — the exemption covers only the FIRST failure of a streak. A scan still failing on the
+# next scheduled run is ours to repair (build, code-scanning config, or advanced setup), and must not
+# sit behind a permanent NO-ACTION line while security coverage is silently dead.
+grep -Fq 'GITHUB-MANAGED-SCAN (REPEATED — ACTIONABLE)' "${surveyor}" ||
+  fail "surveyor must escalate a GitHub-managed scan that fails on consecutive scheduled runs (#2536)"
+
+grep -Fq 'Only the **first** failure of a streak is exempt' "${surveyor}" ||
+  fail "surveyor must bound the GitHub-managed exemption to the first failure of a streak (#2536)"
+
+grep -Fq 'but a (REPEATED — ACTIONABLE) one does' "${surveyor}" ||
+  fail "surveyor must count a repeated GitHub-managed failure against nothing_on_fire (#2536)"
 
 # NEGATIVE CONTROL — the repository's own failing workflow must remain rung-0 breakage. Without this,
 # a future edit could exempt runs wholesale and every assertion above would still pass.

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -1099,8 +1099,20 @@ grep -Fq 'a GITHUB-MANAGED-SCAN line never makes this false' "${surveyor}" ||
 
 # NEGATIVE CONTROL — the repository's own failing workflow must remain rung-0 breakage. Without this,
 # a future edit could exempt runs wholesale and every assertion above would still pass.
+#
+# Two assertions, because the digest LINE and the CLASSIFICATION are separable: an edit could keep the
+# `CI red on main` template while quietly detaching it from `nothing_on_fire`, and the line's presence
+# alone would not notice.
 grep -Fq '<repo>: CI red on main @<sha>' "${surveyor}" ||
   fail "surveyor must still report a repository-owned failing workflow as CI red on main (#2536)"
+
+grep -Fq 'true only if NO CI red on main' "${surveyor}" ||
+  fail "surveyor must keep a repository-owned red on main driving nothing_on_fire: false — the GitHub-managed exemption must not detach the general rule (#2536)"
+
+# The rung-0 definition in the constitution must carry the same carve-out, or the two surfaces
+# disagree about what preempts a run.
+grep -Fq 'A failing GitHub-*managed* run is NOT breakage' "${constitution}" ||
+  fail "AGENTS.md rung-0 must state that a GitHub-managed run is not breakage (#2536)"
 
 # The exemption must key on the run PATH, not on `event: dynamic`, or it would exempt every future
 # GitHub-managed run type — including actionable ones. `dynamic` stays a main-branch event.

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -1126,6 +1126,20 @@ grep -Fq 'true only if NO CI red on main' "${surveyor}" ||
 grep -Fq 'A failing GitHub-*managed* run is NOT breakage' "${constitution}" ||
   fail "AGENTS.md rung-0 must state that a GitHub-managed run is not breakage (#2536)"
 
+# The constitution must carry the STREAK BOUND too. Without this, AGENTS.md could be edited to exempt
+# every repeated failure while the overlay still escalates — the two surfaces would then disagree about
+# whether dead security scanning is breakage, and only the overlay assertion above would notice.
+grep -Fq 'Only the first failure of a streak' "${constitution}" ||
+  fail "AGENTS.md must bound the GitHub-managed exemption to the first failure of a streak (#2536)"
+
+# The streak walk must use the same red set and the same branch filter as the red-set query, or it
+# misclassifies timeout streaks and lets pull-request scans pollute the history.
+grep -Fq 'Red means `failure` OR `timed_out`' "${surveyor}" ||
+  fail "surveyor's streak walk must treat timed_out as red, matching the red set (#2536)"
+
+grep -Fq 'runs?branch=main&per_page=100' "${surveyor}" ||
+  fail "surveyor's streak walk must filter to main, or a PR-triggered managed run pollutes it (#2536)"
+
 # The exemption must key on the run PATH, not on `event: dynamic`, or it would exempt every future
 # GitHub-managed run type — including actionable ones. `dynamic` stays a main-branch event.
 grep -Fq 'never on `event: dynamic` alone' "${surveyor}" ||

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -1081,4 +1081,33 @@ done <<EOF
 ${json_specs}
 EOF
 
+# --- GitHub-managed code scanning is not repository breakage (#2536) ----------
+#
+# A default-setup code-scanning run has no workflow file to fix and GitHub refuses to re-run it, so
+# ranking it at rung 0 — which preempts everything — burns a run's opening minutes on something
+# structurally unactionable that self-heals. It must still be REPORTED, because a failure persisting
+# across several scheduled ticks is a real signal.
+
+grep -Fq 'dynamic/github-code-scanning/' "${surveyor}" ||
+  fail "surveyor must classify runs whose path starts 'dynamic/github-code-scanning/' as GitHub-managed (#2536)"
+
+grep -Fq 'GITHUB-MANAGED-SCAN (NO-ACTION) <repo> <workflow> @<sha> failed' "${surveyor}" ||
+  fail "surveyor must define the GITHUB-MANAGED-SCAN (NO-ACTION) digest line (#2536)"
+
+grep -Fq 'a GITHUB-MANAGED-SCAN line never makes this false' "${surveyor}" ||
+  fail "surveyor must state that a GitHub-managed scan never sets nothing_on_fire: false (#2536)"
+
+# NEGATIVE CONTROL — the repository's own failing workflow must remain rung-0 breakage. Without this,
+# a future edit could exempt runs wholesale and every assertion above would still pass.
+grep -Fq '<repo>: CI red on main @<sha>' "${surveyor}" ||
+  fail "surveyor must still report a repository-owned failing workflow as CI red on main (#2536)"
+
+# The exemption must key on the run PATH, not on `event: dynamic`, or it would exempt every future
+# GitHub-managed run type — including actionable ones. `dynamic` stays a main-branch event.
+grep -Fq 'never on `event: dynamic` alone' "${surveyor}" ||
+  fail "surveyor must key the GitHub-managed exemption on the run path, not the dynamic event (#2536)"
+
+grep -Fq '`workflow_dispatch`, `dynamic`' "${surveyor}" ||
+  fail "surveyor must keep 'dynamic' in the main-branch event list — the exemption is by path (#2536)"
+
 echo "portfolio surveyor contract: all assertions passed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -594,7 +594,7 @@ actionable work**:
 
 | # | Rung | What it covers |
 |---|---|---|
-| **0** | **Live breakage** | CI red on `main`, a broken build or site, an urgent security fix. Preempts everything and is the one exception to capture-before-you-build. **A failing GitHub-*managed* run is NOT breakage** — a `dynamic/github-code-scanning/*` run has no workflow file to fix, cannot be re-run (`403`), and self-heals; it is reported `GITHUB-MANAGED-SCAN (NO-ACTION)` and never counts against `nothing_on_fire`. **Only the first failure of a streak** — a scan still failing on the next scheduled run is ours to repair (build, code-scanning config, or advanced setup) and IS actionable (see the surveyor). |
+| **0** | **Live breakage** | CI red on `main`, a broken build or site, an urgent security fix. Preempts everything and is the one exception to capture-before-you-build. **A failing GitHub-*managed* run is NOT breakage** — a `dynamic/github-code-scanning/*` run has no workflow file to fix, cannot be re-run (`403`), and self-heals; it is reported `GITHUB-MANAGED-SCAN (NO-ACTION)` and never counts against `nothing_on_fire`. **Only the first failure of a streak** — a scan still red (`failure` or `timed_out`) on the next run of `main` is ours to repair (build, code-scanning config, or advanced setup) and IS actionable (see the surveyor). |
 | **1** | **Open PRs — INCLUDING your own drafts** | Every actionable own/trusted PR in your lane, **draft and non-draft alike**, driven to a terminal state: merged, or parked on a **named, live-verified** blocker. Automation-owned dependency PRs are excluded (see *Merge policy*). |
 | **2** | **Security issues** | `type:"Security"`, regardless of age. |
 | **3** | **Bugs** | `type:"Bug"`, regardless of age. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -594,7 +594,7 @@ actionable work**:
 
 | # | Rung | What it covers |
 |---|---|---|
-| **0** | **Live breakage** | CI red on `main`, a broken build or site, an urgent security fix. Preempts everything and is the one exception to capture-before-you-build. |
+| **0** | **Live breakage** | CI red on `main`, a broken build or site, an urgent security fix. Preempts everything and is the one exception to capture-before-you-build. **A failing GitHub-*managed* run is NOT breakage** — a `dynamic/github-code-scanning/*` run has no workflow file to fix, cannot be re-run (`403`), and self-heals; it is reported `GITHUB-MANAGED-SCAN (NO-ACTION)` and never counts against `nothing_on_fire` (see the surveyor). |
 | **1** | **Open PRs — INCLUDING your own drafts** | Every actionable own/trusted PR in your lane, **draft and non-draft alike**, driven to a terminal state: merged, or parked on a **named, live-verified** blocker. Automation-owned dependency PRs are excluded (see *Merge policy*). |
 | **2** | **Security issues** | `type:"Security"`, regardless of age. |
 | **3** | **Bugs** | `type:"Bug"`, regardless of age. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -594,7 +594,7 @@ actionable work**:
 
 | # | Rung | What it covers |
 |---|---|---|
-| **0** | **Live breakage** | CI red on `main`, a broken build or site, an urgent security fix. Preempts everything and is the one exception to capture-before-you-build. **A failing GitHub-*managed* run is NOT breakage** — a `dynamic/github-code-scanning/*` run has no workflow file to fix, cannot be re-run (`403`), and self-heals; it is reported `GITHUB-MANAGED-SCAN (NO-ACTION)` and never counts against `nothing_on_fire` (see the surveyor). |
+| **0** | **Live breakage** | CI red on `main`, a broken build or site, an urgent security fix. Preempts everything and is the one exception to capture-before-you-build. **A failing GitHub-*managed* run is NOT breakage** — a `dynamic/github-code-scanning/*` run has no workflow file to fix, cannot be re-run (`403`), and self-heals; it is reported `GITHUB-MANAGED-SCAN (NO-ACTION)` and never counts against `nothing_on_fire`. **Only the first failure of a streak** — a scan still failing on the next scheduled run is ours to repair (build, code-scanning config, or advanced setup) and IS actionable (see the surveyor). |
 | **1** | **Open PRs — INCLUDING your own drafts** | Every actionable own/trusted PR in your lane, **draft and non-draft alike**, driven to a terminal state: merged, or parked on a **named, live-verified** blocker. Automation-owned dependency PRs are excluded (see *Merge policy*). |
 | **2** | **Security issues** | `type:"Security"`, regardless of age. |
 | **3** | **Bugs** | `type:"Bug"`, regardless of age. |


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Rung 0 of the work-selection ladder preempts everything, so anything ranked there sets a run's
opening priority. A GitHub-managed code-scanning failure was being ranked as repository breakage —
but there is no workflow file to fix, GitHub refuses to re-run it, and it clears itself on the next
scheduled tick. A run therefore spent its first minutes on something it could not act on. That has
now happened twice, on two different repositories.

It also mislabelled the portfolio: `nothing_on_fire: false` is what gates a run's willingness to do
advance work, and a GitHub-side scan blip is not the portfolio being on fire.

## What

The surveyor now recognises these runs and reports them on their own no-action line instead of as
breakage, and they no longer count against `nothing_on_fire`. They are still reported every run
rather than hidden — a failure that persists across several ticks is a real signal, and only a line
that keeps appearing can surface it.

The exemption is bounded to the **first** failure of a streak. A scan that fails again on the next
scheduled run is ours to repair — a broken build, a configuration that no longer suits default setup —
so it is reported as actionable and does count as the portfolio being on fire. Without that bound the
fix would trade a noisy false alarm for a silent one, which is worse.

The negative control matters as much as the fix: a failing workflow the repository actually owns is
unchanged and still ranks as breakage. Both directions are covered by the contract test.

Fixes #2536

