### PR TITLE
fix(telemetry): batch credential scans

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -21,6 +21,7 @@ MAX_FILES=400
 SECTION=all
 INJECTION_PROVENANCE=0
 CREDENTIAL_PROVENANCE=0
+CREDENTIAL_SCAN_BATCH_FILES="${CREDENTIAL_SCAN_BATCH_FILES:-128}"
 
 # Require a value before shifting past it. `shift 2` with only one arg left is a
 # no-op error under `set +e`, which spins the loop on the same $1 forever — a
@@ -46,6 +47,9 @@ done
 
 case "$SINCE_DAYS" in ''|*[!0-9]*) echo "--since-days must be an integer" >&2; exit 2 ;; esac
 case "$MAX_FILES"  in ''|*[!0-9]*) echo "--max-files must be an integer"  >&2; exit 2 ;; esac
+case "$CREDENTIAL_SCAN_BATCH_FILES" in
+  ''|*[!0-9]*|0) echo "CREDENTIAL_SCAN_BATCH_FILES must be a positive integer" >&2; exit 2 ;;
+esac
 # Lowercase letters AND digits — section names include `a2a`, which a
 # letters-only class silently rejected.
 # Validate against the REAL section names. A misspelling like `effciency` used
@@ -1447,8 +1451,60 @@ if want safety; then
     # the shapes are counted separately, the weak-signal generic bucket is
     # labelled as such, and the counts are of DISTINCT matched values (one leak
     # pasted into fifty transcripts is one credential to rotate, not fifty).
-    printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | while IFS= read -r f; do
-      # Dedupe per file before the portfolio-wide distinct-value reduction.
+    # One jq process per session dominated the live seven-day runtime (thousands
+    # of startups). Feed bounded NUL-delimited file batches to the SAME decoder
+    # instead. jq applies the filter independently to every input line, and the
+    # portfolio-wide `sort -u` below already makes file order and per-file
+    # boundaries irrelevant. Batch size 1 is therefore the byte-identical
+    # reference path used by the contract test; no raw pre-filter is introduced,
+    # so JSON-escaped matches remain visible.
+    CRED_DECODE_FILTER='
+        def image_payload_entry($parent):
+          if (($parent.type? // "") == "input_image"
+              and .key == "image_url"
+              and (.value | type) == "string")
+          then (.value | test("^data:image/[^,]*;base64,[A-Za-z0-9+/]*={0,2}$"; "i"))
+          else false
+          end;
+
+        def decoded_strings:
+          if type == "object" then
+            . as $parent
+            | (
+                keys_unsorted[],
+                (to_entries[]
+                 # Preserve the key/value association only where the generic
+                 # credential regex needs it; duplicating every large text
+                 # field as `key=value` would double the scan volume.
+                 | select((.key | test("(secret|token|password|passwd|api[_-]?key)"; "i"))
+                          and ((.value | type) == "string")
+                          and (image_payload_entry($parent) | not))
+                 | "\(.key)=\(.value)"),
+                (to_entries[]
+                 | select(image_payload_entry($parent) | not)
+                 | .value
+                 | decoded_strings)
+              )
+          elif type == "array" then .[] | decoded_strings
+          elif type == "string" then .
+          else empty
+          end;
+
+        select(length > 0) as $raw
+        | try (
+            $raw | fromjson | decoded_strings
+          ) catch $raw
+      '
+    printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | tr '\n' '\000' \
+      | xargs -0 -n "$CREDENTIAL_SCAN_BATCH_FILES" jq -Rr "$CRED_DECODE_FILTER" -- 2>/dev/null \
+      | sed -E "s/$(printf '\033')\[[0-9;:]*[A-Za-z]//g" \
+      | grep -ahoEi "$CRED_TABLE_RE" 2>/dev/null \
+      | tr ';&|' '\n' | grep -v '^$' \
+      | sed -E -e 's/^[^A-Za-z0-9_-]//' \
+        -e "s/^[^:=]*[:=][[:space:]]*[\"']?(.+)$/\1/" \
+        -e "s/^[^:=]*[:=][[:space:]]*[\"']?([^=].*)$/\1/" \
+        -e 's/^([A-Za-z0-9_-]+)\*\*\*+.*$/\1***/' \
+      | grep -E . | sort -u |
       # Normalise every match to its UNDERLYING VALUE before any dedup:
       # (1) split compound assignments on `;` — the generic alternative's value
       #     class includes `;`, so `GITHUB_TOKEN=ghp_…;AWS_…=AKIA…` is ONE
@@ -1486,52 +1542,7 @@ if want safety; then
       #     weak-bucket rows; the asymmetry is chosen — a splittable fragment
       #     only ever reaches a high-signal row by passing a FULL shape regex,
       #     while not splitting silently drops a real second credential.
-      jq -Rr '
-        def image_payload_entry($parent):
-          if (($parent.type? // "") == "input_image"
-              and .key == "image_url"
-              and (.value | type) == "string")
-          then (.value | test("^data:image/[^,]*;base64,[A-Za-z0-9+/]*={0,2}$"; "i"))
-          else false
-          end;
-
-        def decoded_strings:
-          if type == "object" then
-            . as $parent
-            | (
-                keys_unsorted[],
-                (to_entries[]
-                 # Preserve the key/value association only where the generic
-                 # credential regex needs it; duplicating every large text
-                 # field as `key=value` would double the scan volume.
-                 | select((.key | test("(secret|token|password|passwd|api[_-]?key)"; "i"))
-                          and ((.value | type) == "string")
-                          and (image_payload_entry($parent) | not))
-                 | "\(.key)=\(.value)"),
-                (to_entries[]
-                 | select(image_payload_entry($parent) | not)
-                 | .value
-                 | decoded_strings)
-              )
-          elif type == "array" then .[] | decoded_strings
-          elif type == "string" then .
-          else empty
-          end;
-
-        select(length > 0) as $raw
-        | try (
-            $raw | fromjson | decoded_strings
-          ) catch $raw
-      ' "$f" 2>/dev/null \
-        | sed -E "s/$(printf '\033')\[[0-9;:]*[A-Za-z]//g" \
-        | grep -ahoEi "$CRED_TABLE_RE" 2>/dev/null \
-        | tr ';&|' '\n' | grep -v '^$' \
-        | sed -E -e 's/^[^A-Za-z0-9_-]//' \
-        -e "s/^[^:=]*[:=][[:space:]]*[\"']?(.+)$/\1/" \
-        -e "s/^[^:=]*[:=][[:space:]]*[\"']?([^=].*)$/\1/" \
-        -e 's/^([A-Za-z0-9_-]+)\*\*\*+.*$/\1***/' \
-        | grep -E . | sort -u
-    done | sort -u | awk '
+    awk '
       # FULL-shape validation, not prefix sniffing: a generic value that merely
       # BEGINS like a token (`token=ghp_abcdefgh`, too short to be one) must
       # stay in the weak bucket, or the high-signal rows inherit false

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -48,7 +48,9 @@ done
 case "$SINCE_DAYS" in ''|*[!0-9]*) echo "--since-days must be an integer" >&2; exit 2 ;; esac
 case "$MAX_FILES"  in ''|*[!0-9]*) echo "--max-files must be an integer"  >&2; exit 2 ;; esac
 case "$CREDENTIAL_SCAN_BATCH_FILES" in
-  ''|*[!0-9]*|0) echo "CREDENTIAL_SCAN_BATCH_FILES must be a positive integer" >&2; exit 2 ;;
+  ''|*[!0-9]*) echo "CREDENTIAL_SCAN_BATCH_FILES must be a positive integer" >&2; exit 2 ;;
+  *[1-9]*) ;;
+  *) echo "CREDENTIAL_SCAN_BATCH_FILES must be a positive integer" >&2; exit 2 ;;
 esac
 # Lowercase letters AND digits — section names include `a2a`, which a
 # letters-only class silently rejected.

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1457,7 +1457,9 @@ if want safety; then
     # portfolio-wide `sort -u` below already makes file order and per-file
     # boundaries irrelevant. Batch size 1 is therefore the byte-identical
     # reference path used by the contract test; no raw pre-filter is introduced,
-    # so JSON-escaped matches remain visible.
+    # so JSON-escaped matches remain visible. One awk process per batch restores
+    # a trailing record separator at every file boundary; without it, jq -R
+    # joins an unterminated live-session record to the next file.
     CRED_DECODE_FILTER='
         def image_payload_entry($parent):
           if (($parent.type? // "") == "input_image"
@@ -1495,8 +1497,10 @@ if want safety; then
             $raw | fromjson | decoded_strings
           ) catch $raw
       '
+    export CRED_DECODE_FILTER
     printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | tr '\n' '\000' \
-      | xargs -0 -n "$CREDENTIAL_SCAN_BATCH_FILES" jq -Rr "$CRED_DECODE_FILTER" -- 2>/dev/null \
+      | xargs -0 -n "$CREDENTIAL_SCAN_BATCH_FILES" bash -c \
+          'awk "{ print }" "$@" | jq -Rr "$CRED_DECODE_FILTER" --' _ 2>/dev/null \
       | sed -E "s/$(printf '\033')\[[0-9;:]*[A-Za-z]//g" \
       | grep -ahoEi "$CRED_TABLE_RE" 2>/dev/null \
       | tr ';&|' '\n' | grep -v '^$' \

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1245,6 +1245,79 @@ if printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p' | 
   ok "a credential AFTER a malformed record is still found"
 else bad "a credential AFTER a malformed record is still found" "jq aborted at the bad line"; fi
 
+# The credential table used to start one jq process per session file. At the
+# live seven-day volume that means thousands of process startups before the
+# scorecard can print anything. Batch size 1 is the byte-for-byte reference
+# behaviour; the default batch must produce the SAME complete safety output
+# while invoking the decoded-string filter once for this small corpus.
+#
+# Production mutation this catches: replacing the batched jq call with the old
+# per-file loop makes batched_calls equal reference_calls while every ordinary
+# detector assertion remains green.
+mkdir -p "$FIX/credbatch" "$FIX/jqbatchshim"
+for batch_i in 01 02 03 04 05 06 07 08 09 10 11 12; do
+  printf '{"type":"user","message":{"content":[{"type":"text","text":"ordinary record %s"}]}}\n' \
+    "$batch_i" > "$FIX/credbatch/plain-${batch_i}.jsonl"
+done
+cat > "$FIX/credbatch/escaped.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"config says api_key=\"__GEN__\""}]}}
+EOF
+cat > "$FIX/credbatch/token.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"example __GHPB__"}]}}
+EOF
+subst "$FIX/credbatch/escaped.jsonl" "$FIX/credbatch/token.jsonl"
+
+real_jq=$(command -v jq)
+real_date=$(command -v date)
+cat > "$FIX/jqbatchshim/jq" <<'EOF'
+#!/usr/bin/env bash
+for jq_arg in "$@"; do
+  case "$jq_arg" in
+    *'def decoded_strings:'*) printf 'credential-table\n' >> "$JQ_BATCH_TRACE" ;;
+  esac
+done
+exec "$REAL_JQ" "$@"
+EOF
+cat > "$FIX/jqbatchshim/date" <<'EOF'
+#!/usr/bin/env bash
+if [ "$#" -eq 2 ] && [ "$1" = "-u" ] && [ "$2" = "+%Y-%m-%dT%H:%M:%SZ" ]; then
+  printf '%s\n' '2026-07-29T05:00:00Z'
+else
+  exec "$REAL_DATE" "$@"
+fi
+EOF
+chmod +x "$FIX/jqbatchshim/jq"
+chmod +x "$FIX/jqbatchshim/date"
+
+: > "$FIX/jq-batch-trace"
+REFERENCE=$(PATH="$FIX/jqbatchshim:$PATH" REAL_JQ="$real_jq" REAL_DATE="$real_date" \
+  JQ_BATCH_TRACE="$FIX/jq-batch-trace" \
+  CREDENTIAL_SCAN_BATCH_FILES=1 \
+  CLAUDE_PROJECTS_DIR="$FIX/credbatch" CODEX_HOME="$FIX/nocodex" \
+  MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+  bash "$TARGET" --since-days 3650 --section safety 2>&1)
+reference_calls=$(grep -c '^credential-table$' "$FIX/jq-batch-trace")
+
+: > "$FIX/jq-batch-trace"
+BATCHED=$(PATH="$FIX/jqbatchshim:$PATH" REAL_JQ="$real_jq" REAL_DATE="$real_date" \
+  JQ_BATCH_TRACE="$FIX/jq-batch-trace" \
+  CREDENTIAL_SCAN_BATCH_FILES=64 \
+  CLAUDE_PROJECTS_DIR="$FIX/credbatch" CODEX_HOME="$FIX/nocodex" \
+  MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+  bash "$TARGET" --since-days 3650 --section safety 2>&1)
+batched_calls=$(grep -c '^credential-table$' "$FIX/jq-batch-trace")
+
+if [ "$REFERENCE" = "$BATCHED" ]; then
+  ok "credential batching preserves the complete safety output byte-for-byte"
+else
+  bad "credential batching preserves the complete safety output byte-for-byte" \
+    "$(diff -u <(printf '%s\n' "$REFERENCE") <(printf '%s\n' "$BATCHED") | head -40)"; fi
+if [ "$reference_calls" -gt 1 ] && [ "$batched_calls" -eq 1 ]; then
+  ok "credential batching replaces per-file decoded-string jq startups"
+else
+  bad "credential batching replaces per-file decoded-string jq startups" \
+    "reference calls=$reference_calls batched calls=$batched_calls"; fi
+
 # Interrupts must come from the structured flag, not prose quoting it.
 mkdir -p "$FIX/interrupt"
 cat > "$FIX/interrupt/s.jsonl" <<'EOF'

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1299,6 +1299,19 @@ EOF
 chmod +x "$FIX/jqbatchshim/jq"
 chmod +x "$FIX/jqbatchshim/date"
 
+INVALID_BATCH=$(CREDENTIAL_SCAN_BATCH_FILES=00 \
+  CLAUDE_PROJECTS_DIR="$FIX/credbatch" CODEX_HOME="$FIX/nocodex" \
+  MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+  bash "$TARGET" --since-days 3650 --section safety 2>&1)
+invalid_batch_status=$?
+if [ "$invalid_batch_status" -eq 2 ] \
+   && printf '%s' "$INVALID_BATCH" | grep -qF 'CREDENTIAL_SCAN_BATCH_FILES must be a positive integer'; then
+  ok "zero-padded zero credential batch size fails closed"
+else
+  bad "zero-padded zero credential batch size fails closed" \
+    "status=$invalid_batch_status output=$INVALID_BATCH"
+fi
+
 : > "$FIX/jq-batch-trace"
 REFERENCE=$(PATH="$FIX/jqbatchshim:$PATH" REAL_JQ="$real_jq" REAL_DATE="$real_date" \
   JQ_BATCH_TRACE="$FIX/jq-batch-trace" \

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1259,6 +1259,16 @@ for batch_i in 01 02 03 04 05 06 07 08 09 10 11 12; do
   printf '{"type":"user","message":{"content":[{"type":"text","text":"ordinary record %s"}]}}\n' \
     "$batch_i" > "$FIX/credbatch/plain-${batch_i}.jsonl"
 done
+# A live session is concurrently written and can end on an unterminated record
+# while the scan reads it. These names sort newest-first in z→y order when their
+# mtimes tie, so batch mode must keep the file boundary between them.
+printf '%s' '{"type":"user","message":{"content":[{"type":"text","text":"unterminated record"}]}}' \
+  > "$FIX/credbatch/boundary-z.jsonl"
+cat > "$FIX/credbatch/boundary-y.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"boundary api_key=\"__GENPAD__\""}]}}
+EOF
+subst "$FIX/credbatch/boundary-y.jsonl"
+touch -t 202607290500 "$FIX/credbatch/boundary-z.jsonl" "$FIX/credbatch/boundary-y.jsonl"
 cat > "$FIX/credbatch/escaped.jsonl" <<'EOF'
 {"type":"user","message":{"content":[{"type":"text","text":"config says api_key=\"__GEN__\""}]}}
 EOF
@@ -1312,6 +1322,12 @@ if [ "$REFERENCE" = "$BATCHED" ]; then
 else
   bad "credential batching preserves the complete safety output byte-for-byte" \
     "$(diff -u <(printf '%s\n' "$REFERENCE") <(printf '%s\n' "$BATCHED") | head -40)"; fi
+if printf '%s' "$BATCHED" | sed -n '/credential-shaped/,/rotate the credential/p' \
+   | grep -q '2 generic-assignment'; then
+  ok "credential batching preserves a decoded secret after an unterminated file"
+else
+  bad "credential batching preserves a decoded secret after an unterminated file" \
+    "$(printf '%s' "$BATCHED" | sed -n '/credential-shaped/,/rotate the credential/p')"; fi
 if [ "$reference_calls" -gt 1 ] && [ "$batched_calls" -eq 1 ]; then
   ok "credential batching replaces per-file decoded-string jq startups"
 else


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Fixes #2545

## Evidence

The seven-day safety scan previously took about 40 minutes because the credential table launched one jq decoder per session file. This change batches the same decoder across bounded groups of files without adding a raw pre-filter or storing credential values on disk.

## Verification

- RED: the batching contract observed 14 decoder startups instead of one; focused regressions also reproduced the unterminated-file detection miss and the zero-padded zero fail-open case.
- GREEN: 230/230 telemetry tests pass; batch sizes 1 and 64 produce byte-identical full safety output, including an escaped credential immediately after an unterminated file.
- Exact-head live runtime: seven-day safety plus credential provenance completed successfully in 682 seconds (11m22s), versus about 40 minutes previously.
- Shell syntax, ShellCheck error severity, agent-role delivery contract, and the reviewed plugin manifest validator pass.
- All hosted checks pass at ba411f40eaa34a2aaf3e35b5a9bbe9e5fcb8c3da.

## Review findings

CodeRabbit and Codex independently found that jq raw-input batching could merge an unterminated file with the next record; Codex also found that 00 bypassed the positive-batch validation. Both findings were reproduced with failing tests, fixed, answered, and resolved. A fresh CodeRabbit review completed at the exact final head with no new findings.

## User evaluation

Ran the real seven-day operator path successfully at the final head. The report completed inside this Agent Improver run and preserved the existing output surface.