### PR TITLE
fix(scripts): name the resolved slug in branch-cleanup's abort message

### DIFF
--- a/.claude/scripts/branch-cleanup.sh
+++ b/.claude/scripts/branch-cleanup.sh
@@ -187,8 +187,13 @@ check_remote_identity() {
   _nwo=$(github_nwo "$_url")
   if [ -n "$_nwo" ]; then
     if [ "$_nwo" != "$slug_lc" ]; then
-      echo "$SLUG: ABORT — slug '$SLUG' does not match the checkout at '$REPO_PATH', whose" >&2
-      echo "  $_kind is '$_nwo'. The keep-set would be fetched for the wrong repository." >&2
+      # Name the value actually COMPARED ($slug_lc), not just the raw argument.
+      # <slug> is a bare repo name and the owner is prepended, so an
+      # owner-qualified argument prints an identical-looking pair otherwise:
+      #   slug 'devantler-tech/x' ... whose origin is 'devantler-tech/x'
+      echo "$SLUG: ABORT — slug '$SLUG' (resolved to '$slug_lc') does not match the checkout" >&2
+      echo "  at '$REPO_PATH', whose $_kind is '$_nwo'. The keep-set would be fetched for the" >&2
+      echo "  wrong repository. <slug> is a BARE repo name — 'devantler-tech/' is prepended." >&2
       exit 2
     fi
   elif [ "$MODE" = "apply" ] && [ "${BRANCH_CLEANUP_ALLOW_UNVERIFIABLE_ORIGIN:-}" != "1" ]; then

--- a/.claude/scripts/branch-cleanup.test.sh
+++ b/.claude/scripts/branch-cleanup.test.sh
@@ -192,6 +192,24 @@ report "slug that disagrees with origin is refused (exit 2)" \
 report "slug refusal names both the slug and the origin repo" \
   "$(grep -q 'ksail' <<<"$out" && grep -q 'does-not-exist-2531' <<<"$out" && echo yes || echo no)" "out=$out"
 
+# --- 7a. an OWNER-QUALIFIED slug must be diagnosable ----------------------
+# <slug> is a BARE repo name; the helper prepends `devantler-tech/`. Passing the
+# owner-qualified form — the shape `gh -R` takes everywhere, so the likely
+# mistake — resolves to `devantler-tech/devantler-tech/<repo>` and is correctly
+# refused. But the message printed the RAW argument next to the parsed origin,
+# so for a slug whose repo half is right it rendered as a contradiction:
+#   slug 'devantler-tech/x' does not match the checkout ... whose origin is 'devantler-tech/x'
+# Identical strings, no stated reason — the reader cannot see that a second
+# owner was prepended. The refusal must name the value actually COMPARED.
+git -C "$slugwork" remote set-url origin "https://github.com/devantler-tech/does-not-exist-2531.git"
+manifest="$tmp/manifest7a"
+: >"$manifest"
+out="$("$helper" "$slugwork" "devantler-tech/does-not-exist-2531" "$manifest" dry-run claude 2>&1)" && rc=0 || rc=$?
+report "owner-qualified slug is refused (exit 2)" \
+  "$([[ ${rc:-0} -eq 2 ]] && echo yes || echo no)" "rc=${rc:-0} out=$out"
+report "owner-qualified refusal names the RESOLVED slug, not just the raw argument" \
+  "$(grep -q 'devantler-tech/devantler-tech/does-not-exist-2531' <<<"$out" && echo yes || echo no)" "out=$out"
+
 # --- 7b. an UPPERCASE GitHub host must not slip past the identity check ---
 # Hostnames are case-insensitive, so a case-sensitive host match would leave
 # origin unparsed and skip the slug comparison entirely — a silent bypass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2294,9 +2294,13 @@ a task explicitly calls for it. Leave every checkout/worktree clean when done.
 you to always clean up and switch back to the default branch after a tick."*). Left unswept, every run's
 worktree branch survives it: the first sweep found **~1,140 spent branches** (monorepo alone had **589**
 local; `.github` had **35** stale remote). **Remove your own per-run worktree FIRST, then run**
-[`.claude/scripts/branch-cleanup.sh <repo_path> <slug> <manifest> [apply|dry-run] [namespace]`](.claude/scripts/branch-cleanup.sh)
+[`.claude/scripts/branch-cleanup.sh <repo_path> <repo-name> <manifest> [apply|dry-run] [namespace]`](.claude/scripts/branch-cleanup.sh)
 for each repo touched — a branch still checked out by your own worktree sits in the keep-set, so a
 sweep run before the worktree removal silently spares the very branch the tick just spent.
+**`<repo-name>` is the BARE repository name** (`monorepo`, `platform`) — the script prepends
+`devantler-tech/` itself. It is **not** your session/worktree slug and **not** `owner/repo`; both are
+rejected, and passing the owner-qualified form is the likelier mistake because the first rejection
+names the origin.
 **Namespace:** default `claude` sweeps local + remote `claude/*`. Pass `cursor` as the fifth argument
 for a **remote-only** sweep of spent `cursor/*` (the cloud lane has no local checkout on this host;
 local instances run that pass so cursor remotes do not accumulate forever — monorepo#2298). Never pass


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The end-of-tick branch sweep refuses to run when its slug argument disagrees with the checkout's origin — a good guard, since a wrong slug would fetch the keep-set for the wrong repository and delete branches that belong to open PRs. But the rejection could not be acted on. The parameter is the bare repository name and the script prepends the owner itself, while the message printed the raw argument beside the parsed origin. Pass the owner-qualified form — which is exactly what the first rejection's own hint steers you toward — and it asserts that two byte-identical strings do not match.

I hit this during this run's own cleanup: two failed invocations of a step every run is required to perform, and I only resolved it by reading the source. The risk is an instance concluding its checkout is broken rather than its argument, and skipping the sweep — which is how stale branches accumulate quietly.

## What

Report the value actually compared and say what to pass; name the parameter `<repo-name>` in the contract so it cannot read as the session worktree slug. The guard's decision is untouched — it refuses exactly the same inputs as before; only the explanation changes.

Fixes #2550
