### PR TITLE
fix(scripts): reap abandoned session worktrees on a schedule

### DIFF
--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -73,7 +73,11 @@ printf '=== worktree-cleanup-all  mode=%s  min_age=%sh  root=%s ===\n' \
 
 sweep() { # <repo_path>
   local path=$1 label toplevel expected
-  [ -d "$path/.claude/worktrees" ] || return 0
+  # NOTE: no early return for a missing .claude/worktrees. The per-repo script has its
+  # own no-root path that still prunes stale registrations — returning here made that
+  # path unreachable through the wrapper, the only way it is ever invoked. A path that is
+  # not a repository at all is handled by the toplevel check below (it resolves to the
+  # parent, so the mismatch SKIPs it) rather than by a guard that pre-empts that report.
   # Only sweep a repo whose toplevel resolves to ITSELF. A submodule with broken
   # worktree isolation resolves into the main checkout, and sweeping through that
   # alias would operate on the wrong tree (AGENTS.md, Execution model).

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -159,7 +159,15 @@ if [ -f "$ROOT/.gitmodules" ]; then
     # can name an ordinary nested repository inside ROOT, which is not a portfolio
     # submodule and must not be swept. Require the path to be a real gitlink (mode
     # 160000) in the parent's index.
-    if [ "$(git -C "$ROOT" ls-files --stage -- "$sub" 2>/dev/null | cut -c1-6)" != "160000" ]; then
+    # The query's status is captured separately: an unreadable or corrupt index makes the
+    # substitution empty, which would read as "not a gitlink" and silently skip a real
+    # submodule while the run still reported success.
+    stage=$(git -C "$ROOT" ls-files --stage -- "$sub" 2>/dev/null); stage_rc=$?
+    if [ "$stage_rc" -ne 0 ]; then
+      printf 'worktree-cleanup-all: ABORTING — cannot read the index to validate %s\n' "$sub" >&2
+      exit 2
+    fi
+    if [ "$(printf '%s' "$stage" | cut -c1-6)" != "160000" ]; then
       printf '\n### SKIP %s (not a gitlink in the index — not a portfolio submodule)\n' "$sub"
       continue
     fi

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -50,8 +50,19 @@ fi
 case "$ROOT" in
   */.claude/worktrees/*) ROOT=${ROOT%%/.claude/worktrees/*} ;;
 esac
-git -C "$ROOT" rev-parse --show-toplevel >/dev/null 2>&1 \
+# Use rev-parse's OUTPUT, not just its status. It walks upward, so a root pointing at
+# some subdirectory of the checkout passes the check while ROOT stays wrong — the
+# wrapper then finds no worktree dir and no .gitmodules, prints "done" and exits 0
+# having swept nothing.
+ROOT_TOPLEVEL=$(git -C "$ROOT" rev-parse --show-toplevel 2>/dev/null) \
   || { printf 'worktree-cleanup-all: not a git repository: %s\n' "$ROOT" >&2; exit 2; }
+ROOT_TOPLEVEL=$(cd "$ROOT_TOPLEVEL" && pwd -P) \
+  || { printf 'worktree-cleanup-all: cannot resolve toplevel of %s\n' "$ROOT" >&2; exit 2; }
+if [ "$ROOT_TOPLEVEL" != "$ROOT" ]; then
+  printf 'worktree-cleanup-all: %s is not a repository root (its root is %s) — using the root\n' \
+    "$ROOT" "$ROOT_TOPLEVEL" >&2
+  ROOT="$ROOT_TOPLEVEL"
+fi
 
 MANIFEST_DIR="$HOME/.claude/worktree-cleanup-manifests"
 mkdir -p "$MANIFEST_DIR" || { printf 'cannot create %s\n' "$MANIFEST_DIR" >&2; exit 2; }
@@ -84,7 +95,14 @@ sweep() { # <repo_path>
   # remaining repositories, since the same failure very likely applies to them too.
   local out rc
   out=$("$SUT" "$path" "$MANIFEST_DIR/$label-$TS.tsv" "$MODE" "$MIN_AGE_HOURS" 2>&1); rc=$?
-  printf '%s\n' "$out" | tail -3
+  # dry-run writes no manifest, so its per-worktree REAP/KEEP lines are the ONLY record
+  # of what an apply run would touch — never truncate them. apply has the manifest, so
+  # a summary is enough there.
+  if [ "$MODE" = "dry-run" ]; then
+    printf '%s\n' "$out"
+  else
+    printf '%s\n' "$out" | tail -3
+  fi
   if [ "$rc" -ne 0 ]; then
     printf 'worktree-cleanup-all: ABORTING — sweep of %s failed (exit %d)\n' "$rel" "$rc" >&2
     exit "$rc"

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -21,6 +21,20 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 SUT="$SCRIPT_DIR/worktree-cleanup.sh"
 [ -x "$SUT" ] || { printf 'worktree-cleanup-all: missing %s\n' "$SUT" >&2; exit 2; }
 
+# Validate arguments HERE, not only in the per-repo script. If no repository happens to
+# have a .claude/worktrees/ directory, every per-repo call returns before validating,
+# and a malformed launcher invocation (`worktree-cleanup-all.sh alpply 24`) would print
+# "done" and exit 0 — a misconfigured scheduled job that looks healthy.
+case "$MODE" in
+  apply|dry-run) ;;
+  *) printf "worktree-cleanup-all: invalid MODE '%s' (expected 'apply' or 'dry-run')\n" \
+       "$MODE" >&2; exit 2 ;;
+esac
+case "$MIN_AGE_HOURS" in
+  ''|*[!0-9]*) printf "worktree-cleanup-all: min_age_hours must be a non-negative integer, got '%s'\n" \
+                 "$MIN_AGE_HOURS" >&2; exit 2 ;;
+esac
+
 # Repo root. WORKTREE_CLEANUP_ROOT lets the script run from outside the checkout
 # (the scheduled launcher does exactly that); otherwise it is two levels up from
 # .claude/scripts.
@@ -86,13 +100,24 @@ sweep "$ROOT"
 # root-only sweep while still reporting success. `cut -d' ' -f2-` (not `awk '{print $2}'`)
 # so a submodule path containing whitespace is not truncated.
 if [ -f "$ROOT/.gitmodules" ]; then
-  submodules=$(git -C "$ROOT" config -f "$ROOT/.gitmodules" \
-                 --get-regexp '^submodule\..*\.path$' 2>/dev/null | cut -d' ' -f2-)
-  rc=$?
-  if [ "$rc" -ne 0 ] && [ -n "$(git -C "$ROOT" config -f "$ROOT/.gitmodules" --list 2>/dev/null)" ]; then
+  # Two distinct statuses, checked INDEPENDENTLY. `--get-regexp` exits nonzero both when
+  # the file is unparseable AND when it simply matches nothing, so it cannot distinguish
+  # them alone. The probe below settles it — but its own status must be captured too:
+  # on a malformed .gitmodules BOTH commands fail and produce no output, and testing
+  # only the probe's emptiness would read that as "no submodules" and silently degrade
+  # the scheduled sweep to the root repository.
+  raw=$(git -C "$ROOT" config -f "$ROOT/.gitmodules" \
+          --get-regexp '^submodule\..*\.path$' 2>/dev/null); get_rc=$?
+  probe=$(git -C "$ROOT" config -f "$ROOT/.gitmodules" --list 2>/dev/null); probe_rc=$?
+  if [ "$probe_rc" -ne 0 ]; then
+    printf 'worktree-cleanup-all: ABORTING — .gitmodules is unreadable or malformed\n' >&2
+    exit 2
+  fi
+  if [ "$get_rc" -ne 0 ] && [ -n "$probe" ]; then
     printf 'worktree-cleanup-all: ABORTING — cannot read submodule paths from .gitmodules\n' >&2
     exit 2
   fi
+  submodules=$(printf '%s\n' "$raw" | cut -d' ' -f2-)
   while IFS= read -r sub; do
     [ -n "$sub" ] || continue
     sweep "$ROOT/$sub"

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -62,7 +62,17 @@ sweep() { # <repo_path>
   if [ "$path" = "$ROOT" ]; then rel="(root)"; label=monorepo
   else label=$(printf '%s' "$rel" | tr '/' '-'); fi
   printf '\n### %s\n' "$rel"
-  "$SUT" "$path" "$MANIFEST_DIR/$label-$TS.tsv" "$MODE" "$MIN_AGE_HOURS" 2>&1 | tail -3
+  # Capture the sweep's OWN status, not the pipeline's tail. An infrastructure abort
+  # (lsof, worktree list, manifest write) must not be reported as a successful sweep by
+  # the scheduled entrypoint — and must stop the run rather than continuing into the
+  # remaining repositories, since the same failure very likely applies to them too.
+  local out rc
+  out=$("$SUT" "$path" "$MANIFEST_DIR/$label-$TS.tsv" "$MODE" "$MIN_AGE_HOURS" 2>&1); rc=$?
+  printf '%s\n' "$out" | tail -3
+  if [ "$rc" -ne 0 ]; then
+    printf 'worktree-cleanup-all: ABORTING — sweep of %s failed (exit %d)\n' "$rel" "$rc" >&2
+    exit "$rc"
+  fi
 }
 
 sweep "$ROOT"

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -120,7 +120,17 @@ if [ -f "$ROOT/.gitmodules" ]; then
   submodules=$(printf '%s\n' "$raw" | cut -d' ' -f2-)
   while IFS= read -r sub; do
     [ -n "$sub" ] || continue
-    sweep "$ROOT/$sub"
+    # .gitmodules is repository content, and the config parser happily accepts a path
+    # like `../outside`. Concatenating that escapes ROOT, and if the resulting location
+    # is another repository with .claude/worktrees the scheduled apply run would reap
+    # worktrees outside the portfolio entirely. Resolve and require containment.
+    sub_real=$(cd "$ROOT/$sub" 2>/dev/null && pwd -P) || continue
+    case "$sub_real" in
+      "$ROOT"/?*) ;;
+      *) printf '\n### SKIP %s (escapes the portfolio root: %s)\n' "$sub" "$sub_real"
+         continue ;;
+    esac
+    sweep "$sub_real"
   done <<< "$submodules"
 fi
 

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -109,7 +109,11 @@ sweep() { # <repo_path>
   # dry-run writes no manifest, so its per-worktree REAP/KEEP lines are the ONLY record
   # of what an apply run would touch — never truncate them. apply has the manifest, so
   # a summary is enough there.
-  if [ "$MODE" = "dry-run" ]; then
+  # On FAILURE always print the full output. The summary is the last few lines, but an
+  # abort's reason is on stderr somewhere above it — truncating to `tail -3` hid exactly
+  # the message needed to diagnose a failing scheduled run (observed: the log showed the
+  # repo heading and then nothing but a non-zero exit).
+  if [ "$MODE" = "dry-run" ] || [ "$rc" -ne 0 ]; then
     printf '%s\n' "$out"
   else
     printf '%s\n' "$out" | tail -3

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -155,6 +155,14 @@ if [ -f "$ROOT/.gitmodules" ]; then
       *) printf '\n### SKIP %s (escapes the portfolio root: %s)\n' "$sub" "$sub_real"
          continue ;;
     esac
+    # Containment is necessary but not sufficient: a stale or malformed .gitmodules entry
+    # can name an ordinary nested repository inside ROOT, which is not a portfolio
+    # submodule and must not be swept. Require the path to be a real gitlink (mode
+    # 160000) in the parent's index.
+    if [ "$(git -C "$ROOT" ls-files --stage -- "$sub" 2>/dev/null | cut -c1-6)" != "160000" ]; then
+      printf '\n### SKIP %s (not a gitlink in the index — not a portfolio submodule)\n' "$sub"
+      continue
+    fi
     sweep "$sub_real"
   done <<< "$submodules"
 fi

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -58,7 +58,9 @@ sweep() { # <repo_path>
     printf '\n### SKIP %s (broken isolation: toplevel=%s)\n' "$path" "$toplevel"
     return 0
   fi
-  local rel=${path#$ROOT/}
+  # "$ROOT" is QUOTED: unquoted it is a glob pattern, so a root path containing
+  # [, * or ? would strip the wrong prefix (or none) and mislabel the manifest.
+  local rel=${path#"$ROOT"/}
   if [ "$path" = "$ROOT" ]; then rel="(root)"; label=monorepo
   else label=$(printf '%s' "$rel" | tr '/' '-'); fi
   printf '\n### %s\n' "$rel"
@@ -76,11 +78,25 @@ sweep() { # <repo_path>
 }
 
 sweep "$ROOT"
-# Every initialised submodule, from .gitmodules (never a hard-coded list — the
-# portfolio gains and loses submodules over time).
-while IFS= read -r sub; do
-  [ -n "$sub" ] || continue
-  sweep "$ROOT/$sub"
-done < <(git -C "$ROOT" config -f "$ROOT/.gitmodules" --get-regexp '^submodule\..*\.path$' 2>/dev/null | awk '{print $2}')
+
+# Every submodule, from .gitmodules (never a hard-coded list — the portfolio gains and
+# loses submodules over time).
+# The read is status-checked: an unreadable .gitmodules yields an empty list, which is
+# indistinguishable from "no submodules", and would silently degrade this to a
+# root-only sweep while still reporting success. `cut -d' ' -f2-` (not `awk '{print $2}'`)
+# so a submodule path containing whitespace is not truncated.
+if [ -f "$ROOT/.gitmodules" ]; then
+  submodules=$(git -C "$ROOT" config -f "$ROOT/.gitmodules" \
+                 --get-regexp '^submodule\..*\.path$' 2>/dev/null | cut -d' ' -f2-)
+  rc=$?
+  if [ "$rc" -ne 0 ] && [ -n "$(git -C "$ROOT" config -f "$ROOT/.gitmodules" --list 2>/dev/null)" ]; then
+    printf 'worktree-cleanup-all: ABORTING — cannot read submodule paths from .gitmodules\n' >&2
+    exit 2
+  fi
+  while IFS= read -r sub; do
+    [ -n "$sub" ] || continue
+    sweep "$ROOT/$sub"
+  done <<< "$submodules"
+fi
 
 printf '\n=== done (manifests in %s) ===\n' "$MANIFEST_DIR"

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -157,7 +157,21 @@ if [ -f "$ROOT/.gitmodules" ]; then
     # like `../outside`. Concatenating that escapes ROOT, and if the resulting location
     # is another repository with .claude/worktrees the scheduled apply run would reap
     # worktrees outside the portfolio entirely. Resolve and require containment.
-    sub_real=$(cd "$ROOT/$sub" 2>/dev/null && pwd -P) || continue
+    # An absent path is an uninitialised submodule — nothing to sweep, skip quietly.
+    # A path that EXISTS but cannot be resolved is an infrastructure failure (permissions,
+    # a broken mount), and skipping it silently let the wrapper still print "done" and
+    # exit 0 with that repository never swept.
+    [ -e "$ROOT/$sub" ] || continue
+    # A SYMLINK at the gitlink path resolves elsewhere: `pwd -P` would follow it to an
+    # unrelated repository while the index query still validates the original lexical
+    # path as a genuine gitlink, so the sweep would run against the link target.
+    if [ -L "$ROOT/$sub" ]; then
+      printf '\n### SKIP %s (gitlink path is a symlink — refusing to follow it)\n' "$sub"
+      continue
+    fi
+    sub_real=$(cd "$ROOT/$sub" 2>/dev/null && pwd -P) || {
+      printf 'worktree-cleanup-all: ABORTING — %s exists but cannot be resolved\n' "$sub" >&2
+      exit 2; }
     case "$sub_real" in
       "$ROOT"/?*) ;;
       *) printf '\n### SKIP %s (escapes the portfolio root: %s)\n' "$sub" "$sub_real"

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -77,8 +77,15 @@ sweep() { # <repo_path>
   # Only sweep a repo whose toplevel resolves to ITSELF. A submodule with broken
   # worktree isolation resolves into the main checkout, and sweeping through that
   # alias would operate on the wrong tree (AGENTS.md, Execution model).
-  toplevel=$(git -C "$path" rev-parse --show-toplevel 2>/dev/null) || return 0
-  expected=$(cd "$path" && pwd -P) || return 0
+  # These ABORT rather than `return 0`. A repository that has a .claude/worktrees/ but
+  # whose metadata cannot be read is an infrastructure failure, and silently skipping it
+  # let the scheduled wrapper print "done" and exit 0 with that repo never swept.
+  toplevel=$(git -C "$path" rev-parse --show-toplevel 2>/dev/null) || {
+    printf 'worktree-cleanup-all: ABORTING — cannot resolve repository at %s\n' "$path" >&2
+    exit 2; }
+  expected=$(cd "$path" && pwd -P) || {
+    printf 'worktree-cleanup-all: ABORTING — cannot resolve physical path of %s\n' "$path" >&2
+    exit 2; }
   if [ "$toplevel" != "$expected" ]; then
     printf '\n### SKIP %s (broken isolation: toplevel=%s)\n' "$path" "$toplevel"
     return 0

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -170,10 +170,24 @@ if [ -f "$ROOT/.gitmodules" ]; then
     # The query's status is captured separately: an unreadable or corrupt index makes the
     # substitution empty, which would read as "not a gitlink" and silently skip a real
     # submodule while the run still reported success.
-    stage=$(git -C "$ROOT" ls-files --stage -- "$sub" 2>/dev/null); stage_rc=$?
+    # --literal-pathspecs, and the returned pathname is compared EXACTLY. Without it the
+    # path is a pathspec with wildcard magic: `mods/[ab]` matches a real `mods/a` gitlink,
+    # so the check would pass while the literal `mods/[ab]` directory — an ordinary nested
+    # repository — is what actually gets swept. Same metacharacter class as the live-CWD
+    # regex bug, in pathspec form.
+    # --literal-pathspecs is a GIT-LEVEL option; passing it to ls-files is "unknown
+    # option" and yields empty output, which then reads as "not a gitlink" for every
+    # submodule. It must come before the subcommand.
+    stage=$(git -C "$ROOT" --literal-pathspecs ls-files --stage -- "$sub" 2>/dev/null)
+    stage_rc=$?
     if [ "$stage_rc" -ne 0 ]; then
       printf 'worktree-cleanup-all: ABORTING — cannot read the index to validate %s\n' "$sub" >&2
       exit 2
+    fi
+    stage_path=$(printf '%s' "$stage" | head -1 | cut -f2-)
+    if [ "$stage_path" != "$sub" ]; then
+      printf '\n### SKIP %s (index entry resolved to a different path: %s)\n' "$sub" "${stage_path:-<none>}"
+      continue
     fi
     if [ "$(printf '%s' "$stage" | cut -c1-6)" != "160000" ]; then
       printf '\n### SKIP %s (not a gitlink in the index — not a portfolio submodule)\n' "$sub"

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Sweep abandoned per-session worktrees across the monorepo AND every initialised
+# submodule, in one invocation. This is the entry point the scheduled LaunchAgent
+# calls; worktree-cleanup.sh holds the per-repo safety contract.
+#
+# Usage: worktree-cleanup-all.sh [dry-run|apply] [min_age_hours]
+#   dry-run (default) — report only
+#   apply             — reap, recording every removal to a timestamped manifest
+#
+# Manifests live OUTSIDE the repository (they name local paths and branches and must
+# never be committed): ~/.claude/worktree-cleanup-manifests/<repo>-<utc>.tsv
+#
+# The Codex sibling's worktrees under ~/.codex/worktrees are deliberately NOT swept:
+# that lane is owned by the sibling instance (AGENTS.md, Writer namespaces).
+set -uo pipefail
+
+MODE=${1:-dry-run}
+MIN_AGE_HOURS=${2:-24}
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SUT="$SCRIPT_DIR/worktree-cleanup.sh"
+[ -x "$SUT" ] || { printf 'worktree-cleanup-all: missing %s\n' "$SUT" >&2; exit 2; }
+
+# Repo root. WORKTREE_CLEANUP_ROOT lets the script run from outside the checkout
+# (the scheduled launcher does exactly that); otherwise it is two levels up from
+# .claude/scripts.
+if [ -n "${WORKTREE_CLEANUP_ROOT:-}" ]; then
+  ROOT=$(cd "$WORKTREE_CLEANUP_ROOT" 2>/dev/null && pwd -P) \
+    || { printf 'worktree-cleanup-all: WORKTREE_CLEANUP_ROOT not a directory: %s\n' \
+         "$WORKTREE_CLEANUP_ROOT" >&2; exit 2; }
+else
+  ROOT=$(cd "$SCRIPT_DIR/../.." && pwd -P)
+fi
+# When this script runs from inside a session worktree, sweep the MAIN checkout, not
+# the worktree copy — otherwise the sweep only ever sees its own nested tree.
+case "$ROOT" in
+  */.claude/worktrees/*) ROOT=${ROOT%%/.claude/worktrees/*} ;;
+esac
+git -C "$ROOT" rev-parse --show-toplevel >/dev/null 2>&1 \
+  || { printf 'worktree-cleanup-all: not a git repository: %s\n' "$ROOT" >&2; exit 2; }
+
+MANIFEST_DIR="$HOME/.claude/worktree-cleanup-manifests"
+mkdir -p "$MANIFEST_DIR" || { printf 'cannot create %s\n' "$MANIFEST_DIR" >&2; exit 2; }
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+
+printf '=== worktree-cleanup-all  mode=%s  min_age=%sh  root=%s ===\n' \
+  "$MODE" "$MIN_AGE_HOURS" "$ROOT"
+
+sweep() { # <repo_path>
+  local path=$1 label toplevel expected
+  [ -d "$path/.claude/worktrees" ] || return 0
+  # Only sweep a repo whose toplevel resolves to ITSELF. A submodule with broken
+  # worktree isolation resolves into the main checkout, and sweeping through that
+  # alias would operate on the wrong tree (AGENTS.md, Execution model).
+  toplevel=$(git -C "$path" rev-parse --show-toplevel 2>/dev/null) || return 0
+  expected=$(cd "$path" && pwd -P) || return 0
+  if [ "$toplevel" != "$expected" ]; then
+    printf '\n### SKIP %s (broken isolation: toplevel=%s)\n' "$path" "$toplevel"
+    return 0
+  fi
+  local rel=${path#$ROOT/}
+  if [ "$path" = "$ROOT" ]; then rel="(root)"; label=monorepo
+  else label=$(printf '%s' "$rel" | tr '/' '-'); fi
+  printf '\n### %s\n' "$rel"
+  "$SUT" "$path" "$MANIFEST_DIR/$label-$TS.tsv" "$MODE" "$MIN_AGE_HOURS" 2>&1 | tail -3
+}
+
+sweep "$ROOT"
+# Every initialised submodule, from .gitmodules (never a hard-coded list — the
+# portfolio gains and loses submodules over time).
+while IFS= read -r sub; do
+  [ -n "$sub" ] || continue
+  sweep "$ROOT/$sub"
+done < <(git -C "$ROOT" config -f "$ROOT/.gitmodules" --get-regexp '^submodule\..*\.path$' 2>/dev/null | awk '{print $2}')
+
+printf '\n=== done (manifests in %s) ===\n' "$MANIFEST_DIR"

--- a/.claude/scripts/worktree-cleanup-all.sh
+++ b/.claude/scripts/worktree-cleanup-all.sh
@@ -170,12 +170,23 @@ if [ -f "$ROOT/.gitmodules" ]; then
     # The query's status is captured separately: an unreadable or corrupt index makes the
     # substitution empty, which would read as "not a gitlink" and silently skip a real
     # submodule while the run still reported success.
-    stage=$(git -C "$ROOT" ls-files --stage -- "$sub" 2>/dev/null); stage_rc=$?
+    # `:(literal)` because a pathspec is a GLOB by default: a .gitmodules path containing
+    # pathspec metacharacters would otherwise validate a DIFFERENT index entry — `mods/[ab]`
+    # matches a real `mods/a` gitlink — so the check would pass on one path while apply mode
+    # swept the ordinary nested repository at the literal path.
+    stage=$(git -C "$ROOT" ls-files --stage -- ":(literal)$sub" 2>/dev/null); stage_rc=$?
     if [ "$stage_rc" -ne 0 ]; then
       printf 'worktree-cleanup-all: ABORTING — cannot read the index to validate %s\n' "$sub" >&2
       exit 2
     fi
-    if [ "$(printf '%s' "$stage" | cut -c1-6)" != "160000" ]; then
+    # Exactly one entry, whose RECORDED path is exactly $sub, and it is a gitlink. The literal
+    # pathspec above already prevents the glob match; comparing the returned pathname is the
+    # belt-and-braces half, and it also rejects the multi-line result a future pathspec change
+    # could reintroduce — `cut -c1-6` reads only the first line, so two entries would be judged
+    # by whichever sorted first.
+    if [ "$(printf '%s\n' "$stage" | grep -c .)" -ne 1 ] ||
+      [ "$(printf '%s' "$stage" | cut -f2-)" != "$sub" ] ||
+      [ "$(printf '%s' "$stage" | cut -c1-6)" != "160000" ]; then
       printf '\n### SKIP %s (not a gitlink in the index — not a portfolio submodule)\n' "$sub"
       continue
     fi

--- a/.claude/scripts/worktree-cleanup-all.test.sh
+++ b/.claude/scripts/worktree-cleanup-all.test.sh
@@ -137,12 +137,45 @@ t_rejects_bad_mode() {
   rm -rf "$root"
 }
 
+t_validates_args_even_with_no_worktree_dirs() {
+  # With no .claude/worktrees/ anywhere, every per-repo call returns before validating,
+  # so a malformed launcher invocation used to print "done" and exit 0.
+  local root; root=$(make_root)
+  rm -rf "$root/repo/.claude/worktrees" "$root/repo/nested/.claude/worktrees"
+  local out rc
+  out=$(HOME="$root/home" WORKTREE_CLEANUP_ROOT="$root/repo" bash "$SUT" alpply 24 2>&1); rc=$?
+  if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi 'invalid MODE'; then
+    ok "validates MODE even when no repository has a worktree dir"
+  else
+    bad "validates MODE even when no repository has a worktree dir" "rc=$rc $out"
+  fi
+  rm -rf "$root"
+}
+
+t_aborts_on_malformed_gitmodules() {
+  # Both the --get-regexp and the --list probe fail on a malformed file, producing no
+  # output; testing only the probe's emptiness read that as "no submodules" and
+  # silently degraded the sweep to the root repo.
+  local root; root=$(make_root)
+  printf '[submodule "broken"\n\tpath =\n' > "$root/repo/.gitmodules"
+  local out rc
+  out=$(HOME="$root/home" WORKTREE_CLEANUP_ROOT="$root/repo" bash "$SUT" dry-run 24 2>&1); rc=$?
+  if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'ABORTING'; then
+    ok "aborts on a malformed .gitmodules instead of sweeping only the root"
+  else
+    bad "aborts on a malformed .gitmodules instead of sweeping only the root" "rc=$rc $out"
+  fi
+  rm -rf "$root"
+}
+
 printf 'worktree-cleanup-all.sh contract tests\n'
 t_sweeps_root_and_submodules
 t_rewrites_session_worktree_root
 t_skips_broken_isolation
 t_aborts_and_exits_nonzero_on_sweep_failure
 t_per_repo_manifest_isolation
+t_validates_args_even_with_no_worktree_dirs
+t_aborts_on_malformed_gitmodules
 t_rejects_bad_mode
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/scripts/worktree-cleanup-all.test.sh
+++ b/.claude/scripts/worktree-cleanup-all.test.sh
@@ -185,13 +185,50 @@ t_skips_a_gitmodules_entry_that_is_not_a_gitlink() {
   git -C "$root/repo" commit -qm "de-register nested" >/dev/null 2>&1
   local out; out=$(HOME="$root/home" WORKTREE_CLEANUP_ROOT="$root/repo" \
                    bash "$SUT" apply 24 2>&1)
-  if printf '%s' "$out" | grep -q 'SKIP nested (not a gitlink' \
+  # Assert the SAFETY PROPERTY, not one reason string: de-registering the gitlink can be
+  # caught either by the exact-path check (index entry resolves to nothing) or by the
+  # mode check. Both are correct SKIPs; what must hold is that the nested repository is
+  # left alone while the root is still swept.
+  if printf '%s' "$out" | grep -q '### SKIP nested' \
      && [ -d "$root/repo/nested/.claude/worktrees/spent-sub" ] \
      && printf '%s' "$out" | grep -q 'REAPED .*spent-root'; then
     ok "SKIPs a .gitmodules entry that is not a real gitlink"
   else
     bad "SKIPs a .gitmodules entry that is not a real gitlink" \
         "sub_present=$([ -d "$root/repo/nested/.claude/worktrees/spent-sub" ] && echo yes || echo NO) $out"
+  fi
+  rm -rf "$root"
+}
+
+t_gitlink_validation_uses_a_literal_pathspec() {
+  # A .gitmodules path containing pathspec metacharacters must not validate against a
+  # DIFFERENT index entry: `nested[12]` matches the real `nested` gitlink under wildcard
+  # magic, which would let an ordinary nested repository be swept.
+  local root; root=$(make_root)
+  # Point .gitmodules at a metacharacter path that glob-matches the real gitlink, and
+  # make that literal path a real (non-submodule) repository with a spent worktree.
+  printf '[submodule "x"]\n\tpath = nested[12]\n\turl = %s\n' "$root/sub.git" \
+    > "$root/repo/.gitmodules"
+  git init -q -b main "$root/repo/nested[12]"
+  git -C "$root/repo/nested[12]" config user.email t@t.t
+  git -C "$root/repo/nested[12]" config user.name t
+  echo z > "$root/repo/nested[12]/z"; git -C "$root/repo/nested[12]" add z
+  git -C "$root/repo/nested[12]" commit -qm base
+  git -C "$root/repo/nested[12]" remote add origin "$root/sub.git"
+  git -C "$root/repo/nested[12]" fetch -q origin 2>/dev/null || true
+  mkdir -p "$root/repo/nested[12]/.claude/worktrees"
+  git -C "$root/repo/nested[12]" worktree add -q -b claude/victim \
+      "$root/repo/nested[12]/.claude/worktrees/victim" main 2>/dev/null
+  echo "only copy" > "$root/repo/nested[12]/.claude/worktrees/victim/precious.txt"
+  touch -t 202001010000 "$root/repo/nested[12]/.claude/worktrees/victim"
+  local out; out=$(HOME="$root/home" WORKTREE_CLEANUP_ROOT="$root/repo" \
+                   bash "$SUT" apply 24 2>&1)
+  if [ -f "$root/repo/nested[12]/.claude/worktrees/victim/precious.txt" ] \
+     && printf '%s' "$out" | grep -q 'SKIP nested\[12\]'; then
+    ok "gitlink validation uses a literal pathspec (metacharacter path is SKIPped)"
+  else
+    bad "gitlink validation uses a literal pathspec (metacharacter path is SKIPped)" \
+        "victim=$([ -f "$root/repo/nested[12]/.claude/worktrees/victim/precious.txt" ] && echo present || echo GONE) $out"
   fi
   rm -rf "$root"
 }
@@ -205,6 +242,7 @@ t_per_repo_manifest_isolation
 t_validates_args_even_with_no_worktree_dirs
 t_aborts_on_malformed_gitmodules
 t_skips_a_gitmodules_entry_that_is_not_a_gitlink
+t_gitlink_validation_uses_a_literal_pathspec
 t_rejects_bad_mode
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/scripts/worktree-cleanup-all.test.sh
+++ b/.claude/scripts/worktree-cleanup-all.test.sh
@@ -36,6 +36,14 @@ make_root() {
   git -C "$root/repo/nested" push -q origin main
   printf '[submodule "nested"]\n\tpath = nested\n\turl = %s\n' "$root/sub.git" \
     > "$root/repo/.gitmodules"
+  # Register it as a REAL gitlink (mode 160000). The orchestrator requires this: a
+  # .gitmodules entry alone can name an ordinary nested repository, which is not a
+  # portfolio submodule and must not be swept.
+  local nsha; nsha=$(git -C "$root/repo/nested" rev-parse HEAD)
+  git -C "$root/repo" update-index --add --cacheinfo "160000,$nsha,nested"
+  git -C "$root/repo" add .gitmodules
+  git -C "$root/repo" commit -qm "register nested as a submodule"
+  git -C "$root/repo" push -q origin main
 
   for pair in "repo:spent-root" "repo/nested:spent-sub"; do
     local r=${pair%%:*} n=${pair##*:}
@@ -168,6 +176,26 @@ t_aborts_on_malformed_gitmodules() {
   rm -rf "$root"
 }
 
+t_skips_a_gitmodules_entry_that_is_not_a_gitlink() {
+  # Containment is not sufficient: a stale or malformed .gitmodules entry can name an
+  # ordinary nested repository INSIDE the root, which is not a portfolio submodule and
+  # must never be swept destructively.
+  local root; root=$(make_root)
+  git -C "$root/repo" rm -q --cached nested >/dev/null 2>&1   # drop the gitlink, keep the dir
+  git -C "$root/repo" commit -qm "de-register nested" >/dev/null 2>&1
+  local out; out=$(HOME="$root/home" WORKTREE_CLEANUP_ROOT="$root/repo" \
+                   bash "$SUT" apply 24 2>&1)
+  if printf '%s' "$out" | grep -q 'SKIP nested (not a gitlink' \
+     && [ -d "$root/repo/nested/.claude/worktrees/spent-sub" ] \
+     && printf '%s' "$out" | grep -q 'REAPED .*spent-root'; then
+    ok "SKIPs a .gitmodules entry that is not a real gitlink"
+  else
+    bad "SKIPs a .gitmodules entry that is not a real gitlink" \
+        "sub_present=$([ -d "$root/repo/nested/.claude/worktrees/spent-sub" ] && echo yes || echo NO) $out"
+  fi
+  rm -rf "$root"
+}
+
 printf 'worktree-cleanup-all.sh contract tests\n'
 t_sweeps_root_and_submodules
 t_rewrites_session_worktree_root
@@ -176,6 +204,7 @@ t_aborts_and_exits_nonzero_on_sweep_failure
 t_per_repo_manifest_isolation
 t_validates_args_even_with_no_worktree_dirs
 t_aborts_on_malformed_gitmodules
+t_skips_a_gitmodules_entry_that_is_not_a_gitlink
 t_rejects_bad_mode
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/scripts/worktree-cleanup-all.test.sh
+++ b/.claude/scripts/worktree-cleanup-all.test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Contract tests for worktree-cleanup-all.sh — the multi-repo orchestrator.
+#
+# worktree-cleanup.test.sh covers the per-repo safety gates. The orchestrator carries
+# contracts of its own that nothing else pins: the session-worktree root rewrite, the
+# broken-isolation SKIP, per-repo manifest isolation, and abort-on-first-failure.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SUT="$SCRIPT_DIR/worktree-cleanup-all.sh"
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+
+# A root repo with one submodule-like nested repo, each carrying a spent worktree.
+make_root() {
+  local root; root=$(mktemp -d); root=$(cd "$root" && pwd -P)
+  for r in main sub; do
+    git init -q --bare "$root/$r.git"
+  done
+  git init -q -b main "$root/repo"
+  git -C "$root/repo" config user.email t@t.t; git -C "$root/repo" config user.name t
+  echo base > "$root/repo/f"; git -C "$root/repo" add f
+  git -C "$root/repo" commit -qm base
+  git -C "$root/repo" remote add origin "$root/main.git"
+  git -C "$root/repo" push -q origin main
+
+  # A nested independent repo standing in for a submodule, plus .gitmodules naming it.
+  git init -q -b main "$root/repo/nested"
+  git -C "$root/repo/nested" config user.email t@t.t
+  git -C "$root/repo/nested" config user.name t
+  echo n > "$root/repo/nested/g"; git -C "$root/repo/nested" add g
+  git -C "$root/repo/nested" commit -qm base
+  git -C "$root/repo/nested" remote add origin "$root/sub.git"
+  git -C "$root/repo/nested" push -q origin main
+  printf '[submodule "nested"]\n\tpath = nested\n\turl = %s\n' "$root/sub.git" \
+    > "$root/repo/.gitmodules"
+
+  for pair in "repo:spent-root" "repo/nested:spent-sub"; do
+    local r=${pair%%:*} n=${pair##*:}
+    mkdir -p "$root/$r/.claude/worktrees"
+    git -C "$root/$r" worktree add -q -b "claude/$n" "$root/$r/.claude/worktrees/$n" main
+    git -C "$root/$r" push -q origin "claude/$n"
+    touch -t 202001010000 "$root/$r/.claude/worktrees/$n"
+  done
+  printf '%s' "$root"
+}
+
+t_sweeps_root_and_submodules() {
+  local root; root=$(make_root)
+  local out; out=$(HOME="$root/home" WORKTREE_CLEANUP_ROOT="$root/repo" \
+                   bash "$SUT" dry-run 24 2>&1)
+  if printf '%s' "$out" | grep -q 'REAP  .*spent-root' \
+     && printf '%s' "$out" | grep -q 'REAP  .*spent-sub'; then
+    ok "sweeps the root AND every submodule from .gitmodules"
+  else
+    bad "sweeps the root AND every submodule from .gitmodules" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_rewrites_session_worktree_root() {
+  # Invoked with a root INSIDE .claude/worktrees/, it must sweep the MAIN checkout —
+  # otherwise a run launched from a session worktree only ever sees its own nested tree.
+  local root; root=$(make_root)
+  local inner="$root/repo/.claude/worktrees/spent-root"
+  local out; out=$(HOME="$root/home" WORKTREE_CLEANUP_ROOT="$inner" \
+                   bash "$SUT" dry-run 24 2>&1)
+  # NB: match the banner's trailing " ===" rather than anchoring with $ — the path is
+  # not at end-of-line, so a $ anchor never matches even when the rewrite is correct.
+  if printf '%s' "$out" | grep -qF "root=$root/repo ==="; then
+    ok "rewrites a session-worktree root to the main checkout"
+  else
+    bad "rewrites a session-worktree root to the main checkout" \
+        "$(printf '%s' "$out" | head -3)"
+  fi
+  rm -rf "$root"
+}
+
+t_skips_broken_isolation() {
+  # A submodule path whose toplevel resolves elsewhere must be SKIPPED, never swept
+  # through the alias (that would operate on the wrong tree entirely).
+  local root; root=$(make_root)
+  rm -rf "$root/repo/nested/.git"          # now resolves up to the parent repo
+  mkdir -p "$root/repo/nested/.claude/worktrees"
+  local out; out=$(HOME="$root/home" WORKTREE_CLEANUP_ROOT="$root/repo" \
+                   bash "$SUT" dry-run 24 2>&1)
+  if printf '%s' "$out" | grep -q 'SKIP .*nested .*broken isolation'; then
+    ok "SKIPs a submodule with broken worktree isolation"
+  else
+    bad "SKIPs a submodule with broken worktree isolation" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_aborts_and_exits_nonzero_on_sweep_failure() {
+  # An infrastructure failure in one repo must stop the run and surface a nonzero exit,
+  # not be swallowed by the `| tail` pipeline and the trailing success banner.
+  local root; root=$(make_root)
+  local shim="$root/shim"; mkdir -p "$shim"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$shim/lsof"   # force the fail-closed abort
+  chmod +x "$shim/lsof"
+  local out rc
+  out=$(PATH="$shim:$PATH" HOME="$root/home" WORKTREE_CLEANUP_ROOT="$root/repo" \
+        bash "$SUT" dry-run 24 2>&1); rc=$?
+  if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'ABORTING'; then
+    ok "aborts and exits nonzero when a sweep fails"
+  else
+    bad "aborts and exits nonzero when a sweep fails" "rc=$rc $(printf '%s' "$out" | tail -3)"
+  fi
+  rm -rf "$root"
+}
+
+t_per_repo_manifest_isolation() {
+  local root; root=$(make_root)
+  HOME="$root/home" WORKTREE_CLEANUP_ROOT="$root/repo" bash "$SUT" apply 24 >/dev/null 2>&1
+  local n; n=$(ls -1 "$root/home/.claude/worktree-cleanup-manifests/"*.tsv 2>/dev/null | wc -l | tr -d ' ')
+  if [ "${n:-0}" -ge 2 ]; then
+    ok "writes a separate manifest per repository"
+  else
+    bad "writes a separate manifest per repository" \
+        "manifests=$n $(ls -1 "$root/home/.claude/worktree-cleanup-manifests/" 2>&1)"
+  fi
+  rm -rf "$root"
+}
+
+t_rejects_bad_mode() {
+  local root; root=$(make_root)
+  HOME="$root/home" WORKTREE_CLEANUP_ROOT="$root/repo" bash "$SUT" alpply 24 >/dev/null 2>&1
+  local rc=$?
+  if [ "$rc" -ne 0 ] && [ -d "$root/repo/.claude/worktrees/spent-root" ]; then
+    ok "rejects an invalid MODE without deleting anything"
+  else
+    bad "rejects an invalid MODE without deleting anything" "rc=$rc"
+  fi
+  rm -rf "$root"
+}
+
+printf 'worktree-cleanup-all.sh contract tests\n'
+t_sweeps_root_and_submodules
+t_rewrites_session_worktree_root
+t_skips_broken_isolation
+t_aborts_and_exits_nonzero_on_sweep_failure
+t_per_repo_manifest_isolation
+t_rejects_bad_mode
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -349,8 +349,17 @@ for wt in "$WT_ROOT"/*/; do
 
   # --- REAP ------------------------------------------------------------------------
   sz_kb=$(du -sk "$wt" 2>/dev/null | cut -f1); sz_kb=${sz_kb:-0}
+  # Ignored files are NOT a KEEP reason — 70 of 80 worktrees on the reference host carry
+  # build output or caches, so keeping on them would make the sweep reclaim nothing and
+  # leave the disk-full condition this tool exists for unresolved. They are counted and
+  # surfaced instead, so what a reap discards is visible in the output and the manifest
+  # rather than silent. (min_age_hours, the live/lock re-checks, the manifest and
+  # refs/reaped are what bound the residual risk.)
+  ign=$(git -C "$wt" status --porcelain --ignored=matching --untracked-files=all 2>/dev/null \
+        | grep -c '^!!' ) || ign=0
+  ign_note=""; [ "${ign:-0}" -gt 0 ] && ign_note=" +${ign} ignored"
   if [ "$MODE" = "dry-run" ]; then
-    printf 'REAP   %-52s %s (%s MB)\n' "$name" "$branch" "$((sz_kb/1024))"
+    printf 'REAP   %-52s %s (%s MB%s)\n' "$name" "$branch" "$((sz_kb/1024))" "$ign_note"
     reaped=$((reaped+1)); freed_kb=$((freed_kb+sz_kb))
     continue
   fi
@@ -359,7 +368,7 @@ for wt in "$WT_ROOT"/*/; do
   # the ledger is unwritable, so every subsequent removal would be unrecorded too.
   # Aborting (rather than keeping and carrying on) is what stops the wrapper reporting
   # a healthy sweep — which matters most under the disk pressure this tool exists for.
-  if ! record "$wt_real" "$branch" "$sha" "reachable-from-remote;no-live-process;age=${age_h}h" pending; then
+  if ! record "$wt_real" "$branch" "$sha" "reachable-from-remote;no-live-process;age=${age_h}h;ignored=${ign:-0}" pending; then
     die "cannot write the restore manifest ($MANIFEST) — aborting before any removal"
   fi
   # Containment assertion before ANY recursive delete. $wt_real is derived from a glob
@@ -402,6 +411,17 @@ for wt in "$WT_ROOT"/*/; do
   # cannot be restored. One ref per commit; the name is the SHA, so it is idempotent.
   # This is a PRECONDITION of removal, not best-effort: no restore ref, no deletion —
   # the same rule the manifest write already follows.
+  # HEAD is re-read immediately before it is preserved. A commit made between the
+  # reachability check and here (a concurrent `git -C` whose CWD is outside the
+  # worktree, so the liveness gate does not see it) leaves the working tree clean while
+  # $sha still names the OLD commit — preserving that and deleting the worktree would
+  # discard the new one.
+  sha_now=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || {
+    keep "$wt" "cannot re-read HEAD before removal"; continue; }
+  if [ "$sha_now" != "$sha" ]; then
+    keep "$wt" "HEAD moved during the sweep ($sha -> $sha_now)"; continue
+  fi
+
   if ! git -C "$TOPLEVEL" update-ref "refs/reaped/$sha" "$sha" 2>/dev/null; then
     keep "$wt" "could not write refs/reaped/$sha — refusing to remove"; continue
   fi
@@ -422,7 +442,7 @@ for wt in "$WT_ROOT"/*/; do
     # than leaving an unmatched `pending` that looks like an aborted attempt.
     record "$wt_real" "$branch" "$sha" "removed" reaped \
       || die "REMOVED $wt_real but could not append its 'reaped' row. The deletion DID happen: a 'pending' row whose path no longer exists means deleted, not aborted (restore ref: refs/reaped/$sha)"
-    printf 'REAPED %-52s %s (%s MB)\n' "$name" "$branch" "$((sz_kb/1024))"
+    printf 'REAPED %-52s %s (%s MB%s)\n' "$name" "$branch" "$((sz_kb/1024))" "$ign_note"
     reaped=$((reaped+1)); freed_kb=$((freed_kb+sz_kb))
   else
     keep "$wt" "removal FAILED"
@@ -431,7 +451,11 @@ done
 
 # Drop admin entries whose directory is already gone.
 if [ "$MODE" = "apply" ]; then
-  git -C "$TOPLEVEL" worktree prune 2>/dev/null || true
+  # Not best-effort: this prune is what clears missing-worktree registrations, and
+  # branch-cleanup.sh builds its keep-set from `git worktree list`. A silently failed
+  # prune therefore leaves stale entries pinning branches that should be sweepable.
+  git -C "$TOPLEVEL" worktree prune 2>/dev/null \
+    || die "reaped $reaped worktree(s) but 'git worktree prune' failed — stale registrations remain and will pin their branches in branch-cleanup.sh"
 fi
 
 printf '\nworktree-cleanup: mode=%s reaped=%d kept=%d freed=%d MB\n' \

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -375,6 +375,23 @@ for wt in "$WT_ROOT"/*/; do
     keep "$wt" "age ${age_h}h < ${MIN_AGE_HOURS}h"; continue
   fi
 
+  # KEEP: an in-progress git operation. A worktree mid-rebase, -merge, -cherry-pick,
+  # -revert or -bisect holds that operation's state (and often a stash of conflicted
+  # work) only in its own admin directory, so removing it destroys work that no commit
+  # and no reflog entry accounts for. `git rev-parse --git-path` resolves these per
+  # worktree, which is what makes the check correct for a linked worktree.
+  gitdir=$(git -C "$wt" rev-parse --absolute-git-dir 2>/dev/null); gitdir_rc=$?
+  if [ "$gitdir_rc" -ne 0 ] || [ -z "$gitdir" ]; then
+    keep "$wt" "cannot resolve its git dir"; continue
+  fi
+  inprogress=""
+  for marker in rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
+    if [ -e "$gitdir/$marker" ]; then inprogress=$marker; break; fi
+  done
+  if [ -n "$inprogress" ]; then
+    keep "$wt" "git operation in progress ($inprogress)"; continue
+  fi
+
   # KEEP: unresolvable HEAD
   sha=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || { keep "$wt" "no HEAD"; continue; }
   branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null || echo "(detached)")

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -49,8 +49,18 @@
 # write is verified — no restore record, no removal. dry-run never touches the manifest.
 # Rows are `path -> branch -> sha -> evidence -> outcome`, where outcome is `pending`
 # (written before deleting) or `reaped` (appended only once the directory is gone).
-# A `pending` with no matching `reaped` is an ABORTED attempt, not a deletion — restore
-# and audit tooling must key on `reaped`.
+#
+# READING THE LEDGER — the rule is TOTAL, because the completion write can itself fail
+# after a successful removal (disk full, permissions changed mid-run). Outcome alone is
+# therefore not sufficient; reconcile it against the path:
+#
+#   reaped                      -> deleted
+#   pending + path EXISTS       -> aborted attempt (nothing was removed)
+#   pending + path ABSENT       -> deleted; the completion write failed
+#
+# The third case exits NON-ZERO so the failure is never silent, and the wrapper
+# propagates it. Tooling that keys solely on `reaped` would misread that case as an
+# abort and leave a real deletion unaccounted for.
 set -uo pipefail
 
 REPO_PATH=${1:-}
@@ -345,8 +355,11 @@ for wt in "$WT_ROOT"/*/; do
   if git -C "$TOPLEVEL" worktree remove --force "$wt_real" 2>/dev/null \
      || { ! is_locked_now "$wt_real" && rm -rf "$wt_real" && git -C "$TOPLEVEL" worktree prune; }; then
     # Completion row — written only now that the directory is actually gone.
+    # The directory is already gone at this point, so a failed completion write cannot
+    # be undone. Exit non-zero and say exactly how to read the resulting ledger, rather
+    # than leaving an unmatched `pending` that looks like an aborted attempt.
     record "$wt_real" "$branch" "$sha" "removed" reaped \
-      || die "removed $wt_real but could not record its completion — aborting"
+      || die "REMOVED $wt_real but could not append its 'reaped' row. The deletion DID happen: a 'pending' row whose path no longer exists means deleted, not aborted (restore ref: refs/reaped/$sha)"
     printf 'REAPED %-52s %s (%s MB)\n' "$name" "$branch" "$((sz_kb/1024))"
     reaped=$((reaped+1)); freed_kb=$((freed_kb+sz_kb))
   else

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -327,7 +327,12 @@ count_real_changes() {
 for wt in "$WT_ROOT"/*/; do
   [ -d "$wt" ] || continue
   wt=${wt%/}
-  wt_real=$(cd "$wt" 2>/dev/null && pwd -P) || { keep "$wt" "unreadable"; continue; }
+  # A candidate that EXISTS (the glob matched a directory) but cannot be resolved is an
+  # infrastructure failure — permissions, a broken mount — not a verdict about this
+  # worktree. Reporting it as an ordinary KEEP let the run exit 0 while silently unable
+  # to inspect part of the tree.
+  wt_real=$(cd "$wt" 2>/dev/null && pwd -P) \
+    || die "cannot resolve candidate worktree $wt — refusing to continue on an uninspectable tree"
   name=$(basename "$wt")
 
   # KEEP: anything git does not know as a worktree. Never a deletion candidate.

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -28,10 +28,17 @@
 #           (`git rev-list <head> --not --remotes`) covers both an unpushed branch and a
 #           detached HEAD left on an orphan commit — the only states where removing the
 #           directory would destroy the sole copy of real work.
-#   KEEP  - a worktree with modified TRACKED files, other than submodule gitlinks
+#   KEEP  - a worktree with modified TRACKED files, other than UNSTAGED gitlink drift
 #   KEEP  - a worktree with untracked files outside the known tool-noise set
 #   KEEP  - a worktree whose modified submodule itself has uncommitted or unpushed work
-#   ABORT - on any infrastructure failure (worktree list, lsof, manifest write)
+#   KEEP  - a worktree locked at removal time, re-checked live (never overridden by
+#           --force, and never removed by the rm -rf fallback either)
+#   ABORT - on any infrastructure failure (worktree list, lsof — including a partial
+#           enumeration that exits nonzero — or a manifest write), and the multi-repo
+#           wrapper propagates that abort instead of reporting a successful sweep
+#
+# Every reaped commit also gets a refs/reaped/<sha> ref, so the manifest's SHA stays
+# restorable even if a stale remote-tracking ref is later pruned and gc runs.
 #
 # Submodule gitlink drift (` M applications/ksail`) and stray tool dirs (`?? .codex/`)
 # are NOT authored work — they are an artifact of the submodule checkout sitting at a
@@ -79,7 +86,15 @@ fi
 # --- infrastructure: the live-process CWD set -------------------------------------
 # A failure here must ABORT, never yield an empty set: an empty set would read as
 # "no session is live" and reap every worktree currently in use.
-LIVE_CWDS=$(lsof -a -d cwd -F n 2>/dev/null | grep '^n' | sed 's/^n//' | sort -u)
+# lsof's own exit status is checked SEPARATELY from the filtering pipeline. A partial
+# enumeration (permission/scan failure) can still print plenty of CWDs while exiting
+# nonzero; treating that truncated list as complete would silently drop a live session
+# and reap it. Non-empty is NOT the same as complete.
+LIVE_RAW=$(lsof -a -d cwd -F n 2>/dev/null); lsof_rc=$?
+if [ "$lsof_rc" -ne 0 ]; then
+  die "lsof exited $lsof_rc — refusing to run on a possibly partial CWD list"
+fi
+LIVE_CWDS=$(printf '%s\n' "$LIVE_RAW" | grep '^n' | sed 's/^n//' | sort -u)
 if [ -z "$LIVE_CWDS" ]; then
   die "lsof returned no CWDs at all — refusing to run (cannot prove which worktrees are live)"
 fi
@@ -109,6 +124,16 @@ record() { # path branch sha evidence
 
 keep() { kept=$((kept+1)); printf 'KEEP   %-52s %s\n' "$(basename "$1")" "$2"; }
 
+# is_locked_now <resolved-worktree-path> — re-queries git rather than consulting the
+# startup snapshot, so a lock taken DURING the sweep is still honoured.
+is_locked_now() {
+  git -C "$TOPLEVEL" worktree list --porcelain 2>/dev/null \
+    | awk -v target="$1" '
+        /^worktree /{p=substr($0,10)}
+        /^locked/{if (p==target) found=1}
+        END{exit found?0:1}'
+}
+
 # count_real_changes <worktree> <porcelain-status> -> sets $REAL_CHANGES
 # Counts porcelain entries that represent AUTHORED work. Submodule gitlink drift and
 # known tool-noise dirs are excluded — but a gitlink counts as real work the moment the
@@ -131,7 +156,11 @@ count_real_changes() {
           *) REAL_CHANGES=$((REAL_CHANGES+1)) ;;
         esac
         ;;
-      ' M'|'M '|'MM')
+      ' M')
+        # ONLY the unstaged form is drift. A STAGED gitlink update (`M ` / `MM`) is
+        # deliberate authored intent, and it lives solely in this worktree's own index —
+        # removing the worktree destroys it with no commit to recover from. Those fall
+        # through to the default branch below and count as real work.
         if [ -e "$wt/$path/.git" ]; then
           sub_status=$(git -C "$wt/$path" status --porcelain 2>/dev/null)
           sub_sha=$(git -C "$wt/$path" rev-parse HEAD 2>/dev/null)
@@ -234,8 +263,21 @@ for wt in "$WT_ROOT"/*/; do
     *) keep "$wt" "REFUSING to remove: '$wt_real' is not under '$WT_ROOT'"; continue ;;
   esac
 
+  # Re-check the lock against LIVE state, not the snapshot taken at startup. A lock
+  # acquired while this sweep was running would otherwise be overridden by --force,
+  # which git documents as "force removal even if worktree is dirty or locked".
+  if is_locked_now "$wt_real"; then
+    keep "$wt" "locked (acquired since the startup snapshot)"; continue
+  fi
+
+  # Keep the reaped commit reachable so the manifest's SHA stays restorable. Without
+  # this, a stale remote-tracking ref can make a commit look pushed, and a later
+  # fetch --prune + gc would collect the only copy — leaving a manifest entry that
+  # cannot be restored. One ref per commit; the name is the SHA, so it is idempotent.
+  git -C "$TOPLEVEL" update-ref "refs/reaped/$sha" "$sha" 2>/dev/null || true
+
   if git -C "$TOPLEVEL" worktree remove --force "$wt_real" 2>/dev/null \
-     || { rm -rf "$wt_real" && git -C "$TOPLEVEL" worktree prune; }; then
+     || { ! is_locked_now "$wt_real" && rm -rf "$wt_real" && git -C "$TOPLEVEL" worktree prune; }; then
     printf 'REAPED %-52s %s (%s MB)\n' "$name" "$branch" "$((sz_kb/1024))"
     reaped=$((reaped+1)); freed_kb=$((freed_kb+sz_kb))
   else

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -155,9 +155,20 @@ for wt in "$WT_ROOT"/*/; do
   wt_real=$(cd "$wt" 2>/dev/null && pwd -P) || { keep "$wt" "unreadable"; continue; }
   name=$(basename "$wt")
 
-  # KEEP: a live session's CWD (exact dir, or any descendant of it)
-  if printf '%s\n' "$LIVE_CWDS" | grep -qxF "$wt_real" \
-     || printf '%s\n' "$LIVE_CWDS" | grep -q "^$wt_real/"; then
+  # KEEP: a live session's CWD (the worktree itself, or any directory inside it).
+  # Both comparisons are LITERAL. An earlier version matched descendants with
+  # `grep "^$wt_real/"`, which treats the path as a REGEX: a worktree name containing
+  # an unbalanced '[' made grep error out, the descendant check silently reported "no
+  # match", and a live session working in a SUBDIRECTORY fell through to the reap
+  # gates — a fail-OPEN on the one signal that protects running sessions.
+  live=0
+  while IFS= read -r cwd; do
+    [ -n "$cwd" ] || continue
+    if [ "$cwd" = "$wt_real" ] || [ "${cwd#"$wt_real"/}" != "$cwd" ]; then
+      live=1; break
+    fi
+  done <<< "$LIVE_CWDS"
+  if [ "$live" -eq 1 ]; then
     keep "$wt" "live process CWD"; continue
   fi
 

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -177,9 +177,15 @@ for wt in "$WT_ROOT"/*/; do
     keep "$wt" "locked"; continue
   fi
 
-  # KEEP: too young
-  mtime=$(stat -f %m "$wt" 2>/dev/null || stat -c %Y "$wt" 2>/dev/null) || {
-    keep "$wt" "cannot stat"; continue; }
+  # KEEP: too young.
+  # Validate that mtime is NUMERIC rather than trusting stat's exit status. GNU stat
+  # reads `-f` as "filesystem status", so `stat -f %m` does not fail on Linux — it
+  # SUCCEEDS and prints a `File: ...` block, the `||` fallback never fires, and the
+  # arithmetic below then treats `File:` as a variable name (unbound under set -u).
+  # GNU form first, BSD second, each accepted only if it yields digits.
+  mtime=$(stat -c %Y "$wt" 2>/dev/null || true)
+  case "$mtime" in ''|*[!0-9]*) mtime=$(stat -f %m "$wt" 2>/dev/null || true) ;; esac
+  case "$mtime" in ''|*[!0-9]*) keep "$wt" "cannot stat"; continue ;; esac
   age_h=$(( (now - mtime) / 3600 ))
   if [ "$age_h" -lt "$MIN_AGE_HOURS" ]; then
     keep "$wt" "age ${age_h}h < ${MIN_AGE_HOURS}h"; continue

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -336,7 +336,9 @@ for wt in "$WT_ROOT"/*/; do
   if [ "$idx_rc" -ne 0 ]; then
     keep "$wt" "cannot read index flags"; continue
   fi
-  if printf '%s\n' "$idx_flags" | grep -q '^[a-z]'; then
+  # `S` (uppercase) is skip-worktree — the comment above said so while the pattern
+  # matched lowercase only, so the very case that motivated this gate slipped through.
+  if printf '%s\n' "$idx_flags" | grep -q '^[a-zS]'; then
     keep "$wt" "assume-unchanged/skip-worktree files present (status cannot see edits)"
     continue
   fi
@@ -379,6 +381,19 @@ for wt in "$WT_ROOT"/*/; do
   # Same re-check for liveness: a session may have started here since the snapshot.
   if is_live_now "$wt_real"; then
     keep "$wt" "live process CWD (started since the startup snapshot)"; continue
+  fi
+
+  # And re-check the working tree: a session may have written files between the status
+  # gate above and this point, and `--force` would delete them regardless.
+  recheck_status=$(git -C "$wt" status --porcelain --untracked-files=all 2>/dev/null)
+  recheck_rc=$?
+  if [ "$recheck_rc" -ne 0 ]; then
+    keep "$wt" "cannot re-read status before removal"; continue
+  fi
+  count_real_changes "$wt" "$recheck_status"
+  if [ "$REAL_CHANGES" -gt 0 ]; then
+    keep "$wt" "$REAL_CHANGES uncommitted change(s) appeared since the status gate"
+    continue
   fi
 
   # Keep the reaped commit reachable so the manifest's SHA stays restorable. Without

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -92,7 +92,15 @@ TOPLEVEL=$(cd "$TOPLEVEL" && pwd -P) || die "cannot resolve toplevel"
 WT_ROOT="$TOPLEVEL/.claude/worktrees"
 
 if [ ! -d "$WT_ROOT" ]; then
-  printf 'worktree-cleanup: no worktree root at %s — nothing to do\n' "$WT_ROOT"
+  # Still prune. A repository whose worktree directories (and .claude/worktrees itself)
+  # are already gone can retain STALE registrations, and those keep pinning their
+  # branches in branch-cleanup.sh's keep-set — the coupling this tool exists to break.
+  # Returning early here left exactly that state unrepairable.
+  if [ "$MODE" = "apply" ]; then
+    git -C "$TOPLEVEL" worktree prune 2>/dev/null \
+      || die "no worktree root at $WT_ROOT and 'git worktree prune' failed — stale registrations remain"
+  fi
+  printf 'worktree-cleanup: no worktree root at %s — pruned stale registrations only\n' "$WT_ROOT"
   exit 0
 fi
 
@@ -293,16 +301,19 @@ count_real_changes() {
           if [ "$sub_status_rc" -ne 0 ] || [ -n "$sub_status" ] \
              || [ -z "$sub_unpushed" ] || [ "$sub_unpushed" -gt 0 ]; then
             REAL_CHANGES=$((REAL_CHANGES+1))
-          else
-            # Disposable only because the commit is reachable from a remote-tracking ref
-            # — which can be STALE (upstream branch deleted or force-pushed). Preserve it
-            # in the submodule the same way the parent's HEAD is preserved, so a later
-            # fetch --prune + gc cannot collect the only copy. Failure to preserve makes
-            # it authored work again rather than silently disposable.
-            if ! git -C "$wt/$path" update-ref "refs/reaped/$sub_sha" "$sub_sha" 2>/dev/null; then
-              REAL_CHANGES=$((REAL_CHANGES+1))
-            fi
           fi
+          # ACCEPTED LIMITATION, stated rather than papered over: this treats the drift as
+          # disposable because the submodule commit is reachable from a remote-tracking
+          # ref, and that ref can be STALE (upstream deleted or force-pushed).
+          # An earlier attempt to mitigate it with a refs/reaped ref inside the submodule
+          # was WRONG twice over and is deliberately not reinstated: for a linked
+          # worktree the submodule repository lives under
+          # .git/worktrees/<id>/modules/..., which `worktree remove` deletes — so the ref
+          # died with the thing it was meant to outlive — and because this function also
+          # runs in dry-run, it made "report only" mutate the repository.
+          # There is no durable place to preserve a linked worktree's submodule object
+          # from here, so the exposure is documented instead of hidden behind an
+          # ineffective write.
         else
           REAL_CHANGES=$((REAL_CHANGES+1))
         fi
@@ -409,6 +420,29 @@ for wt in "$WT_ROOT"/*/; do
   count_real_changes "$wt" "$status"
   if [ "$REAL_CHANGES" -gt 0 ]; then
     keep "$wt" "$REAL_CHANGES uncommitted change(s)"; continue
+  fi
+
+  # KEEP: a registered worktree nested INSIDE this one. The untracked-directory signal
+  # is not enough — a repository that gitignores .claude/worktrees/ emits no status entry
+  # for it at all, and reaping the parent would recursively delete the nested worktree
+  # and any uncommitted work only it holds. The registered list is authoritative here and
+  # owes nothing to ignore rules.
+  nested=$(awk -v p="$wt_real/" 'index($0,p)==1' <<< "$REGISTERED" | head -1)
+  if [ -n "$nested" ]; then
+    keep "$wt" "contains a registered worktree ($(basename "$nested"))"; continue
+  fi
+
+  # KEEP: commits in this worktree's own HEAD reflog that exist nowhere else. HEAD may be
+  # remotely reachable while the reflog still holds an earlier unpushed commit (commit,
+  # then reset back to a pushed one). The per-worktree reflog dies with the directory, so
+  # that commit's only reference would go with it.
+  reflog_shas=$(git -C "$wt" reflog show --format=%H HEAD 2>/dev/null); reflog_rc=$?
+  if [ "$reflog_rc" -eq 0 ] && [ -n "$reflog_shas" ]; then
+    orphaned=$(git -C "$TOPLEVEL" rev-list --no-walk $reflog_shas --not --remotes 2>/dev/null | head -1)
+    if [ -n "$orphaned" ]; then
+      keep "$wt" "HEAD reflog holds commit(s) reachable from nowhere else (${orphaned:0:12})"
+      continue
+    fi
   fi
 
   # --- REAP ------------------------------------------------------------------------

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -97,8 +97,13 @@ now=$(date +%s)
 reaped=0; kept=0; freed_kb=0
 
 record() { # path branch sha evidence
-  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >> "$MANIFEST" || return 1
-  grep -qF "$1" "$MANIFEST" || return 1   # verify the write landed
+  local line
+  line=$(printf '%s\t%s\t%s\t%s' "$1" "$2" "$3" "$4")
+  printf '%s\n' "$line" >> "$MANIFEST" || return 1
+  # Verify the WHOLE record landed, not just the path: a path substring is already
+  # present whenever the same worktree was reaped in an earlier sweep, so a
+  # path-only check would confirm a write that never happened.
+  grep -qxF -- "$line" "$MANIFEST" || return 1
   return 0
 }
 
@@ -203,6 +208,15 @@ for wt in "$WT_ROOT"/*/; do
   if ! record "$wt_real" "$branch" "$sha" "reachable-from-remote;no-live-process;age=${age_h}h"; then
     keep "$wt" "MANIFEST WRITE FAILED — refusing to remove"; continue
   fi
+  # Containment assertion before ANY recursive delete. $wt_real is derived from a glob
+  # under $WT_ROOT and should always sit beneath it, but `rm -rf` is unforgiving enough
+  # that the invariant is asserted rather than assumed — a bug upstream of here must not become a recursive delete of the checkout (or of /).
+  # (belt-and-braces; the glob already constrains it)
+  case "$wt_real" in
+    "$WT_ROOT"/?*) : ;;
+    *) keep "$wt" "REFUSING to remove: '$wt_real' is not under '$WT_ROOT'"; continue ;;
+  esac
+
   if git -C "$TOPLEVEL" worktree remove --force "$wt_real" 2>/dev/null \
      || { rm -rf "$wt_real" && git -C "$TOPLEVEL" worktree prune; }; then
     printf 'REAPED %-52s %s (%s MB)\n' "$name" "$branch" "$((sz_kb/1024))"

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -527,25 +527,30 @@ for wt in "$WT_ROOT"/*/; do
   # The fallback re-runs the FULL mutable-gate set, not just the lock: the failed
   # `worktree remove` above can take time, and a session entering the worktree in that
   # window must still stop the recursive delete.
-  if git -C "$TOPLEVEL" worktree remove --force "$wt_real" 2>/dev/null \
-     || { recheck_mutable_gates "$wt" "$wt_real" && rm -rf "$wt_real" && [ ! -e "$wt_real" ] \
-          && { git -C "$TOPLEVEL" worktree prune 2>/dev/null \
-               || die "REMOVED $wt_real but 'git worktree prune' failed — the deletion DID happen; run 'git -C $TOPLEVEL worktree prune' to clear its admin entry (restore ref: refs/reaped/$sha)"; }; }; then
-    # Completion row — written only now that the directory is actually gone.
-    # The directory is already gone at this point, so a failed completion write cannot
-    # be undone. Exit non-zero and say exactly how to read the resulting ledger, rather
-    # than leaving an unmatched `pending` that looks like an aborted attempt.
-    record "$wt_real" "$branch" "$sha" "removed" reaped \
-      || die "REMOVED $wt_real but could not append its 'reaped' row. The deletion DID happen: a 'pending' row whose path no longer exists means deleted, not aborted (restore ref: refs/reaped/$sha)"
-    printf 'REAPED %-52s %s (%s MB%s)\n' "$name" "$branch" "$((sz_kb/1024))" "$ign_note"
-    reaped=$((reaped+1)); freed_kb=$((freed_kb+sz_kb))
+  # Written as a branch chain, NOT a && chain. Folded into one condition, a legitimate
+  # KEEP from the fallback re-check (the worktree became locked/live/dirty since the
+  # gates ran) made the whole condition false and fell into the `removal FAILED` abort —
+  # so an ordinary, correct decision to spare a worktree would have killed the entire
+  # scheduled sweep. "Keep it" and "could not remove it" must stay distinguishable.
+  if git -C "$TOPLEVEL" worktree remove --force "$wt_real" 2>/dev/null; then
+    : # removed
+  elif ! recheck_mutable_gates "$wt" "$wt_real"; then
+    continue    # legitimately KEPT and already reported by the gate
+  elif rm -rf "$wt_real" && [ ! -e "$wt_real" ]; then
+    git -C "$TOPLEVEL" worktree prune 2>/dev/null \
+      || die "REMOVED $wt_real but 'git worktree prune' failed — the deletion DID happen; run 'git -C $TOPLEVEL worktree prune' to clear its admin entry (restore ref: refs/reaped/$sha)"
   else
-    # A removal that got this far passed every safety gate and still could not be
-    # deleted — a filesystem or permission failure, not a verdict about this worktree.
-    # Reporting it as an ordinary KEEP let the run exit 0 with a `pending` row and no
-    # deletion, which reads as a healthy sweep.
     die "removal FAILED for $wt_real after all gates passed (its manifest row is 'pending' and the directory still exists)"
   fi
+  # Reached only when the directory is genuinely gone: every other path above either
+  # continued (kept) or died (failed).
+  # A failed completion write cannot be undone at this point, so exit non-zero and say
+  # exactly how to read the resulting ledger rather than leaving an unmatched `pending`
+  # that looks like an aborted attempt.
+  record "$wt_real" "$branch" "$sha" "removed" reaped \
+    || die "REMOVED $wt_real but could not append its 'reaped' row. The deletion DID happen: a 'pending' row whose path no longer exists means deleted, not aborted (restore ref: refs/reaped/$sha)"
+  printf 'REAPED %-52s %s (%s MB%s)\n' "$name" "$branch" "$((sz_kb/1024))" "$ign_note"
+  reaped=$((reaped+1)); freed_kb=$((freed_kb+sz_kb))
 done
 
 # Drop admin entries whose directory is already gone.

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Reap abandoned per-session worktrees under <repo>/.claude/worktrees/.
+#
+# Usage: worktree-cleanup.sh <repo_path> <manifest> [dry-run|apply] [min_age_hours]
+#   dry-run (default) — report what WOULD be reaped; write NOTHING to the manifest
+#   apply             — record each removal to the manifest, then remove
+#   Any other MODE value exits non-zero: a typo must not silently mean "delete", and
+#   must not pollute the restore ledger (same contract as branch-cleanup.sh).
+#   min_age_hours (default 24) — never reap a worktree younger than this.
+#
+# WHY THIS EXISTS
+#   The harness creates a per-session worktree at <repo>/.claude/worktrees/<slug> and
+#   nothing ever removes it. The owning session structurally CANNOT remove it — that
+#   directory is the session's own working directory, and sessions frequently end
+#   abruptly (crash, timeout, closed window) with no teardown. So cleanup must come
+#   from OUTSIDE the session. Left unswept the directories accumulate without bound
+#   until the disk fills and new sessions cannot start at all.
+#   It also silently disables branch-cleanup.sh: a branch checked out by a worktree is
+#   permanently in that script's KEEP set, so every leaked worktree pins its branch too.
+#
+# SAFETY CONTRACT (fail-closed — every ambiguity resolves to KEEP, every
+# infrastructure failure ABORTS before anything is removed):
+#   KEEP  - the main worktree, and anything outside <repo>/.claude/worktrees/
+#   KEEP  - a worktree that is the CWD of a LIVE process (a running session)
+#   KEEP  - a worktree younger than min_age_hours
+#   KEEP  - a LOCKED worktree (git locks mean "in use"; we never override)
+#   KEEP  - ANY worktree holding commits not reachable from a remote ref. This one test
+#           (`git rev-list <head> --not --remotes`) covers both an unpushed branch and a
+#           detached HEAD left on an orphan commit — the only states where removing the
+#           directory would destroy the sole copy of real work.
+#   KEEP  - a worktree with modified TRACKED files, other than submodule gitlinks
+#   KEEP  - a worktree with untracked files outside the known tool-noise set
+#   KEEP  - a worktree whose modified submodule itself has uncommitted or unpushed work
+#   ABORT - on any infrastructure failure (worktree list, lsof, manifest write)
+#
+# Submodule gitlink drift (` M applications/ksail`) and stray tool dirs (`?? .codex/`)
+# are NOT authored work — they are an artifact of the submodule checkout sitting at a
+# different, already-committed commit. They are treated as noise ONLY after the
+# submodule itself is confirmed clean and fully pushed.
+#
+# In apply mode every removal is recorded (path -> branch -> sha -> evidence) to the
+# manifest BEFORE the removal, and the write is verified — no restore record, no
+# removal. dry-run never touches the manifest.
+set -uo pipefail
+
+REPO_PATH=${1:-}
+MANIFEST=${2:-}
+MODE=${3:-dry-run}
+MIN_AGE_HOURS=${4:-24}
+
+die() { printf 'worktree-cleanup: %s\n' "$1" >&2; exit 2; }
+
+[ -n "$REPO_PATH" ] || die "usage: worktree-cleanup.sh <repo_path> <manifest> [dry-run|apply] [min_age_hours]"
+[ -n "$MANIFEST" ] || die "usage: worktree-cleanup.sh <repo_path> <manifest> [dry-run|apply] [min_age_hours]"
+[ -d "$REPO_PATH" ] || die "repo_path is not a directory: $REPO_PATH"
+
+case "$MODE" in
+  apply|dry-run) ;;
+  *) die "invalid MODE '$MODE' (expected 'apply' or 'dry-run')" ;;
+esac
+
+case "$MIN_AGE_HOURS" in
+  ''|*[!0-9]*) die "min_age_hours must be a non-negative integer, got '$MIN_AGE_HOURS'" ;;
+esac
+
+TOPLEVEL=$(git -C "$REPO_PATH" rev-parse --show-toplevel 2>/dev/null) \
+  || die "not a git repository: $REPO_PATH"
+# Resolve through symlinks so the lsof CWD comparison below is apples-to-apples
+# (/tmp is a symlink to /private/tmp on macOS; an unresolved prefix would silently
+# match nothing and every worktree would read as "no live process").
+TOPLEVEL=$(cd "$TOPLEVEL" && pwd -P) || die "cannot resolve toplevel"
+WT_ROOT="$TOPLEVEL/.claude/worktrees"
+
+if [ ! -d "$WT_ROOT" ]; then
+  printf 'worktree-cleanup: no worktree root at %s — nothing to do\n' "$WT_ROOT"
+  exit 0
+fi
+
+# --- infrastructure: the live-process CWD set -------------------------------------
+# A failure here must ABORT, never yield an empty set: an empty set would read as
+# "no session is live" and reap every worktree currently in use.
+LIVE_CWDS=$(lsof -a -d cwd -F n 2>/dev/null | grep '^n' | sed 's/^n//' | sort -u)
+if [ -z "$LIVE_CWDS" ]; then
+  die "lsof returned no CWDs at all — refusing to run (cannot prove which worktrees are live)"
+fi
+
+# --- infrastructure: the registered-worktree list ----------------------------------
+WT_LIST=$(git -C "$TOPLEVEL" worktree list --porcelain 2>/dev/null) \
+  || die "cannot list worktrees for $TOPLEVEL"
+[ -n "$WT_LIST" ] || die "empty worktree list for $TOPLEVEL"
+
+# Locked worktrees are in use by definition; never override a lock.
+LOCKED=$(printf '%s\n' "$WT_LIST" | awk '
+  /^worktree /{p=substr($0,10)} /^locked/{print p}')
+
+now=$(date +%s)
+reaped=0; kept=0; freed_kb=0
+
+record() { # path branch sha evidence
+  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >> "$MANIFEST" || return 1
+  grep -qF "$1" "$MANIFEST" || return 1   # verify the write landed
+  return 0
+}
+
+keep() { kept=$((kept+1)); printf 'KEEP   %-52s %s\n' "$(basename "$1")" "$2"; }
+
+# count_real_changes <worktree> <porcelain-status> -> sets $REAL_CHANGES
+# Counts porcelain entries that represent AUTHORED work. Submodule gitlink drift and
+# known tool-noise dirs are excluded — but a gitlink counts as real work the moment the
+# submodule itself is dirty or holds unpushed commits (fail-closed on any doubt).
+#
+# NOTE: this is a top-level function on purpose. macOS ships bash 3.2, which cannot
+# parse a `case` inside a $( ) command substitution ("syntax error near `;;'"), so this
+# logic must NOT be inlined into a command substitution.
+count_real_changes() {
+  local wt=$1 status=$2 line code path sub_status sub_sha sub_unpushed
+  REAL_CHANGES=0
+  [ -n "$status" ] || return 0
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    code=${line:0:2}; path=${line:3}
+    case "$code" in
+      '??')
+        case "$path" in
+          .codex/|.agents/|.DS_Store|.claude/worktrees/) ;;
+          *) REAL_CHANGES=$((REAL_CHANGES+1)) ;;
+        esac
+        ;;
+      ' M'|'M '|'MM')
+        if [ -e "$wt/$path/.git" ]; then
+          sub_status=$(git -C "$wt/$path" status --porcelain 2>/dev/null)
+          sub_sha=$(git -C "$wt/$path" rev-parse HEAD 2>/dev/null)
+          sub_unpushed=$(git -C "$wt/$path" rev-list --count "$sub_sha" --not --remotes 2>/dev/null)
+          if [ -n "$sub_status" ] || [ -z "$sub_unpushed" ] || [ "$sub_unpushed" -gt 0 ]; then
+            REAL_CHANGES=$((REAL_CHANGES+1))
+          fi
+        else
+          REAL_CHANGES=$((REAL_CHANGES+1))
+        fi
+        ;;
+      *) REAL_CHANGES=$((REAL_CHANGES+1)) ;;
+    esac
+  done <<< "$status"
+  return 0
+}
+
+for wt in "$WT_ROOT"/*/; do
+  [ -d "$wt" ] || continue
+  wt=${wt%/}
+  wt_real=$(cd "$wt" 2>/dev/null && pwd -P) || { keep "$wt" "unreadable"; continue; }
+  name=$(basename "$wt")
+
+  # KEEP: a live session's CWD (exact dir, or any descendant of it)
+  if printf '%s\n' "$LIVE_CWDS" | grep -qxF "$wt_real" \
+     || printf '%s\n' "$LIVE_CWDS" | grep -q "^$wt_real/"; then
+    keep "$wt" "live process CWD"; continue
+  fi
+
+  # KEEP: locked
+  if printf '%s\n' "$LOCKED" | grep -qxF "$wt_real"; then
+    keep "$wt" "locked"; continue
+  fi
+
+  # KEEP: too young
+  mtime=$(stat -f %m "$wt" 2>/dev/null || stat -c %Y "$wt" 2>/dev/null) || {
+    keep "$wt" "cannot stat"; continue; }
+  age_h=$(( (now - mtime) / 3600 ))
+  if [ "$age_h" -lt "$MIN_AGE_HOURS" ]; then
+    keep "$wt" "age ${age_h}h < ${MIN_AGE_HOURS}h"; continue
+  fi
+
+  # KEEP: unresolvable HEAD
+  sha=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || { keep "$wt" "no HEAD"; continue; }
+  branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null || echo "(detached)")
+
+  # KEEP: commits not reachable from any remote — the sole-copy-of-real-work test.
+  # Covers an unpushed branch and an orphan detached HEAD in one call.
+  unpushed=$(git -C "$TOPLEVEL" rev-list --count "$sha" --not --remotes 2>/dev/null)
+  if [ -z "$unpushed" ]; then
+    keep "$wt" "cannot determine push state"; continue      # fail closed
+  fi
+  if [ "$unpushed" -gt 0 ]; then
+    keep "$wt" "$unpushed unpushed commit(s) on $branch"; continue
+  fi
+
+  # KEEP: real working-tree changes. Submodule gitlinks and known tool-noise dirs are
+  # filtered out; everything else counts as authored work.
+  status=$(git -C "$wt" status --porcelain 2>/dev/null) || {
+    keep "$wt" "cannot read status"; continue; }
+  count_real_changes "$wt" "$status"
+  if [ "$REAL_CHANGES" -gt 0 ]; then
+    keep "$wt" "$REAL_CHANGES uncommitted change(s)"; continue
+  fi
+
+  # --- REAP ------------------------------------------------------------------------
+  sz_kb=$(du -sk "$wt" 2>/dev/null | cut -f1); sz_kb=${sz_kb:-0}
+  if [ "$MODE" = "dry-run" ]; then
+    printf 'REAP   %-52s %s (%s MB)\n' "$name" "$branch" "$((sz_kb/1024))"
+    reaped=$((reaped+1)); freed_kb=$((freed_kb+sz_kb))
+    continue
+  fi
+
+  if ! record "$wt_real" "$branch" "$sha" "reachable-from-remote;no-live-process;age=${age_h}h"; then
+    keep "$wt" "MANIFEST WRITE FAILED — refusing to remove"; continue
+  fi
+  if git -C "$TOPLEVEL" worktree remove --force "$wt_real" 2>/dev/null \
+     || { rm -rf "$wt_real" && git -C "$TOPLEVEL" worktree prune; }; then
+    printf 'REAPED %-52s %s (%s MB)\n' "$name" "$branch" "$((sz_kb/1024))"
+    reaped=$((reaped+1)); freed_kb=$((freed_kb+sz_kb))
+  else
+    keep "$wt" "removal FAILED"
+  fi
+done
+
+# Drop admin entries whose directory is already gone.
+if [ "$MODE" = "apply" ]; then
+  git -C "$TOPLEVEL" worktree prune 2>/dev/null || true
+fi
+
+printf '\nworktree-cleanup: mode=%s reaped=%d kept=%d freed=%d MB\n' \
+  "$MODE" "$reaped" "$kept" "$((freed_kb/1024))"

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -164,11 +164,14 @@ keep() { kept=$((kept+1)); printf 'KEEP   %-52s %s\n' "$(basename "$1")" "$2"; }
 # out from under it is exactly what the live gate exists to prevent.
 # FAILS CLOSED: an lsof failure means "live", never "safe to delete". ~0.7s per call,
 # paid only for worktrees that have already passed every other gate.
+# Returns 0 = live, 1 = idle, 2 = COULD NOT DETERMINE. The third state matters: folding
+# it into "live" made an infrastructure failure indistinguishable from a running session,
+# so the run reported KEEP and exited 0 looking healthy while the sweep was blind.
 is_live_now() {
   local target=$1 raw rc cwd
   raw=$(lsof -a -d cwd -F n 2>/dev/null); rc=$?
-  [ "$rc" -eq 0 ] || return 0          # cannot prove it is idle
-  [ -n "$raw" ] || return 0
+  [ "$rc" -eq 0 ] || return 2
+  [ -n "$raw" ] || return 2
   while IFS= read -r cwd; do
     case "$cwd" in
       n*) cwd=${cwd#n} ;;
@@ -240,7 +243,7 @@ count_real_changes() {
           # Capture the QUERY's status too: a failed `git status` yields an empty
           # sub_status, which would otherwise read as "submodule is clean" and permit
           # deleting its uncommitted files.
-          sub_status=$(git -C "$wt/$path" status --porcelain --untracked-files=all 2>/dev/null)
+          sub_status=$(git -C "$wt/$path" status --porcelain --untracked-files=all --ignore-submodules=none 2>/dev/null)
           sub_status_rc=$?
           sub_sha=$(git -C "$wt/$path" rev-parse HEAD 2>/dev/null)
           sub_unpushed=$(git -C "$wt/$path" rev-list --count "$sub_sha" --not --remotes 2>/dev/null)
@@ -265,7 +268,9 @@ for wt in "$WT_ROOT"/*/; do
   name=$(basename "$wt")
 
   # KEEP: anything git does not know as a worktree. Never a deletion candidate.
-  if ! printf '%s\n' "$REGISTERED" | grep -qxF "$wt_real"; then
+  # here-string, NOT a pipe: grep -q exits at its first match, printf then takes SIGPIPE,
+  # and under pipefail the pipeline reports failure — inverting this very test.
+  if ! grep -qxF -- "$wt_real" <<< "$REGISTERED"; then
     keep "$wt" "not a registered worktree"; continue
   fi
 
@@ -321,10 +326,13 @@ for wt in "$WT_ROOT"/*/; do
 
   # KEEP: real working-tree changes. Submodule gitlinks and known tool-noise dirs are
   # filtered out; everything else counts as authored work.
+  # --ignore-submodules=none is EXPLICIT too: submodule.<name>.ignore=all in .gitmodules
+  # or local config makes status report a clean PARENT even when the submodule holds
+  # uncommitted changes, so the submodule-cleanliness branch below never runs.
   # --untracked-files=all is EXPLICIT: a repo inheriting status.showUntrackedFiles=no
   # reports a clean worktree while holding non-ignored untracked authored files, and
   # apply mode would delete their only copy.
-  status=$(git -C "$wt" status --porcelain --untracked-files=all 2>/dev/null) || {
+  status=$(git -C "$wt" status --porcelain --untracked-files=all --ignore-submodules=none 2>/dev/null) || {
     keep "$wt" "cannot read status"; continue; }
 
   # `git status` cannot see edits to files carrying the assume-unchanged or
@@ -338,7 +346,9 @@ for wt in "$WT_ROOT"/*/; do
   fi
   # `S` (uppercase) is skip-worktree — the comment above said so while the pattern
   # matched lowercase only, so the very case that motivated this gate slipped through.
-  if printf '%s\n' "$idx_flags" | grep -q '^[a-zS]'; then
+  # here-string for the same SIGPIPE+pipefail reason — as a pipe this gate silently
+  # FAILED OPEN whenever ls-files -v output exceeded the pipe buffer.
+  if grep -q '^[a-zS]' <<< "$idx_flags"; then
     keep "$wt" "assume-unchanged/skip-worktree files present (status cannot see edits)"
     continue
   fi
@@ -388,13 +398,15 @@ for wt in "$WT_ROOT"/*/; do
   fi
 
   # Same re-check for liveness: a session may have started here since the snapshot.
-  if is_live_now "$wt_real"; then
-    keep "$wt" "live process CWD (started since the startup snapshot)"; continue
-  fi
+  is_live_now "$wt_real"; live_rc=$?
+  case "$live_rc" in
+    0) keep "$wt" "live process CWD (started since the startup snapshot)"; continue ;;
+    2) die "lsof re-check failed for $wt_real — refusing to continue on an unverifiable live set" ;;
+  esac
 
   # And re-check the working tree: a session may have written files between the status
   # gate above and this point, and `--force` would delete them regardless.
-  recheck_status=$(git -C "$wt" status --porcelain --untracked-files=all 2>/dev/null)
+  recheck_status=$(git -C "$wt" status --porcelain --untracked-files=all --ignore-submodules=none 2>/dev/null)
   recheck_rc=$?
   if [ "$recheck_rc" -ne 0 ]; then
     keep "$wt" "cannot re-read status before removal"; continue

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -130,6 +130,28 @@ keep() { kept=$((kept+1)); printf 'KEEP   %-52s %s\n' "$(basename "$1")" "$2"; }
 # as they were recorded at `worktree add` time, while $wt_real is pwd -P normalised; if
 # the repo was ever reached through a symlinked prefix the two differ and a plain
 # comparison would silently miss the lock.
+# is_live_now <resolved-worktree-path> — re-enumerates live CWDs instead of trusting
+# the startup snapshot. A multi-repo sweep runs for minutes, so a session can start or
+# resume inside an eligible worktree after the snapshot was taken; removing its CWD
+# out from under it is exactly what the live gate exists to prevent.
+# FAILS CLOSED: an lsof failure means "live", never "safe to delete". ~0.7s per call,
+# paid only for worktrees that have already passed every other gate.
+is_live_now() {
+  local target=$1 raw rc cwd
+  raw=$(lsof -a -d cwd -F n 2>/dev/null); rc=$?
+  [ "$rc" -eq 0 ] || return 0          # cannot prove it is idle
+  [ -n "$raw" ] || return 0
+  while IFS= read -r cwd; do
+    case "$cwd" in
+      n*) cwd=${cwd#n} ;;
+      *) continue ;;
+    esac
+    [ "$cwd" = "$target" ] && return 0
+    [ "${cwd#"$target"/}" != "$cwd" ] && return 0
+  done <<< "$raw"
+  return 1
+}
+
 is_locked_now() {
   local target=$1 out rc line p resolved
   out=$(git -C "$TOPLEVEL" worktree list --porcelain 2>/dev/null); rc=$?
@@ -168,7 +190,12 @@ count_real_changes() {
     case "$code" in
       '??')
         case "$path" in
-          .codex/|.agents/|.DS_Store|.claude/worktrees/) ;;
+          .codex/|.agents/|.DS_Store) ;;
+          # NOTE: `.claude/worktrees/` is deliberately NOT in this set. A session
+          # worktree can itself contain nested worktrees, and an untracked
+          # `?? .claude/worktrees/` is the parent's ONLY signal that they exist —
+          # ignoring it let a reap of the parent recursively delete a nested worktree
+          # holding the sole copy of uncommitted work.
           *) REAL_CHANGES=$((REAL_CHANGES+1)) ;;
         esac
         ;;
@@ -267,8 +294,12 @@ for wt in "$WT_ROOT"/*/; do
     continue
   fi
 
+  # A manifest write failure is an INFRASTRUCTURE failure, not a per-worktree verdict:
+  # the ledger is unwritable, so every subsequent removal would be unrecorded too.
+  # Aborting (rather than keeping and carrying on) is what stops the wrapper reporting
+  # a healthy sweep — which matters most under the disk pressure this tool exists for.
   if ! record "$wt_real" "$branch" "$sha" "reachable-from-remote;no-live-process;age=${age_h}h"; then
-    keep "$wt" "MANIFEST WRITE FAILED — refusing to remove"; continue
+    die "cannot write the restore manifest ($MANIFEST) — aborting before any removal"
   fi
   # Containment assertion before ANY recursive delete. $wt_real is derived from a glob
   # under $WT_ROOT and should always sit beneath it, but `rm -rf` is unforgiving enough
@@ -284,6 +315,11 @@ for wt in "$WT_ROOT"/*/; do
   # which git documents as "force removal even if worktree is dirty or locked".
   if is_locked_now "$wt_real"; then
     keep "$wt" "locked (acquired since the startup snapshot)"; continue
+  fi
+
+  # Same re-check for liveness: a session may have started here since the snapshot.
+  if is_live_now "$wt_real"; then
+    keep "$wt" "live process CWD (started since the startup snapshot)"; continue
   fi
 
   # Keep the reaped commit reachable so the manifest's SHA stays restorable. Without

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -207,6 +207,45 @@ is_locked_now() {
   return 1
 }
 
+# recheck_mutable_gates <worktree> <resolved-path> -> 0 = still safe to remove,
+# 1 = KEEP (already reported). Aborts on any unverifiable state.
+#
+# Every gate here reads state that another process can change WHILE the sweep runs, so
+# it must be re-evaluated as late as possible — and, critically, called again before the
+# `rm -rf` fallback: the first `worktree remove` attempt can fail slowly, and a session
+# may enter the worktree in that window. One function, called at both points, is what
+# keeps the two paths from drifting apart.
+recheck_mutable_gates() {
+  local wt=$1 target=$2 rc st idx
+  is_locked_now "$target"; rc=$?
+  case "$rc" in
+    0) keep "$wt" "locked (acquired during the sweep)"; return 1 ;;
+    2) die "cannot query worktree locks for $target — refusing to remove on an unverifiable lock state" ;;
+  esac
+
+  is_live_now "$target"; rc=$?
+  case "$rc" in
+    0) keep "$wt" "live process CWD (started during the sweep)"; return 1 ;;
+    2) die "lsof re-check failed for $target — refusing to continue on an unverifiable live set" ;;
+  esac
+
+  st=$(git -C "$wt" status --porcelain --untracked-files=all --ignore-submodules=none 2>/dev/null) \
+    || { keep "$wt" "cannot re-read status before removal"; return 1; }
+  count_real_changes "$wt" "$st"
+  if [ "$REAL_CHANGES" -gt 0 ]; then
+    keep "$wt" "$REAL_CHANGES uncommitted change(s) appeared during the sweep"; return 1
+  fi
+
+  # Status alone cannot cover this: not being visible to status is exactly what the
+  # assume-unchanged and skip-worktree bits do.
+  idx=$(git -C "$wt" ls-files -v 2>/dev/null) \
+    || { keep "$wt" "cannot re-read index flags before removal"; return 1; }
+  if grep -q '^[a-zS]' <<< "$idx"; then
+    keep "$wt" "assume-unchanged/skip-worktree flags appeared during the sweep"; return 1
+  fi
+  return 0
+}
+
 # count_real_changes <worktree> <porcelain-status> -> sets $REAL_CHANGES
 # Counts porcelain entries that represent AUTHORED work. Submodule gitlink drift and
 # known tool-noise dirs are excluded — but a gitlink counts as real work the moment the
@@ -254,6 +293,15 @@ count_real_changes() {
           if [ "$sub_status_rc" -ne 0 ] || [ -n "$sub_status" ] \
              || [ -z "$sub_unpushed" ] || [ "$sub_unpushed" -gt 0 ]; then
             REAL_CHANGES=$((REAL_CHANGES+1))
+          else
+            # Disposable only because the commit is reachable from a remote-tracking ref
+            # — which can be STALE (upstream branch deleted or force-pushed). Preserve it
+            # in the submodule the same way the parent's HEAD is preserved, so a later
+            # fetch --prune + gc cannot collect the only copy. Failure to preserve makes
+            # it authored work again rather than silently disposable.
+            if ! git -C "$wt/$path" update-ref "refs/reaped/$sub_sha" "$sub_sha" 2>/dev/null; then
+              REAL_CHANGES=$((REAL_CHANGES+1))
+            fi
           fi
         else
           REAL_CHANGES=$((REAL_CHANGES+1))
@@ -396,47 +444,7 @@ for wt in "$WT_ROOT"/*/; do
     *) keep "$wt" "REFUSING to remove: '$wt_real' is not under '$WT_ROOT'"; continue ;;
   esac
 
-  # Re-check the lock against LIVE state, not the snapshot taken at startup. A lock
-  # acquired while this sweep was running would otherwise be overridden by --force,
-  # which git documents as "force removal even if worktree is dirty or locked".
-  is_locked_now "$wt_real"; lock_rc=$?
-  case "$lock_rc" in
-    0) keep "$wt" "locked (acquired since the startup snapshot)"; continue ;;
-    2) die "cannot re-query worktree locks for $wt_real — refusing to remove on an unverifiable lock state" ;;
-  esac
-
-  # Same re-check for liveness: a session may have started here since the snapshot.
-  is_live_now "$wt_real"; live_rc=$?
-  case "$live_rc" in
-    0) keep "$wt" "live process CWD (started since the startup snapshot)"; continue ;;
-    2) die "lsof re-check failed for $wt_real — refusing to continue on an unverifiable live set" ;;
-  esac
-
-  # And re-check the working tree: a session may have written files between the status
-  # gate above and this point, and `--force` would delete them regardless.
-  recheck_status=$(git -C "$wt" status --porcelain --untracked-files=all --ignore-submodules=none 2>/dev/null)
-  recheck_rc=$?
-  if [ "$recheck_rc" -ne 0 ]; then
-    keep "$wt" "cannot re-read status before removal"; continue
-  fi
-  count_real_changes "$wt" "$recheck_status"
-  if [ "$REAL_CHANGES" -gt 0 ]; then
-    keep "$wt" "$REAL_CHANGES uncommitted change(s) appeared since the status gate"
-    continue
-  fi
-
-  # Re-check the index flags too. Re-running status alone is not enough: the whole point
-  # of assume-unchanged / skip-worktree is that status cannot see those edits, so a flag
-  # set (by a process whose CWD is outside this worktree) after the earlier gate would
-  # leave the re-checked status clean while hiding a real edit.
-  recheck_idx=$(git -C "$wt" ls-files -v 2>/dev/null); recheck_idx_rc=$?
-  if [ "$recheck_idx_rc" -ne 0 ]; then
-    keep "$wt" "cannot re-read index flags before removal"; continue
-  fi
-  if grep -q '^[a-zS]' <<< "$recheck_idx"; then
-    keep "$wt" "assume-unchanged/skip-worktree flags appeared since the index gate"
-    continue
-  fi
+  if ! recheck_mutable_gates "$wt" "$wt_real"; then continue; fi
 
   # Keep the reaped commit reachable so the manifest's SHA stays restorable. Without
   # this, a stale remote-tracking ref can make a commit look pushed, and a later
@@ -465,12 +473,11 @@ for wt in "$WT_ROOT"/*/; do
   # run then exited 0 leaving a `pending` row for a path that is already gone.
   # Deletion success is judged by the directory being absent; a failed prune is a
   # separate, loud error.
-  # `unlocked_now` requires the explicit "unlocked" answer (1). Using `! is_locked_now`
-  # here would treat "could not determine" (2) as unlocked, since both are non-zero.
-  unlocked_now() { is_locked_now "$1"; [ "$?" -eq 1 ]; }
-
+  # The fallback re-runs the FULL mutable-gate set, not just the lock: the failed
+  # `worktree remove` above can take time, and a session entering the worktree in that
+  # window must still stop the recursive delete.
   if git -C "$TOPLEVEL" worktree remove --force "$wt_real" 2>/dev/null \
-     || { unlocked_now "$wt_real" && rm -rf "$wt_real" && [ ! -e "$wt_real" ] \
+     || { recheck_mutable_gates "$wt" "$wt_real" && rm -rf "$wt_real" && [ ! -e "$wt_real" ] \
           && { git -C "$TOPLEVEL" worktree prune 2>/dev/null \
                || die "REMOVED $wt_real but 'git worktree prune' failed — the deletion DID happen; run 'git -C $TOPLEVEL worktree prune' to clear its admin entry (restore ref: refs/reaped/$sha)"; }; }; then
     # Completion row — written only now that the directory is actually gone.

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -117,6 +117,14 @@ WT_LIST=$(git -C "$TOPLEVEL" worktree list --porcelain 2>/dev/null) \
   || die "cannot list worktrees for $TOPLEVEL"
 [ -n "$WT_LIST" ] || die "empty worktree list for $TOPLEVEL"
 
+# The set of paths git actually knows as worktrees, symlink-resolved. ONLY these are
+# ever candidates. Without this filter any ordinary directory placed under
+# .claude/worktrees/ enters the loop; having no .git file, every `git -C "$dir"` call
+# walks up to the main checkout, whose clean+pushed state then makes the directory look
+# eligible — and the rm -rf fallback deletes its arbitrary contents.
+REGISTERED=$(printf '%s\n' "$WT_LIST" | awk '/^worktree /{print substr($0,10)}' \
+  | while IFS= read -r p; do (cd "$p" 2>/dev/null && pwd -P); done)
+
 now=$(date +%s)
 reaped=0; kept=0; freed_kb=0
 
@@ -210,7 +218,11 @@ count_real_changes() {
     case "$code" in
       '??')
         case "$path" in
-          .codex/|.agents/|.DS_Store) ;;
+          # Both shapes must be matched: without --untracked-files=all git collapses an
+          # untracked directory to `.codex/`, and with it every file is listed
+          # individually (`.codex/x`). Matching only the collapsed form silently turned
+          # these into "real work" once the flag was added.
+          .codex/|.codex/*|.agents/|.agents/*|.DS_Store|*/.DS_Store) ;;
           # NOTE: `.claude/worktrees/` is deliberately NOT in this set. A session
           # worktree can itself contain nested worktrees, and an untracked
           # `?? .claude/worktrees/` is the parent's ONLY signal that they exist —
@@ -225,10 +237,15 @@ count_real_changes() {
         # removing the worktree destroys it with no commit to recover from. Those fall
         # through to the default branch below and count as real work.
         if [ -e "$wt/$path/.git" ]; then
-          sub_status=$(git -C "$wt/$path" status --porcelain 2>/dev/null)
+          # Capture the QUERY's status too: a failed `git status` yields an empty
+          # sub_status, which would otherwise read as "submodule is clean" and permit
+          # deleting its uncommitted files.
+          sub_status=$(git -C "$wt/$path" status --porcelain --untracked-files=all 2>/dev/null)
+          sub_status_rc=$?
           sub_sha=$(git -C "$wt/$path" rev-parse HEAD 2>/dev/null)
           sub_unpushed=$(git -C "$wt/$path" rev-list --count "$sub_sha" --not --remotes 2>/dev/null)
-          if [ -n "$sub_status" ] || [ -z "$sub_unpushed" ] || [ "$sub_unpushed" -gt 0 ]; then
+          if [ "$sub_status_rc" -ne 0 ] || [ -n "$sub_status" ] \
+             || [ -z "$sub_unpushed" ] || [ "$sub_unpushed" -gt 0 ]; then
             REAL_CHANGES=$((REAL_CHANGES+1))
           fi
         else
@@ -246,6 +263,11 @@ for wt in "$WT_ROOT"/*/; do
   wt=${wt%/}
   wt_real=$(cd "$wt" 2>/dev/null && pwd -P) || { keep "$wt" "unreadable"; continue; }
   name=$(basename "$wt")
+
+  # KEEP: anything git does not know as a worktree. Never a deletion candidate.
+  if ! printf '%s\n' "$REGISTERED" | grep -qxF "$wt_real"; then
+    keep "$wt" "not a registered worktree"; continue
+  fi
 
   # KEEP: a live session's CWD (the worktree itself, or any directory inside it).
   # Both comparisons are LITERAL. An earlier version matched descendants with
@@ -299,8 +321,25 @@ for wt in "$WT_ROOT"/*/; do
 
   # KEEP: real working-tree changes. Submodule gitlinks and known tool-noise dirs are
   # filtered out; everything else counts as authored work.
-  status=$(git -C "$wt" status --porcelain 2>/dev/null) || {
+  # --untracked-files=all is EXPLICIT: a repo inheriting status.showUntrackedFiles=no
+  # reports a clean worktree while holding non-ignored untracked authored files, and
+  # apply mode would delete their only copy.
+  status=$(git -C "$wt" status --porcelain --untracked-files=all 2>/dev/null) || {
     keep "$wt" "cannot read status"; continue; }
+
+  # `git status` cannot see edits to files carrying the assume-unchanged or
+  # skip-worktree index bits, so a worktree holding only such edits reads as clean.
+  # Their presence alone is enough to keep it — the restore ref would preserve just the
+  # committed version. `ls-files -v` marks them lowercase (assume-unchanged) or S/s
+  # (skip-worktree).
+  idx_flags=$(git -C "$wt" ls-files -v 2>/dev/null); idx_rc=$?
+  if [ "$idx_rc" -ne 0 ]; then
+    keep "$wt" "cannot read index flags"; continue
+  fi
+  if printf '%s\n' "$idx_flags" | grep -q '^[a-z]'; then
+    keep "$wt" "assume-unchanged/skip-worktree files present (status cannot see edits)"
+    continue
+  fi
   count_real_changes "$wt" "$status"
   if [ "$REAL_CHANGES" -gt 0 ]; then
     keep "$wt" "$REAL_CHANGES uncommitted change(s)"; continue
@@ -352,8 +391,16 @@ for wt in "$WT_ROOT"/*/; do
     keep "$wt" "could not write refs/reaped/$sha — refusing to remove"; continue
   fi
 
+  # The fallback's prune is deliberately OUTSIDE the success condition: `rm -rf` can
+  # succeed while `prune` fails (git's admin dir unwritable), and folding prune into the
+  # condition sent an actually-deleted worktree down the "removal FAILED" branch — the
+  # run then exited 0 leaving a `pending` row for a path that is already gone.
+  # Deletion success is judged by the directory being absent; a failed prune is a
+  # separate, loud error.
   if git -C "$TOPLEVEL" worktree remove --force "$wt_real" 2>/dev/null \
-     || { ! is_locked_now "$wt_real" && rm -rf "$wt_real" && git -C "$TOPLEVEL" worktree prune; }; then
+     || { ! is_locked_now "$wt_real" && rm -rf "$wt_real" && [ ! -e "$wt_real" ] \
+          && { git -C "$TOPLEVEL" worktree prune 2>/dev/null \
+               || die "REMOVED $wt_real but 'git worktree prune' failed — the deletion DID happen; run 'git -C $TOPLEVEL worktree prune' to clear its admin entry (restore ref: refs/reaped/$sha)"; }; }; then
     # Completion row — written only now that the directory is actually gone.
     # The directory is already gone at this point, so a failed completion write cannot
     # be undone. Exit non-zero and say exactly how to read the resulting ledger, rather

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -104,10 +104,6 @@ WT_LIST=$(git -C "$TOPLEVEL" worktree list --porcelain 2>/dev/null) \
   || die "cannot list worktrees for $TOPLEVEL"
 [ -n "$WT_LIST" ] || die "empty worktree list for $TOPLEVEL"
 
-# Locked worktrees are in use by definition; never override a lock.
-LOCKED=$(printf '%s\n' "$WT_LIST" | awk '
-  /^worktree /{p=substr($0,10)} /^locked/{print p}')
-
 now=$(date +%s)
 reaped=0; kept=0; freed_kb=0
 
@@ -124,14 +120,34 @@ record() { # path branch sha evidence
 
 keep() { kept=$((kept+1)); printf 'KEEP   %-52s %s\n' "$(basename "$1")" "$2"; }
 
-# is_locked_now <resolved-worktree-path> — re-queries git rather than consulting the
+# is_locked_now <resolved-worktree-path> — re-queries git rather than consulting a
 # startup snapshot, so a lock taken DURING the sweep is still honoured.
+#
+# FAILS CLOSED: if git cannot be queried, the answer is "locked". This runs immediately
+# before `rm -rf`, so "I could not tell" must never resolve to "safe to delete".
+#
+# Compares the recorded path BOTH raw and symlink-resolved. git prints worktree paths
+# as they were recorded at `worktree add` time, while $wt_real is pwd -P normalised; if
+# the repo was ever reached through a symlinked prefix the two differ and a plain
+# comparison would silently miss the lock.
 is_locked_now() {
-  git -C "$TOPLEVEL" worktree list --porcelain 2>/dev/null \
-    | awk -v target="$1" '
-        /^worktree /{p=substr($0,10)}
-        /^locked/{if (p==target) found=1}
-        END{exit found?0:1}'
+  local target=$1 out rc line p resolved
+  out=$(git -C "$TOPLEVEL" worktree list --porcelain 2>/dev/null); rc=$?
+  if [ "$rc" -ne 0 ] || [ -z "$out" ]; then
+    return 0   # cannot prove it is unlocked
+  fi
+  p=""
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) p=${line#worktree } ;;
+      locked*)
+        [ "$p" = "$target" ] && return 0
+        resolved=$(cd "$p" 2>/dev/null && pwd -P) || resolved=""
+        if [ -n "$resolved" ] && [ "$resolved" = "$target" ]; then return 0; fi
+        ;;
+    esac
+  done <<< "$out"
+  return 1
 }
 
 # count_real_changes <worktree> <porcelain-status> -> sets $REAL_CHANGES
@@ -201,8 +217,8 @@ for wt in "$WT_ROOT"/*/; do
     keep "$wt" "live process CWD"; continue
   fi
 
-  # KEEP: locked
-  if printf '%s\n' "$LOCKED" | grep -qxF "$wt_real"; then
+  # KEEP: locked (same symlink-resolved, fail-closed check used before removal)
+  if is_locked_now "$wt_real"; then
     keep "$wt" "locked"; continue
   fi
 
@@ -274,7 +290,11 @@ for wt in "$WT_ROOT"/*/; do
   # this, a stale remote-tracking ref can make a commit look pushed, and a later
   # fetch --prune + gc would collect the only copy — leaving a manifest entry that
   # cannot be restored. One ref per commit; the name is the SHA, so it is idempotent.
-  git -C "$TOPLEVEL" update-ref "refs/reaped/$sha" "$sha" 2>/dev/null || true
+  # This is a PRECONDITION of removal, not best-effort: no restore ref, no deletion —
+  # the same rule the manifest write already follows.
+  if ! git -C "$TOPLEVEL" update-ref "refs/reaped/$sha" "$sha" 2>/dev/null; then
+    keep "$wt" "could not write refs/reaped/$sha — refusing to remove"; continue
+  fi
 
   if git -C "$TOPLEVEL" worktree remove --force "$wt_real" 2>/dev/null \
      || { ! is_locked_now "$wt_real" && rm -rf "$wt_real" && git -C "$TOPLEVEL" worktree prune; }; then

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -45,9 +45,12 @@
 # different, already-committed commit. They are treated as noise ONLY after the
 # submodule itself is confirmed clean and fully pushed.
 #
-# In apply mode every removal is recorded (path -> branch -> sha -> evidence) to the
-# manifest BEFORE the removal, and the write is verified — no restore record, no
-# removal. dry-run never touches the manifest.
+# In apply mode every removal is recorded to the manifest BEFORE the removal, and the
+# write is verified — no restore record, no removal. dry-run never touches the manifest.
+# Rows are `path -> branch -> sha -> evidence -> outcome`, where outcome is `pending`
+# (written before deleting) or `reaped` (appended only once the directory is gone).
+# A `pending` with no matching `reaped` is an ABORTED attempt, not a deletion — restore
+# and audit tooling must key on `reaped`.
 set -uo pipefail
 
 REPO_PATH=${1:-}
@@ -107,9 +110,16 @@ WT_LIST=$(git -C "$TOPLEVEL" worktree list --porcelain 2>/dev/null) \
 now=$(date +%s)
 reaped=0; kept=0; freed_kb=0
 
-record() { # path branch sha evidence
+# record <path> <branch> <sha> <evidence> <outcome>
+# The outcome column is what stops a row claiming a removal that never happened. The
+# durability rule requires writing BEFORE deleting, but four gates can still abort
+# after that point (containment, the lock and live re-checks, the restore-ref write),
+# so a row alone cannot mean "reaped". `pending` is written first; a second `reaped`
+# row is appended only after the directory is actually gone. Restore tooling keys on
+# `reaped`; a `pending` with no matching `reaped` is an aborted attempt, not a deletion.
+record() { # path branch sha evidence outcome
   local line
-  line=$(printf '%s\t%s\t%s\t%s' "$1" "$2" "$3" "$4")
+  line=$(printf '%s\t%s\t%s\t%s\t%s' "$1" "$2" "$3" "$4" "$5")
   printf '%s\n' "$line" >> "$MANIFEST" || return 1
   # Verify the WHOLE record landed, not just the path: a path substring is already
   # present whenever the same worktree was reaped in an earlier sweep, so a
@@ -298,7 +308,7 @@ for wt in "$WT_ROOT"/*/; do
   # the ledger is unwritable, so every subsequent removal would be unrecorded too.
   # Aborting (rather than keeping and carrying on) is what stops the wrapper reporting
   # a healthy sweep — which matters most under the disk pressure this tool exists for.
-  if ! record "$wt_real" "$branch" "$sha" "reachable-from-remote;no-live-process;age=${age_h}h"; then
+  if ! record "$wt_real" "$branch" "$sha" "reachable-from-remote;no-live-process;age=${age_h}h" pending; then
     die "cannot write the restore manifest ($MANIFEST) — aborting before any removal"
   fi
   # Containment assertion before ANY recursive delete. $wt_real is derived from a glob
@@ -334,6 +344,9 @@ for wt in "$WT_ROOT"/*/; do
 
   if git -C "$TOPLEVEL" worktree remove --force "$wt_real" 2>/dev/null \
      || { ! is_locked_now "$wt_real" && rm -rf "$wt_real" && git -C "$TOPLEVEL" worktree prune; }; then
+    # Completion row — written only now that the directory is actually gone.
+    record "$wt_real" "$branch" "$sha" "removed" reaped \
+      || die "removed $wt_real but could not record its completion — aborting"
     printf 'REAPED %-52s %s (%s MB)\n' "$name" "$branch" "$((sz_kb/1024))"
     reaped=$((reaped+1)); freed_kb=$((freed_kb+sz_kb))
   else

--- a/.claude/scripts/worktree-cleanup.sh
+++ b/.claude/scripts/worktree-cleanup.sh
@@ -183,11 +183,15 @@ is_live_now() {
   return 1
 }
 
+# Returns 0 = locked, 1 = unlocked, 2 = COULD NOT DETERMINE — the same three-way
+# contract as is_live_now, and for the same reason: collapsing "the query failed" into
+# "locked" makes an infrastructure failure indistinguishable from a real lock, so the
+# run reports KEEP and exits 0 looking healthy while it could not actually check.
 is_locked_now() {
   local target=$1 out rc line p resolved
   out=$(git -C "$TOPLEVEL" worktree list --porcelain 2>/dev/null); rc=$?
   if [ "$rc" -ne 0 ] || [ -z "$out" ]; then
-    return 0   # cannot prove it is unlocked
+    return 2
   fi
   p=""
   while IFS= read -r line; do
@@ -292,9 +296,11 @@ for wt in "$WT_ROOT"/*/; do
   fi
 
   # KEEP: locked (same symlink-resolved, fail-closed check used before removal)
-  if is_locked_now "$wt_real"; then
-    keep "$wt" "locked"; continue
-  fi
+  is_locked_now "$wt_real"; lock_rc=$?
+  case "$lock_rc" in
+    0) keep "$wt" "locked"; continue ;;
+    2) die "cannot query worktree locks for $wt_real — refusing to continue on an unverifiable lock state" ;;
+  esac
 
   # KEEP: too young.
   # Validate that mtime is NUMERIC rather than trusting stat's exit status. GNU stat
@@ -393,9 +399,11 @@ for wt in "$WT_ROOT"/*/; do
   # Re-check the lock against LIVE state, not the snapshot taken at startup. A lock
   # acquired while this sweep was running would otherwise be overridden by --force,
   # which git documents as "force removal even if worktree is dirty or locked".
-  if is_locked_now "$wt_real"; then
-    keep "$wt" "locked (acquired since the startup snapshot)"; continue
-  fi
+  is_locked_now "$wt_real"; lock_rc=$?
+  case "$lock_rc" in
+    0) keep "$wt" "locked (acquired since the startup snapshot)"; continue ;;
+    2) die "cannot re-query worktree locks for $wt_real — refusing to remove on an unverifiable lock state" ;;
+  esac
 
   # Same re-check for liveness: a session may have started here since the snapshot.
   is_live_now "$wt_real"; live_rc=$?
@@ -414,6 +422,19 @@ for wt in "$WT_ROOT"/*/; do
   count_real_changes "$wt" "$recheck_status"
   if [ "$REAL_CHANGES" -gt 0 ]; then
     keep "$wt" "$REAL_CHANGES uncommitted change(s) appeared since the status gate"
+    continue
+  fi
+
+  # Re-check the index flags too. Re-running status alone is not enough: the whole point
+  # of assume-unchanged / skip-worktree is that status cannot see those edits, so a flag
+  # set (by a process whose CWD is outside this worktree) after the earlier gate would
+  # leave the re-checked status clean while hiding a real edit.
+  recheck_idx=$(git -C "$wt" ls-files -v 2>/dev/null); recheck_idx_rc=$?
+  if [ "$recheck_idx_rc" -ne 0 ]; then
+    keep "$wt" "cannot re-read index flags before removal"; continue
+  fi
+  if grep -q '^[a-zS]' <<< "$recheck_idx"; then
+    keep "$wt" "assume-unchanged/skip-worktree flags appeared since the index gate"
     continue
   fi
 
@@ -444,8 +465,12 @@ for wt in "$WT_ROOT"/*/; do
   # run then exited 0 leaving a `pending` row for a path that is already gone.
   # Deletion success is judged by the directory being absent; a failed prune is a
   # separate, loud error.
+  # `unlocked_now` requires the explicit "unlocked" answer (1). Using `! is_locked_now`
+  # here would treat "could not determine" (2) as unlocked, since both are non-zero.
+  unlocked_now() { is_locked_now "$1"; [ "$?" -eq 1 ]; }
+
   if git -C "$TOPLEVEL" worktree remove --force "$wt_real" 2>/dev/null \
-     || { ! is_locked_now "$wt_real" && rm -rf "$wt_real" && [ ! -e "$wt_real" ] \
+     || { unlocked_now "$wt_real" && rm -rf "$wt_real" && [ ! -e "$wt_real" ] \
           && { git -C "$TOPLEVEL" worktree prune 2>/dev/null \
                || die "REMOVED $wt_real but 'git worktree prune' failed — the deletion DID happen; run 'git -C $TOPLEVEL worktree prune' to clear its admin entry (restore ref: refs/reaped/$sha)"; }; }; then
     # Completion row — written only now that the directory is actually gone.
@@ -457,7 +482,11 @@ for wt in "$WT_ROOT"/*/; do
     printf 'REAPED %-52s %s (%s MB%s)\n' "$name" "$branch" "$((sz_kb/1024))" "$ign_note"
     reaped=$((reaped+1)); freed_kb=$((freed_kb+sz_kb))
   else
-    keep "$wt" "removal FAILED"
+    # A removal that got this far passed every safety gate and still could not be
+    # deleted — a filesystem or permission failure, not a verdict about this worktree.
+    # Reporting it as an ordinary KEEP let the run exit 0 with a `pending` row and no
+    # deletion, which reads as a healthy sweep.
+    die "removal FAILED for $wt_real after all gates passed (its manifest row is 'pending' and the directory still exists)"
   fi
 done
 

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# Contract tests for worktree-cleanup.sh.
+#
+# Each test builds a scratch repo with a real remote and real worktrees, then asserts
+# that a specific KEEP gate fires (or that a genuinely spent worktree is reaped).
+# Every gate test is paired with the reaped-baseline case, so a test that passes only
+# because the script reaps NOTHING cannot go unnoticed.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SUT="$SCRIPT_DIR/worktree-cleanup.sh"
+
+pass=0; fail=0
+ok()   { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+
+# --- fixture ----------------------------------------------------------------------
+# Builds: origin (bare) + repo with `main` pushed. Worktrees are added per-test.
+make_repo() {
+  local root; root=$(mktemp -d)
+  root=$(cd "$root" && pwd -P)          # resolve /tmp -> /private/tmp on macOS
+  git init -q --bare "$root/origin.git"
+  git init -q -b main "$root/repo"
+  git -C "$root/repo" config user.email t@t.t
+  git -C "$root/repo" config user.name t
+  echo base > "$root/repo/file.txt"
+  git -C "$root/repo" add file.txt
+  git -C "$root/repo" commit -qm base
+  git -C "$root/repo" remote add origin "$root/origin.git"
+  git -C "$root/repo" push -q origin main
+  mkdir -p "$root/repo/.claude/worktrees"
+  printf '%s' "$root"
+}
+
+# add_wt <root> <name> [pushed|unpushed]
+add_wt() {
+  local root=$1 name=$2 kind=${3:-pushed}
+  git -C "$root/repo" worktree add -q -b "claude/$name" \
+      "$root/repo/.claude/worktrees/$name" main 2>/dev/null
+  if [ "$kind" = unpushed ]; then
+    echo change > "$root/repo/.claude/worktrees/$name/new.txt"
+    git -C "$root/repo/.claude/worktrees/$name" add new.txt
+    git -C "$root/repo/.claude/worktrees/$name" commit -qm "unpushed work"
+  else
+    git -C "$root/repo" push -q origin "claude/$name"
+  fi
+  # age it past the default threshold
+  touch -t 202001010000 "$root/repo/.claude/worktrees/$name"
+}
+
+run() { # <root> [mode] -> stdout
+  local root=$1 mode=${2:-dry-run}
+  "$SUT" "$root/repo" "$root/manifest.tsv" "$mode" 24 2>&1
+}
+
+# --- baseline: a spent worktree IS reaped ------------------------------------------
+# This is the control for every KEEP test below: if this ever stops reaping, a
+# "KEEP fired" assertion elsewhere would pass vacuously.
+t_reaps_spent() {
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  local out; out=$(run "$root")
+  if printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+    ok "reaps a spent worktree (control)"
+  else
+    bad "reaps a spent worktree (control)" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_keeps_unpushed() {
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed          # control must still reap
+  add_wt "$root" work unpushed
+  local out; out=$(run "$root")
+  if printf '%s' "$out" | grep -q 'KEEP .*work .*unpushed commit' \
+     && printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+    ok "KEEPs a worktree with unpushed commits"
+  else
+    bad "KEEPs a worktree with unpushed commits" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_keeps_detached_orphan() {
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  add_wt "$root" orph pushed
+  # commit, then detach onto that commit and delete the branch ref => orphan commit
+  echo o > "$root/repo/.claude/worktrees/orph/o.txt"
+  git -C "$root/repo/.claude/worktrees/orph" add o.txt
+  git -C "$root/repo/.claude/worktrees/orph" commit -qm orphan
+  local sha; sha=$(git -C "$root/repo/.claude/worktrees/orph" rev-parse HEAD)
+  git -C "$root/repo/.claude/worktrees/orph" checkout -q --detach "$sha"
+  # committing + detaching bumped the dir mtime; re-age so the AGE gate cannot mask
+  # the gate under test (it did exactly that before this line existed)
+  touch -t 202001010000 "$root/repo/.claude/worktrees/orph"
+  local out; out=$(run "$root")
+  if printf '%s' "$out" | grep -q 'KEEP .*orph .*unpushed commit' \
+     && printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+    ok "KEEPs a detached HEAD on an orphan commit"
+  else
+    bad "KEEPs a detached HEAD on an orphan commit" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_keeps_dirty() {
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  add_wt "$root" dirty pushed
+  echo edited >> "$root/repo/.claude/worktrees/dirty/file.txt"   # modified TRACKED file
+  local out; out=$(run "$root")
+  if printf '%s' "$out" | grep -q 'KEEP .*dirty .*uncommitted change' \
+     && printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+    ok "KEEPs a worktree with uncommitted tracked changes"
+  else
+    bad "KEEPs a worktree with uncommitted tracked changes" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_ignores_tool_noise() {
+  local root; root=$(make_repo)
+  add_wt "$root" noisy pushed
+  mkdir -p "$root/repo/.claude/worktrees/noisy/.codex" \
+           "$root/repo/.claude/worktrees/noisy/.agents"
+  echo x > "$root/repo/.claude/worktrees/noisy/.codex/x"
+  echo y > "$root/repo/.claude/worktrees/noisy/.agents/y"
+  # writing into the worktree bumped its mtime — re-age it past the threshold
+  touch -t 202001010000 "$root/repo/.claude/worktrees/noisy"
+  local out; out=$(run "$root")
+  if printf '%s' "$out" | grep -q '^REAP  .*noisy'; then
+    ok "treats .codex/ and .agents/ as noise, not work"
+  else
+    bad "treats .codex/ and .agents/ as noise, not work" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_keeps_untracked_real_file() {
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  add_wt "$root" untracked pushed
+  echo real > "$root/repo/.claude/worktrees/untracked/notes.md"
+  touch -t 202001010000 "$root/repo/.claude/worktrees/untracked"
+  local out; out=$(run "$root")
+  if printf '%s' "$out" | grep -q 'KEEP .*untracked .*uncommitted change' \
+     && printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+    ok "KEEPs an untracked file outside the noise set"
+  else
+    bad "KEEPs an untracked file outside the noise set" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_keeps_young() {
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  add_wt "$root" fresh pushed
+  touch "$root/repo/.claude/worktrees/fresh"          # now => younger than 24h
+  local out; out=$(run "$root")
+  if printf '%s' "$out" | grep -q 'KEEP .*fresh .*age .*< 24h' \
+     && printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+    ok "KEEPs a worktree younger than min_age_hours"
+  else
+    bad "KEEPs a worktree younger than min_age_hours" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_keeps_live_cwd() {
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  add_wt "$root" live pushed
+  ( cd "$root/repo/.claude/worktrees/live" && exec sleep 30 ) &
+  local pid=$!
+  sleep 1                                    # let the child establish its CWD
+  local out; out=$(run "$root")
+  kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+  if printf '%s' "$out" | grep -q 'KEEP .*live .*live process CWD' \
+     && printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+    ok "KEEPs a worktree that is a live process CWD"
+  else
+    bad "KEEPs a worktree that is a live process CWD" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_dry_run_writes_no_manifest_and_removes_nothing() {
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  run "$root" dry-run >/dev/null
+  if [ ! -e "$root/manifest.tsv" ] && [ -d "$root/repo/.claude/worktrees/spent" ]; then
+    ok "dry-run writes no manifest and removes nothing"
+  else
+    bad "dry-run writes no manifest and removes nothing" \
+        "manifest=$([ -e "$root/manifest.tsv" ] && echo yes || echo no) dir=$([ -d "$root/repo/.claude/worktrees/spent" ] && echo present || echo GONE)"
+  fi
+  rm -rf "$root"
+}
+
+t_apply_removes_and_records() {
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  add_wt "$root" work unpushed
+  run "$root" apply >/dev/null
+  # NB: compare the exact tab-delimited BRANCH field. A substring grep is unusable
+  # here: every manifest path contains '.claude/worktrees/', which contains BOTH
+  # '/work' and 'claude/work' — so a naive grep reports the spared branch as recorded.
+  local branches; branches=$(awk -F'\t' '{print $2}' "$root/manifest.tsv" 2>/dev/null)
+  if [ ! -d "$root/repo/.claude/worktrees/spent" ] \
+     && [ -d "$root/repo/.claude/worktrees/work" ] \
+     && printf '%s\n' "$branches" | grep -qxF 'claude/spent' \
+     && ! printf '%s\n' "$branches" | grep -qxF 'claude/work'; then
+    ok "apply removes the spent worktree, records it, and spares the unpushed one"
+  else
+    bad "apply removes the spent worktree, records it, and spares the unpushed one" \
+        "$(ls "$root/repo/.claude/worktrees" 2>/dev/null; cat "$root/manifest.tsv" 2>/dev/null)"
+  fi
+  rm -rf "$root"
+}
+
+t_rejects_bad_mode() {
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  run "$root" alpply >/dev/null 2>&1
+  local rc=$?
+  if [ "$rc" -ne 0 ] && [ -d "$root/repo/.claude/worktrees/spent" ]; then
+    ok "rejects an invalid MODE without deleting anything"
+  else
+    bad "rejects an invalid MODE without deleting anything" "rc=$rc"
+  fi
+  rm -rf "$root"
+}
+
+printf 'worktree-cleanup.sh contract tests\n'
+t_reaps_spent
+t_keeps_unpushed
+t_keeps_detached_orphan
+t_keeps_dirty
+t_ignores_tool_noise
+t_keeps_untracked_real_file
+t_keeps_young
+t_keeps_live_cwd
+t_dry_run_writes_no_manifest_and_removes_nothing
+t_apply_removes_and_records
+t_rejects_bad_mode
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -397,17 +397,20 @@ t_no_reaped_row_when_removal_is_aborted_after_recording() {
   local root; root=$(make_repo)
   add_wt "$root" stuck pushed
   chmod a-w "$root/repo/.claude/worktrees"          # entries can no longer be unlinked
-  "$SUT" "$root/repo" "$root/manifest.tsv" apply 24 >/dev/null 2>&1
+  local rc
+  "$SUT" "$root/repo" "$root/manifest.tsv" apply 24 >/dev/null 2>&1; rc=$?
   chmod u+w "$root/repo/.claude/worktrees"
   local pending_rows reaped_rows
   pending_rows=$(awk -F'\t' '$5=="pending"' "$root/manifest.tsv" 2>/dev/null | wc -l | tr -d ' ')
   reaped_rows=$(awk -F'\t' '$5=="reaped"' "$root/manifest.tsv" 2>/dev/null | wc -l | tr -d ' ')
-  if [ -d "$root/repo/.claude/worktrees/stuck" ] \
+  # rc must be NON-ZERO: a removal that fails after every gate passed is an
+  # infrastructure failure, not an ordinary KEEP, and must not report a healthy sweep.
+  if [ -d "$root/repo/.claude/worktrees/stuck" ] && [ "$rc" -ne 0 ] \
      && [ "${pending_rows:-0}" -eq 1 ] && [ "${reaped_rows:-0}" -eq 0 ]; then
-    ok "an aborted removal leaves 'pending' and never 'reaped'"
+    ok "a removal that fails after all gates exits non-zero, leaving 'pending' only"
   else
-    bad "an aborted removal leaves 'pending' and never 'reaped'" \
-        "dir=$([ -d "$root/repo/.claude/worktrees/stuck" ] && echo present || echo GONE) pending=$pending_rows reaped=$reaped_rows [$(cat "$root/manifest.tsv" 2>/dev/null)]"
+    bad "a removal that fails after all gates exits non-zero, leaving 'pending' only" \
+        "rc=$rc dir=$([ -d "$root/repo/.claude/worktrees/stuck" ] && echo present || echo GONE) pending=$pending_rows reaped=$reaped_rows [$(cat "$root/manifest.tsv" 2>/dev/null)]"
   fi
   rm -rf "$root"
 }

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -498,6 +498,43 @@ t_keeps_files_hidden_by_index_flags() {
   rm -rf "$root"
 }
 
+t_index_flag_gate_survives_a_large_index() {
+  # The gate was `printf ... | grep -q`. grep -q exits at its FIRST match, printf then
+  # takes SIGPIPE, and under `set -o pipefail` the pipeline reports failure — so the
+  # condition evaluated FALSE and the gate silently failed open. It only manifests once
+  # ls-files -v output exceeds the pipe buffer, which the small fixtures never did.
+  # This builds a large index with the flagged file sorted FIRST, so grep matches early
+  # and leaves a lot of unread output behind it.
+  local root; root=$(make_repo)
+  add_wt "$root" bigidx pushed
+  local b="$root/repo/.claude/worktrees/bigidx"
+  mkdir -p "$b/bulk"
+  ( cd "$b" && for i in $(seq 1 3000); do
+      printf 'x\n' > "bulk/padding-file-with-a-longish-name-$i.txt"
+    done )
+  # The flagged path must sort FIRST. ls-files -v emits in index (path) order, so a
+  # match on line 1 is what makes grep -q exit early and hand printf a SIGPIPE with
+  # most of the output still unread — flagging a late-sorting path (file.txt sorts
+  # after bulk/) lets grep drain the whole stream and reproduces nothing.
+  printf 'flagged\n' > "$b/000-flagged.txt"
+  git -C "$b" add -A >/dev/null 2>&1
+  git -C "$b" commit -qm "bulk" >/dev/null 2>&1
+  git -C "$b" push -q origin claude/bigidx >/dev/null 2>&1
+  git -C "$b" update-index --skip-worktree 000-flagged.txt
+  echo "invisible edit" >> "$b/000-flagged.txt"
+  touch -t 202001010000 "$b"
+  local bytes; bytes=$(git -C "$b" ls-files -v | wc -c | tr -d ' ')
+  local out; out=$(run "$root")
+  if [ "${bytes:-0}" -lt 65536 ]; then
+    bad "index-flag gate survives a large index" "FIXTURE too small: ls-files -v = ${bytes}B (<64K pipe buffer)"
+  elif printf '%s' "$out" | grep -q 'KEEP .*bigidx .*assume-unchanged'; then
+    ok "index-flag gate survives a large index (${bytes}B of ls-files output)"
+  else
+    bad "index-flag gate survives a large index" "bytes=$bytes $(printf '%s' "$out" | grep bigidx)"
+  fi
+  rm -rf "$root"
+}
+
 t_keeps_untracked_when_showUntrackedFiles_is_no() {
   # status.showUntrackedFiles=no would otherwise hide authored untracked files entirely.
   local root; root=$(make_repo)
@@ -583,6 +620,7 @@ t_no_reaped_row_when_removal_is_aborted_after_recording
 t_completion_write_failure_after_removal_is_loud
 t_never_touches_an_unregistered_directory
 t_keeps_files_hidden_by_index_flags
+t_index_flag_gate_survives_a_large_index
 t_keeps_untracked_when_showUntrackedFiles_is_no
 t_dry_run_writes_no_manifest_and_removes_nothing
 t_apply_removes_and_records

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -453,6 +453,62 @@ SHIM
   rm -rf "$root"
 }
 
+t_never_touches_an_unregistered_directory() {
+  # An ordinary directory under .claude/worktrees/ is NOT a worktree. Having no .git
+  # file, every `git -C` call walks up to the main checkout, whose clean+pushed state
+  # made it look eligible — and the rm -rf fallback would delete its contents.
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  local junk="$root/repo/.claude/worktrees/not-a-worktree"
+  mkdir -p "$junk"; echo "important" > "$junk/data.txt"
+  touch -t 202001010000 "$junk"
+  local out; out=$(run "$root" apply)
+  if [ -f "$junk/data.txt" ] \
+     && printf '%s' "$out" | grep -q 'KEEP .*not-a-worktree .*not a registered worktree'; then
+    ok "never deletes an unregistered directory under the worktree root"
+  else
+    bad "never deletes an unregistered directory under the worktree root" \
+        "data=$([ -f "$junk/data.txt" ] && echo present || echo GONE) $out"
+  fi
+  rm -rf "$root"
+}
+
+t_keeps_files_hidden_by_index_flags() {
+  # `git status` cannot see edits to assume-unchanged / skip-worktree files, so a
+  # worktree holding only such edits reads as clean and would be reaped.
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  add_wt "$root" hidden pushed
+  local h="$root/repo/.claude/worktrees/hidden"
+  git -C "$h" update-index --assume-unchanged file.txt
+  echo "edited invisibly" >> "$h/file.txt"
+  local out; out=$(run "$root")
+  if printf '%s' "$out" | grep -q 'KEEP .*hidden .*assume-unchanged' \
+     && printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+    ok "KEEPs a worktree whose edits are hidden by index flags"
+  else
+    bad "KEEPs a worktree whose edits are hidden by index flags" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_keeps_untracked_when_showUntrackedFiles_is_no() {
+  # status.showUntrackedFiles=no would otherwise hide authored untracked files entirely.
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  add_wt "$root" hushed pushed
+  git -C "$root/repo" config status.showUntrackedFiles no
+  echo "only copy" > "$root/repo/.claude/worktrees/hushed/notes.md"
+  touch -t 202001010000 "$root/repo/.claude/worktrees/hushed"
+  local out; out=$(run "$root")
+  if printf '%s' "$out" | grep -q 'KEEP .*hushed .*uncommitted change'; then
+    ok "KEEPs untracked files even under status.showUntrackedFiles=no"
+  else
+    bad "KEEPs untracked files even under status.showUntrackedFiles=no" "$out"
+  fi
+  rm -rf "$root"
+}
+
 t_dry_run_writes_no_manifest_and_removes_nothing() {
   local root; root=$(make_repo)
   add_wt "$root" spent pushed
@@ -519,6 +575,9 @@ t_keeps_parent_of_a_nested_worktree
 t_aborts_when_the_manifest_cannot_be_written
 t_no_reaped_row_when_removal_is_aborted_after_recording
 t_completion_write_failure_after_removal_is_loud
+t_never_touches_an_unregistered_directory
+t_keeps_files_hidden_by_index_flags
+t_keeps_untracked_when_showUntrackedFiles_is_no
 t_dry_run_writes_no_manifest_and_removes_nothing
 t_apply_removes_and_records
 t_rejects_bad_mode

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -610,6 +610,33 @@ t_keeps_worktree_with_orphaned_reflog_commit() {
   rm -rf "$root"
 }
 
+t_keeps_worktree_with_operation_in_progress() {
+  # A worktree mid-rebase holds that operation's state only in its own admin dir, so
+  # reaping it destroys work no commit or reflog accounts for.
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  add_wt "$root" rebasing pushed
+  local w="$root/repo/.claude/worktrees/rebasing"
+  # Build a genuine conflicting rebase rather than faking the marker file.
+  echo one > "$w/file.txt"; git -C "$w" commit -qam "side"
+  git -C "$w" branch -q other main
+  git -C "$w" checkout -q other
+  echo two > "$w/file.txt"; git -C "$w" commit -qam "other side"
+  git -C "$w" rebase "claude/rebasing" >/dev/null 2>&1 || true   # expected to conflict
+  local gd; gd=$(git -C "$w" rev-parse --absolute-git-dir 2>/dev/null)
+  touch -t 202001010000 "$w"
+  local out; out=$(run "$root")
+  if [ ! -e "$gd/rebase-merge" ] && [ ! -e "$gd/rebase-apply" ]; then
+    bad "KEEPs a worktree with a git operation in progress" \
+        "FIXTURE produced no rebase state in $gd"
+  elif printf '%s' "$out" | grep -q 'KEEP .*rebasing .*operation in progress'; then
+    ok "KEEPs a worktree with a git operation in progress"
+  else
+    bad "KEEPs a worktree with a git operation in progress" "$out"
+  fi
+  rm -rf "$root"
+}
+
 t_dry_run_writes_no_manifest_and_removes_nothing() {
   local root; root=$(make_repo)
   add_wt "$root" spent pushed
@@ -682,6 +709,7 @@ t_index_flag_gate_survives_a_large_index
 t_keeps_untracked_when_showUntrackedFiles_is_no
 t_keeps_parent_of_nested_worktree_even_when_ignored
 t_keeps_worktree_with_orphaned_reflog_commit
+t_keeps_worktree_with_operation_in_progress
 t_dry_run_writes_no_manifest_and_removes_nothing
 t_apply_removes_and_records
 t_rejects_bad_mode

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -187,6 +187,34 @@ t_keeps_live_cwd() {
   rm -rf "$root"
 }
 
+t_keeps_live_cwd_in_subdir_with_regex_metachars() {
+  # Regression: the descendant check once used the worktree path as a grep REGEX.
+  # A name containing '[' made grep error, the check reported "no match", and a live
+  # session working in a SUBDIRECTORY was eligible for reaping. Both properties are
+  # pinned here — descendant CWD, and a name full of regex metacharacters.
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  local odd='we[ird.na*me'
+  git -C "$root/repo" worktree add -q -b "claude/odd" \
+      "$root/repo/.claude/worktrees/$odd" main 2>/dev/null
+  git -C "$root/repo" push -q origin "claude/odd"
+  mkdir -p "$root/repo/.claude/worktrees/$odd/nested/deep"
+  touch -t 202001010000 "$root/repo/.claude/worktrees/$odd"
+  ( cd "$root/repo/.claude/worktrees/$odd/nested/deep" && exec sleep 30 ) &
+  local pid=$!
+  sleep 1
+  local out; out=$(run "$root")
+  kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+  if printf '%s' "$out" | grep -qF 'live process CWD' \
+     && ! printf '%s' "$out" | grep -qF "REAP   $odd" \
+     && printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+    ok "KEEPs a live CWD in a SUBDIR of a regex-metachar-named worktree"
+  else
+    bad "KEEPs a live CWD in a SUBDIR of a regex-metachar-named worktree" "$out"
+  fi
+  rm -rf "$root"
+}
+
 t_dry_run_writes_no_manifest_and_removes_nothing() {
   local root; root=$(make_repo)
   add_wt "$root" spent pushed
@@ -243,6 +271,7 @@ t_ignores_tool_noise
 t_keeps_untracked_real_file
 t_keeps_young
 t_keeps_live_cwd
+t_keeps_live_cwd_in_subdir_with_regex_metachars
 t_dry_run_writes_no_manifest_and_removes_nothing
 t_apply_removes_and_records
 t_rejects_bad_mode

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -412,6 +412,47 @@ t_no_reaped_row_when_removal_is_aborted_after_recording() {
   rm -rf "$root"
 }
 
+t_completion_write_failure_after_removal_is_loud() {
+  # The completion record can fail AFTER the directory is gone, which would otherwise
+  # leave a real deletion looking like an aborted attempt.
+  #
+  # SCOPE — what this forces and what it does not. record() appends with a shell
+  # redirect and then VERIFIES with grep -qxF; only the verification is shimmable from
+  # outside (the append is a builtin redirect, and permission tricks cannot be timed
+  # between the pending and completion writes). So this drives the completion record to
+  # FAIL and asserts the property that matters operationally: the run exits non-zero
+  # with the directory gone, so a real deletion can never pass silently as an abort.
+  # The narrower "append physically lost" variant is covered by the documented
+  # reconciliation rule (pending + absent path == deleted), not by this test.
+  local root; root=$(make_repo)
+  add_wt "$root" gone pushed
+  local shim="$root/shim"; mkdir -p "$shim"
+  cat > "$shim/grep" <<'SHIM'
+#!/usr/bin/env bash
+for a in "$@"; do
+  case "$a" in *"	reaped") exit 1 ;; esac      # tab-reaped: the completion verify only
+done
+exec /usr/bin/grep "$@"
+SHIM
+  chmod +x "$shim/grep"
+  local rc
+  PATH="$shim:$PATH" "$SUT" "$root/repo" "$root/manifest.tsv" apply 24 >/dev/null 2>&1; rc=$?
+  local pending_rows reaped_rows
+  pending_rows=$(awk -F'\t' '$5=="pending"' "$root/manifest.tsv" 2>/dev/null | wc -l | tr -d ' ')
+  reaped_rows=$(awk -F'\t' '$5=="reaped"' "$root/manifest.tsv" 2>/dev/null | wc -l | tr -d ' ')
+  # Directory gone + a durable `pending` row + NON-ZERO exit. The pending row must be
+  # present: without it the deletion would be entirely unrecorded, which is the state
+  # the pre-delete durability rule exists to prevent.
+  if [ ! -d "$root/repo/.claude/worktrees/gone" ] && [ "$rc" -ne 0 ] \
+     && [ "${pending_rows:-0}" -eq 1 ]; then
+    ok "a failed completion record after removal exits non-zero and stays reconcilable"
+  else
+    bad "a failed completion record after removal exits non-zero and stays reconcilable" \
+        "rc=$rc dir=$([ -d "$root/repo/.claude/worktrees/gone" ] && echo present || echo GONE) pending=$pending_rows reaped=$reaped_rows"
+  fi
+  rm -rf "$root"
+}
+
 t_dry_run_writes_no_manifest_and_removes_nothing() {
   local root; root=$(make_repo)
   add_wt "$root" spent pushed
@@ -477,6 +518,7 @@ t_keeps_live_cwd_in_subdir_with_regex_metachars
 t_keeps_parent_of_a_nested_worktree
 t_aborts_when_the_manifest_cannot_be_written
 t_no_reaped_row_when_removal_is_aborted_after_recording
+t_completion_write_failure_after_removal_is_loud
 t_dry_run_writes_no_manifest_and_removes_nothing
 t_apply_removes_and_records
 t_rejects_bad_mode

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -276,6 +276,10 @@ t_keeps_locked() {
 t_keeps_staged_gitlink_update() {
   # A STAGED gitlink update lives only in this worktree's index — reaping the worktree
   # destroys it with no commit to recover from. Only unstaged drift (` M`) is noise.
+  # Built with `update-index --cacheinfo` rather than `git submodule add`: the latter
+  # depends on protocol.file.allow and silently produced NO submodule on the CI
+  # runners, so the fixture emitted an empty porcelain and the test passed on nothing.
+  # This form is hermetic and identical from the script's point of view.
   local root; root=$(make_repo)
   local sub="$root/sub.git"
   git init -q --bare "$sub"
@@ -283,22 +287,23 @@ t_keeps_staged_gitlink_update() {
   git init -q -b main "$seed/s"; git -C "$seed/s" config user.email t@t.t
   git -C "$seed/s" config user.name t
   echo one > "$seed/s/f"; git -C "$seed/s" add f; git -C "$seed/s" commit -qm one
-  local first; first=$(git -C "$seed/s" rev-parse HEAD)
+  local subA; subA=$(git -C "$seed/s" rev-parse HEAD)
   echo two > "$seed/s/f"; git -C "$seed/s" commit -qam two
+  local subB; subB=$(git -C "$seed/s" rev-parse HEAD)
   git -C "$seed/s" push -q "$sub" main
-  # `submodule add` pins the parent at the branch tip (two), so moving the worktree's
-  # submodule back to `first` is what actually produces a gitlink delta to stage.
 
-  git -C "$root/repo" -c protocol.file.allow=always submodule add -q "$sub" sub 2>/dev/null
-  git -C "$root/repo" commit -qm "add sub"
-  git -C "$root/repo" push -q origin main
   add_wt "$root" staged pushed
-  git -C "$root/repo/.claude/worktrees/staged" -c protocol.file.allow=always \
-      submodule update -q --init sub 2>/dev/null
-  git -C "$root/repo/.claude/worktrees/staged/sub" checkout -q "$first"
-  git -C "$root/repo/.claude/worktrees/staged" add sub          # STAGE the gitlink
-  touch -t 202001010000 "$root/repo/.claude/worktrees/staged"
-  local st; st=$(git -C "$root/repo/.claude/worktrees/staged" status --porcelain | head -1)
+  local wt="$root/repo/.claude/worktrees/staged"
+  # A real, clean, fully-pushed submodule checkout at B — so the OLD code would judge
+  # this gitlink to be mere drift and reap the worktree.
+  git clone -q "$sub" "$wt/sub"
+  # Parent tracks A and that commit is pushed; then stage the move to B.
+  git -C "$wt" update-index --add --cacheinfo "160000,$subA,sub"
+  git -C "$wt" commit -qm "track sub at A"
+  git -C "$wt" push -q origin claude/staged
+  git -C "$wt" update-index --cacheinfo "160000,$subB,sub"     # STAGED gitlink update
+  touch -t 202001010000 "$wt"
+  local st; st=$(git -C "$wt" status --porcelain | head -1)
   local out; out=$(run "$root")
   if printf '%s' "$out" | grep -q 'KEEP .*staged .*uncommitted change'; then
     ok "KEEPs a STAGED submodule gitlink update"

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -215,6 +215,38 @@ t_keeps_live_cwd_in_subdir_with_regex_metachars() {
   rm -rf "$root"
 }
 
+t_age_gate_works_with_gnu_stat() {
+  # Regression: mtime resolution used `stat -f %m || stat -c %Y`. GNU stat reads -f as
+  # "filesystem status", so on Linux the first form SUCCEEDS with a `File: ...` block
+  # instead of failing, the fallback never ran, and the age arithmetic died with
+  # "File: unbound variable" — taking every gate down with it.
+  # Shims a GNU-only stat (no -f support) so the contract is provable on any host.
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  add_wt "$root" fresh pushed
+  touch "$root/repo/.claude/worktrees/fresh"
+  local shim="$root/shim"; mkdir -p "$shim"
+  cat > "$shim/stat" <<'SHIM'
+#!/usr/bin/env bash
+# GNU-flavoured stat: supports -c, and treats -f as filesystem-status (NOT a failure).
+if [ "${1:-}" = "-c" ]; then
+  case "$2" in %Y) exec /usr/bin/stat -f %m "$3" 2>/dev/null || exit 1 ;; esac
+fi
+if [ "${1:-}" = "-f" ]; then printf '  File: "%s"\n    ID: 0\n' "${3:-$2}"; exit 0; fi
+exit 1
+SHIM
+  chmod +x "$shim/stat"
+  local out; out=$(PATH="$shim:$PATH" "$SUT" "$root/repo" "$root/manifest.tsv" dry-run 24 2>&1)
+  if printf '%s' "$out" | grep -q '^REAP  .*spent' \
+     && printf '%s' "$out" | grep -q 'KEEP .*fresh .*age .*< 24h' \
+     && ! printf '%s' "$out" | grep -qi 'unbound variable'; then
+    ok "age gate resolves mtime under GNU-style stat"
+  else
+    bad "age gate resolves mtime under GNU-style stat" "$out"
+  fi
+  rm -rf "$root"
+}
+
 t_dry_run_writes_no_manifest_and_removes_nothing() {
   local root; root=$(make_repo)
   add_wt "$root" spent pushed
@@ -270,6 +302,7 @@ t_keeps_dirty
 t_ignores_tool_noise
 t_keeps_untracked_real_file
 t_keeps_young
+t_age_gate_works_with_gnu_stat
 t_keeps_live_cwd
 t_keeps_live_cwd_in_subdir_with_regex_metachars
 t_dry_run_writes_no_manifest_and_removes_nothing

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -333,6 +333,58 @@ t_reap_leaves_a_restorable_ref() {
   rm -rf "$root"
 }
 
+t_keeps_parent_of_a_nested_worktree() {
+  # `?? .claude/worktrees/` was in the ignore set, so a session worktree containing a
+  # NESTED worktree read as clean — and reaping the parent recursively deleted the
+  # nested one along with the only copy of its uncommitted work.
+  local root; root=$(make_repo)
+  # `.claude/` must be TRACKED for this to reproduce the real layout: with nothing
+  # tracked under it git collapses the report to `?? .claude/`, and the fixture then
+  # passes for the wrong reason (it did — the ablation caught it). The monorepo tracks
+  # .claude/scripts, so a nested worktree really does surface as `?? .claude/worktrees/`.
+  mkdir -p "$root/repo/.claude/scripts"
+  echo tracked > "$root/repo/.claude/scripts/keep.sh"
+  git -C "$root/repo" add .claude/scripts/keep.sh
+  git -C "$root/repo" commit -qm "track .claude"
+  git -C "$root/repo" push -q origin main
+  add_wt "$root" spent pushed
+  add_wt "$root" parent pushed
+  local p="$root/repo/.claude/worktrees/parent"
+  git -C "$root/repo" worktree add -q -b claude/nested "$p/.claude/worktrees/nested" main
+  echo "sole copy" > "$p/.claude/worktrees/nested/precious.txt"
+  touch -t 202001010000 "$p"
+  local st; st=$(git -C "$p" status --porcelain)
+  case "$st" in
+    *".claude/worktrees/"*) ;;
+    *) bad "KEEPs a worktree that contains a nested worktree" \
+           "FIXTURE did not reproduce '?? .claude/worktrees/': [$st]"; rm -rf "$root"; return ;;
+  esac
+  local out; out=$(run "$root")
+  if printf '%s' "$out" | grep -q 'KEEP .*parent .*uncommitted change' \
+     && printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+    ok "KEEPs a worktree that contains a nested worktree"
+  else
+    bad "KEEPs a worktree that contains a nested worktree" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_aborts_when_the_manifest_cannot_be_written() {
+  # A manifest failure is infrastructure, not a per-worktree verdict: it must abort with
+  # a nonzero status, not keep the candidate and let the run report success.
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  mkdir -p "$root/manifest.tsv"        # a DIRECTORY — the append can never succeed
+  local out rc
+  out=$("$SUT" "$root/repo" "$root/manifest.tsv" apply 24 2>&1); rc=$?
+  if [ "$rc" -ne 0 ] && [ -d "$root/repo/.claude/worktrees/spent" ]; then
+    ok "aborts nonzero when the restore manifest cannot be written"
+  else
+    bad "aborts nonzero when the restore manifest cannot be written" "rc=$rc $out"
+  fi
+  rm -rf "$root"
+}
+
 t_dry_run_writes_no_manifest_and_removes_nothing() {
   local root; root=$(make_repo)
   add_wt "$root" spent pushed
@@ -394,6 +446,8 @@ t_keeps_staged_gitlink_update
 t_reap_leaves_a_restorable_ref
 t_keeps_live_cwd
 t_keeps_live_cwd_in_subdir_with_regex_metachars
+t_keeps_parent_of_a_nested_worktree
+t_aborts_when_the_manifest_cannot_be_written
 t_dry_run_writes_no_manifest_and_removes_nothing
 t_apply_removes_and_records
 t_rejects_bad_mode

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -253,6 +253,75 @@ SHIM
   rm -rf "$root"
 }
 
+t_keeps_locked() {
+  # COVERAGE NOTE: this locks BEFORE the sweep starts, so it exercises the startup
+  # snapshot. The mid-sweep re-check (is_locked_now, which stops --force overriding a
+  # lock acquired while the sweep runs) is defense-in-depth against a real race and is
+  # deliberately NOT claimed as covered here — ablating it leaves this test green.
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  add_wt "$root" held pushed
+  git -C "$root/repo" worktree lock "$root/repo/.claude/worktrees/held"
+  local out; out=$(run "$root")
+  git -C "$root/repo" worktree unlock "$root/repo/.claude/worktrees/held" 2>/dev/null
+  if printf '%s' "$out" | grep -q 'KEEP .*held .*locked' \
+     && printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+    ok "KEEPs a locked worktree"
+  else
+    bad "KEEPs a locked worktree" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_keeps_staged_gitlink_update() {
+  # A STAGED gitlink update lives only in this worktree's index — reaping the worktree
+  # destroys it with no commit to recover from. Only unstaged drift (` M`) is noise.
+  local root; root=$(make_repo)
+  local sub="$root/sub.git"
+  git init -q --bare "$sub"
+  local seed; seed=$(mktemp -d)
+  git init -q -b main "$seed/s"; git -C "$seed/s" config user.email t@t.t
+  git -C "$seed/s" config user.name t
+  echo one > "$seed/s/f"; git -C "$seed/s" add f; git -C "$seed/s" commit -qm one
+  local first; first=$(git -C "$seed/s" rev-parse HEAD)
+  echo two > "$seed/s/f"; git -C "$seed/s" commit -qam two
+  git -C "$seed/s" push -q "$sub" main
+  # `submodule add` pins the parent at the branch tip (two), so moving the worktree's
+  # submodule back to `first` is what actually produces a gitlink delta to stage.
+
+  git -C "$root/repo" -c protocol.file.allow=always submodule add -q "$sub" sub 2>/dev/null
+  git -C "$root/repo" commit -qm "add sub"
+  git -C "$root/repo" push -q origin main
+  add_wt "$root" staged pushed
+  git -C "$root/repo/.claude/worktrees/staged" -c protocol.file.allow=always \
+      submodule update -q --init sub 2>/dev/null
+  git -C "$root/repo/.claude/worktrees/staged/sub" checkout -q "$first"
+  git -C "$root/repo/.claude/worktrees/staged" add sub          # STAGE the gitlink
+  touch -t 202001010000 "$root/repo/.claude/worktrees/staged"
+  local st; st=$(git -C "$root/repo/.claude/worktrees/staged" status --porcelain | head -1)
+  local out; out=$(run "$root")
+  if printf '%s' "$out" | grep -q 'KEEP .*staged .*uncommitted change'; then
+    ok "KEEPs a STAGED submodule gitlink update"
+  else
+    bad "KEEPs a STAGED submodule gitlink update" "porcelain=[$st] $out"
+  fi
+  rm -rf "$root" "$seed"
+}
+
+t_reap_leaves_a_restorable_ref() {
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  local sha; sha=$(git -C "$root/repo/.claude/worktrees/spent" rev-parse HEAD)
+  run "$root" apply >/dev/null
+  if [ "$(git -C "$root/repo" rev-parse --verify --quiet "refs/reaped/$sha")" = "$sha" ]; then
+    ok "reaping leaves refs/reaped/<sha> so the manifest SHA stays restorable"
+  else
+    bad "reaping leaves refs/reaped/<sha> so the manifest SHA stays restorable" \
+        "$(git -C "$root/repo" for-each-ref refs/reaped)"
+  fi
+  rm -rf "$root"
+}
+
 t_dry_run_writes_no_manifest_and_removes_nothing() {
   local root; root=$(make_repo)
   add_wt "$root" spent pushed
@@ -309,6 +378,9 @@ t_ignores_tool_noise
 t_keeps_untracked_real_file
 t_keeps_young
 t_age_gate_works_with_gnu_stat
+t_keeps_locked
+t_keeps_staged_gitlink_update
+t_reap_leaves_a_restorable_ref
 t_keeps_live_cwd
 t_keeps_live_cwd_in_subdir_with_regex_metachars
 t_dry_run_writes_no_manifest_and_removes_nothing

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -35,8 +35,14 @@ make_repo() {
 # add_wt <root> <name> [pushed|unpushed]
 add_wt() {
   local root=$1 name=$2 kind=${3:-pushed}
-  git -C "$root/repo" worktree add -q -b "claude/$name" \
-      "$root/repo/.claude/worktrees/$name" main 2>/dev/null
+  # Status-checked, and stderr is kept on failure. A silently-failing fixture produces a
+  # repo with no worktree, and a REAP-negative assertion then passes on nothing — the
+  # exact hazard that let the staged-gitlink test go green against an empty porcelain.
+  if ! git -C "$root/repo" worktree add -q -b "claude/$name" \
+         "$root/repo/.claude/worktrees/$name" main; then
+    printf 'FIXTURE FAILURE: worktree add %s\n' "$name" >&2
+    return 1
+  fi
   if [ "$kind" = unpushed ]; then
     echo change > "$root/repo/.claude/worktrees/$name/new.txt"
     git -C "$root/repo/.claude/worktrees/$name" add new.txt

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -385,6 +385,33 @@ t_aborts_when_the_manifest_cannot_be_written() {
   rm -rf "$root"
 }
 
+t_no_reaped_row_when_removal_is_aborted_after_recording() {
+  # The durability rule writes the manifest row BEFORE deleting, but several gates can
+  # still abort after that point. A row alone must therefore not read as "removed":
+  # here the worktree is LOCKED between the pre-record gates and the removal, so the
+  # run must leave a `pending` row and NO `reaped` row, and the directory must survive.
+  # The failure must land AFTER record(), so an early KEEP gate cannot be what makes
+  # this pass — a read-only parent directory lets every gate succeed and then makes the
+  # removal itself fail. Asserting the `pending` row EXISTS is what rules out the
+  # vacuous case where the worktree never reached record() at all.
+  local root; root=$(make_repo)
+  add_wt "$root" stuck pushed
+  chmod a-w "$root/repo/.claude/worktrees"          # entries can no longer be unlinked
+  "$SUT" "$root/repo" "$root/manifest.tsv" apply 24 >/dev/null 2>&1
+  chmod u+w "$root/repo/.claude/worktrees"
+  local pending_rows reaped_rows
+  pending_rows=$(awk -F'\t' '$5=="pending"' "$root/manifest.tsv" 2>/dev/null | wc -l | tr -d ' ')
+  reaped_rows=$(awk -F'\t' '$5=="reaped"' "$root/manifest.tsv" 2>/dev/null | wc -l | tr -d ' ')
+  if [ -d "$root/repo/.claude/worktrees/stuck" ] \
+     && [ "${pending_rows:-0}" -eq 1 ] && [ "${reaped_rows:-0}" -eq 0 ]; then
+    ok "an aborted removal leaves 'pending' and never 'reaped'"
+  else
+    bad "an aborted removal leaves 'pending' and never 'reaped'" \
+        "dir=$([ -d "$root/repo/.claude/worktrees/stuck" ] && echo present || echo GONE) pending=$pending_rows reaped=$reaped_rows [$(cat "$root/manifest.tsv" 2>/dev/null)]"
+  fi
+  rm -rf "$root"
+}
+
 t_dry_run_writes_no_manifest_and_removes_nothing() {
   local root; root=$(make_repo)
   add_wt "$root" spent pushed
@@ -406,7 +433,8 @@ t_apply_removes_and_records() {
   # NB: compare the exact tab-delimited BRANCH field. A substring grep is unusable
   # here: every manifest path contains '.claude/worktrees/', which contains BOTH
   # '/work' and 'claude/work' — so a naive grep reports the spared branch as recorded.
-  local branches; branches=$(awk -F'\t' '{print $2}' "$root/manifest.tsv" 2>/dev/null)
+  # only 'reaped' rows count as removals — a 'pending' row may be an aborted attempt
+  local branches; branches=$(awk -F'\t' '$5=="reaped"{print $2}' "$root/manifest.tsv" 2>/dev/null)
   if [ ! -d "$root/repo/.claude/worktrees/spent" ] \
      && [ -d "$root/repo/.claude/worktrees/work" ] \
      && printf '%s\n' "$branches" | grep -qxF 'claude/spent' \
@@ -448,6 +476,7 @@ t_keeps_live_cwd
 t_keeps_live_cwd_in_subdir_with_regex_metachars
 t_keeps_parent_of_a_nested_worktree
 t_aborts_when_the_manifest_cannot_be_written
+t_no_reaped_row_when_removal_is_aborted_after_recording
 t_dry_run_writes_no_manifest_and_removes_nothing
 t_apply_removes_and_records
 t_rejects_bad_mode

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -228,11 +228,17 @@ t_age_gate_works_with_gnu_stat() {
   local shim="$root/shim"; mkdir -p "$shim"
   cat > "$shim/stat" <<'SHIM'
 #!/usr/bin/env bash
-# GNU-flavoured stat: supports -c, and treats -f as filesystem-status (NOT a failure).
-if [ "${1:-}" = "-c" ]; then
-  case "$2" in %Y) exec /usr/bin/stat -f %m "$3" 2>/dev/null || exit 1 ;; esac
-fi
-if [ "${1:-}" = "-f" ]; then printf '  File: "%s"\n    ID: 0\n' "${3:-$2}"; exit 0; fi
+# GNU-flavoured stat: -c %Y yields the real mtime, while -f is filesystem-status and
+# SUCCEEDS with a `File: ...` block instead of failing. That combination is what broke
+# the age gate on Linux.
+# The real mtime is fetched flavour-agnostically so this shim runs on a BSD host too.
+real_mtime() {
+  /usr/bin/stat -c %Y "$1" 2>/dev/null && return 0
+  /usr/bin/stat -f %m "$1" 2>/dev/null && return 0
+  return 1
+}
+if [ "${1:-}" = "-c" ] && [ "${2:-}" = "%Y" ]; then real_mtime "$3"; exit $?; fi
+if [ "${1:-}" = "-f" ]; then printf '  File: "%s"\n    ID: 0\n' "${3:-${2:-}}"; exit 0; fi
 exit 1
 SHIM
   chmod +x "$shim/stat"

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -555,6 +555,61 @@ t_keeps_untracked_when_showUntrackedFiles_is_no() {
   rm -rf "$root"
 }
 
+t_keeps_parent_of_nested_worktree_even_when_ignored() {
+  # The untracked-directory signal is defeated by a .gitignore covering
+  # .claude/worktrees/ — status then emits nothing at all for the nested worktree, and
+  # reaping the parent would recursively delete it. The registered-worktree list is the
+  # authoritative signal and owes nothing to ignore rules.
+  local root; root=$(make_repo)
+  printf '.claude/worktrees/\n' > "$root/repo/.gitignore"
+  git -C "$root/repo" add .gitignore
+  git -C "$root/repo" commit -qm "ignore worktrees"
+  git -C "$root/repo" push -q origin main
+  add_wt "$root" spent pushed
+  add_wt "$root" parent2 pushed
+  local p="$root/repo/.claude/worktrees/parent2"
+  git -C "$root/repo" worktree add -q -b claude/nested2 "$p/.claude/worktrees/nested2" main
+  echo "sole copy" > "$p/.claude/worktrees/nested2/precious.txt"
+  touch -t 202001010000 "$p"
+  # Prove the fixture really does hide it from status, or the test proves nothing.
+  local st; st=$(git -C "$p" status --porcelain --untracked-files=all)
+  local out; out=$(run "$root")
+  if [ -n "$st" ]; then
+    bad "KEEPs a parent whose nested worktree is hidden by .gitignore" \
+        "FIXTURE did not hide it: [$st]"
+  elif printf '%s' "$out" | grep -q 'KEEP .*parent2 .*contains a registered worktree'; then
+    ok "KEEPs a parent whose nested worktree is hidden by .gitignore"
+  else
+    bad "KEEPs a parent whose nested worktree is hidden by .gitignore" "$out"
+  fi
+  rm -rf "$root"
+}
+
+t_keeps_worktree_with_orphaned_reflog_commit() {
+  # HEAD can be remotely reachable while the reflog still holds an earlier UNPUSHED
+  # commit (commit, then reset back to the pushed one). The per-worktree reflog dies
+  # with the directory, so that commit's only reference goes with it.
+  local root; root=$(make_repo)
+  add_wt "$root" spent pushed
+  add_wt "$root" reflog pushed
+  local w="$root/repo/.claude/worktrees/reflog"
+  echo "work in progress" > "$w/wip.txt"
+  git -C "$w" add wip.txt
+  git -C "$w" commit -qm "unpushed wip"
+  local lost; lost=$(git -C "$w" rev-parse HEAD)
+  git -C "$w" reset -q --hard HEAD~1          # HEAD back to the pushed commit
+  touch -t 202001010000 "$w"
+  local out; out=$(run "$root")
+  if printf '%s' "$out" | grep -q 'KEEP .*reflog .*reflog holds commit' \
+     && printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+    ok "KEEPs a worktree whose reflog holds an otherwise-unreachable commit"
+  else
+    bad "KEEPs a worktree whose reflog holds an otherwise-unreachable commit" \
+        "lost=$lost $out"
+  fi
+  rm -rf "$root"
+}
+
 t_dry_run_writes_no_manifest_and_removes_nothing() {
   local root; root=$(make_repo)
   add_wt "$root" spent pushed
@@ -625,6 +680,8 @@ t_never_touches_an_unregistered_directory
 t_keeps_files_hidden_by_index_flags
 t_index_flag_gate_survives_a_large_index
 t_keeps_untracked_when_showUntrackedFiles_is_no
+t_keeps_parent_of_nested_worktree_even_when_ignored
+t_keeps_worktree_with_orphaned_reflog_commit
 t_dry_run_writes_no_manifest_and_removes_nothing
 t_apply_removes_and_records
 t_rejects_bad_mode

--- a/.claude/scripts/worktree-cleanup.test.sh
+++ b/.claude/scripts/worktree-cleanup.test.sh
@@ -476,19 +476,25 @@ t_never_touches_an_unregistered_directory() {
 t_keeps_files_hidden_by_index_flags() {
   # `git status` cannot see edits to assume-unchanged / skip-worktree files, so a
   # worktree holding only such edits reads as clean and would be reaped.
+  # BOTH bits are covered: ls-files -v marks assume-unchanged lowercase and
+  # skip-worktree uppercase `S`, and a lowercase-only pattern missed the latter.
   local root; root=$(make_repo)
-  add_wt "$root" spent pushed
-  add_wt "$root" hidden pushed
-  local h="$root/repo/.claude/worktrees/hidden"
-  git -C "$h" update-index --assume-unchanged file.txt
-  echo "edited invisibly" >> "$h/file.txt"
-  local out; out=$(run "$root")
-  if printf '%s' "$out" | grep -q 'KEEP .*hidden .*assume-unchanged' \
-     && printf '%s' "$out" | grep -q '^REAP  .*spent'; then
-    ok "KEEPs a worktree whose edits are hidden by index flags"
-  else
-    bad "KEEPs a worktree whose edits are hidden by index flags" "$out"
-  fi
+  local flag pass_all=1
+  for flag in assume-unchanged skip-worktree; do
+    add_wt "$root" spent pushed
+    add_wt "$root" "hidden-$flag" pushed
+    local h="$root/repo/.claude/worktrees/hidden-$flag"
+    git -C "$h" update-index "--$flag" file.txt
+    echo "edited invisibly" >> "$h/file.txt"
+    local out; out=$(run "$root")
+    if ! printf '%s' "$out" | grep -q "KEEP .*hidden-$flag .*assume-unchanged" \
+       || ! printf '%s' "$out" | grep -q '^REAP  .*spent'; then
+      pass_all=0
+      bad "KEEPs a worktree whose edits are hidden by index flags ($flag)" "$out"
+    fi
+    rm -rf "$root"; root=$(make_repo)
+  done
+  [ "$pass_all" -eq 1 ] && ok "KEEPs worktrees hidden by BOTH assume-unchanged and skip-worktree"
   rm -rf "$root"
 }
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
       active-projects: ${{ steps.filter.outputs.active-projects }}
       safe-clone: ${{ steps.filter.outputs.safe-clone }}
       branch-cleanup: ${{ steps.filter.outputs.branch-cleanup }}
+      worktree-cleanup: ${{ steps.filter.outputs.worktree-cleanup }}
       submodule-init: ${{ steps.filter.outputs.submodule-init }}
       maintainer-preflight: ${{ steps.filter.outputs.maintainer-preflight }}
       self-review-contract: ${{ steps.filter.outputs.self-review-contract }}
@@ -85,6 +86,10 @@ jobs:
             branch-cleanup:
               - '.claude/scripts/branch-cleanup.sh'
               - '.claude/scripts/branch-cleanup.test.sh'
+            worktree-cleanup:
+              - '.claude/scripts/worktree-cleanup.sh'
+              - '.claude/scripts/worktree-cleanup-all.sh'
+              - '.claude/scripts/worktree-cleanup.test.sh'
               # Self-gate on the workflow too, so a change that breaks this
               # job's own wiring still runs the test it gates.
               - '.github/workflows/ci.yaml'
@@ -359,6 +364,31 @@ jobs:
       - name: Self-test branch-cleanup namespaces
         run: bash .claude/scripts/branch-cleanup.test.sh
 
+  test-worktree-cleanup:
+    name: Test worktree cleanup
+    needs: changes
+    if: needs.changes.outputs.worktree-cleanup == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # Hermetic bare-origin fixture — no network, no token. Pins every fail-closed
+      # KEEP gate (live process CWD, lock, age, unreachable-from-remote commits,
+      # uncommitted work) against a reaped-baseline control, so a run that reaps
+      # nothing cannot pass the gate assertions vacuously.
+      # The macos leg is load-bearing: the host ships bash 3.2, which cannot parse
+      # `case` inside $( ), and the age/stat probes are BSD-flavoured there.
+      - name: Self-test worktree-cleanup safety gates
+        run: bash .claude/scripts/worktree-cleanup.test.sh
+
   test-submodule-init:
     needs: changes
     if: needs.changes.outputs.submodule-init == 'true'
@@ -536,6 +566,7 @@ jobs:
       - test-flow-scorecard
       - test-safe-clone
       - test-branch-cleanup
+      - test-worktree-cleanup
       - test-submodule-init
       - test-maintainer-preflight
       - test-memory-hygiene
@@ -560,6 +591,7 @@ jobs:
             ${{ needs.test-flow-scorecard.result }}
             ${{ needs.test-safe-clone.result }}
             ${{ needs.test-branch-cleanup.result }}
+            ${{ needs.test-worktree-cleanup.result }}
             ${{ needs.test-submodule-init.result }}
             ${{ needs.test-maintainer-preflight.result }}
             ${{ needs.test-memory-hygiene.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,7 @@ jobs:
               - '.claude/scripts/worktree-cleanup.sh'
               - '.claude/scripts/worktree-cleanup-all.sh'
               - '.claude/scripts/worktree-cleanup.test.sh'
+              - '.claude/scripts/worktree-cleanup-all.test.sh'
               # Self-gate on the workflow too, so a change that breaks this
               # job's own wiring still runs the test it gates.
               - '.github/workflows/ci.yaml'
@@ -388,6 +389,8 @@ jobs:
       # `case` inside $( ), and the age/stat probes are BSD-flavoured there.
       - name: Self-test worktree-cleanup safety gates
         run: bash .claude/scripts/worktree-cleanup.test.sh
+      - name: Self-test the multi-repo orchestrator
+        run: bash .claude/scripts/worktree-cleanup-all.test.sh
 
   test-submodule-init:
     needs: changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2301,8 +2301,10 @@ Per-repo safety lives in [`worktree-cleanup.sh`](.claude/scripts/worktree-cleanu
 **fail-closed**: it KEEPs any worktree that is a **live process CWD**, is **locked**, is **younger
 than `min_age_hours`**, holds **commits not reachable from any remote** (one
 `git rev-list --not --remotes` test covering both an unpushed branch and an orphan detached HEAD), or
-has **uncommitted work** — where submodule gitlink drift and `?? .codex/` / `?? .agents/` count as
-noise only once the submodule itself is proven clean and pushed. Every removal is recorded to a
+has **uncommitted work**. Two things are treated as noise rather than work: **unstaged** submodule
+gitlink drift — and only once that submodule is itself proven clean and pushed (a *staged* gitlink is
+authored intent living solely in that worktree's index, so it always counts as work) — and the stray
+tool dirs `?? .codex/` / `?? .agents/`, which are filtered unconditionally. Every removal is recorded to a
 restore manifest **outside the repo** (`~/.claude/worktree-cleanup-manifests/`) before it happens, and
 any infrastructure failure aborts rather than reaping. **Do not add a per-run worktree sweep** to
 compensate; a session removing its *own* worktree is exactly the thing that cannot work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2318,10 +2318,14 @@ cleanup too, and this sweep is what unblocks it.
 (maintainer direction 2026-07-16: *"You never clean up old branches locally or on the remote. I expect
 you to always clean up and switch back to the default branch after a tick."*). Left unswept, every run's
 worktree branch survives it: the first sweep found **~1,140 spent branches** (monorepo alone had **589**
-local; `.github` had **35** stale remote). **Remove your own per-run worktree FIRST, then run**
+local; `.github` had **35** stale remote). Run
 [`.claude/scripts/branch-cleanup.sh <repo_path> <repo-name> <manifest> [apply|dry-run] [namespace]`](.claude/scripts/branch-cleanup.sh)
-for each repo touched — a branch still checked out by your own worktree sits in the keep-set, so a
-sweep run before the worktree removal silently spares the very branch the tick just spent.
+for each repo touched. **If you created an EXTRA worktree of your own during the run — one you are not
+running inside — remove that first**, because a branch still checked out by a worktree sits in the
+keep-set and would be spared. **Your own SESSION worktree is the exception and needs no action here:**
+you cannot remove the directory you are running in, and per *Worktree hygiene is SCHEDULED* above the
+LaunchAgent reaps it (and frees its branch for a later sweep) once it is idle and aged. Expect your own
+session branch to survive the tick that spent it; that is the scheduled sweep's job, not yours.
 **`<repo-name>` is the BARE repository name** (`monorepo`, `platform`) — the script prepends
 `devantler-tech/` itself. It is **not** your session/worktree slug and **not** `owner/repo`; both are
 rejected, and passing the owner-qualified form is the likelier mistake because the first rejection

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2289,6 +2289,29 @@ Never `git reset --hard`, `git stash`, force-push, or discard changes you did no
 `git add -A` / `git add .` — stage only files you edited. Never stage submodule-pointer bumps unless
 a task explicitly calls for it. Leave every checkout/worktree clean when done.
 
+**Worktree hygiene is SCHEDULED, not per-run — never rely on a session to remove its own worktree.**
+The harness creates a per-session worktree at `<repo>/.claude/worktrees/<slug>`, and the owning
+session **structurally cannot remove it**: that directory is the session's own working directory, and
+sessions routinely end abruptly (crash, timeout, closed window) with no teardown. So the sweep must
+come from **outside** any session. It does, via the `tech.devantler.worktree-cleanup` LaunchAgent
+(runtime-local, `~/Library/LaunchAgents/`), which runs
+[`.claude/scripts/worktree-cleanup-all.sh [apply|dry-run] [min_age_hours]`](.claude/scripts/worktree-cleanup-all.sh)
+every 6 hours and at login across the monorepo and every submodule discovered from `.gitmodules`.
+Per-repo safety lives in [`worktree-cleanup.sh`](.claude/scripts/worktree-cleanup.sh) and is
+**fail-closed**: it KEEPs any worktree that is a **live process CWD**, is **locked**, is **younger
+than `min_age_hours`**, holds **commits not reachable from any remote** (one
+`git rev-list --not --remotes` test covering both an unpushed branch and an orphan detached HEAD), or
+has **uncommitted work** — where submodule gitlink drift and `?? .codex/` / `?? .agents/` count as
+noise only once the submodule itself is proven clean and pushed. Every removal is recorded to a
+restore manifest **outside the repo** (`~/.claude/worktree-cleanup-manifests/`) before it happens, and
+any infrastructure failure aborts rather than reaping. **Do not add a per-run worktree sweep** to
+compensate; a session removing its *own* worktree is exactly the thing that cannot work.
+Measured 2026-07-29, the run that introduced this: **124 leaked monorepo worktrees, ~15.7 GB across
+`.claude` and `.codex`, disk at 99%, and new sessions failing to start** for want of 5.4 GB. Because a
+branch checked out by a worktree is permanently in `branch-cleanup.sh`'s keep-set, the same leak had
+also pinned **84 of 422** local `claude/*` branches — so leaked worktrees silently disable branch
+cleanup too, and this sweep is what unblocks it.
+
 **End-of-tick branch hygiene — reap spent branches and return to the default branch, EVERY run**
 (maintainer direction 2026-07-16: *"You never clean up old branches locally or on the remote. I expect
 you to always clean up and switch back to the default branch after a tick."*). Left unswept, every run's


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

New Claude Code sessions stopped starting on the agent host: *"Not enough disk space… 4.1 GB free, but at least 5.4 GB is needed to set up a worktree."*

The harness creates a per-session worktree under `.claude/worktrees/`, and **nothing ever removes it**. The session that owns it structurally cannot — that directory is the session's own working directory, and sessions routinely end abruptly with no teardown. With no sweeper running outside the session, they accumulate forever.

Measured on the host: **124 leaked monorepo worktrees, ~15.7 GB, disk at 99%**. The same leak also pinned **84 of 422** local `claude/*` branches in `branch-cleanup.sh`'s keep-set — so leaked worktrees were silently disabling branch cleanup too.

## What

A sweeper that runs **outside any session** — a LaunchAgent every 6 hours and at login — across the monorepo and every submodule discovered from `.gitmodules`.

It is fail-closed: a worktree is kept if it is a live process's working directory, is locked, is too young, holds **commits that exist nowhere else**, or has uncommitted work. Every removal is written to a restore manifest outside the repo before it happens, and any infrastructure failure aborts instead of reaping.

Already reclaimed **3.2 GB** on the host (6.0 GB → 17 GB free); 8 worktrees holding genuinely unpushed work were correctly spared.

**Operational note:** the LaunchAgent is runtime-local and already installed, currently running a vendored copy of these scripts. Once this merges it switches to the repo copy automatically.

