### PR TITLE
fix(agents): drain oldest drafts before recent work

### DIFF
--- a/.claude/scripts/work-priority-ladder.test.sh
+++ b/.claude/scripts/work-priority-ladder.test.sh
@@ -76,10 +76,18 @@ assert_prose 'scoping below bounds the merge COMMAND, never the SWEEP' \
 # ── 3. rung 1 drains the oldest work before the freshest ──────────────────────
 assert_prose 'oldest-updated first across the whole lane' \
   "${constitution_flat}" "rung 1 does not order drafts oldest-updated first across the lane"
+# Markdown backticks are literal prose, not command substitution.
+# shellcheck disable=SC2016
+assert_prose 'Sort the actionable own/trusted set by `updatedAt` ascending' \
+  "${constitution_flat}" "rung 1 does not specify the normative updatedAt ascending sort"
+assert_prose 'a stale draft is not worth reviving' \
+  "${constitution_flat}" "rung 1 allows close-and-refile for a draft still worth reviving"
 assert_prose 'closed with every still-valid finding re-filed as an issue' \
   "${constitution_flat}" "rung 1 does not name close-and-refile as a legitimate terminal state"
 assert_prose "the lane's total open own-PR count must not rise while the oldest cohort drains" \
   "${constitution_flat}" "rung 1 lets old-draft disposal finance replacement intake"
+assert_prose 'no replacement draft may be opened merely because an old one was disposed of' \
+  "${constitution_flat}" "rung 1 permits replacement drafts after old-draft disposal"
 
 # ── 4. severity outranks age ──────────────────────────────────────────────────
 assert_prose 'Severity outranks age at rungs 2–3; age decides only *within* a rung' \

--- a/.claude/scripts/work-priority-ladder.test.sh
+++ b/.claude/scripts/work-priority-ladder.test.sh
@@ -16,10 +16,12 @@
 #   1. the ladder exists, is ordered, and names all five rungs;
 #   2. rung 1 explicitly covers OWN DRAFTS, and Merge policy's `non-draft` is explicitly scoped to
 #      the merge command rather than the sweep — the exact misreading that produced the pile;
-#   3. severity outranks age, so a Security issue is not queued behind an older Docs one;
-#   4. the run-loop skill agrees with the contract — three surfaces restate this ordering, and a
+#   3. rung 1 is oldest-updated first across the whole lane, with explicit terminal states and no
+#      replacement-intake loophole;
+#   4. severity outranks age, so a Security issue is not queued behind an older Docs one;
+#   5. the run-loop skill agrees with the contract — three surfaces restate this ordering, and a
 #      silent divergence between them is how the previous wording drifted;
-#   5. intake is CAPPED and not merely ordered — because fixing (2) still did not drain the pile, and
+#   6. intake is CAPPED and not merely ordered — because fixing (2) still did not drain the pile, and
 #      the re-measurement showed why: ordering is not the binding constraint, review capacity is.
 
 set -euo pipefail
@@ -71,11 +73,19 @@ assert_prose 'draft and non-draft alike' \
 assert_prose 'scoping below bounds the merge COMMAND, never the SWEEP' \
   "${constitution_flat}" "Merge policy does not scope its non-draft clause to the merge command"
 
-# ── 3. severity outranks age ──────────────────────────────────────────────────
+# ── 3. rung 1 drains the oldest work before the freshest ──────────────────────
+assert_prose 'oldest-updated first across the whole lane' \
+  "${constitution_flat}" "rung 1 does not order drafts oldest-updated first across the lane"
+assert_prose 'closed with every still-valid finding re-filed as an issue' \
+  "${constitution_flat}" "rung 1 does not name close-and-refile as a legitimate terminal state"
+assert_prose "the lane's total open own-PR count must not rise while the oldest cohort drains" \
+  "${constitution_flat}" "rung 1 lets old-draft disposal finance replacement intake"
+
+# ── 4. severity outranks age ──────────────────────────────────────────────────
 assert_prose 'Severity outranks age at rungs 2–3; age decides only *within* a rung' \
   "${constitution_flat}" "contract does not state that severity outranks age"
 
-# ── 4. the run-loop skill agrees with the contract ────────────────────────────
+# ── 5. the run-loop skill agrees with the contract ────────────────────────────
 assert_prose 'Your own DRAFTS are rung-1 work' \
   "${skill_flat}" "run-loop skill does not carry the own-drafts rung-1 rule"
 assert_prose 'severity is the primary sort, age the tiebreaker within a tier' \
@@ -83,7 +93,7 @@ assert_prose 'severity is the primary sort, age the tiebreaker within a tier' \
 assert_prose 'Resolve the next issue by the ladder' \
   "${skill_flat}" "run-loop skill's advance step does not follow the ladder"
 
-# ── 5. intake is CAPPED, not merely ordered ──────────────────────────────────
+# ── 6. intake is CAPPED, not merely ordered ──────────────────────────────────
 # Re-measured 2026-07-26, after §2's fix landed: the pile did NOT drain. 99 → 91 open own PRs, still
 # 100% drafts, and median age ROSE 6.9d → 8.0d. Per lane it was 88/91 `codex/*` — and 63 of those 88
 # (72%) were opened on ONE day, all on one repo, all one theme, every sampled one NEVER reviewed and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -617,10 +617,11 @@ is what *starting* outruns *finishing* looks like, and closing it is rung 1's jo
 **Within rung 1, work oldest-updated first across the whole lane, not per repository.** Sort the
 actionable own/trusted set by `updatedAt` ascending; choosing the freshest or easiest PR first is not
 following the rung. A PR reaches a terminal state when it is merged, parked on a named live-verified
-blocker, or closed with every still-valid finding re-filed as an issue (an invalid or superseded
-finding may instead be closed with the reason recorded). Closing old work creates no intake credit:
-the lane's total open own-PR count must not rise while the oldest cohort drains, and no replacement
-draft may be opened merely because an old one was disposed of.
+blocker, or—when a stale draft is not worth reviving—closed with every still-valid finding re-filed
+as an issue (an invalid or superseded finding may instead be closed with the reason recorded).
+Closing old work creates no intake credit: the lane's total open own-PR count must not rise while the
+oldest cohort drains, and no replacement draft may be opened merely because an old one was disposed
+of.
 
 **Severity outranks age at rungs 2–3; age decides only *within* a rung.** A three-week-old `Docs`
 issue never precedes an open `Security` one. Rungs 2 and 3 are otherwise ordinary issue work under

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -614,6 +614,14 @@ promoted**, median age **6.9 days** — of which **18 were already `CLEAN`** (me
 were opened**. Throughput was never the problem: ~27 own PRs merged per day that same week. The pile
 is what *starting* outruns *finishing* looks like, and closing it is rung 1's job.
 
+**Within rung 1, work oldest-updated first across the whole lane, not per repository.** Sort the
+actionable own/trusted set by `updatedAt` ascending; choosing the freshest or easiest PR first is not
+following the rung. A PR reaches a terminal state when it is merged, parked on a named live-verified
+blocker, or closed with every still-valid finding re-filed as an issue (an invalid or superseded
+finding may instead be closed with the reason recorded). Closing old work creates no intake credit:
+the lane's total open own-PR count must not rise while the oldest cohort drains, and no replacement
+draft may be opened merely because an old one was disposed of.
+
 **Severity outranks age at rungs 2–3; age decides only *within* a rung.** A three-week-old `Docs`
 issue never precedes an open `Security` one. Rungs 2 and 3 are otherwise ordinary issue work under
 *Drain oldest-first* — the same actionability test, the same claim protocol, the same


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- order rung-1 PR work by oldest `updatedAt` across the whole writer lane
- make close-and-refile an explicit terminal state when reviving a stale draft is no longer worthwhile
- prevent old-draft disposal from becoming credit to open replacement drafts
- pin all three invariants in the existing work-priority contract suite

## Evidence

The Codex lane drained open drafts while leaving its oldest fixed cohort effectively untouched:

| Measurement | 2026-07-26 | 2026-07-29 | 2026-07-30 |
|---|---:|---:|---:|
| Open `codex/*` drafts | 88 | 72 | 69 |
| Open pre-2026-07-19 cohort | 63 | 62 | 62 |

The lane finished 19 drafts while the oldest cohort moved by one, and median draft age rose from 8.0 to 10.9 days. This isolates missing within-rung ordering rather than throughput or intake as the remaining defect.

## Verification

- RED: the new contract assertion failed because rung 1 had no oldest-updated ordering
- GREEN: the focused work-priority contract test passes
- ablation: removing the guarded phrase changed the file hash and restored the exact RED failure; restoring it returned GREEN
- neighboring agent-role, portfolio-surveyor, product-value, self-review, review-provider, and merge-confirmation contract suites pass
- ShellCheck, Bash syntax, and `git diff --check` pass

Fixes #2528
