### PR TITLE
chore(agents): dispatch local engineers hourly

### DIFF
--- a/.claude/loaders/cursor-daily-ai-engineer.md
+++ b/.claude/loaders/cursor-daily-ai-engineer.md
@@ -2,7 +2,7 @@
 
 The **third deployed instance** of the Agentic Engineer brain, running as a
 [Cursor Automation](https://cursor.com/docs/cloud-agent/automations) (cloud agent) alongside the two
-machine-local instances (Claude Code and ChatGPT/Codex, whose per-hour split is the table in
+machine-local instances (Claude Code and ChatGPT/Codex, whose hourly minute offsets are the table in
 `AGENTS.md` → *Cadence & focus*).
 
 Cursor Automations have **no local config file and no CLI** — they live server-side and are created in
@@ -23,20 +23,16 @@ this file and the deployed automation is a defect to fix here first.
 | Tools | `prComment` — add others only when a run demonstrably needs them |
 | Scope | **Private** automation (not team-scoped) — see *Identity* below |
 
-**Why that cron.** The machine-local lanes split by parity — **Claude on even hours, Codex on uneven
-hours** (see the *Cadence & focus* table) — so `:30` past **uneven** hours drops Cursor into the one
-remaining gap: 30 minutes after the Codex dispatch it follows, and ~38 minutes before the next Claude
-one. No two consecutive dispatches land less than 30 minutes apart, and Cursor is **never simultaneous
-with a sibling**. The 30-minute trail behind Codex is deliberate and sufficient: the claim protocol requires a
-claim to be pushed *before* building, within the first minutes of a run, so a claim Codex just took is
-already visible when Cursor selects its issue.
+**Why that cron.** The machine-local Agentic Engineer lanes run every hour — Codex at `:10` and Claude
+at `:50` (see the *Cadence & focus* table) — so `:30` past uneven hours centers Cursor between their
+scheduled starts. The claim protocol requires a claim to be pushed *before* building, within the first
+minutes of a run, so a claim Codex just took is visible when Cursor selects its issue. Runtime jitter
+and long-running work still make overlap normal, which is why every lane scans sibling branches and
+PRs before claiming.
 
-**This cron did not change when the local lanes densified — do not re-paste the automation for it.**
-The value is still `30 1-23/2 * * *` and the prompt below still describes it correctly; only the
-*rationale* above was rewritten, because the premise it used to give ("both local lanes dispatch on
-even hours", and a local gap at 18:00) is no longer true. Changing the cron is a one-field edit in the
-Automations UI — but keep the offset, since a third instance selecting simultaneously with a sibling is
-exactly what the claim protocol cannot arbitrate across lanes.
+Keep the Cursor value at `30 1-23/2 * * *`; changing an existing Cursor Automation remains a UI-only
+operation, and the cloud lane's distinct offset avoids an identical scheduled start with either
+machine-local engineer.
 
 ## Instructions (paste this into the automation's prompt)
 

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1877,9 +1877,10 @@ if want drift; then
   echo
   echo "  cadence table vs all four runtime schedule pointers:"
 
-  # Canonicalise an hour set for exact comparison. The contract prints zero-
-  # padded hours while RRULE uses integers; comparing the raw strings would
-  # report false drift for equivalent schedules.
+  # Canonicalise schedule slots for exact comparison. The compact form is
+  # "hours@minute" (for example 0,12@0), with * representing every hour.
+  # This keeps the output readable while still distinguishing staggered
+  # schedules that share the same hour set.
   normalise_hours() {
     awk -F',' '
       {
@@ -1913,22 +1914,66 @@ if want drift; then
     ' | normalise_hours
   }
 
-  cadence_expected() {
-    local provider="$1" column="$2" lane
-    [ -f "$AGENTS_MD" ] || return 0
-    lane=$(printf '%s' "$provider" | tr '[:upper:]' '[:lower:]')
-    awk -F'|' -v p="$provider" -v lane="$lane/*" -v c="$column" '
-      index($2, "**" p "**") && index($2, lane) { print $c; exit }
-    ' "$AGENTS_MD" 2>/dev/null | tr -cd '0-9, \n' | normalise_hours
+  schedule_from_parts() {
+    local hours="$1" minute="$2" normalised all_hours
+    [[ "$minute" =~ ^[0-9][0-9]?$ ]] || return 0
+    [ "$minute" -ge 0 ] && [ "$minute" -le 59 ] || return 0
+    if [ "$hours" = "*" ]; then
+      normalised="*"
+    else
+      normalised=$(printf '%s\n' "$hours" | validated_hours)
+      [ -n "$normalised" ] || return 0
+      all_hours="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"
+      [ "$normalised" = "$all_hours" ] && normalised="*"
+    fi
+    printf '%s@%s\n' "$normalised" "$((10#$minute))"
   }
 
-  codex_pointer_hours() {
-    local rule
+  cadence_expected() {
+    local provider="$1" column="$2" lane cell minute parsed hours
+    [ -f "$AGENTS_MD" ] || return 0
+    lane=$(printf '%s' "$provider" | tr '[:upper:]' '[:lower:]')
+    cell=$(awk -F'|' -v p="$provider" -v lane="$lane/*" -v c="$column" '
+      index($2, "**" p "**") && index($2, lane) { print $c; exit }
+    ' "$AGENTS_MD" 2>/dev/null)
+    [ -n "$cell" ] || return 0
+    if printf '%s\n' "$cell" | grep -qi 'every hour'; then
+      minute=$(printf '%s\n' "$cell" | sed -nE 's/.*:([0-9][0-9]?).*/\1/p')
+      schedule_from_parts "*" "$minute"
+      return 0
+    fi
+    parsed=$(printf '%s\n' "$cell" | awk '
+      {
+        value = $0
+        while (match(value, /[0-9][0-9]?:[0-9][0-9]/)) {
+          token = substr(value, RSTART, RLENGTH)
+          split(token, pair, ":")
+          if (pair[1] + 0 < 0 || pair[1] + 0 > 23 ||
+              pair[2] + 0 < 0 || pair[2] + 0 > 59) exit 1
+          if (minute != "" && minute != pair[2] + 0) exit 1
+          minute = pair[2] + 0
+          hours = hours (hours == "" ? "" : ",") pair[1]
+          value = substr(value, RSTART + RLENGTH)
+        }
+      }
+      END {
+        if (hours == "" || minute == "") exit 1
+        print hours "|" minute
+      }
+    ')
+    [ -n "$parsed" ] || return 0
+    hours=${parsed%%|*}
+    minute=${parsed#*|}
+    schedule_from_parts "$hours" "$minute"
+  }
+
+  codex_pointer_schedule() {
+    local rule parsed hours minute
     [ -f "$1" ] || return 0
     rule=$(sed -nE 's/^rrule[[:space:]]*=[[:space:]]*"RRULE:([^"]+)".*/\1/p' "$1" \
       | head -1)
     [ -n "$rule" ] || return 0
-    printf '%s\n' "$rule" | awk -F';' '
+    parsed=$(printf '%s\n' "$rule" | awk -F';' '
       {
         for (i = 1; i <= NF; i++) {
           split($i, pair, "=")
@@ -1946,11 +1991,17 @@ if want drift; then
       END {
         if (invalid || (freq != "DAILY" && freq != "HOURLY") ||
             (interval != "" && interval != "1") ||
-            hours !~ /^[0-9][0-9]?(,[0-9][0-9]?)*$/ ||
-            minute != "0" || second != "0") exit 1
-        print hours
+            (hours != "" && hours !~ /^[0-9][0-9]?(,[0-9][0-9]?)*$/) ||
+            (freq == "DAILY" && hours == "") ||
+            minute !~ /^[0-9][0-9]?$/ || minute + 0 > 59 ||
+            second != "0") exit 1
+        print (hours == "" ? "*" : hours) "|" minute
       }
-    ' | validated_hours
+    ')
+    [ -n "$parsed" ] || return 0
+    hours=${parsed%%|*}
+    minute=${parsed#*|}
+    schedule_from_parts "$hours" "$minute"
   }
 
   claude_store_field() {
@@ -1964,13 +2015,19 @@ if want drift; then
     ' "$store" 2>/dev/null
   }
 
-  claude_store_hours() {
-    local store="$1" id="$2" pointer="$3" cron
+  claude_store_schedule() {
+    local store="$1" id="$2" pointer="$3" cron parsed hours minute
     cron=$(claude_store_field "$store" "$id" "$pointer" cronExpression)
     [ -n "$cron" ] || return 0
-    printf '%s\n' "$cron" | awk '
-      NF == 5 && $1 == "0" && $3 == "*" && $4 == "*" && $5 == "*" { print $2 }
-    ' | validated_hours
+    parsed=$(printf '%s\n' "$cron" | awk '
+      NF == 5 && $1 ~ /^[0-9][0-9]?$/ && $1 + 0 <= 59 &&
+        ($2 == "*" || $2 ~ /^[0-9][0-9]?(,[0-9][0-9]?)*$/) &&
+        $3 == "*" && $4 == "*" && $5 == "*" { print $2 "|" $1 }
+    ')
+    [ -n "$parsed" ] || return 0
+    hours=${parsed%%|*}
+    minute=${parsed#*|}
+    schedule_from_parts "$hours" "$minute"
   }
 
   claude_store_marker() {
@@ -2036,10 +2093,10 @@ if want drift; then
   CLAUDE_IMPROVER_EXPECTED=$(cadence_expected Claude 4)
   CODEX_ENGINEER_EXPECTED=$(cadence_expected Codex 3)
   CODEX_IMPROVER_EXPECTED=$(cadence_expected Codex 4)
-  CLAUDE_ENGINEER_ACTUAL=$(claude_store_hours "$CLAUDE_SCHEDULE_STORE" daily-ai-assistant "$CLAUDE_LOADER")
-  CLAUDE_IMPROVER_ACTUAL=$(claude_store_hours "$CLAUDE_SCHEDULE_STORE" agent-improver "$CLAUDE_IMPROVER_LOADER")
-  CODEX_ENGINEER_ACTUAL=$(codex_pointer_hours "$CODEX_LOADER")
-  CODEX_IMPROVER_ACTUAL=$(codex_pointer_hours "$CODEX_IMPROVER_LOADER")
+  CLAUDE_ENGINEER_ACTUAL=$(claude_store_schedule "$CLAUDE_SCHEDULE_STORE" daily-ai-assistant "$CLAUDE_LOADER")
+  CLAUDE_IMPROVER_ACTUAL=$(claude_store_schedule "$CLAUDE_SCHEDULE_STORE" agent-improver "$CLAUDE_IMPROVER_LOADER")
+  CODEX_ENGINEER_ACTUAL=$(codex_pointer_schedule "$CODEX_LOADER")
+  CODEX_IMPROVER_ACTUAL=$(codex_pointer_schedule "$CODEX_IMPROVER_LOADER")
   CLAUDE_ENGINEER_MARKER=$(claude_store_marker "$CLAUDE_SCHEDULE_STORE" daily-ai-assistant "$CLAUDE_LOADER")
   CLAUDE_IMPROVER_MARKER=$(claude_store_marker "$CLAUDE_SCHEDULE_STORE" agent-improver "$CLAUDE_IMPROVER_LOADER")
   CODEX_ENGINEER_MARKER=$(codex_change_marker "$CODEX_LOADER")
@@ -2066,25 +2123,31 @@ if want drift; then
        "$CODEX_ENGINEER_MARKER" "$CODEX_ENGINEER_BASELINE" \
      && schedule_measured "$CODEX_IMPROVER_LOADER" "$CODEX_IMPROVER_EXPECTED" "$CODEX_IMPROVER_ACTUAL" \
        "$CODEX_IMPROVER_MARKER" "$CODEX_IMPROVER_BASELINE"; then
-    COLLISIONS=$(awk -v schedules="$CLAUDE_ENGINEER_ACTUAL,$CLAUDE_IMPROVER_ACTUAL,$CODEX_ENGINEER_ACTUAL,$CODEX_IMPROVER_ACTUAL" '
-      BEGIN {
-        count = split(schedules, slots, ",")
-        for (i = 1; i <= count; i++) {
-          if (slots[i] != "") starts[slots[i]]++
+    expand_schedules() {
+      awk -F'@' '
+        NF == 2 {
+          if ($1 == "*") {
+            for (hour = 0; hour <= 23; hour++) print hour ":" $2
+          } else {
+            count = split($1, hours, ",")
+            for (i = 1; i <= count; i++) print hours[i] ":" $2
+          }
         }
-        for (hour in starts) {
-          if (starts[hour] > 1) collisions += starts[hour] - 1
+      '
+    }
+    ALL_SLOTS=$(printf '%s\n' "$CLAUDE_ENGINEER_ACTUAL" "$CLAUDE_IMPROVER_ACTUAL" \
+      "$CODEX_ENGINEER_ACTUAL" "$CODEX_IMPROVER_ACTUAL" | expand_schedules)
+    COLLISIONS=$(printf '%s\n' "$ALL_SLOTS" | awk '
+      NF { starts[$0]++ }
+      END {
+        for (slot in starts) {
+          if (starts[slot] > 1) collisions += starts[slot] - 1
         }
         print collisions + 0
       }
     ')
-    ENGINEER_DISPATCHES=$(awk -v a="$CLAUDE_ENGINEER_ACTUAL" -v b="$CODEX_ENGINEER_ACTUAL" '
-      BEGIN {
-        na = split(a, aa, ",")
-        nb = split(b, bb, ",")
-        print (a == "" ? 0 : na) + (b == "" ? 0 : nb)
-      }
-    ')
+    ENGINEER_DISPATCHES=$(printf '%s\n' "$CLAUDE_ENGINEER_ACTUAL" "$CODEX_ENGINEER_ACTUAL" \
+      | expand_schedules | awk 'NF { count++ } END { print count + 0 }')
     echo "    local simultaneous starts/day: $COLLISIONS"
     echo "    local engineer dispatches/day: $ENGINEER_DISPATCHES"
   else

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1835,6 +1835,7 @@ if want drift; then
   CLAUDE_IMPROVER_LOADER="${CLAUDE_IMPROVER_LOADER_PATH:-$HOME/.claude/scheduled-tasks/agent-improver/SKILL.md}"
   CODEX_LOADER="${CODEX_LOADER_PATH:-$CODEX_HOME/automations/daily-ai-engineer/automation.toml}"
   CODEX_IMPROVER_LOADER="${CODEX_IMPROVER_LOADER_PATH:-$CODEX_HOME/automations/agent-improver/automation.toml}"
+  CODEX_AUTOMATION_STORE="${CODEX_AUTOMATION_STORE_PATH:-$CODEX_HOME/sqlite/codex-dev.db}"
   AGENTS_MD="$MONOREPO/AGENTS.md"
 
   discover_claude_schedule_store() {
@@ -2039,15 +2040,12 @@ if want drift; then
     ' 2>/dev/null
   }
 
-  codex_change_marker() {
-    [ -f "$1" ] || return 0
-    awk -F'=' '
-      /^updated_at[[:space:]]*=/ {
-        gsub(/[[:space:]]/, "", $2)
-        print $2
-        exit
-      }
-    ' "$1" 2>/dev/null
+  codex_dispatch_marker() {
+    local store="$1" id="$2"
+    [ -f "$store" ] || return 0
+    sqlite3 -readonly "$store" \
+      "SELECT last_run_at FROM automations WHERE id = '$id';" 2>/dev/null \
+      | awk 'NF { print; exit }'
   }
 
   marker_advanced() {
@@ -2099,8 +2097,8 @@ if want drift; then
   CODEX_IMPROVER_ACTUAL=$(codex_pointer_schedule "$CODEX_IMPROVER_LOADER")
   CLAUDE_ENGINEER_MARKER=$(claude_store_marker "$CLAUDE_SCHEDULE_STORE" daily-ai-assistant "$CLAUDE_LOADER")
   CLAUDE_IMPROVER_MARKER=$(claude_store_marker "$CLAUDE_SCHEDULE_STORE" agent-improver "$CLAUDE_IMPROVER_LOADER")
-  CODEX_ENGINEER_MARKER=$(codex_change_marker "$CODEX_LOADER")
-  CODEX_IMPROVER_MARKER=$(codex_change_marker "$CODEX_IMPROVER_LOADER")
+  CODEX_ENGINEER_MARKER=$(codex_dispatch_marker "$CODEX_AUTOMATION_STORE" daily-ai-engineer)
+  CODEX_IMPROVER_MARKER=$(codex_dispatch_marker "$CODEX_AUTOMATION_STORE" agent-improver)
   CLAUDE_ENGINEER_BASELINE="${CLAUDE_ENGINEER_MARKER_BASELINE:-}"
   CLAUDE_IMPROVER_BASELINE="${CLAUDE_IMPROVER_MARKER_BASELINE:-}"
   CODEX_ENGINEER_BASELINE="${CODEX_ENGINEER_MARKER_BASELINE:-}"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1968,11 +1968,9 @@ if want drift; then
     schedule_from_parts "$hours" "$minute"
   }
 
-  codex_pointer_schedule() {
-    local rule parsed hours minute
-    [ -f "$1" ] || return 0
-    rule=$(sed -nE 's/^rrule[[:space:]]*=[[:space:]]*"RRULE:([^"]+)".*/\1/p' "$1" \
-      | head -1)
+  codex_rrule_schedule() {
+    local rule="$1" parsed hours minute
+    rule=${rule#RRULE:}
     [ -n "$rule" ] || return 0
     parsed=$(printf '%s\n' "$rule" | awk -F';' '
       {
@@ -2003,6 +2001,23 @@ if want drift; then
     hours=${parsed%%|*}
     minute=${parsed#*|}
     schedule_from_parts "$hours" "$minute"
+  }
+
+  codex_pointer_schedule() {
+    local rule
+    [ -f "$1" ] || return 0
+    rule=$(sed -nE 's/^rrule[[:space:]]*=[[:space:]]*"(RRULE:[^"]+)".*/\1/p' "$1" \
+      | head -1)
+    codex_rrule_schedule "$rule"
+  }
+
+  codex_store_schedule() {
+    local store="$1" id="$2" rule
+    [ -f "$store" ] || return 0
+    rule=$(sqlite3 -readonly "$store" \
+      "SELECT rrule FROM automations WHERE id = '$id';" 2>/dev/null \
+      | awk 'NF { print; exit }')
+    codex_rrule_schedule "$rule"
   }
 
   claude_store_field() {
@@ -2081,6 +2096,25 @@ if want drift; then
     fi
   }
 
+  compare_codex_schedule() {
+    local label="$1" expected="$2" pointer_actual="$3" scheduler_actual="$4"
+    local pointer="$5" store="$6" marker="$7" baseline="$8"
+    if [ ! -f "$pointer" ]; then
+      echo "    UNKNOWN: $label schedule pointer missing"
+    elif [ ! -f "$store" ]; then
+      echo "    UNKNOWN: $label authoritative scheduler store missing"
+    elif [ -z "$pointer_actual" ]; then
+      echo "    UNKNOWN: $label recurrence rule is incomplete or unsupported"
+    elif [ -z "$scheduler_actual" ]; then
+      echo "    UNKNOWN: $label authoritative scheduler recurrence is missing or unsupported"
+    elif [ "$pointer_actual" != "$scheduler_actual" ]; then
+      echo "    ⚠️  DRIFT: $label schedule pointer=$pointer_actual scheduler=$scheduler_actual marker=${marker:-missing} baseline=${baseline:-missing}"
+    else
+      compare_schedule "$label" "$expected" "$scheduler_actual" "$pointer" \
+        "$marker" "$baseline" recurrence
+    fi
+  }
+
   schedule_measured() {
     local file="$1" expected="$2" actual="$3" marker="$4" baseline="$5"
     [ -f "$file" ] && [ -n "$expected" ] && [ -n "$actual" ] \
@@ -2093,8 +2127,18 @@ if want drift; then
   CODEX_IMPROVER_EXPECTED=$(cadence_expected Codex 4)
   CLAUDE_ENGINEER_ACTUAL=$(claude_store_schedule "$CLAUDE_SCHEDULE_STORE" daily-ai-assistant "$CLAUDE_LOADER")
   CLAUDE_IMPROVER_ACTUAL=$(claude_store_schedule "$CLAUDE_SCHEDULE_STORE" agent-improver "$CLAUDE_IMPROVER_LOADER")
-  CODEX_ENGINEER_ACTUAL=$(codex_pointer_schedule "$CODEX_LOADER")
-  CODEX_IMPROVER_ACTUAL=$(codex_pointer_schedule "$CODEX_IMPROVER_LOADER")
+  CODEX_ENGINEER_POINTER_ACTUAL=$(codex_pointer_schedule "$CODEX_LOADER")
+  CODEX_IMPROVER_POINTER_ACTUAL=$(codex_pointer_schedule "$CODEX_IMPROVER_LOADER")
+  CODEX_ENGINEER_STORE_ACTUAL=$(codex_store_schedule "$CODEX_AUTOMATION_STORE" daily-ai-engineer)
+  CODEX_IMPROVER_STORE_ACTUAL=$(codex_store_schedule "$CODEX_AUTOMATION_STORE" agent-improver)
+  CODEX_ENGINEER_ACTUAL=""
+  CODEX_IMPROVER_ACTUAL=""
+  [ -n "$CODEX_ENGINEER_POINTER_ACTUAL" ] \
+    && [ "$CODEX_ENGINEER_POINTER_ACTUAL" = "$CODEX_ENGINEER_STORE_ACTUAL" ] \
+    && CODEX_ENGINEER_ACTUAL="$CODEX_ENGINEER_STORE_ACTUAL"
+  [ -n "$CODEX_IMPROVER_POINTER_ACTUAL" ] \
+    && [ "$CODEX_IMPROVER_POINTER_ACTUAL" = "$CODEX_IMPROVER_STORE_ACTUAL" ] \
+    && CODEX_IMPROVER_ACTUAL="$CODEX_IMPROVER_STORE_ACTUAL"
   CLAUDE_ENGINEER_MARKER=$(claude_store_marker "$CLAUDE_SCHEDULE_STORE" daily-ai-assistant "$CLAUDE_LOADER")
   CLAUDE_IMPROVER_MARKER=$(claude_store_marker "$CLAUDE_SCHEDULE_STORE" agent-improver "$CLAUDE_IMPROVER_LOADER")
   CODEX_ENGINEER_MARKER=$(codex_dispatch_marker "$CODEX_AUTOMATION_STORE" daily-ai-engineer)
@@ -2108,10 +2152,12 @@ if want drift; then
     "$CLAUDE_LOADER" "$CLAUDE_ENGINEER_MARKER" "$CLAUDE_ENGINEER_BASELINE" cron
   compare_schedule "claude improver" "$CLAUDE_IMPROVER_EXPECTED" "$CLAUDE_IMPROVER_ACTUAL" \
     "$CLAUDE_IMPROVER_LOADER" "$CLAUDE_IMPROVER_MARKER" "$CLAUDE_IMPROVER_BASELINE" cron
-  compare_schedule "codex engineer" "$CODEX_ENGINEER_EXPECTED" "$CODEX_ENGINEER_ACTUAL" \
-    "$CODEX_LOADER" "$CODEX_ENGINEER_MARKER" "$CODEX_ENGINEER_BASELINE" recurrence
-  compare_schedule "codex improver" "$CODEX_IMPROVER_EXPECTED" "$CODEX_IMPROVER_ACTUAL" \
-    "$CODEX_IMPROVER_LOADER" "$CODEX_IMPROVER_MARKER" "$CODEX_IMPROVER_BASELINE" recurrence
+  compare_codex_schedule "codex engineer" "$CODEX_ENGINEER_EXPECTED" \
+    "$CODEX_ENGINEER_POINTER_ACTUAL" "$CODEX_ENGINEER_STORE_ACTUAL" \
+    "$CODEX_LOADER" "$CODEX_AUTOMATION_STORE" "$CODEX_ENGINEER_MARKER" "$CODEX_ENGINEER_BASELINE"
+  compare_codex_schedule "codex improver" "$CODEX_IMPROVER_EXPECTED" \
+    "$CODEX_IMPROVER_POINTER_ACTUAL" "$CODEX_IMPROVER_STORE_ACTUAL" \
+    "$CODEX_IMPROVER_LOADER" "$CODEX_AUTOMATION_STORE" "$CODEX_IMPROVER_MARKER" "$CODEX_IMPROVER_BASELINE"
 
   if schedule_measured "$CLAUDE_LOADER" "$CLAUDE_ENGINEER_EXPECTED" "$CLAUDE_ENGINEER_ACTUAL" \
        "$CLAUDE_ENGINEER_MARKER" "$CLAUDE_ENGINEER_BASELINE" \

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -2012,10 +2012,11 @@ if want drift; then
   }
 
   codex_store_schedule() {
-    local store="$1" id="$2" rule
+    local store="$1" id="$2" rule escaped_id
     [ -f "$store" ] || return 0
+    escaped_id=${id//\'/\'\'}
     rule=$(sqlite3 -readonly "$store" \
-      "SELECT rrule FROM automations WHERE id = '$id';" 2>/dev/null \
+      "SELECT rrule FROM automations WHERE id = '$escaped_id';" 2>/dev/null \
       | awk 'NF { print; exit }')
     codex_rrule_schedule "$rule"
   }
@@ -2056,10 +2057,11 @@ if want drift; then
   }
 
   codex_dispatch_marker() {
-    local store="$1" id="$2"
+    local store="$1" id="$2" escaped_id
     [ -f "$store" ] || return 0
+    escaped_id=${id//\'/\'\'}
     sqlite3 -readonly "$store" \
-      "SELECT last_run_at FROM automations WHERE id = '$id';" 2>/dev/null \
+      "SELECT last_run_at FROM automations WHERE id = '$escaped_id';" 2>/dev/null \
       | awk 'NF { print; exit }'
   }
 

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -154,6 +154,17 @@ cat > "$FIX/codex/automations/agent-improver/automation.toml" <<'EOF'
 rrule = "RRULE:FREQ=DAILY;BYHOUR=7,19;BYMINUTE=0;BYSECOND=0"
 updated_at = 1785222863850
 EOF
+CODEX_AUTOMATION_STORE="$FIX/codex/codex-dev.db"
+sqlite3 "$CODEX_AUTOMATION_STORE" <<'SQL'
+CREATE TABLE automations (
+  id TEXT PRIMARY KEY,
+  rrule TEXT NOT NULL,
+  last_run_at INTEGER
+);
+INSERT INTO automations (id, rrule, last_run_at) VALUES
+  ('daily-ai-engineer', 'RRULE:FREQ=HOURLY;INTERVAL=1;BYMINUTE=10;BYSECOND=0', 1785238560676),
+  ('agent-improver', 'RRULE:FREQ=DAILY;BYHOUR=7,19;BYMINUTE=0;BYSECOND=0', 1785222864850);
+SQL
 cat > "$FIX/monorepo/AGENTS.md" <<'EOF'
 Definition PRs: their separate human promotion gate was retired by maintainer direction 2026-07-18.
 
@@ -177,6 +188,7 @@ run() {
   CLAUDE_IMPROVER_LOADER_PATH="$FIX/claude-sched/agent-improver/SKILL.md" \
   CODEX_LOADER_PATH="$FIX/codex/automations/daily-ai-engineer/automation.toml" \
   CODEX_IMPROVER_LOADER_PATH="$FIX/codex/automations/agent-improver/automation.toml" \
+  CODEX_AUTOMATION_STORE_PATH="$CODEX_AUTOMATION_STORE" \
   CLAUDE_ENGINEER_MARKER_BASELINE="${CLAUDE_ENGINEER_MARKER_BASELINE:-1750000000}" \
   CLAUDE_IMPROVER_MARKER_BASELINE="${CLAUDE_IMPROVER_MARKER_BASELINE:-1750000000}" \
   CODEX_ENGINEER_MARKER_BASELINE="${CODEX_ENGINEER_MARKER_BASELINE:-1785238559000}" \
@@ -230,8 +242,8 @@ check "compares Claude engineer schedule" "$OUT" "claude engineer: expected=*@50
 check "compares Claude improver schedule" "$OUT" "claude improver: expected=0,12@0 actual=0,12@0 MATCH"
 check "compares Codex engineer schedule"  "$OUT" "codex engineer:  expected=*@10 actual=*@10 MATCH"
 check "compares Codex improver schedule"  "$OUT" "codex improver:  expected=7,19@0 actual=7,19@0 MATCH"
-check "reports Codex engineer marker advance" "$OUT" "MATCH marker=1785238559676 baseline=1785238559000"
-check "reports Codex improver marker advance" "$OUT" "MATCH marker=1785222863850 baseline=1785222863000"
+check "reports Codex engineer dispatch advance" "$OUT" "MATCH marker=1785238560676 baseline=1785238559000"
+check "reports Codex improver dispatch advance" "$OUT" "MATCH marker=1785222864850 baseline=1785222863000"
 check "proves staggered local starts"      "$OUT" "local simultaneous starts/day: 0"
 check "proves hourly engineer dispatches"  "$OUT" "local engineer dispatches/day: 48"
 
@@ -245,20 +257,20 @@ check "missing improver pointer is explicit" "$OUT" "UNKNOWN: codex improver sch
 mv "$FIX/codex/automations/agent-improver/automation.toml.missing" \
    "$FIX/codex/automations/agent-improver/automation.toml"
 
-# A matching value without the runtime's own write marker cannot prove that a
+# A matching value without the runtime's own dispatch marker cannot prove that a
 # dispatch occurred after the edit, so persistence remains explicitly unknown.
-sed -i.bak '/^updated_at = /d' \
-  "$FIX/codex/automations/agent-improver/automation.toml"
+sqlite3 "$CODEX_AUTOMATION_STORE" \
+  "UPDATE automations SET last_run_at = NULL WHERE id = 'agent-improver';"
 OUT=$(run --section drift)
 check "missing runtime marker is explicit" "$OUT" "UNKNOWN: codex improver change marker missing"
 nocheck "missing runtime marker never claims persistence" "$OUT" "codex improver:  expected=7,19@0 actual=7,19@0 MATCH"
 check "missing runtime marker invalidates parity total" "$OUT" "local simultaneous starts/day: UNKNOWN"
 check "missing runtime marker invalidates dispatch total" "$OUT" "local engineer dispatches/day: UNKNOWN"
-mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
-   "$FIX/codex/automations/agent-improver/automation.toml"
+sqlite3 "$CODEX_AUTOMATION_STORE" \
+  "UPDATE automations SET last_run_at = 1785222864850 WHERE id = 'agent-improver';"
 
 # An unchanged marker is the in-session read-back, not persistence proof.
-OUT=$(CODEX_IMPROVER_MARKER_BASELINE=1785222863850 run --section drift)
+OUT=$(CODEX_IMPROVER_MARKER_BASELINE=1785222864850 run --section drift)
 check "unchanged marker is not persistence proof" "$OUT" "UNKNOWN: codex improver change marker did not advance"
 nocheck "unchanged marker never claims persistence" "$OUT" "codex improver:  expected=7,19@0 actual=7,19@0 MATCH"
 

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -155,7 +155,7 @@ rrule = "RRULE:FREQ=DAILY;BYHOUR=7,19;BYMINUTE=0;BYSECOND=0"
 updated_at = 1785222863850
 EOF
 CODEX_AUTOMATION_STORE="$FIX/codex/codex-dev.db"
-sqlite3 "$CODEX_AUTOMATION_STORE" <<'SQL'
+if ! sqlite3 "$CODEX_AUTOMATION_STORE" <<'SQL'
 CREATE TABLE automations (
   id TEXT PRIMARY KEY,
   rrule TEXT NOT NULL,
@@ -165,6 +165,10 @@ INSERT INTO automations (id, rrule, last_run_at) VALUES
   ('daily-ai-engineer', 'RRULE:FREQ=HOURLY;INTERVAL=1;BYMINUTE=10;BYSECOND=0', 1785238560676),
   ('agent-improver', 'RRULE:FREQ=DAILY;BYHOUR=7,19;BYMINUTE=0;BYSECOND=0', 1785222864850);
 SQL
+then
+  echo "failed to create Codex automation store fixture" >&2
+  exit 1
+fi
 cat > "$FIX/monorepo/AGENTS.md" <<'EOF'
 Definition PRs: their separate human promotion gate was retired by maintainer direction 2026-07-18.
 
@@ -203,6 +207,18 @@ echo
 echo "syntax"
 if bash -n "$TARGET" 2>/dev/null; then ok "parses"; else bad "parses" "bash -n failed"; fi
 if [ -x "$TARGET" ]; then ok "executable"; else bad "executable" "chmod +x missing"; fi
+if [ "$(grep -Fc "escaped_id=\${id//\\'/\\'\\'}" "$TARGET")" -eq 2 ]; then
+  ok "escapes both Codex automation ids before SQL interpolation"
+else
+  bad "escapes both Codex automation ids before SQL interpolation" \
+    "expected two defensive single-quote substitutions"
+fi
+if [ "$(grep -Fc "WHERE id = '\$escaped_id';" "$TARGET")" -eq 2 ]; then
+  ok "uses escaped ids in both Codex scheduler queries"
+else
+  bad "uses escaped ids in both Codex scheduler queries" \
+    "expected both queries to interpolate escaped_id"
+fi
 
 # ── 2. reliability: errors attributed to the right tool ───────────────────────
 echo

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -120,7 +120,7 @@ subst "$FIX/projects/proj-a/s1.jsonl"
 
 # Loader fixtures: Codex asserts the RETIRED gate; the constitution records it retired.
 cat > "$FIX/claude-sched/daily-ai-assistant/SKILL.md" <<'EOF'
-description: Thin scheduler pointer for the Agentic Engineer (claude/* lane: EVEN hours 02–22, minus the 00/12 Agent Improver slots).
+description: Thin scheduler pointer for the Agentic Engineer (claude/* lane: hourly at :50).
 EOF
 cat > "$FIX/claude-sched/agent-improver/SKILL.md" <<'EOF'
 description: Thin scheduler pointer for the Agent Improver (claude/* lane: 00 and 12 local).
@@ -132,7 +132,7 @@ cat > "$FIX/claude-store/scheduled-tasks.json" <<EOF
       "id": "daily-ai-assistant",
       "enabled": true,
       "filePath": "$FIX/claude-sched/daily-ai-assistant/SKILL.md",
-      "cronExpression": "0 2,4,6,8,10,14,16,18,20,22 * * *",
+      "cronExpression": "50 * * * *",
       "lastRunAt": "2026-07-25T20:00:00.000Z"
     },
     {
@@ -147,7 +147,7 @@ cat > "$FIX/claude-store/scheduled-tasks.json" <<EOF
 EOF
 cat > "$FIX/codex/automations/daily-ai-engineer/automation.toml" <<'EOF'
 prompt = "definition/self-improvement PRs are the one exception: NEVER self-promote those"
-rrule = "RRULE:FREQ=HOURLY;INTERVAL=1;BYHOUR=1,3,5,9,11,13,15,17,21,23;BYMINUTE=0;BYSECOND=0"
+rrule = "RRULE:FREQ=HOURLY;INTERVAL=1;BYMINUTE=10;BYSECOND=0"
 updated_at = 1785238559676
 EOF
 cat > "$FIX/codex/automations/agent-improver/automation.toml" <<'EOF'
@@ -164,8 +164,8 @@ Definition PRs: their separate human promotion gate was retired by maintainer di
 ### Cadence & focus
 | Lane | Agentic Engineer | Agent Improver |
 |---|---|---|
-| **Claude** — `claude/*`, even hours | 02, 04, 06, 08, 10, 14, 16, 18, 20, 22 | 00, 12 |
-| **Codex** — `codex/*`, uneven hours | 01, 03, 05, 09, 11, 13, 15, 17, 21, 23 | 07, 19 |
+| **Claude** — `claude/*`, hourly at `:50` | Every hour at `:50` | 00:00, 12:00 |
+| **Codex** — `codex/*`, hourly at `:10` | Every hour at `:10` | 07:00, 19:00 |
 EOF
 mkdir -p "$FIX/monorepo/.claude"
 
@@ -226,14 +226,14 @@ echo
 echo "drift"
 OUT=$(run --section drift)
 check "detects retired-rule residue"   "$OUT" "DRIFT"
-check "compares Claude engineer schedule" "$OUT" "claude engineer: expected=2,4,6,8,10,14,16,18,20,22 actual=2,4,6,8,10,14,16,18,20,22 MATCH"
-check "compares Claude improver schedule" "$OUT" "claude improver: expected=0,12 actual=0,12 MATCH"
-check "compares Codex engineer schedule"  "$OUT" "codex engineer:  expected=1,3,5,9,11,13,15,17,21,23 actual=1,3,5,9,11,13,15,17,21,23 MATCH"
-check "compares Codex improver schedule"  "$OUT" "codex improver:  expected=7,19 actual=7,19 MATCH"
+check "compares Claude engineer schedule" "$OUT" "claude engineer: expected=*@50 actual=*@50 MATCH"
+check "compares Claude improver schedule" "$OUT" "claude improver: expected=0,12@0 actual=0,12@0 MATCH"
+check "compares Codex engineer schedule"  "$OUT" "codex engineer:  expected=*@10 actual=*@10 MATCH"
+check "compares Codex improver schedule"  "$OUT" "codex improver:  expected=7,19@0 actual=7,19@0 MATCH"
 check "reports Codex engineer marker advance" "$OUT" "MATCH marker=1785238559676 baseline=1785238559000"
 check "reports Codex improver marker advance" "$OUT" "MATCH marker=1785222863850 baseline=1785222863000"
-check "proves local start parity"         "$OUT" "local simultaneous starts/day: 0"
-check "proves engineer dispatch volume"   "$OUT" "local engineer dispatches/day: 20"
+check "proves staggered local starts"      "$OUT" "local simultaneous starts/day: 0"
+check "proves hourly engineer dispatches"  "$OUT" "local engineer dispatches/day: 48"
 
 # Removing one pointer must fail closed rather than leaving the schedule surface
 # silently unmeasured. This is the exact blind spot that hid the reverted Codex
@@ -251,7 +251,7 @@ sed -i.bak '/^updated_at = /d' \
   "$FIX/codex/automations/agent-improver/automation.toml"
 OUT=$(run --section drift)
 check "missing runtime marker is explicit" "$OUT" "UNKNOWN: codex improver change marker missing"
-nocheck "missing runtime marker never claims persistence" "$OUT" "codex improver:  expected=7,19 actual=7,19 MATCH"
+nocheck "missing runtime marker never claims persistence" "$OUT" "codex improver:  expected=7,19@0 actual=7,19@0 MATCH"
 check "missing runtime marker invalidates parity total" "$OUT" "local simultaneous starts/day: UNKNOWN"
 check "missing runtime marker invalidates dispatch total" "$OUT" "local engineer dispatches/day: UNKNOWN"
 mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
@@ -260,15 +260,24 @@ mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
 # An unchanged marker is the in-session read-back, not persistence proof.
 OUT=$(CODEX_IMPROVER_MARKER_BASELINE=1785222863850 run --section drift)
 check "unchanged marker is not persistence proof" "$OUT" "UNKNOWN: codex improver change marker did not advance"
-nocheck "unchanged marker never claims persistence" "$OUT" "codex improver:  expected=7,19 actual=7,19 MATCH"
+nocheck "unchanged marker never claims persistence" "$OUT" "codex improver:  expected=7,19@0 actual=7,19@0 MATCH"
 
-# RRULE parity includes minute, second, frequency, interval, and filters, not
-# merely the set of hours.
+# RRULE comparison includes minute, second, frequency, interval, and filters,
+# not merely the set of hours. A valid alternate minute is concrete drift, not
+# an unreadable schedule.
 sed -i.bak 's/BYMINUTE=0/BYMINUTE=30/' \
   "$FIX/codex/automations/agent-improver/automation.toml"
 OUT=$(run --section drift)
-check "minute drift invalidates recurrence" "$OUT" "UNKNOWN: codex improver recurrence rule is incomplete or unsupported"
-check "minute drift invalidates aggregate parity" "$OUT" "local simultaneous starts/day: UNKNOWN"
+check "minute drift is reported concretely" "$OUT" "DRIFT: codex improver schedule expected=7,19@0 actual=7,19@30"
+check "valid minute drift remains measurable" "$OUT" "local simultaneous starts/day: 0"
+mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
+   "$FIX/codex/automations/agent-improver/automation.toml"
+
+# An out-of-range minute is malformed and must fail closed.
+sed -i.bak 's/BYMINUTE=0/BYMINUTE=60/' \
+  "$FIX/codex/automations/agent-improver/automation.toml"
+OUT=$(run --section drift)
+check "out-of-range minute invalidates recurrence" "$OUT" "UNKNOWN: codex improver recurrence rule is incomplete or unsupported"
 mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
    "$FIX/codex/automations/agent-improver/automation.toml"
 
@@ -277,7 +286,7 @@ sed -i.bak 's/BYHOUR=7,19/BYHOUR=7,19,24/' \
   "$FIX/codex/automations/agent-improver/automation.toml"
 OUT=$(run --section drift)
 check "out-of-range hour invalidates recurrence" "$OUT" "UNKNOWN: codex improver recurrence rule is incomplete or unsupported"
-nocheck "out-of-range hour never normalizes to MATCH" "$OUT" "codex improver:  expected=7,19 actual=7,19 MATCH"
+nocheck "out-of-range hour never normalizes to MATCH" "$OUT" "codex improver:  expected=7,19@0 actual=7,19@0 MATCH"
 mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
    "$FIX/codex/automations/agent-improver/automation.toml"
 
@@ -285,21 +294,21 @@ mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
 sed -i.bak 's/BYHOUR=7,19/BYHOUR=19,7/' \
   "$FIX/codex/automations/agent-improver/automation.toml"
 OUT=$(run --section drift)
-check "hour sets are sorted before comparison" "$OUT" "codex improver:  expected=7,19 actual=7,19 MATCH"
+check "hour sets are sorted before comparison" "$OUT" "codex improver:  expected=7,19@0 actual=7,19@0 MATCH"
 mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
    "$FIX/codex/automations/agent-improver/automation.toml"
 
 # Loader prose is not scheduler state. A stale description must not override the
 # authoritative cron record.
-sed -i.bak -e 's/02–22/00–22/' -e 's|00/12|02/04|' \
+sed -i.bak -e 's/hourly at :50/hourly at :40/' \
   "$FIX/claude-sched/daily-ai-assistant/SKILL.md"
 OUT=$(run --section drift)
-check "Claude cadence comes from scheduler store" "$OUT" "claude engineer: expected=2,4,6,8,10,14,16,18,20,22 actual=2,4,6,8,10,14,16,18,20,22 MATCH"
+check "Claude cadence comes from scheduler store" "$OUT" "claude engineer: expected=*@50 actual=*@50 MATCH"
 mv "$FIX/claude-sched/daily-ai-assistant/SKILL.md.bak" \
    "$FIX/claude-sched/daily-ai-assistant/SKILL.md"
 
 # Same-provider overlaps in the authoritative store are collisions too.
-sed -i.bak 's/"cronExpression": "0 0,12/"cronExpression": "0 0,10/' \
+sed -i.bak 's/"cronExpression": "0 0,12/"cronExpression": "50 0/' \
   "$FIX/claude-store/scheduled-tasks.json"
 OUT=$(run --section drift)
 check "same-provider overlap is counted" "$OUT" "local simultaneous starts/day: 1"
@@ -307,10 +316,10 @@ mv "$FIX/claude-store/scheduled-tasks.json.bak" \
    "$FIX/claude-store/scheduled-tasks.json"
 
 # A persisted runtime rewrite must report the concrete expected/actual delta.
-sed -i.bak 's/BYHOUR=7,19/BYHOUR=6,18/' \
+sed -i.bak 's/BYHOUR=7,19;BYMINUTE=0/BYHOUR=6,18;BYMINUTE=50/' \
   "$FIX/codex/automations/agent-improver/automation.toml"
 OUT=$(run --section drift)
-check "runtime schedule rewrite is detected" "$OUT" "DRIFT: codex improver schedule expected=7,19 actual=6,18"
+check "runtime schedule rewrite is detected" "$OUT" "DRIFT: codex improver schedule expected=7,19@0 actual=6,18@50"
 check "runtime rewrite exposes collisions"   "$OUT" "local simultaneous starts/day: 2"
 mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
    "$FIX/codex/automations/agent-improver/automation.toml"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -274,16 +274,33 @@ OUT=$(CODEX_IMPROVER_MARKER_BASELINE=1785222864850 run --section drift)
 check "unchanged marker is not persistence proof" "$OUT" "UNKNOWN: codex improver change marker did not advance"
 nocheck "unchanged marker never claims persistence" "$OUT" "codex improver:  expected=7,19@0 actual=7,19@0 MATCH"
 
+# The dispatch marker and recurrence must come from one correlated scheduler
+# record. A database-side rewrite cannot be hidden by the desired pointer while
+# last_run_at continues advancing.
+sqlite3 "$CODEX_AUTOMATION_STORE" \
+  "UPDATE automations SET rrule = 'RRULE:FREQ=DAILY;BYHOUR=6,18;BYMINUTE=50;BYSECOND=0' WHERE id = 'agent-improver';"
+OUT=$(run --section drift)
+check "scheduler-store rewrite is detected" "$OUT" "DRIFT: codex improver schedule pointer=7,19@0 scheduler=6,18@50"
+nocheck "scheduler-store rewrite never claims MATCH" "$OUT" "codex improver:  expected=7,19@0 actual=7,19@0 MATCH"
+check "scheduler-store rewrite invalidates collision total" "$OUT" "local simultaneous starts/day: UNKNOWN"
+check "scheduler-store rewrite invalidates dispatch total" "$OUT" "local engineer dispatches/day: UNKNOWN"
+sqlite3 "$CODEX_AUTOMATION_STORE" \
+  "UPDATE automations SET rrule = 'RRULE:FREQ=DAILY;BYHOUR=7,19;BYMINUTE=0;BYSECOND=0' WHERE id = 'agent-improver';"
+
 # RRULE comparison includes minute, second, frequency, interval, and filters,
 # not merely the set of hours. A valid alternate minute is concrete drift, not
 # an unreadable schedule.
 sed -i.bak 's/BYMINUTE=0/BYMINUTE=30/' \
   "$FIX/codex/automations/agent-improver/automation.toml"
+sqlite3 "$CODEX_AUTOMATION_STORE" \
+  "UPDATE automations SET rrule = 'RRULE:FREQ=DAILY;BYHOUR=7,19;BYMINUTE=30;BYSECOND=0' WHERE id = 'agent-improver';"
 OUT=$(run --section drift)
 check "minute drift is reported concretely" "$OUT" "DRIFT: codex improver schedule expected=7,19@0 actual=7,19@30"
 check "valid minute drift remains measurable" "$OUT" "local simultaneous starts/day: 0"
 mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
    "$FIX/codex/automations/agent-improver/automation.toml"
+sqlite3 "$CODEX_AUTOMATION_STORE" \
+  "UPDATE automations SET rrule = 'RRULE:FREQ=DAILY;BYHOUR=7,19;BYMINUTE=0;BYSECOND=0' WHERE id = 'agent-improver';"
 
 # An out-of-range minute is malformed and must fail closed.
 sed -i.bak 's/BYMINUTE=0/BYMINUTE=60/' \
@@ -330,11 +347,15 @@ mv "$FIX/claude-store/scheduled-tasks.json.bak" \
 # A persisted runtime rewrite must report the concrete expected/actual delta.
 sed -i.bak 's/BYHOUR=7,19;BYMINUTE=0/BYHOUR=6,18;BYMINUTE=50/' \
   "$FIX/codex/automations/agent-improver/automation.toml"
+sqlite3 "$CODEX_AUTOMATION_STORE" \
+  "UPDATE automations SET rrule = 'RRULE:FREQ=DAILY;BYHOUR=6,18;BYMINUTE=50;BYSECOND=0' WHERE id = 'agent-improver';"
 OUT=$(run --section drift)
 check "runtime schedule rewrite is detected" "$OUT" "DRIFT: codex improver schedule expected=7,19@0 actual=6,18@50"
 check "runtime rewrite exposes collisions"   "$OUT" "local simultaneous starts/day: 2"
 mv "$FIX/codex/automations/agent-improver/automation.toml.bak" \
    "$FIX/codex/automations/agent-improver/automation.toml"
+sqlite3 "$CODEX_AUTOMATION_STORE" \
+  "UPDATE automations SET rrule = 'RRULE:FREQ=DAILY;BYHOUR=7,19;BYMINUTE=0;BYSECOND=0' WHERE id = 'agent-improver';"
 
 # ── 6. clean-state: no false positives when nothing is wrong ──────────────────
 echo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,12 +346,13 @@ post-dispatch check passes. Supply that post-apply baseline to the drift check a
 `CLAUDE_ENGINEER_MARKER_BASELINE`, `CLAUDE_IMPROVER_MARKER_BASELINE`,
 `CODEX_ENGINEER_MARKER_BASELINE`, or `CODEX_IMPROVER_MARKER_BASELINE`. Claude cadence comes from the
 authoritative `scheduled-tasks.json` record selected by exact task id plus pointer path, with
-`lastRunAt` as its marker; the `SKILL.md` description is not scheduler state. Codex cadence and
-markers come respectively from `automation.toml`'s complete RRULE and the exact automation id's
-`last_run_at` in Codex's local `sqlite/codex-dev.db` scheduler store; `automation.toml.updated_at` is
-an apply marker and does not advance on dispatch. A missing or ambiguous store,
-missing baseline, marker that did not advance, or incomplete recurrence rule is `UNKNOWN`, never
-`MATCH`.
+`lastRunAt` as its marker; the `SKILL.md` description is not scheduler state. Codex cadence and its
+dispatch marker come from the exact automation id's `rrule` and `last_run_at` fields in Codex's local
+`sqlite/codex-dev.db` scheduler store. The complete RRULE in `automation.toml` is a required thin
+pointer and must equal that scheduler record before the drift check reports `MATCH`;
+`automation.toml.updated_at` is only an apply marker and does not advance on dispatch. A missing or
+ambiguous store, missing baseline, marker that did not advance, or incomplete recurrence rule is
+`UNKNOWN`, never `MATCH`.
 
 The deployed Cursor Automation has no supported local write surface. Its reviewed source is
 `.claude/loaders/cursor-daily-ai-engineer.md`; after that source merges, use a declared Maintainer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,7 +347,9 @@ post-dispatch check passes. Supply that post-apply baseline to the drift check a
 `CODEX_ENGINEER_MARKER_BASELINE`, or `CODEX_IMPROVER_MARKER_BASELINE`. Claude cadence comes from the
 authoritative `scheduled-tasks.json` record selected by exact task id plus pointer path, with
 `lastRunAt` as its marker; the `SKILL.md` description is not scheduler state. Codex cadence and
-markers come from `automation.toml`'s complete RRULE and `updated_at`. A missing or ambiguous store,
+markers come respectively from `automation.toml`'s complete RRULE and the exact automation id's
+`last_run_at` in Codex's local `sqlite/codex-dev.db` scheduler store; `automation.toml.updated_at` is
+an apply marker and does not advance on dispatch. A missing or ambiguous store,
 missing baseline, marker that did not advance, or incomplete recurrence rule is `UNKNOWN`, never
 `MATCH`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,7 @@ The **brain is version-controlled here** (this file + `.claude/`), so the self-i
 improving it; the machine-local scheduled-task entry is only a **thin pointer** that hands off to it.
 This brain is deployed as **more than one agent instance** — currently the Claude Code scheduled task,
 the **sibling ChatGPT/Codex routine**, and the **Cursor Automation cloud instance** (`:30` past uneven
-hours); the per-hour split across the two machine-local lanes is the table in
+hours); the hourly minute offsets across the two machine-local lanes are the table in
 *Cadence & focus* — each booted by its own routine/scheduler prompt. Those prompts
 are part of the definition too: **each instance monitors and enhances its own dispatch prompt** (see
 *Self-improvement → Routine-prompt stewardship*). The first two are machine-local and their prompts are
@@ -2597,45 +2597,42 @@ schedule; see *Agentic engineering plugin contract*). Times are the agent host's
 runtime-local scheduler entries are **thin pointers that must match this table**; when the two
 disagree, the scheduler is the defect — reconcile it there, per *Agent definition locations*.
 
-**The parity invariant IS the schedule: Claude takes EVEN hours, Codex takes UNEVEN hours, and no two
-local instances ever share a dispatch hour.** Read your lane's row for your own slots; read the
-invariant to know that whatever else is running, it did not start when you did.
+**The stagger invariant IS the schedule: both machine-local Agentic Engineer lanes dispatch every
+hour, at distinct minute offsets — Codex at `:10`, Cursor at `:30` on uneven hours, and Claude at
+`:50`; the four Agent Improver starts remain at `:00`.** No two scheduled roles share an exact start
+time. Read your lane's row for your own slots, and treat runtime jitter plus long-running siblings as
+normal overlap rather than evidence that a slot is free.
 
 | Lane | Agentic Engineer | Agent Improver |
 |---|---|---|
-| **Claude** — `claude/*`, even hours | 02, 04, 06, 08, 10, 14, 16, 18, 20, 22 | 00, 12 |
-| **Codex** — `codex/*`, uneven hours | 01, 03, 05, 09, 11, 13, 15, 17, 21, 23 | 07, 19 |
+| **Claude** — `claude/*`, hourly at `:50` | Every hour at `:50` | 00:00, 12:00 |
+| **Codex** — `codex/*`, hourly at `:10` | Every hour at `:10` | 07:00, 19:00 |
 | **Cursor** — `cursor/*`, uneven hours at `:30` | 01:30 … 23:30 | — |
 
-Each lane dispatches **every 2 hours**, uniformly, and the three lanes interleave so that consecutive
-dispatches are **never less than 30 minutes apart** (the Claude runtime adds a few minutes of dispatch
-jitter, which only widens the gaps). The Agent
-Improver keeps its 4×/day rotation, alternating lanes (00 Claude, 07 Codex, 12 Claude, 19 Codex).
-This table covers the two scheduled engineering roles only — spend stewardship has no dispatch slot
-of its own (see *Spend contract*).
+Both machine-local Agentic Engineer lanes dispatch **every hour**. Cursor keeps its every-2-hours
+cloud cadence, centered between the two machine-local offsets on uneven hours. The Agent Improver
+keeps its 4×/day rotation (00 Claude, 07 Codex, 12 Claude, 19 Codex) as additional `:00` starts; those
+slots no longer replace an Agentic Engineer tick. This table covers the two scheduled engineering
+roles only — spend stewardship has no dispatch slot of its own (see *Spend contract*).
 
 **Two properties of this schedule change how you plan a run.**
 ⚠️ **A sibling being mid-run is the NORMAL case — scan cross-lane on EVERY run, never at one special
-hour.** The parity invariant removes simultaneous *starts*, which is the window where two instances
-select the same issue; it does **not** remove overlap, because runs outlive their hour. Measured over
+hour.** The stagger invariant removes identical scheduled *start times*; it does **not** remove
+overlap, because runtimes add jitter and runs outlive their hour. Measured over
 the 7 days to 2026-07-28 (n=26 completed Claude dispatches): **median 51 min, p75 79 min, 46% ran
 longer than 60 minutes, max 377**. So a sibling lane is very often still working when you start.
 *Claim protocol* rule 4 records that claim arbitration does **not** work across lanes — each instance
 writes its own namespace, so both pushes succeed and both believe they won. Scan `codex/*`,
 `claude/*` **and** `cursor/*` branches and open PRs before claiming, always.
-**Same-lane overlap is expected, and it IS arbitrated.** With 2-hour spacing and ~12% of runs
-exceeding 120 minutes, your own lane's next dispatch can start before you finish. That case is safe
-by construction — same namespace, same deterministic branch name, and a non-forced push is refused
-(see *Claim protocol* rule 4) — so it needs no handling beyond never force-pushing a claim branch.
+**Same-lane overlap is expected, and it IS arbitrated.** With hourly spacing and 46% of measured
+Claude runs exceeding 60 minutes, your own lane's next dispatch often starts before you finish. That
+case is safe by construction — same namespace, same deterministic branch name, and a non-forced push
+is refused (see *Claim protocol* rule 4) — so it needs no handling beyond never force-pushing a claim
+branch.
 
-**Your LANE fires every 2 hours; your own ROLE's next slot is sometimes 4.** Two of each lane's twelve
-slots belong to the Agent Improver, so an Agentic Engineer's own next tick is **2 hours away eight
-times a day and 4 hours away twice** — Claude across its 12:00 and 00:00 improver slots (10→14, 22→02),
-Codex across its 07:00 and 19:00 ones (05→09, 17→21). That interval is the gap **between
-runs, not a per-run time
-budget** — and it is the *instance's* own gap that bounds a carry-forward, so **check which slot you
-are in before deferring**: a watch item handed to "the next tick" from a Claude **10:00/22:00** or a
-Codex **05:00/17:00** run waits four hours, not two. Each run works
+**Your Agentic Engineer's next scheduled tick is always one hour later.** The Agent Improver's four
+daily starts are additional work, not replacement slots. That hour is the gap **between runs, not a
+per-run time budget**; it bounds a carry-forward without telling an active run to stop early. Each run works
 *The work-selection ladder* top-down — **breakage → every open PR you own or trust, drafts included →
 security issues → bugs → the oldest actionable issue** — capturing new
 non-trivial finds as issues (see *Issue-driven*).


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Direct maintainer direction is to use the providers more frequent reset windows by dispatching both machine-local Agentic Engineer lanes every hour. The previous even/uneven split left available engineering capacity unused.

## What

- schedules Claude every hour at :50 and Codex every hour at :10
- keeps Cursor at :30 on uneven hours and both Agent Improver schedules unchanged
- replaces the parity invariant with exact staggered start times and hourly carry-forward guidance
- upgrades drift checks to correlate complete scheduler recurrences with real post-dispatch markers
- preserves fail-closed handling for malformed, incomplete, or disagreeing runtime state
- updates the Cursor loader rationale without changing its deployed cron

## Definition boundary

The agentic-engineering plugin remains the canonical generic role and deliberately contains no fixed schedule. Its provider-neutral desired state points to AGENTS.md#Cadence. The concrete times therefore belong in the deployment AGENTS.md contract and thin runtime scheduler pointers; no plugin or installed-cache edit is needed.

## Runtime rollout

Both machine-local schedules are active through their supported control planes and persisted through a later dispatch. Claude advanced its scheduler last-run marker at 10:58 CEST. Codex created the first hourly task at 11:11 CEST while retaining the hourly recurrence. Runtime pointer backups were taken before either change.

## Validation

- agent telemetry: 241 passed, 0 failed
- all AGENTS-triggered local contract suites
- live drift proof: 48 local engineer dispatches/day and zero exact scheduled collisions
- bash syntax, diff check, and ShellCheck with the files existing warning allowlist

Fixes #2604