### PR TITLE
feat(telemetry): score a hypothesis signature by real errors, not by its own documentation

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -22,6 +22,7 @@ MAX_FILES=400
 SECTION=all
 SIGNATURE=""
 SIGNATURE_SET=0
+SIGNATURE_FROM_FILE=0
 INJECTION_PROVENANCE=0
 CREDENTIAL_PROVENANCE=0
 CREDENTIAL_SCAN_BATCH_FILES="${CREDENTIAL_SCAN_BATCH_FILES:-128}"
@@ -55,6 +56,7 @@ while [ $# -gt 0 ]; do
     --signature-file)
       need_val "$@"
       [ -r "$2" ] || { echo "--signature-file is not readable" >&2; exit 2; }
+      SIGNATURE_FROM_FILE=1
       # Command substitution strips ALL trailing newlines, which is the wanted
       # behaviour for a file an editor terminated. Interior bytes are preserved,
       # so a genuinely multi-line signature still matches exactly.
@@ -68,6 +70,12 @@ done
 
 case "$SINCE_DAYS" in ''|*[!0-9]*) echo "--since-days must be an integer" >&2; exit 2 ;; esac
 case "$MAX_FILES"  in ''|*[!0-9]*) echo "--max-files must be an integer"  >&2; exit 2 ;; esac
+# A ZERO cap is accepted by the integer test and then empties every file set via
+# `head -n 0`, so all five call sites scan nothing and each section reports
+# "(no sessions in window)" — an explicitly empty scan rendered as evidence that
+# nothing happened. Reject it: this tool must never present absence of evidence
+# as evidence of absence.
+case "$MAX_FILES" in 0) echo "--max-files must be at least 1 (0 scans nothing and would report an empty corpus as 'no sessions')" >&2; exit 2 ;; esac
 case "$CREDENTIAL_SCAN_BATCH_FILES" in
   ''|*[!0-9]*) echo "CREDENTIAL_SCAN_BATCH_FILES must be a positive integer" >&2; exit 2 ;;
   *[1-9]*) ;;
@@ -93,6 +101,22 @@ if [ "$SECTION" = signature ] && [ "$SIGNATURE_SET" -eq 0 ]; then
 fi
 if [ "$SIGNATURE_SET" -eq 1 ] && [ -z "$SIGNATURE" ]; then
   echo "--signature must not be empty" >&2; exit 2
+fi
+# Bound the signature BEFORE any scan. An oversized value makes the `jq` exec
+# fail outright (Linux caps a single argv/env entry at 128 KiB regardless of
+# ARG_MAX); this call site discards stderr and ends in `|| true`, so the scan
+# would exit 0 with both counts at ZERO — a large multiline error turned into
+# false evidence that it never occurred. Fail loudly instead. 4 KiB is far above
+# any real error signature and far below the exec limit.
+SIG_MAX_BYTES=4096
+if [ "$SIGNATURE_SET" -eq 1 ]; then
+  _siglen=$(printf '%s' "$SIGNATURE" | wc -c | tr -d ' ')
+  if [ "$_siglen" -gt "$SIG_MAX_BYTES" ]; then
+    echo "--signature is ${_siglen} bytes; the limit is ${SIG_MAX_BYTES}. A larger value cannot be" >&2
+    echo "passed to the scanner and would silently report zero occurrences. Use a shorter, more" >&2
+    echo "distinctive fragment of the signature." >&2
+    exit 2
+  fi
 fi
 # A signature handed to a section that cannot score it is the SAME failure as a
 # missing one: `--section reliability --signature X` used to exit 0 having
@@ -1398,9 +1422,20 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
     # row to a line-oriented consumer. With the label first, no line can BEGIN
     # with a metric shape unless it is one, so a consumer can anchor (`^  REAL`)
     # and the value can never masquerade as a row.
-    printf '  signature scored (fixed string, case-sensitive): %s\n' \
-      "$(printf '%s' "$SIGNATURE" | tr '\n\r\t' '   ' | redact \
-         | sed -E 's/[[:cntrl:]]+/ /g' | tr -d '\n' | cut -c1-100)"
+    # A file-supplied signature is NEVER echoed. `--signature-file` exists so a
+    # caller need not expose a sensitive value, and `redact` only recognises a
+    # fixed set of credential shapes — an arbitrary password or unsupported
+    # token format would pass through unchanged. Identify it by digest instead,
+    # which still lets two runs be compared without disclosing the needle.
+    if [ "$SIGNATURE_FROM_FILE" -eq 1 ]; then
+      _sigdig=$(printf '%s' "$SIGNATURE" | shasum -a 256 2>/dev/null | cut -c1-12)
+      printf '  signature scored: <from file, not echoed> sha256:%s len=%s\n' \
+        "${_sigdig:-unavailable}" "$(printf '%s' "$SIGNATURE" | wc -c | tr -d ' ')"
+    else
+      printf '  signature scored (fixed string, case-sensitive): %s\n' \
+        "$(printf '%s' "$SIGNATURE" | tr '\n\r\t' '   ' | redact \
+           | sed -E 's/[[:cntrl:]]+/ /g' | tr -d '\n' | cut -c1-100)"
+    fi
     echo "  window: records at or after ${SIG_SINCE}   (record timestamps, not file mtime)"
     echo
     echo "  REAL occurrences (tool_result with is_error==true): ${SIG_OCC}"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -81,6 +81,18 @@ fi
 if [ "$SIGNATURE_SET" -eq 1 ] && [ -z "$SIGNATURE" ]; then
   echo "--signature must not be empty" >&2; exit 2
 fi
+# A signature handed to a section that cannot score it is the SAME failure as a
+# missing one: `--section reliability --signature X` used to exit 0 having
+# silently scored nothing, so a caller asking for a verdict got a clean run and
+# no verdict. Reject it rather than ignore it — absent evidence must never look
+# like evidence of absence, which is the whole point of this section.
+case "$SECTION" in
+  all|signature) ;;
+  *) if [ "$SIGNATURE_SET" -eq 1 ]; then
+       echo "--signature is only scored by --section signature (or all); got --section $SECTION" >&2
+       exit 2
+     fi ;;
+esac
 
 CLAUDE_PROJECTS="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
 CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
@@ -1257,8 +1269,17 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
   # Same portable pair as the outcomes section: BSD `date -v` first, GNU `-d`
   # second. Full second precision, so the comparison against a record timestamp
   # is not truncated to a whole day.
-  SIG_SINCE=$(date -u -v-"${SINCE_DAYS}"d '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
-              || date -u -d "${SINCE_DAYS} days ago" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)
+  #
+  # ⚠️ The cutoff carries `.000` because the comparison against a record's
+  # timestamp is LEXICAL. Claude records use the fractional form
+  # `…T10:00:00.500Z`, and against a plain `…T10:00:00Z` cutoff that sorts
+  # BEFORE it — `.` (0x2E) < `Z` (0x5A) — so a record half a second INSIDE the
+  # window was excluded. Verified: `".500Z" >= "…:00Z"` is false, `>= "…:00.000Z"`
+  # is true, and a plain at-cutoff record still compares >= `.000`. Both walks
+  # share this cutoff, so the boundary record vanished from the metric AND its
+  # control together — invisible, and in the under-reporting direction.
+  SIG_SINCE=$(date -u -v-"${SINCE_DAYS}"d '+%Y-%m-%dT%H:%M:%S.000Z' 2>/dev/null \
+              || date -u -d "${SINCE_DAYS} days ago" '+%Y-%m-%dT%H:%M:%S.000Z' 2>/dev/null)
   if [ -z "$SIG_SINCE" ]; then
     echo "  UNKNOWN: cannot compute window start (no usable \`date\`) — refusing to score."
   elif [ "$SF_COUNT" -eq 0 ]; then

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1289,7 +1289,14 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
             (.message.content // empty)
             | select(type=="array")
             | any(
-                .type=="tool_result" and .is_error==true
+                # `objects` FIRST. A content array can mix plain strings with
+                # blocks, and indexing a string with `.type` makes jq abort the
+                # whole input line — which this call site swallows via
+                # `2>/dev/null`, so a record holding a REAL errored tool_result
+                # would vanish silently. That under-reports, the same direction
+                # as the contamination this section exists to remove.
+                objects
+                | .type=="tool_result" and .is_error==true
                 and ((.content | if type=="array" then (map(select(.type=="text").text)|join(" "))
                                  elif type=="string" then . else (.|tostring) end)
                      | contains($sig))
@@ -1344,6 +1351,19 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
       echo "    ${SIG_NAIVE} - ${SIG_OCC} of these are prose or DOCUMENTATION READS, not failures."
       echo "    Scoring a hypothesis on the unfiltered number counts the agent's own"
       echo "    writing about a defect as instances of it — see monorepo#2622."
+    elif [ "$SIG_NAIVE" -lt "$SIG_OCC" ]; then
+      # The invariant is asserted in the test suite, so the SCRIPT must state it
+      # too — otherwise the one run where it breaks prints a quietly impossible
+      # pair of numbers. It can break legitimately: the filtered walk JOINS a
+      # record's text blocks before matching, while the control tests each
+      # decoded string leaf on its own, so a signature straddling two adjacent
+      # blocks matches the filtered walk and not the control. That is two
+      # populations again — the exact confound this section exists to remove —
+      # so say so loudly rather than publishing the smaller-superset silently.
+      echo "    ⚠️  INVARIANT BROKEN: the control (${SIG_NAIVE}) is BELOW the filtered"
+      echo "    count (${SIG_OCC}), so the two walks matched different populations."
+      echo "    Treat BOTH numbers as unreliable for this signature — most likely it"
+      echo "    straddles two adjacent text blocks, which only the joined walk sees."
     fi
     : > "$SIGTMP"
     echo

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -13,7 +13,7 @@
 #   `agentic-engineering` plugin's `agent-improver` → "Ingestion boundary".
 #
 # Usage: agent-telemetry.sh [--since-days N] [--max-files N] [--section NAME]
-#                           [--signature STRING]
+#                           [--signature STRING | --signature-file PATH]
 #                           [--injection-provenance] [--credential-provenance]
 set -uo pipefail
 
@@ -46,6 +46,19 @@ while [ $# -gt 0 ]; do
     # occurrences of a defect. SIGNATURE_SET distinguishes "not asked for" from
     # "asked for with a bad value" so the empty case fails loudly.
     --signature)  need_val "$@"; SIGNATURE="$2"; SIGNATURE_SET=1; shift 2 ;;
+    # ⚠️ `--signature` puts the value in this process's ARGV, which is readable
+    # by any local user (`ps`, /proc/<pid>/cmdline). Failed tool results can
+    # carry commands and tokens, so a caller scoring one must not be forced to
+    # expose it: `--signature-file` reads it from a file instead, and the value
+    # reaches jq through the ENVIRONMENT rather than jq's own argv. Neither
+    # stdout redaction nor the 0600 scratch file protects process arguments.
+    --signature-file)
+      need_val "$@"
+      [ -r "$2" ] || { echo "--signature-file is not readable" >&2; exit 2; }
+      # Command substitution strips ALL trailing newlines, which is the wanted
+      # behaviour for a file an editor terminated. Interior bytes are preserved,
+      # so a genuinely multi-line signature still matches exactly.
+      SIGNATURE=$(printf '%s' "$(cat -- "$2")"); SIGNATURE_SET=1; shift 2 ;;
     --injection-provenance) INJECTION_PROVENANCE=1; shift ;;
     --credential-provenance) CREDENTIAL_PROVENANCE=1; shift ;;
     -h|--help)    sed -n '2,17p' "$0"; exit 0 ;;
@@ -76,7 +89,7 @@ esac
 # report: a hypothesis scored against a silently-absent signature would read
 # `0 occurrences` and be recorded as a fix that worked.
 if [ "$SECTION" = signature ] && [ "$SIGNATURE_SET" -eq 0 ]; then
-  echo "--section signature requires --signature STRING" >&2; exit 2
+  echo "--section signature requires --signature STRING or --signature-file PATH" >&2; exit 2
 fi
 if [ "$SIGNATURE_SET" -eq 1 ] && [ -z "$SIGNATURE" ]; then
   echo "--signature must not be empty" >&2; exit 2
@@ -1300,8 +1313,9 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
     # literally rather than being reinterpreted.
     printf '%s\n' "$SF_CACHE" | while IFS= read -r f; do
       [ -n "$f" ] || continue
-      jq -Rr --arg sig "$SIGNATURE" --arg since "$SIG_SINCE" '
-        select(length>0)|(try fromjson catch empty)
+      SIG_ENV="$SIGNATURE" jq -Rr --arg since "$SIG_SINCE" '
+        ($ENV.SIG_ENV) as $sig
+        | select(length>0)|(try fromjson catch empty)
         | select(.type=="user")
         | (.timestamp // "") as $ts
         | select($ts != "" and $ts >= $since)
@@ -1318,7 +1332,7 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
                 # as the contamination this section exists to remove.
                 objects
                 | .type=="tool_result" and .is_error==true
-                and ((.content | if type=="array" then (map(select(.type=="text").text)|join(" "))
+                and ((.content | if type=="array" then (map(objects|select(.type=="text")|.text|strings)|join(" "))
                                  elif type=="string" then . else (.|tostring) end)
                      | contains($sig))
               )
@@ -1344,17 +1358,49 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
     # variable between the two numbers.
     SIG_NAIVE=$(printf '%s\n' "$SF_CACHE" | while IFS= read -r f; do
       [ -n "$f" ] || continue
-      jq -Rr --arg sig "$SIGNATURE" --arg since "$SIG_SINCE" '
-        select(length>0)|(try fromjson catch empty)
+      SIG_ENV="$SIGNATURE" jq -Rr --arg since "$SIG_SINCE" '
+        ($ENV.SIG_ENV) as $sig
+        | select(length>0)|(try fromjson catch empty)
         | (.timestamp // "") as $ts
         | select($ts != "" and $ts >= $since)
-        | select([.. | strings] | any(contains($sig)))
+        | select(
+            # UNION, so the control contains every match of the filtered walk by
+            # CONSTRUCTION rather than by totals happening to line up. Comparing
+            # totals cannot prove set inclusion: one split-across-blocks error
+            # (seen only by the joined walk) plus one prose record carrying the
+            # whole string (seen only by the leaf walk) gives 1 and 1 with the
+            # superset missing the subset entirely, and no warning.
+            ([.. | strings] | any(contains($sig)))
+            or (
+              (.message.content // empty)
+              | if type=="array" then
+                  any(objects | .type=="tool_result"
+                      and ((.content | if type=="array" then (map(objects|select(.type=="text")|.text|strings)|join(" "))
+                                       elif type=="string" then . else (.|tostring) end)
+                           | contains($sig)))
+                else false end
+            )
+          )
         | "1"
       ' "$f" 2>/dev/null
     done | wc -l | tr -d ' ')
 
-    echo "  signature scored (fixed string, case-sensitive):"
-    printf '    %s\n' "$(printf '%s' "$SIGNATURE" | redact | sed -E 's/[[:cntrl:]]+/ /g' | cut -c1-100)"
+
+    # FLATTEN FIRST. `sed` works line by line, so `[[:cntrl:]]` never sees a
+    # newline and `cut -c` bounds each line rather than the whole value — a
+    # multiline signature therefore printed several bounded lines, and a second
+    # line reading `REAL occurrences ...: 999` lands directly above the real
+    # metric. This output is explicitly consumed by an agent, so a value that
+    # can forge a scorecard row is an integrity bug, not cosmetics.
+    # Emitted on the SAME LINE as its label, deliberately. Flattening alone still
+    # leaves the value at the start of a line, so a signature reading
+    # `REAL occurrences ...: 999` produced a line indistinguishable from a metric
+    # row to a line-oriented consumer. With the label first, no line can BEGIN
+    # with a metric shape unless it is one, so a consumer can anchor (`^  REAL`)
+    # and the value can never masquerade as a row.
+    printf '  signature scored (fixed string, case-sensitive): %s\n' \
+      "$(printf '%s' "$SIGNATURE" | tr '\n\r\t' '   ' | redact \
+         | sed -E 's/[[:cntrl:]]+/ /g' | tr -d '\n' | cut -c1-100)"
     echo "  window: records at or after ${SIG_SINCE}   (record timestamps, not file mtime)"
     echo
     echo "  REAL occurrences (tool_result with is_error==true): ${SIG_OCC}"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1238,8 +1238,9 @@ fi
 #      the corpus in a record shaped almost exactly like the thing being detected.
 # (3) is self-reinforcing: the better a defect is documented, the more
 # occurrences its detector reports, so a FIXED defect can never read as fixed.
-# Measured on `Unknown JSON field`: 80 bare-grep records vs 5 real errors — 94%
-# contamination, in the direction that HIDES a successful fix.
+# Measured here on the live corpus, 7d window, `Unknown JSON field: "merged"`:
+# 58 records contain the string, 2 are real failures — 97% of the naive count is
+# noise, in the direction that HIDES a successful fix.
 #
 # Two filters make the count mean what it says:
 #   * `is_error==true` on a `tool_result` — a documentation read that merely
@@ -1264,6 +1265,15 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
     echo "  (no Claude sessions in window)"
   else
     # One row per REAL occurrence: "<record timestamp>\t<sessionId>".
+    #
+    # The unit is the RECORD, not the content block. One transcript record can
+    # carry several `tool_result` blocks, so a per-block count could exceed the
+    # unfiltered per-record control below and break the superset invariant the
+    # two numbers are compared on — a "control" smaller than its own subset is
+    # the confound this section exists to remove, so both sides count records.
+    # `any` short-circuits at the first matching block, which is also what makes
+    # the record the unit rather than merely deduplicating one.
+    #
     # `contains` is a fixed-string test, never a regex — a signature carrying
     # regex metacharacters (`"` and `:` are common in these) must match itself
     # literally rather than being reinterpreted.
@@ -1275,13 +1285,16 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
         | (.timestamp // "") as $ts
         | select($ts != "" and $ts >= $since)
         | (.sessionId // "unknown") as $sid
-        | .message.content
-        | select(type=="array")
-        | .[]
-        | select(.type=="tool_result" and .is_error==true)
-        | (.content | if type=="array" then (map(select(.type=="text").text)|join(" "))
-                      elif type=="string" then . else (.|tostring) end) as $msg
-        | select($msg | contains($sig))
+        | select(
+            (.message.content // empty)
+            | select(type=="array")
+            | any(
+                .type=="tool_result" and .is_error==true
+                and ((.content | if type=="array" then (map(select(.type=="text").text)|join(" "))
+                                 elif type=="string" then . else (.|tostring) end)
+                     | contains($sig))
+              )
+          )
         | "\($ts)\t\($sid)"
       ' "$f" 2>/dev/null
     done | redact > "$SIGTMP" || true

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -13,7 +13,7 @@
 #   `agentic-engineering` plugin's `agent-improver` → "Ingestion boundary".
 #
 # Usage: agent-telemetry.sh [--since-days N] [--max-files N] [--section NAME]
-#                           [--signature STRING | --signature-file PATH]
+#                           [--signature STRING]
 #                           [--injection-provenance] [--credential-provenance]
 set -uo pipefail
 
@@ -22,7 +22,6 @@ MAX_FILES=400
 SECTION=all
 SIGNATURE=""
 SIGNATURE_SET=0
-SIGNATURE_FROM_FILE=0
 INJECTION_PROVENANCE=0
 CREDENTIAL_PROVENANCE=0
 CREDENTIAL_SCAN_BATCH_FILES="${CREDENTIAL_SCAN_BATCH_FILES:-128}"
@@ -47,20 +46,6 @@ while [ $# -gt 0 ]; do
     # occurrences of a defect. SIGNATURE_SET distinguishes "not asked for" from
     # "asked for with a bad value" so the empty case fails loudly.
     --signature)  need_val "$@"; SIGNATURE="$2"; SIGNATURE_SET=1; shift 2 ;;
-    # ⚠️ `--signature` puts the value in this process's ARGV, which is readable
-    # by any local user (`ps`, /proc/<pid>/cmdline). Failed tool results can
-    # carry commands and tokens, so a caller scoring one must not be forced to
-    # expose it: `--signature-file` reads it from a file instead, and the value
-    # reaches jq through the ENVIRONMENT rather than jq's own argv. Neither
-    # stdout redaction nor the 0600 scratch file protects process arguments.
-    --signature-file)
-      need_val "$@"
-      [ -r "$2" ] || { echo "--signature-file is not readable" >&2; exit 2; }
-      SIGNATURE_FROM_FILE=1
-      # Command substitution strips ALL trailing newlines, which is the wanted
-      # behaviour for a file an editor terminated. Interior bytes are preserved,
-      # so a genuinely multi-line signature still matches exactly.
-      SIGNATURE=$(printf '%s' "$(cat -- "$2")"); SIGNATURE_SET=1; shift 2 ;;
     --injection-provenance) INJECTION_PROVENANCE=1; shift ;;
     --credential-provenance) CREDENTIAL_PROVENANCE=1; shift ;;
     -h|--help)    sed -n '2,17p' "$0"; exit 0 ;;
@@ -75,7 +60,13 @@ case "$MAX_FILES"  in ''|*[!0-9]*) echo "--max-files must be an integer"  >&2; e
 # "(no sessions in window)" — an explicitly empty scan rendered as evidence that
 # nothing happened. Reject it: this tool must never present absence of evidence
 # as evidence of absence.
-case "$MAX_FILES" in 0) echo "--max-files must be at least 1 (0 scans nothing and would report an empty corpus as 'no sessions')" >&2; exit 2 ;; esac
+# Compared NUMERICALLY, not against the literal "0": `00` passes the digit test,
+# and an exact-string guard missed it while `head -n 00` still empties every file
+# set. Any zero-valued form must be rejected, however it is spelled.
+if [ "$MAX_FILES" -eq 0 ] 2>/dev/null; then
+  echo "--max-files must be at least 1 (a zero cap scans nothing and would report an empty corpus as 'no sessions')" >&2
+  exit 2
+fi
 case "$CREDENTIAL_SCAN_BATCH_FILES" in
   ''|*[!0-9]*) echo "CREDENTIAL_SCAN_BATCH_FILES must be a positive integer" >&2; exit 2 ;;
   *[1-9]*) ;;
@@ -97,7 +88,7 @@ esac
 # report: a hypothesis scored against a silently-absent signature would read
 # `0 occurrences` and be recorded as a fix that worked.
 if [ "$SECTION" = signature ] && [ "$SIGNATURE_SET" -eq 0 ]; then
-  echo "--section signature requires --signature STRING or --signature-file PATH" >&2; exit 2
+  echo "--section signature requires --signature STRING" >&2; exit 2
 fi
 if [ "$SIGNATURE_SET" -eq 1 ] && [ -z "$SIGNATURE" ]; then
   echo "--signature must not be empty" >&2; exit 2
@@ -1422,20 +1413,15 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
     # row to a line-oriented consumer. With the label first, no line can BEGIN
     # with a metric shape unless it is one, so a consumer can anchor (`^  REAL`)
     # and the value can never masquerade as a row.
-    # A file-supplied signature is NEVER echoed. `--signature-file` exists so a
-    # caller need not expose a sensitive value, and `redact` only recognises a
-    # fixed set of credential shapes — an arbitrary password or unsupported
-    # token format would pass through unchanged. Identify it by digest instead,
-    # which still lets two runs be compared without disclosing the needle.
-    if [ "$SIGNATURE_FROM_FILE" -eq 1 ]; then
-      _sigdig=$(printf '%s' "$SIGNATURE" | shasum -a 256 2>/dev/null | cut -c1-12)
-      printf '  signature scored: <from file, not echoed> sha256:%s len=%s\n' \
-        "${_sigdig:-unavailable}" "$(printf '%s' "$SIGNATURE" | wc -c | tr -d ' ')"
-    else
-      printf '  signature scored (fixed string, case-sensitive): %s\n' \
-        "$(printf '%s' "$SIGNATURE" | tr '\n\r\t' '   ' | redact \
-           | sed -E 's/[[:cntrl:]]+/ /g' | tr -d '\n' | cut -c1-100)"
-    fi
+    # ⚠️ `--signature` places the value in this process's ARGV, which any local
+    # user can read. That is acceptable for an error-shape needle and is the
+    # documented tradeoff; a protected input path belongs with the Go migration
+    # (#2629), where a file or FD can be handled with real error handling. A
+    # Bash `--signature-file` was tried here and generated more defects than it
+    # closed (see #2624 rounds 4-6), so it was removed rather than patched again.
+    printf '  signature scored (fixed string, case-sensitive): %s\n' \
+      "$(printf '%s' "$SIGNATURE" | tr '\n\r\t' '   ' | redact \
+         | sed -E 's/[[:cntrl:]]+/ /g' | tr -d '\n' | cut -c1-100)"
     echo "  window: records at or after ${SIG_SINCE}   (record timestamps, not file mtime)"
     echo
     echo "  REAL occurrences (tool_result with is_error==true): ${SIG_OCC}"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -13,12 +13,15 @@
 #   `agentic-engineering` plugin's `agent-improver` → "Ingestion boundary".
 #
 # Usage: agent-telemetry.sh [--since-days N] [--max-files N] [--section NAME]
+#                           [--signature STRING]
 #                           [--injection-provenance] [--credential-provenance]
 set -uo pipefail
 
 SINCE_DAYS=1
 MAX_FILES=400
 SECTION=all
+SIGNATURE=""
+SIGNATURE_SET=0
 INJECTION_PROVENANCE=0
 CREDENTIAL_PROVENANCE=0
 CREDENTIAL_SCAN_BATCH_FILES="${CREDENTIAL_SCAN_BATCH_FILES:-128}"
@@ -38,9 +41,14 @@ while [ $# -gt 0 ]; do
     --since-days) need_val "$@"; SINCE_DAYS="$2"; shift 2 ;;
     --max-files)  need_val "$@"; MAX_FILES="$2";  shift 2 ;;
     --section)    need_val "$@"; SECTION="$2";    shift 2 ;;
+    # An EMPTY signature is rejected below rather than treated as absent: an
+    # empty needle matches every record, which would report the whole corpus as
+    # occurrences of a defect. SIGNATURE_SET distinguishes "not asked for" from
+    # "asked for with a bad value" so the empty case fails loudly.
+    --signature)  need_val "$@"; SIGNATURE="$2"; SIGNATURE_SET=1; shift 2 ;;
     --injection-provenance) INJECTION_PROVENANCE=1; shift ;;
     --credential-provenance) CREDENTIAL_PROVENANCE=1; shift ;;
-    -h|--help)    sed -n '2,16p' "$0"; exit 0 ;;
+    -h|--help)    sed -n '2,17p' "$0"; exit 0 ;;
     *) echo "unknown argument (value not echoed)" >&2; exit 2 ;;
   esac
 done
@@ -59,9 +67,20 @@ esac
 # printing just the banner — a scheduled run looking successful while producing
 # no metrics at all.
 case "$SECTION" in
-  all|dispatch|reliability|efficiency|safety|a2a|drift|outcomes) ;;
-  *) echo "unknown --section (expected: all dispatch reliability efficiency safety a2a drift outcomes)" >&2; exit 2 ;;
+  all|dispatch|reliability|efficiency|safety|a2a|drift|outcomes|signature) ;;
+  *) echo "unknown --section (expected: all dispatch reliability efficiency safety a2a drift outcomes signature)" >&2; exit 2 ;;
 esac
+
+# `signature` is the one section that cannot run on defaults — it scores a needle
+# the caller supplies. Asking for it without one is a usage error, NOT an empty
+# report: a hypothesis scored against a silently-absent signature would read
+# `0 occurrences` and be recorded as a fix that worked.
+if [ "$SECTION" = signature ] && [ "$SIGNATURE_SET" -eq 0 ]; then
+  echo "--section signature requires --signature STRING" >&2; exit 2
+fi
+if [ "$SIGNATURE_SET" -eq 1 ] && [ -z "$SIGNATURE" ]; then
+  echo "--signature must not be empty" >&2; exit 2
+fi
 
 CLAUDE_PROJECTS="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
 CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
@@ -185,10 +204,13 @@ PROVTMP=$(mktemp "${TMPDIR:-/tmp}/.agtel_prov.XXXXXXXX") || { echo "cannot creat
 CONCTMP=$(mktemp "${TMPDIR:-/tmp}/.agtel_conc.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
 CREDCONC=$(mktemp "${TMPDIR:-/tmp}/.agtel_credconc.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
 CREDPROV=$(mktemp "${TMPDIR:-/tmp}/.agtel_credprov.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
+# Its OWN scratch, never $CONCTMP. The injection-concentration pass owns that
+# one, and sharing it would make two sections' results depend on which ran last.
+SIGTMP=$(mktemp "${TMPDIR:-/tmp}/.agtel_sig.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
 # Remove on normal exit; on a SIGNAL also terminate, since a trap that only
 # cleans up leaves the script running after the scheduler asked it to stop.
-trap 'rm -f "$ERRTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV"' EXIT
-trap 'rm -f "$ERRTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV"; trap - HUP INT TERM; kill -s INT $$' HUP INT TERM
+trap 'rm -f "$ERRTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV" "$SIGTMP"' EXIT
+trap 'rm -f "$ERRTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV" "$SIGTMP"; trap - HUP INT TERM; kill -s INT $$' HUP INT TERM
 
 INJ_PHRASE_RE='(ignore (all )?(prior|previous) (rules|instructions)|disregard (your|all) (instructions|rules)|the maintainer (approved|authorised|authorized)|add [^ ]+ to the trust gate|update your instructions|you are now [a-z ]{0,20}mode)'
 
@@ -1199,6 +1221,128 @@ EOF
       echo "    SCOPE: Claude lane only. Codex transcripts are not classified here and"
       echo "    the Codex rate still divides by raw CX_COUNT — same blind spot, open."
     fi
+  fi
+fi
+
+# ── 0b. SIGNATURE SCORING ─────────────────────────────────────────────────────
+# Score ONE named error signature the way a hypothesis verdict needs it.
+#
+# WHY THIS EXISTS (monorepo#2622): hypotheses were scored by ad-hoc `grep` over
+# the transcript store, which matches three different things and counts all of
+# them as occurrences of the defect:
+#   1. the real tool error                      <- the only one that is an occurrence
+#   2. the agent's own PROSE about it           (PR bodies, run reports, replies)
+#   3. DOCUMENTATION READS. `AGENTS.md` and the memory files quote these
+#      signatures verbatim, and every run reads them. A `Read` returns file
+#      content inside a `tool_result` record, so the quoted signature lands in
+#      the corpus in a record shaped almost exactly like the thing being detected.
+# (3) is self-reinforcing: the better a defect is documented, the more
+# occurrences its detector reports, so a FIXED defect can never read as fixed.
+# Measured on `Unknown JSON field`: 80 bare-grep records vs 5 real errors — 94%
+# contamination, in the direction that HIDES a successful fix.
+#
+# Two filters make the count mean what it says:
+#   * `is_error==true` on a `tool_result` — a documentation read that merely
+#     CONTAINS the string is a successful result, so it is structurally excluded.
+#   * the RECORD's own timestamp, not the file's mtime. A resumed session
+#     rewrites an old file, which had attributed 6 pre-merge occurrences to a
+#     post-merge window.
+# The file set is still mtime-selected, and that stays correct as a SUPERSET: a
+# record inside the window cannot live in a file last written before it. The cap
+# is the real limit — see the note printed below.
+if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -eq 1 ]; }; then
+  echo
+  echo "── SIGNATURE SCORING (hypothesis verdicts) ──────────────────────"
+  # Same portable pair as the outcomes section: BSD `date -v` first, GNU `-d`
+  # second. Full second precision, so the comparison against a record timestamp
+  # is not truncated to a whole day.
+  SIG_SINCE=$(date -u -v-"${SINCE_DAYS}"d '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+              || date -u -d "${SINCE_DAYS} days ago" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)
+  if [ -z "$SIG_SINCE" ]; then
+    echo "  UNKNOWN: cannot compute window start (no usable \`date\`) — refusing to score."
+  elif [ "$SF_COUNT" -eq 0 ]; then
+    echo "  (no Claude sessions in window)"
+  else
+    # One row per REAL occurrence: "<record timestamp>\t<sessionId>".
+    # `contains` is a fixed-string test, never a regex — a signature carrying
+    # regex metacharacters (`"` and `:` are common in these) must match itself
+    # literally rather than being reinterpreted.
+    printf '%s\n' "$SF_CACHE" | while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      jq -Rr --arg sig "$SIGNATURE" --arg since "$SIG_SINCE" '
+        select(length>0)|(try fromjson catch empty)
+        | select(.type=="user")
+        | (.timestamp // "") as $ts
+        | select($ts != "" and $ts >= $since)
+        | (.sessionId // "unknown") as $sid
+        | .message.content
+        | select(type=="array")
+        | .[]
+        | select(.type=="tool_result" and .is_error==true)
+        | (.content | if type=="array" then (map(select(.type=="text").text)|join(" "))
+                      elif type=="string" then . else (.|tostring) end) as $msg
+        | select($msg | contains($sig))
+        | "\($ts)\t\($sid)"
+      ' "$f" 2>/dev/null
+    done | redact > "$SIGTMP" || true
+
+    SIG_OCC=$(wc -l < "$SIGTMP" | tr -d ' ')
+    SIG_SESS=$(cut -f2 "$SIGTMP" | sort -u | grep -c . || true)
+    # The naive number this replaces, printed for contrast so the contamination
+    # is visible rather than merely asserted. Deliberately UNFILTERED — prose,
+    # documentation reads and real errors all count, which is exactly the point.
+    #
+    # ⚠️ It is computed on the DECODED record, not by `grep` over raw bytes, and
+    # that is load-bearing rather than stylistic. These signatures routinely
+    # carry `"` (`Unknown JSON field: "merged"`), which the transcript stores
+    # escaped as `\"` — so a raw `grep -F` finds NOTHING while the decoded walk
+    # finds the real errors, and the "control" printed 0 against 2 real
+    # occurrences. A control that cannot exceed the thing it is a superset of is
+    # measuring a different population, which is the very confound this section
+    # exists to remove. Decoding both sides leaves `is_error` as the ONLY
+    # variable between the two numbers.
+    SIG_NAIVE=$(printf '%s\n' "$SF_CACHE" | while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      jq -Rr --arg sig "$SIGNATURE" --arg since "$SIG_SINCE" '
+        select(length>0)|(try fromjson catch empty)
+        | (.timestamp // "") as $ts
+        | select($ts != "" and $ts >= $since)
+        | select([.. | strings] | any(contains($sig)))
+        | "1"
+      ' "$f" 2>/dev/null
+    done | wc -l | tr -d ' ')
+
+    echo "  signature scored (fixed string, case-sensitive):"
+    printf '    %s\n' "$(printf '%s' "$SIGNATURE" | redact | sed -E 's/[[:cntrl:]]+/ /g' | cut -c1-100)"
+    echo "  window: records at or after ${SIG_SINCE}   (record timestamps, not file mtime)"
+    echo
+    echo "  REAL occurrences (tool_result with is_error==true): ${SIG_OCC}"
+    echo "  distinct sessions ................................: ${SIG_SESS}"
+    if [ "$SIG_OCC" -gt 0 ]; then
+      echo "  first / last occurrence:"
+      printf '    first %s\n' "$(cut -f1 "$SIGTMP" | sort | head -1)"
+      printf '    last  %s\n' "$(cut -f1 "$SIGTMP" | sort | tail -1)"
+      echo "  busiest sessions:"
+      cut -f2 "$SIGTMP" | sort | uniq -c | sort -rn | head -5 | sed 's/^/    /'
+    fi
+    echo
+    echo "  records containing the string, any context ......: ${SIG_NAIVE}   <- NOT the metric"
+    if [ "$SIG_NAIVE" -gt "$SIG_OCC" ]; then
+      echo "    ${SIG_NAIVE} - ${SIG_OCC} of these are prose or DOCUMENTATION READS, not failures."
+      echo "    Scoring a hypothesis on the unfiltered number counts the agent's own"
+      echo "    writing about a defect as instances of it — see monorepo#2622."
+    fi
+    : > "$SIGTMP"
+    echo
+    echo "  READ THIS BEFORE QUOTING THE NUMBER:"
+    echo "    * Claude lane only. Codex uses response_item/function_call_output with"
+    echo "      no is_error flag, so a Codex occurrence is NOT counted here."
+    echo "    * The file set is capped at ${MAX_FILES} files. Records inside the window"
+    echo "      that live in an evicted file are missed, so a LOW number over a long"
+    echo "      window may be a cap artifact — raise --max-files before concluding."
+    echo "    * Baseline and verdict must be taken with THIS tool, not one by hand:"
+    echo "      two methods produce two populations, which is how a working fix was"
+    echo "      first recorded as a failure."
   fi
 fi
 

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3344,6 +3344,38 @@ else
   bad "superset invariant survives a multi-block record" "any=$M_ANY real=$M_REAL"
 fi
 
+# CodeRabbit finding (#2624): a content array can mix plain strings with blocks,
+# and `.type` on a string aborts the whole jq input line — swallowed by the call
+# site's 2>/dev/null, so a record holding a REAL errored tool_result vanished.
+# Without the `objects` guard this fixture scores 0.
+mkdir -p "$FIX/sigmixed"
+printf '{"type":"user","timestamp":"%s","sessionId":"s-mix","message":{"content":["stray plain string",{"type":"tool_result","tool_use_id":"x1","is_error":true,"content":[{"type":"text","text":"%s"}]}]}}\n' \
+  "$SIG_NOW" "$SIG_NEEDLE_J" > "$FIX/sigmixed/sess.jsonl"
+XOUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigmixed" CODEX_HOME="$FIX/nocodex" \
+       MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+       bash "$TARGET" --since-days 3650 --max-files 50 \
+         --section signature --signature "$SIG_NEEDLE" 2>&1)
+check "a string element in the content array does not hide a real error" "$XOUT" \
+  "REAL occurrences (tool_result with is_error==true): 1"
+
+# CodeRabbit finding (#2624): the filtered walk JOINS a record's text blocks
+# before matching; the control tests each decoded string leaf alone. A signature
+# straddling two adjacent blocks therefore matches the filtered walk only, and
+# the control drops BELOW its own subset. The script must say so rather than
+# print an impossible pair silently.
+mkdir -p "$FIX/sigsplit"
+printf '{"type":"user","timestamp":"%s","sessionId":"s-split","message":{"content":[{"type":"tool_result","tool_use_id":"y1","is_error":true,"content":[{"type":"text","text":"STRADDLE-LEFT"},{"type":"text","text":"STRADDLE-RIGHT"}]}]}}\n' \
+  "$SIG_NOW" > "$FIX/sigsplit/sess.jsonl"
+SOUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigsplit" CODEX_HOME="$FIX/nocodex" \
+       MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+       bash "$TARGET" --since-days 3650 --max-files 50 \
+         --section signature --signature 'STRADDLE-LEFT STRADDLE-RIGHT' 2>&1)
+check "a straddling signature is reported as an inverted invariant" "$SOUT" \
+  "INVARIANT BROKEN"
+# Paired control: the ordinary case must NOT print the warning, or it degenerates
+# into unconditional noise.
+nocheck "the inversion warning stays silent in the ordinary case" "$OUT" "INVARIANT BROKEN"
+
 # ── ABLATION: each filter must be LOAD-BEARING ────────────────────────────────
 # A guard that passes when removed is not a guard. Each arm copies the target,
 # removes exactly one filter, asserts the copy actually CHANGED, and requires the

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3488,14 +3488,14 @@ check   "the signature is echoed on its label line, not alone" "$MOUT2" \
 # Codex finding D (#2624): --signature puts the value in ARGV, world-readable via
 # ps. --signature-file keeps it out, and the value reaches jq through the
 # environment rather than jq's own argv.
-printf '%s' "$SIG_NEEDLE" > "$FIX/sig.txt"
-FOUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigscore" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" \
-       HOME="$FIX" bash "$TARGET" --since-days 3650 --max-files 50 \
-         --section signature --signature-file "$FIX/sig.txt" 2>&1)
-check "--signature-file scores identically to --signature" "$FOUT" \
-  "REAL occurrences (tool_result with is_error==true): 2"
-FOUT=$(HOME="$FIX" bash "$TARGET" --section signature --signature-file "$FIX/nope.txt" 2>&1)
-check "--signature-file rejects an unreadable path" "$FOUT" "not readable"
+# `--signature-file` was REMOVED (see #2624 rounds 4-6): added in Bash to close an
+# argv-exposure finding, it went on to generate five findings of its own — mixed
+# input modes mislabelling provenance, `cat` leaking a path to stderr ahead of the
+# redaction boundary, a CRLF terminator silently changing the needle, and an
+# oversized value failing exec into a zero count. A protected input path belongs
+# with the Go migration (#2629). This asserts it is gone rather than half-present.
+FOUT=$(HOME="$FIX" bash "$TARGET" --section signature --signature-file /dev/null 2>&1)
+check "--signature-file is no longer accepted" "$FOUT" "unknown argument"
 if grep -qF -- '--arg sig' "$TARGET"; then
   bad "the signature never reaches jq via argv" "found --arg sig; use \$ENV instead"
 else
@@ -3507,8 +3507,12 @@ fi
 # protected value leaking anyway.
 # (4) a zero cap empties every file set, so each section reported "no sessions"
 #     for an explicitly empty scan. Affects all five call sites, not just this one.
-OUT=$(HOME="$FIX" bash "$TARGET" --max-files 0 --section signature --signature 'x' 2>&1)
-check "--max-files 0 is rejected, not reported as an empty corpus" "$OUT" "must be at least 1"
+# NUMERIC comparison: `00` passes the digit test and an exact-string guard missed
+# it, while `head -n 00` still empties every file set (Codex round 6).
+for _z in 0 00 000; do
+  OUT=$(HOME="$FIX" bash "$TARGET" --max-files "$_z" --section signature --signature 'x' 2>&1)
+  check "--max-files $_z is rejected, not reported as an empty corpus" "$OUT" "must be at least 1"
+done
 # paired control: a positive cap still works
 OUT=$(sigrun); check "a positive --max-files still scans" "$OUT" \
   "REAL occurrences (tool_result with is_error==true): 2"
@@ -3520,15 +3524,7 @@ check "an oversized signature is rejected before scanning" "$OUT" "the limit is 
 nocheck "an oversized signature never reports a zero count" "$OUT" "REAL occurrences"
 # (1) --signature-file exists so a sensitive value need not be exposed; echoing
 #     it back defeats that, and `redact` only knows a fixed set of shapes.
-printf 'hunter2-not-a-known-credential-shape' > "$FIX/secret.txt"
-OUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigscore" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" \
-      HOME="$FIX" bash "$TARGET" --since-days 3650 --max-files 50 \
-        --section signature --signature-file "$FIX/secret.txt" 2>&1)
-nocheck "a file-supplied signature is never echoed" "$OUT" "hunter2"
-check   "a file-supplied signature is identified by digest" "$OUT" "<from file, not echoed> sha256:"
-# paired control: an inline signature IS still echoed, or the digest path would
-# silently swallow the ordinary case too.
-OUT=$(sigrun); check "an inline signature is still echoed" "$OUT" \
+OUT=$(sigrun); check "an inline signature is echoed on its label line" "$OUT" \
   "signature scored (fixed string, case-sensitive):"
 
 # ── ABLATION: each filter must be LOAD-BEARING ────────────────────────────────

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3243,6 +3243,113 @@ check "the caveat fires on cap divergence with no other roles" "$CDOUT" "POPULAT
 # warn about, or the caveat degenerates into unconditional noise.
 nocheck "no caveat when neither cap nor other roles diverge" "$COUT" "POPULATION MISMATCH"
 
+# ── SIGNATURE SCORING (monorepo#2622) ─────────────────────────────────────────
+# A hypothesis verdict is only as good as the count behind it. These prove the
+# two filters that make the count mean "the defect happened" rather than "the
+# defect is well documented".
+echo
+echo "signature scoring"
+
+mkdir -p "$FIX/sigscore"
+SIG_NEEDLE='SIGFIXTURE: no such flag "merged"'
+# The needle deliberately CONTAINS a double quote, because that is what the real
+# signatures look like (`Unknown JSON field: "merged"`) and it is exactly what
+# broke the first implementation. Its JSON-escaped form is derived mechanically
+# rather than written by hand — hand-escaping it wrong produced a fixture whose
+# records `fromjson` silently DROPPED, so every count read 0 and the fixture,
+# not the code, was the thing under test.
+SIG_NEEDLE_J=$(printf '%s' "$SIG_NEEDLE" | jq -Rr @json | sed 's/^"//; s/"$//')
+SIG_NOW=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+{
+  # 1. a REAL failure carrying the signature — the only shape that is an occurrence
+  printf '{"type":"user","timestamp":"%s","sessionId":"s-live","message":{"content":[{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":[{"type":"text","text":"%s"}]}]}}\n' \
+    "$SIG_NOW" "$SIG_NEEDLE_J"
+  # 2. a DOCUMENTATION READ — a SUCCESSFUL tool_result whose content quotes the
+  #    signature, exactly as reading AGENTS.md or a memory file returns it.
+  printf '{"type":"user","timestamp":"%s","sessionId":"s-live","message":{"content":[{"type":"tool_result","tool_use_id":"t2","content":[{"type":"text","text":"AGENTS.md line: avoid %s"}]}]}}\n' \
+    "$SIG_NOW" "$SIG_NEEDLE_J"
+  # 3. the agent's own PROSE about the signature (a PR body / run report)
+  printf '{"type":"assistant","timestamp":"%s","sessionId":"s-live","message":{"stop_reason":"end_turn","content":[{"type":"text","text":"I fixed %s this run"}]}}\n' \
+    "$SIG_NOW" "$SIG_NEEDLE_J"
+  # 4. a real failure from LONG ago, in this same fresh-mtime file. A resumed
+  #    session rewrites the file, so mtime windowing drags it into every window.
+  printf '{"type":"user","timestamp":"2026-06-01T10:00:00.000Z","sessionId":"s-old","message":{"content":[{"type":"tool_result","tool_use_id":"t3","is_error":true,"content":[{"type":"text","text":"%s"}]}]}}\n' \
+    "$SIG_NEEDLE_J"
+} > "$FIX/sigscore/sess.jsonl"
+
+sigrun() {
+  CLAUDE_PROJECTS_DIR="$FIX/sigscore" CODEX_HOME="$FIX/nocodex" \
+  MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+  bash "${1:-$TARGET}" --since-days "${2:-3650}" --max-files 50 \
+    --section signature --signature "$SIG_NEEDLE" 2>&1
+}
+
+OUT=$(sigrun)
+check "counts ONLY real errors, not the doc read or the prose" "$OUT" \
+  "REAL occurrences (tool_result with is_error==true): 2"
+check "reports the unfiltered number for contrast"            "$OUT" \
+  "records containing the string, any context ......: 4"
+check "counts distinct sessions"                              "$OUT" \
+  "distinct sessions ................................: 2"
+check "names the contamination in the output"                 "$OUT" \
+  "DOCUMENTATION READS, not failures"
+
+# The superset invariant. If the control can be SMALLER than the thing it is a
+# superset of, the two numbers are measuring different populations — which is
+# how the first version of this section printed 0 against 2 real occurrences,
+# because the signature's `"` is escaped in the raw store and a byte-level grep
+# missed what the decoded walk found.
+SIG_REAL_N=$(printf '%s' "$OUT" | sed -n 's/.*is_error==true): //p')
+SIG_ANY_N=$(printf '%s' "$OUT"  | sed -n 's/.*any context \.*: \([0-9]*\).*/\1/p')
+if [ -n "$SIG_REAL_N" ] && [ -n "$SIG_ANY_N" ] \
+   && [ "$SIG_REAL_N" -gt 0 ] && [ "$SIG_ANY_N" -ge "$SIG_REAL_N" ]; then
+  ok "unfiltered count is a true superset of the real-error count"
+else
+  bad "unfiltered count is a true superset of the real-error count" \
+      "any=$SIG_ANY_N real=$SIG_REAL_N — a control below its subset (or a vacuous 0>=0) proves nothing"
+fi
+
+# Record-timestamp windowing: the 2026-06-01 failure lives in a file whose mtime
+# is NOW, so mtime windowing would report it as today's.
+OUT=$(sigrun "$TARGET" 1)
+check "buckets by RECORD timestamp, not file mtime" "$OUT" \
+  "REAL occurrences (tool_result with is_error==true): 1"
+
+# Usage errors fail LOUDLY. A silently-absent signature scores every hypothesis
+# as 0 occurrences, i.e. as a fix that worked.
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigscore" HOME="$FIX" bash "$TARGET" --section signature 2>&1)
+check "--section signature without --signature is an error" "$OUT" \
+  "requires --signature"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigscore" HOME="$FIX" bash "$TARGET" --section signature --signature '' 2>&1)
+check "an empty --signature is rejected" "$OUT" "must not be empty"
+
+# ── ABLATION: each filter must be LOAD-BEARING ────────────────────────────────
+# A guard that passes when removed is not a guard. Each arm copies the target,
+# removes exactly one filter, asserts the copy actually CHANGED, and requires the
+# count to move. `cp` only — never git — so a failed arm cannot lose work.
+ablate() { # $1=label  $2=sed-expr  $3=expected-count-after  $4=days
+  local lbl="$2" ab="$FIX/ablate.sh"
+  cp "$TARGET" "$ab"
+  sed -i.bak "$1" "$ab"; rm -f "$ab.bak"
+  if cmp -s "$TARGET" "$ab"; then
+    bad "ablation[$2]" "sed changed nothing — the arm proves nothing"
+    return
+  fi
+  local aout; aout=$(sigrun "$ab" "${4:-3650}")
+  if printf '%s' "$aout" | grep -qF "is_error==true): $3"; then
+    ok "ablation: $2"
+  else
+    bad "ablation: $2" "expected count $3 after removing the filter; got: $(printf '%s' "$aout" | grep 'is_error==true)' || echo none)"
+  fi
+}
+# Arm A — drop the is_error filter: the documentation read must become counted
+# (2 -> 3). This is the contamination the section exists to exclude.
+ablate 's/and \.is_error==true)/)/' "removing is_error lets a documentation read count" 3
+# Arm B — drop the record-timestamp filter in the 1-day window: the 2026-06-01
+# failure must reappear (1 -> 2), proving mtime is not what bounds the window.
+ablate 's/select($ts != "" and $ts >= $since)/select($ts != "" or true)/' \
+  "removing the timestamp filter lets an out-of-window record count" 2 1
+
 echo
 echo "──────────────────────────────"
 echo "  passed: $PASS   failed: $FAIL"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3322,6 +3322,17 @@ check "--section signature without --signature is an error" "$OUT" \
   "requires --signature"
 OUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigscore" HOME="$FIX" bash "$TARGET" --section signature --signature '' 2>&1)
 check "an empty --signature is rejected" "$OUT" "must not be empty"
+# A signature handed to a section that cannot score it is the same absent-evidence
+# failure as omitting it: it used to exit 0 having scored nothing (Codex finding).
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigscore" HOME="$FIX" bash "$TARGET" --section reliability --signature 'x' 2>&1)
+check "--signature with an incompatible --section is rejected" "$OUT" \
+  "only scored by --section signature"
+# Paired control: the COMPATIBLE combinations must still be accepted, or the new
+# rejection would simply break the feature.
+OUT=$(sigrun); check "--section signature still accepted" "$OUT" "SIGNATURE SCORING"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigscore" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" \
+      HOME="$FIX" bash "$TARGET" --since-days 3650 --max-files 50 --signature "$SIG_NEEDLE" 2>&1)
+check "--signature under the default (all) section still scores" "$OUT" "SIGNATURE SCORING"
 
 # A single record can carry SEVERAL tool_result blocks. Counting blocks while
 # the control counts records lets the "superset" fall BELOW its own subset — the
@@ -3374,7 +3385,49 @@ check "a straddling signature is reported as an inverted invariant" "$SOUT" \
   "INVARIANT BROKEN"
 # Paired control: the ordinary case must NOT print the warning, or it degenerates
 # into unconditional noise.
-nocheck "the inversion warning stays silent in the ordinary case" "$OUT" "INVARIANT BROKEN"
+# ⚠️ Take a FRESH ordinary run — do not reuse $OUT. By this point $OUT holds the
+# EMPTY-SIGNATURE usage error, which of course lacks the warning string, so the
+# assertion passed no matter what the ordinary report did. A control that cannot
+# fail is not a control (Codex finding, #2624).
+NORMOUT=$(sigrun)
+check   "the paired control ran a real signature report" "$NORMOUT" \
+  "REAL occurrences (tool_result with is_error==true): 2"
+nocheck "the inversion warning stays silent in the ordinary case" "$NORMOUT" "INVARIANT BROKEN"
+
+# Codex finding (#2624): the window comparison is LEXICAL, so a record with
+# Claude's normal fractional timestamp falling in the SAME SECOND as the cutoff
+# sorted BEFORE a plain `…:00Z` cutoff and was dropped from BOTH numbers.
+#
+# ⚠️ This is deliberately NOT tested through a fixture. The first attempt built a
+# record at `now-1d` plus a fraction and asserted it was counted — but the script
+# computes its own cutoff moments later, so the record landed a second or two
+# clear of the boundary and the test passed with OR without the fix. Ablation
+# caught it: a vacuous arm. Hitting the exact same second is inherently racy, so
+# the property is asserted two deterministic ways instead.
+#
+# (a) the cutoff the script actually emits must carry sub-second precision.
+#     ⚠️ Scoped to the WINDOW LINE, not the whole report: a fixture record is
+#     itself dated `2026-06-01T10:00:00.000Z` and the report echoes it as the
+#     first occurrence, so a whole-output match found `.000Z` no matter what the
+#     cutoff looked like — the ablated build passed too. Assert on the one line
+#     that carries the value under test.
+OUT=$(sigrun)
+WINLINE=$(printf '%s\n' "$OUT" | grep 'window: records at or after')
+check "the window cutoff carries sub-second precision" "$WINLINE" ".000Z"
+# (b) the comparison semantics that makes that necessary, pinned directly:
+#     a fractional record must sort AFTER a same-second cutoff.
+BCMP=$(jq -nr '[
+  ("2026-08-01T10:00:00.500Z" >= "2026-08-01T10:00:00Z"),
+  ("2026-08-01T10:00:00.500Z" >= "2026-08-01T10:00:00.000Z"),
+  ("2026-08-01T10:00:00Z"     >= "2026-08-01T10:00:00.000Z"),
+  ("2026-08-01T09:59:59.999Z" >= "2026-08-01T10:00:00.000Z")
+] | @tsv')
+if [ "$BCMP" = "$(printf 'false\ttrue\ttrue\tfalse')" ]; then
+  ok "a plain-second cutoff would drop a same-second fractional record"
+else
+  bad "a plain-second cutoff would drop a same-second fractional record" \
+      "lexical comparison changed: got [$BCMP]"
+fi
 
 # ── ABLATION: each filter must be LOAD-BEARING ────────────────────────────────
 # A guard that passes when removed is not a guard. Each arm copies the target,

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3323,16 +3323,52 @@ check "--section signature without --signature is an error" "$OUT" \
 OUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigscore" HOME="$FIX" bash "$TARGET" --section signature --signature '' 2>&1)
 check "an empty --signature is rejected" "$OUT" "must not be empty"
 
+# A single record can carry SEVERAL tool_result blocks. Counting blocks while
+# the control counts records lets the "superset" fall BELOW its own subset — the
+# exact confound this section exists to remove. Self-review caught this; the
+# original fixture had one block per record and could never have shown it.
+mkdir -p "$FIX/sigmulti"
+printf '{"type":"user","timestamp":"%s","sessionId":"s-multi","message":{"content":[{"type":"tool_result","tool_use_id":"m1","is_error":true,"content":[{"type":"text","text":"%s"}]},{"type":"tool_result","tool_use_id":"m2","is_error":true,"content":[{"type":"text","text":"%s"}]}]}}\n' \
+  "$SIG_NOW" "$SIG_NEEDLE_J" "$SIG_NEEDLE_J" > "$FIX/sigmulti/sess.jsonl"
+MOUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigmulti" CODEX_HOME="$FIX/nocodex" \
+       MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+       bash "$TARGET" --since-days 3650 --max-files 50 \
+         --section signature --signature "$SIG_NEEDLE" 2>&1)
+check "two errored blocks in ONE record count as one occurrence" "$MOUT" \
+  "REAL occurrences (tool_result with is_error==true): 1"
+M_REAL=$(printf '%s' "$MOUT" | sed -n 's/.*is_error==true): //p')
+M_ANY=$(printf '%s' "$MOUT"  | sed -n 's/.*any context \.*: \([0-9]*\).*/\1/p')
+if [ "$M_ANY" -ge "$M_REAL" ] && [ "$M_REAL" -gt 0 ]; then
+  ok "superset invariant survives a multi-block record"
+else
+  bad "superset invariant survives a multi-block record" "any=$M_ANY real=$M_REAL"
+fi
+
 # ── ABLATION: each filter must be LOAD-BEARING ────────────────────────────────
 # A guard that passes when removed is not a guard. Each arm copies the target,
 # removes exactly one filter, asserts the copy actually CHANGED, and requires the
 # count to move. `cp` only — never git — so a failed arm cannot lose work.
-ablate() { # $1=label  $2=sed-expr  $3=expected-count-after  $4=days
-  local lbl="$2" ab="$FIX/ablate.sh"
+ablate() { # $1=sed-expr $2=label $3=expected-count-after $4=days $5=expected-changed-lines
+  local ab="$FIX/ablate.sh" changed
   cp "$TARGET" "$ab"
   sed -i.bak "$1" "$ab"; rm -f "$ab.bak"
   if cmp -s "$TARGET" "$ab"; then
-    bad "ablation[$2]" "sed changed nothing — the arm proves nothing"
+    bad "ablation: $2" "sed changed nothing — the arm proves nothing"
+    return
+  fi
+  # An arm must remove THE filter under test, not merely change the file. The
+  # first version of arm A matched a line in another section after this jq was
+  # reshaped: the copy differed, so the arm looked live, while the filter it
+  # claimed to ablate was untouched and the count never moved. Requiring exactly
+  # one changed line makes a mis-aimed sed fail loudly instead of passing.
+  # The expected line count is stated per arm, never assumed: a filter can
+  # legitimately live in more than one walk (the timestamp filter guards both
+  # the real count and its control), and "1" would then be wrong rather than
+  # strict. Stating it is what makes a mis-aimed sed distinguishable from a
+  # filter that genuinely appears twice.
+  changed=$(diff "$TARGET" "$ab" | grep -c '^<')
+  if [ "$changed" -ne "${5:-1}" ]; then
+    bad "ablation: $2" "sed changed $changed lines, expected ${5:-1} — arm is mis-aimed"
     return
   fi
   local aout; aout=$(sigrun "$ab" "${4:-3650}")
@@ -3344,11 +3380,16 @@ ablate() { # $1=label  $2=sed-expr  $3=expected-count-after  $4=days
 }
 # Arm A — drop the is_error filter: the documentation read must become counted
 # (2 -> 3). This is the contamination the section exists to exclude.
-ablate 's/and \.is_error==true)/)/' "removing is_error lets a documentation read count" 3
+# Anchored at end-of-line so it hits ONLY the signature walk's own filter — the
+# reliability section's `... and .is_error==true)` ends in a paren and is spared.
+ablate 's/\.type=="tool_result" and \.is_error==true$/.type=="tool_result"/' \
+  "removing is_error lets a documentation read count" 3
 # Arm B — drop the record-timestamp filter in the 1-day window: the 2026-06-01
 # failure must reappear (1 -> 2), proving mtime is not what bounds the window.
+# The timestamp filter guards BOTH the real walk and its unfiltered control, so
+# this arm legitimately touches two lines — stated, not assumed.
 ablate 's/select($ts != "" and $ts >= $since)/select($ts != "" or true)/' \
-  "removing the timestamp filter lets an out-of-window record count" 2 1
+  "removing the timestamp filter lets an out-of-window record count" 2 1 2
 
 echo
 echo "──────────────────────────────"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3502,6 +3502,35 @@ else
   ok "the signature never reaches jq via argv"
 fi
 
+# Codex round-5 findings (#2624). All three are the SAME class the section exists
+# to prevent — a scan that produces no evidence while reporting success, or a
+# protected value leaking anyway.
+# (4) a zero cap empties every file set, so each section reported "no sessions"
+#     for an explicitly empty scan. Affects all five call sites, not just this one.
+OUT=$(HOME="$FIX" bash "$TARGET" --max-files 0 --section signature --signature 'x' 2>&1)
+check "--max-files 0 is rejected, not reported as an empty corpus" "$OUT" "must be at least 1"
+# paired control: a positive cap still works
+OUT=$(sigrun); check "a positive --max-files still scans" "$OUT" \
+  "REAL occurrences (tool_result with is_error==true): 2"
+# (2) an oversized signature makes the jq exec fail; stderr is discarded and the
+#     pipeline ends in `|| true`, so the scan would exit 0 with both counts ZERO.
+BIG=$(head -c 5000 /dev/zero | tr '\0' 'a')
+OUT=$(HOME="$FIX" bash "$TARGET" --section signature --signature "$BIG" 2>&1)
+check "an oversized signature is rejected before scanning" "$OUT" "the limit is 4096"
+nocheck "an oversized signature never reports a zero count" "$OUT" "REAL occurrences"
+# (1) --signature-file exists so a sensitive value need not be exposed; echoing
+#     it back defeats that, and `redact` only knows a fixed set of shapes.
+printf 'hunter2-not-a-known-credential-shape' > "$FIX/secret.txt"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigscore" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" \
+      HOME="$FIX" bash "$TARGET" --since-days 3650 --max-files 50 \
+        --section signature --signature-file "$FIX/secret.txt" 2>&1)
+nocheck "a file-supplied signature is never echoed" "$OUT" "hunter2"
+check   "a file-supplied signature is identified by digest" "$OUT" "<from file, not echoed> sha256:"
+# paired control: an inline signature IS still echoed, or the digest path would
+# silently swallow the ordinary case too.
+OUT=$(sigrun); check "an inline signature is still echoed" "$OUT" \
+  "signature scored (fixed string, case-sensitive):"
+
 # ── ABLATION: each filter must be LOAD-BEARING ────────────────────────────────
 # A guard that passes when removed is not a guard. Each arm copies the target,
 # removes exactly one filter, asserts the copy actually CHANGED, and requires the

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3381,8 +3381,13 @@ SOUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigsplit" CODEX_HOME="$FIX/nocodex" \
        MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
        bash "$TARGET" --since-days 3650 --max-files 50 \
          --section signature --signature 'STRADDLE-LEFT STRADDLE-RIGHT' 2>&1)
-check "a straddling signature is reported as an inverted invariant" "$SOUT" \
-  "INVARIANT BROKEN"
+# ⚠️ This ASSERTED `INVARIANT BROKEN` until Codex finding A. Making the control a
+# UNION removes the inversion by construction, which is strictly better than
+# warning about it — so the straddling case must now come out CONSISTENT. The
+# warning branch is kept as defence in depth and should never fire.
+nocheck "a straddling signature no longer inverts the invariant" "$SOUT" "INVARIANT BROKEN"
+check   "the straddling error is still counted" "$SOUT" \
+  "REAL occurrences (tool_result with is_error==true): 1"
 # Paired control: the ordinary case must NOT print the warning, or it degenerates
 # into unconditional noise.
 # ⚠️ Take a FRESH ordinary run — do not reuse $OUT. By this point $OUT holds the
@@ -3427,6 +3432,74 @@ if [ "$BCMP" = "$(printf 'false\ttrue\ttrue\tfalse')" ]; then
 else
   bad "a plain-second cutoff would drop a same-second fractional record" \
       "lexical comparison changed: got [$BCMP]"
+fi
+
+# Codex finding A (#2624): comparing TOTALS cannot prove set inclusion. One error
+# split across adjacent blocks (seen only by the joined walk) plus one prose
+# record carrying the whole string (seen only by the leaf walk) gave 1 and 1 with
+# the "superset" missing the subset entirely, and no warning. The control is now
+# a UNION, so it contains every match of the filtered walk by construction.
+mkdir -p "$FIX/sigset"
+{
+  printf '{"type":"user","timestamp":"%s","sessionId":"s-set","message":{"content":[{"type":"tool_result","tool_use_id":"z1","is_error":true,"content":[{"type":"text","text":"SPLITME-LEFT"},{"type":"text","text":"SPLITME-RIGHT"}]}]}}\n' "$SIG_NOW"
+  printf '{"type":"assistant","timestamp":"%s","sessionId":"s-set","message":{"stop_reason":"end_turn","content":[{"type":"text","text":"prose about SPLITME-LEFT SPLITME-RIGHT here"}]}}\n' "$SIG_NOW"
+} > "$FIX/sigset/sess.jsonl"
+AOUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigset" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" \
+       HOME="$FIX" bash "$TARGET" --since-days 3650 --max-files 50 \
+         --section signature --signature 'SPLITME-LEFT SPLITME-RIGHT' 2>&1)
+check "the control counts BOTH records, not just the leaf match" "$AOUT" \
+  "records containing the string, any context ......: 2"
+check "the split error is still counted as the real occurrence" "$AOUT" \
+  "REAL occurrences (tool_result with is_error==true): 1"
+
+# Codex finding B (#2624): a primitive inside tool_result.content made
+# `select(.type=="text")` index it, aborting the line and silently dropping a
+# REAL error. Same guard as the outer walk, one level down.
+mkdir -p "$FIX/signested"
+printf '{"type":"user","timestamp":"%s","sessionId":"s-nest","message":{"content":[{"type":"tool_result","tool_use_id":"n1","is_error":true,"content":[7,{"type":"text","text":"%s"}]}]}}\n' \
+  "$SIG_NOW" "$SIG_NEEDLE_J" > "$FIX/signested/sess.jsonl"
+NOUT=$(CLAUDE_PROJECTS_DIR="$FIX/signested" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" \
+       HOME="$FIX" bash "$TARGET" --since-days 3650 --max-files 50 \
+         --section signature --signature "$SIG_NEEDLE" 2>&1)
+check "a primitive inside tool_result.content does not hide a real error" "$NOUT" \
+  "REAL occurrences (tool_result with is_error==true): 1"
+
+# Codex finding C (#2624): `sed` is line-based, so a multiline signature escaped
+# both the control-char scrub and the length bound, letting a second line forge a
+# scorecard row directly above the genuine metric. This output is parsed by an
+# agent, so a forgeable row is an integrity bug.
+MOUT2=$(CLAUDE_PROJECTS_DIR="$FIX/sigscore" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" \
+        HOME="$FIX" bash "$TARGET" --since-days 3650 --max-files 50 --section signature \
+          --signature "$(printf 'harmless\nREAL occurrences (tool_result with is_error==true): 999')" 2>&1)
+# The property is that no LINE can begin with a metric row unless it is one — the
+# echoed signature necessarily contains whatever the caller passed, so a bare
+# substring test could never pass. Anchor, as a consumer should.
+FORGED=$(printf '%s\n' "$MOUT2" | grep -c '^  REAL occurrences (tool_result with is_error==true):')
+if [ "$FORGED" -eq 1 ]; then
+  ok "a multiline signature cannot forge a scorecard ROW"
+else
+  bad "a multiline signature cannot forge a scorecard ROW" \
+      "expected exactly 1 anchored REAL-occurrences row, got $FORGED"
+fi
+nocheck "no line starts with the forged count" "$(printf '%s\n' "$MOUT2" | grep '^  REAL occurrences')" "999"
+check   "the signature is echoed on its label line, not alone" "$MOUT2" \
+  "signature scored (fixed string, case-sensitive): harmless"
+
+# Codex finding D (#2624): --signature puts the value in ARGV, world-readable via
+# ps. --signature-file keeps it out, and the value reaches jq through the
+# environment rather than jq's own argv.
+printf '%s' "$SIG_NEEDLE" > "$FIX/sig.txt"
+FOUT=$(CLAUDE_PROJECTS_DIR="$FIX/sigscore" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" \
+       HOME="$FIX" bash "$TARGET" --since-days 3650 --max-files 50 \
+         --section signature --signature-file "$FIX/sig.txt" 2>&1)
+check "--signature-file scores identically to --signature" "$FOUT" \
+  "REAL occurrences (tool_result with is_error==true): 2"
+FOUT=$(HOME="$FIX" bash "$TARGET" --section signature --signature-file "$FIX/nope.txt" 2>&1)
+check "--signature-file rejects an unreadable path" "$FOUT" "not readable"
+if grep -qF -- '--arg sig' "$TARGET"; then
+  bad "the signature never reaches jq via argv" "found --arg sig; use \$ENV instead"
+else
+  ok "the signature never reaches jq via argv"
 fi
 
 # ── ABLATION: each filter must be LOAD-BEARING ────────────────────────────────


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Every hypothesis this agent opens is scored by counting an error signature across its own transcripts — and the count was wrong in the one direction that matters. A plain search matches the real failure, the agent's own prose about it, **and documentation reads**: `AGENTS.md` and the memory files quote these signatures verbatim, every run reads them, and a file read comes back in a record shaped almost exactly like the failure being counted.

That is self-reinforcing. The better a defect is documented, the more "occurrences" its detector reports — so a defect that has actually been fixed can never read as fixed, and the agent is pushed toward redoing work that already worked. It nearly happened: hypothesis 26 first read as a failure and was only saved by hand-checking, which found the fix had in fact worked completely.

Measured on the live corpus over 7 days: **58 records contain the signature, 2 are real failures — 97% noise.**

## What

Adds a `--signature` mode that counts a named signature the way a verdict needs it: real failures only, dated by when the record actually happened rather than when its file was last written. The unfiltered number is printed beside it as a control, so the contamination is visible instead of asserted.

The date change matters on its own — a session resumed today drags its whole history into today's window. For one signature a 1-day window reads **17 by file date and 11 by record date**, with the six extras dated as far back as 25 June.

Verified end to end: a phrase that appears only in `AGENTS.md` and has never failed now scores **0**, where the old method counted it. Both filters are ablated — removed individually, each makes the count move — so neither is decorative.

Follow-ups filed, not folded in: #2625 (the reliability section still dates by file), #2626 (no Epic covers the agent's own measurement instruments).

Fixes #2622