### PR TITLE
refactor(telemetry): state each transcript shape guard once, in a shared accessor

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -631,29 +631,43 @@ NEVER_RAN_RE='^[[:space:]]*(<tool_use_error>)?[[:space:]]*('"$NEVER_RAN_SHAPES"'
 # Scalar fallback is `tostring`, never `empty`: stringifying an unexpected scalar
 # keeps the record observable, whereas dropping it reintroduces the silent
 # under-count these accessors exist to remove.
+# The shape lattice is FINITE, so it is handled exhaustively here rather than one
+# position at a time. Three review rounds each found the same defect at a
+# different position — an array element, a `.text` payload, a final-assistant
+# record — because each was patched where it was reported instead of stating the
+# rule once. The positions are: `message.content` (string | array | absent), an
+# array ELEMENT (bare scalar | block object), a block's `.text` (string |
+# non-string | absent), and the `.content`/`.output` of a result (string | array
+# | scalar). At every one of them the rule is the same: **coerce, never drop.**
+# `scalar_text` is that rule, and it is why no position needs its own guard.
 JQ_SHAPE_DEFS='
+def scalar_text: if type=="string" then . else tostring end;
 def content_blocks:
   (.message.content? // empty)
   | if type=="array" then .[] elif type=="object" then . else empty end
   | objects;
+def element_text:
+  if type=="object"
+  then (select(.type=="text") | select(.text != null) | .text | scalar_text)
+  else scalar_text end;
+def content_texts:
+  (.message.content? // empty)
+  | if type=="string" then .
+    elif type=="array" then (.[] | element_text)
+    else empty end;
+def message_text: [content_texts] | join("");
 def block_text:
   .content
-  | if type=="array" then
-      [ .[] | (strings), (objects | select(.type=="text") | .text | strings) ] | join(" ")
+  | if type=="array" then [.[] | element_text] | join(" ")
     elif type=="string" then .
     else tostring end;
 def output_text:
   .output
   | if type=="array" then
-      [ .[] | (strings), (objects | .text | strings) ] | join(" ")
+      [ .[] | if type=="object" then (select(.text != null) | .text | scalar_text)
+              else scalar_text end ] | join(" ")
     elif type=="string" then .
     else tostring end;
-def message_text:
-  (.message.content? // empty)
-  | if type=="string" then .
-    elif type=="array" then
-      [ .[] | (strings), (objects | select(.type=="text") | .text | strings) ] | join("")
-    else "" end;
 '
 
 # tool_use ids whose result shows the call never ran, resolved once per file.
@@ -1095,9 +1109,7 @@ if want dispatch; then
         | ([$recs[] | select(.type=="assistant") | content_blocks
             | select(.type=="tool_use")] | length) as $tu
         | (([$recs[] | select(.type=="assistant")] | last) // {}) as $lastrec
-        | (($lastrec
-            | if ((.message.content? | type) == "string") then .message.content
-              else ([content_blocks | select(.type=="text") | .text | strings] | last) end) // "") as $lastt
+        | ((($lastrec | [content_texts] | last)) // "") as $lastt
         | (($lastrec.timestamp) // ([$recs[]|select(.timestamp)|.timestamp]|last) // "") as $ts
         | (($lastrec.message.stop_reason) // "") as $sr
         | ([$recs[] | select(.type=="assistant")] | length) as $na

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -637,18 +637,21 @@ def content_blocks:
   | if type=="array" then .[] elif type=="object" then . else empty end
   | objects;
 def block_text:
-  (.content? // empty)
+  .content
   | if type=="array" then [.[] | objects | select(.type=="text") | .text | strings] | join(" ")
     elif type=="string" then .
     else tostring end;
 def output_text:
-  (.output? // empty)
+  .output
   | if type=="array" then [.[] | objects | .text | strings] | join(" ")
     elif type=="string" then .
     else tostring end;
 def message_text:
-  if ((.message.content? | type) == "string") then .message.content
-  else [content_blocks | select(.type=="text") | .text | strings] | join("") end;
+  (.message.content? // empty)
+  | if type=="string" then .
+    elif type=="array" then
+      [ .[] | (strings), (objects | select(.type=="text") | .text | strings) ] | join("")
+    else "" end;
 '
 
 # tool_use ids whose result shows the call never ran, resolved once per file.
@@ -1090,7 +1093,9 @@ if want dispatch; then
         | ([$recs[] | select(.type=="assistant") | content_blocks
             | select(.type=="tool_use")] | length) as $tu
         | (([$recs[] | select(.type=="assistant")] | last) // {}) as $lastrec
-        | (([$lastrec | content_blocks | select(.type=="text") | .text | strings] | last) // "") as $lastt
+        | (($lastrec
+            | if ((.message.content? | type) == "string") then .message.content
+              else ([content_blocks | select(.type=="text") | .text | strings] | last) end) // "") as $lastt
         | (($lastrec.timestamp) // ([$recs[]|select(.timestamp)|.timestamp]|last) // "") as $ts
         | (($lastrec.message.stop_reason) // "") as $sr
         | ([$recs[] | select(.type=="assistant")] | length) as $na

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -610,6 +610,47 @@ fi
 NEVER_RAN_SHAPES='Blocked:|Permission to use [A-Za-z_]+ with command|Claude requested permissions to use|approval (denied|required) for tool'
 NEVER_RAN_RE='^[[:space:]]*(<tool_use_error>)?[[:space:]]*('"$NEVER_RAN_SHAPES"')'
 
+# ── SHARED SHAPE ACCESSORS (Claude transcript schema) ─────────────────────────
+# Claude's transcript schema is HETEROGENEOUS by design: `message.content` may be
+# a string or an array, array elements may be blocks or bare strings, a
+# `tool_result`'s `.content` may be a string, an array of blocks, or contain
+# primitives, and `.text` is not guaranteed to be a string.
+#
+# Every hand-rolled walk used to re-derive its own guards against that, so a walk
+# was correct only if its author remembered every case — and the failure when one
+# was forgotten is SILENT AND ALWAYS DOWNWARD: jq aborts the offending input line,
+# the call site's `2>/dev/null` swallows the error, and the record is dropped. A
+# missed record does not look like an error, it looks like improvement, which is
+# exactly the wrong direction for instruments the agent uses to decide whether its
+# own fixes worked.
+#
+# These definitions state each shape rule ONCE. Prepend them to a jq program with
+# "$JQ_SHAPE_DEFS" and use the accessors instead of indexing `.type`/`.text`
+# directly, so a new walk inherits correctness rather than re-deriving it.
+#
+# Scalar fallback is `tostring`, never `empty`: stringifying an unexpected scalar
+# keeps the record observable, whereas dropping it reintroduces the silent
+# under-count these accessors exist to remove.
+JQ_SHAPE_DEFS='
+def content_blocks:
+  (.message.content? // empty)
+  | if type=="array" then .[] elif type=="object" then . else empty end
+  | objects;
+def block_text:
+  (.content? // empty)
+  | if type=="array" then [.[] | objects | select(.type=="text") | .text | strings] | join(" ")
+    elif type=="string" then .
+    else tostring end;
+def output_text:
+  (.output? // empty)
+  | if type=="array" then [.[] | objects | .text | strings] | join(" ")
+    elif type=="string" then .
+    else tostring end;
+def message_text:
+  if ((.message.content? | type) == "string") then .message.content
+  else [content_blocks | select(.type=="text") | .text | strings] | join("") end;
+'
+
 # tool_use ids whose result shows the call never ran, resolved once per file.
 #
 # The content is NORMALISED to its text before matching, exactly as the safety
@@ -619,13 +660,10 @@ NEVER_RAN_RE='^[[:space:]]*(<tool_use_error>)?[[:space:]]*('"$NEVER_RAN_SHAPES"'
 # as an executed foreground launch even though it never ran. Anchoring without
 # normalising is precisely that bug.
 denied_ids() {
-  jq -Rr --arg re "$NEVER_RAN_RE" 'select(length>0)|(try fromjson catch empty)
-          | select(.type=="user") | .message.content[]?
+  jq -Rr --arg re "$NEVER_RAN_RE" "$JQ_SHAPE_DEFS"'select(length>0)|(try fromjson catch empty)
+          | select(.type=="user") | content_blocks
           | select(.type=="tool_result" and .is_error==true)
-          | select((.content
-                    | if type=="array" then (map(select(.type=="text").text // empty)|join(" "))
-                      elif type=="string" then . else tostring end)
-                   | test($re))
+          | select((block_text) | test($re))
           | .tool_use_id // empty' "$1" 2>/dev/null \
     | jq -Rs 'split("\n")|map(select(length>0))' 2>/dev/null
 }
@@ -748,17 +786,12 @@ strip_heredocs() {
 # fabricate the metric.
 tool_result_text() {
   local f="$1"
-  jq -r '
+  jq -r "$JQ_SHAPE_DEFS"'
     .. | objects
     | (
-        (select(.type=="tool_result")
-         | .content
-         | if type=="array" then (map(select(.type=="text").text)|join(" "))
-           elif type=="string" then . else empty end),
+        (select(.type=="tool_result") | block_text),
         (select(.type=="function_call_output" or .type=="custom_tool_call_output")
-         | .output
-         | if type=="array" then (map(.text? // empty)|join(" "))
-           elif type=="string" then . else empty end)
+         | output_text)
       )
     | select(type=="string") | select(length > 0)
   ' "$f" 2>/dev/null
@@ -771,13 +804,10 @@ tool_result_text() {
 # a fresh failure, inflating exactly the numbers the improver acts on.
 tool_result_failure_text() {
   local f="$1"
-  jq -r '
+  jq -r "$JQ_SHAPE_DEFS"'
     .. | objects
     | (
-        (select(.type=="tool_result" and .is_error==true)
-         | .content
-         | if type=="array" then (map(select(.type=="text").text)|join(" "))
-           elif type=="string" then . else empty end),
+        (select(.type=="tool_result" and .is_error==true) | block_text),
         # CODEX FAILURE DETECTION DEPENDS ON A FLAG THAT DOES NOT EXIST.
         # Verified against live sessions: output records carry keys
         # type/id/call_id/output and no is_error/status. A scan of 40 real
@@ -792,9 +822,7 @@ tool_result_failure_text() {
         # single-quoted shell string, so one would terminate it.
         (select(.type=="function_call_output" or .type=="custom_tool_call_output")
          | select(((.is_error? // false) == true) or ((.status? // "") == "error"))
-         | .output
-         | if type=="array" then (map(.text? // empty)|join(" "))
-           elif type=="string" then . else empty end)
+         | output_text)
       )
     | select(type=="string") | select(length > 0)
   ' "$f" 2>/dev/null
@@ -1054,16 +1082,15 @@ if want dispatch; then
       # The role comes from the injected dispatch record and must START it. A
       # substring test would misread this tool's own output, which quotes both
       # the marker and the refusal wording as evidence, as a dispatch record.
-      row=$(jq -Rrs 'split("\n")|map(select(length>0)|(try fromjson catch empty)) as $recs
+      row=$(jq -Rrs "$JQ_SHAPE_DEFS"'split("\n")|map(select(length>0)|(try fromjson catch empty)) as $recs
         | ([$recs[] | select(.type=="user")
-            | ((.message.content | if type=="string" then .
-                else ((map(select(.type=="text")|.text))|join("")) end) // "")
+            | (message_text // "")
             | select(startswith("<scheduled-task"))] | .[0] // "") as $disp
         | (($disp | capture("name=\"(?<n>[a-z0-9-]+)\"") | .n) // "") as $role
-        | ([$recs[] | select(.type=="assistant") | .message.content[]?
+        | ([$recs[] | select(.type=="assistant") | content_blocks
             | select(.type=="tool_use")] | length) as $tu
         | (([$recs[] | select(.type=="assistant")] | last) // {}) as $lastrec
-        | (([$lastrec.message.content[]?|select(.type=="text")|.text] | last) // "") as $lastt
+        | (([$lastrec | content_blocks | select(.type=="text") | .text | strings] | last) // "") as $lastt
         | (($lastrec.timestamp) // ([$recs[]|select(.timestamp)|.timestamp]|last) // "") as $ts
         | (($lastrec.message.stop_reason) // "") as $sr
         | ([$recs[] | select(.type=="assistant")] | length) as $na
@@ -1328,7 +1355,7 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
     # literally rather than being reinterpreted.
     printf '%s\n' "$SF_CACHE" | while IFS= read -r f; do
       [ -n "$f" ] || continue
-      SIG_ENV="$SIGNATURE" jq -Rr --arg since "$SIG_SINCE" '
+      SIG_ENV="$SIGNATURE" jq -Rr --arg since "$SIG_SINCE" "$JQ_SHAPE_DEFS"'
         ($ENV.SIG_ENV) as $sig
         | select(length>0)|(try fromjson catch empty)
         | select(.type=="user")
@@ -1336,21 +1363,16 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
         | select($ts != "" and $ts >= $since)
         | (.sessionId // "unknown") as $sid
         | select(
-            (.message.content // empty)
-            | select(type=="array")
-            | any(
-                # `objects` FIRST. A content array can mix plain strings with
-                # blocks, and indexing a string with `.type` makes jq abort the
-                # whole input line — which this call site swallows via
-                # `2>/dev/null`, so a record holding a REAL errored tool_result
-                # would vanish silently. That under-reports, the same direction
-                # as the contamination this section exists to remove.
-                objects
-                | .type=="tool_result" and .is_error==true
-                and ((.content | if type=="array" then (map(objects|select(.type=="text")|.text|strings)|join(" "))
-                                 elif type=="string" then . else (.|tostring) end)
-                     | contains($sig))
-              )
+            # `content_blocks` yields ONLY object blocks. A content array can mix
+            # plain strings with blocks, and indexing a string with `.type` makes
+            # jq abort the whole input line — which this call site swallows via
+            # `2>/dev/null`, so a record holding a REAL errored tool_result would
+            # vanish silently. That under-reports, the same direction as the
+            # contamination this section exists to remove.
+            [ content_blocks
+              | select(.type=="tool_result" and .is_error==true)
+              | select(block_text | contains($sig))
+            ] | length > 0
           )
         | "\($ts)\t\($sid)"
       ' "$f" 2>/dev/null
@@ -1373,7 +1395,7 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
     # variable between the two numbers.
     SIG_NAIVE=$(printf '%s\n' "$SF_CACHE" | while IFS= read -r f; do
       [ -n "$f" ] || continue
-      SIG_ENV="$SIGNATURE" jq -Rr --arg since "$SIG_SINCE" '
+      SIG_ENV="$SIGNATURE" jq -Rr --arg since "$SIG_SINCE" "$JQ_SHAPE_DEFS"'
         ($ENV.SIG_ENV) as $sig
         | select(length>0)|(try fromjson catch empty)
         | (.timestamp // "") as $ts
@@ -1387,13 +1409,10 @@ if [ "$SECTION" = signature ] || { [ "$SECTION" = all ] && [ "$SIGNATURE_SET" -e
             # superset missing the subset entirely, and no warning.
             ([.. | strings] | any(contains($sig)))
             or (
-              (.message.content // empty)
-              | if type=="array" then
-                  any(objects | .type=="tool_result"
-                      and ((.content | if type=="array" then (map(objects|select(.type=="text")|.text|strings)|join(" "))
-                                       elif type=="string" then . else (.|tostring) end)
-                           | contains($sig)))
-                else false end
+              [ content_blocks
+                | select(.type=="tool_result")
+                | select(block_text | contains($sig))
+              ] | length > 0
             )
           )
         | "1"
@@ -1478,14 +1497,13 @@ if want reliability; then
   else
     printf '%s\n' "$SF_CACHE" | while IFS= read -r f; do
       [ -n "$f" ] || continue
-      jq -Rrs 'split("\n")|map(select(length>0)|(try fromjson catch empty))|
-        (reduce (.[] | select(.type=="assistant") | .message.content[]?
+      jq -Rrs "$JQ_SHAPE_DEFS"'split("\n")|map(select(length>0)|(try fromjson catch empty))|
+        (reduce (.[] | select(.type=="assistant") | content_blocks
                  | select(.type=="tool_use")) as $t ({}; .[$t.id] = $t.name)) as $names
-        | .[] | select(.type=="user") | .message.content[]?
+        | .[] | select(.type=="user") | content_blocks
         | select(.type=="tool_result" and .is_error==true)
         | ($names[.tool_use_id] // "unknown") as $tool
-        | (.content | if type=="array" then (map(select(.type=="text").text)|join(" "))
-                      elif type=="string" then . else (.|tostring) end) as $msg
+        | (block_text) as $msg
         | "\($tool)\t\($msg | gsub("[\\n\\t]+";" ") | .[0:100])"
       ' "$f" 2>/dev/null
     done | redact > "$ERRTMP" || true
@@ -1939,13 +1957,13 @@ if want efficiency; then
     # labelled them "timeout victims" — in a window with zero timeouts it still
     # produced a confident-looking list, which is worse than an empty one.
     printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | while IFS= read -r f; do
-      jq -Rrs 'split("\n")|map(select(length>0)|(try fromjson catch empty))|
-        (reduce (.[] | select(.type=="assistant") | .message.content[]?
+      jq -Rrs "$JQ_SHAPE_DEFS"'split("\n")|map(select(length>0)|(try fromjson catch empty))|
+        (reduce (.[] | select(.type=="assistant") | content_blocks
                  | select(.type=="tool_use")) as $t ({};
                    .[$t.id] = ($t.input?.description? // $t.input?.command? // "?"))) as $desc
-        | .[] | select(.type=="user") | .message.content[]?
+        | .[] | select(.type=="user") | content_blocks
         | select(.type=="tool_result" and .is_error==true)
-        | select((.content | tostring) | test("Command timed out after"))
+        | select((block_text) | test("Command timed out after"))
         | ($desc[.tool_use_id] // "<unknown command>") | .[0:60]
       ' "$f" 2>/dev/null
     done | redact | sort | uniq -c | sort -rn | head -8 | sed 's/^/    /'
@@ -1992,12 +2010,10 @@ if want safety; then
     # counts decide guard-vs-agent, so inflating them argues for loosening a
     # guard that never actually fired.
     printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | while IFS= read -r f; do
-      jq -r --arg never_ran "$NEVER_RAN_RE" '
+      jq -r --arg never_ran "$NEVER_RAN_RE" "$JQ_SHAPE_DEFS"'
         .. | objects
         | (
-            (select(.type=="tool_result" and .is_error==true)
-             | .content | if type=="array" then (map(select(.type=="text").text)|join(" "))
-                          elif type=="string" then . else empty end),
+            (select(.type=="tool_result" and .is_error==true) | block_text),
             # Codex denials are NOT detected here, by decision rather than
             # omission. Its output records carry no error flag, 40 live sessions
             # showed no denial text, and it runs approval-policy=never. Five
@@ -2007,8 +2023,7 @@ if want safety; then
             # removed and the gap is stated in the output instead.
             (select(.type=="function_call_output" or .type=="custom_tool_call_output")
              | select((.is_error? // false) == true or (.status? // "") == "error")
-             | .output | if type=="array" then (map(.text? // empty)|join(" "))
-                         elif type=="string" then . else empty end)
+             | output_text)
           )
         | select(type=="string")
         | select(test($never_ran))

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -638,12 +638,14 @@ def content_blocks:
   | objects;
 def block_text:
   .content
-  | if type=="array" then [.[] | objects | select(.type=="text") | .text | strings] | join(" ")
+  | if type=="array" then
+      [ .[] | (strings), (objects | select(.type=="text") | .text | strings) ] | join(" ")
     elif type=="string" then .
     else tostring end;
 def output_text:
   .output
-  | if type=="array" then [.[] | objects | .text | strings] | join(" ")
+  | if type=="array" then
+      [ .[] | (strings), (objects | .text | strings) ] | join(" ")
     elif type=="string" then .
     else tostring end;
 def message_text:

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3631,6 +3631,21 @@ OUT=$(DISPATCH_HEALTH=on CLAUDE_PROJECTS_DIR="$FIX/strfinal" CODEX_HOME="$FIX/co
 check "a string-form final refusal is classified dead"   "$OUT" "dead ......... 1"
 nocheck "it is not misfiled as incomplete"               "$OUT" "incomplete ... 1"
 
+# (4) A bare string as an ELEMENT of a tool_result's content array. Filtering
+#     array members through `objects` alone dropped it, so a timeout whose message
+#     is stored that way vanished from the efficiency metric. Note this one is an
+#     improvement over origin/main rather than a regression repair: base filtered
+#     the same array through `select(.type=="text")`, which aborts on a bare
+#     string, so base scored it 0 too. Measured base 0 · objects-only 0 · fixed 1.
+mkdir -p "$FIX/barearray/q"
+cat > "$FIX/barearray/q/s.jsonl" <<'EOF'
+{"type":"assistant","timestamp":"2026-08-01T10:00:00Z","message":{"content":[{"type":"tool_use","id":"q1","name":"Bash","input":{"command":"sleep 300","description":"poll CI"}}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:01Z","message":{"content":[{"type":"tool_result","tool_use_id":"q1","is_error":true,"content":["Command timed out after 5m 0s"]}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/barearray" CODEX_HOME="$FIX/codex" MONOREPO_DIR="$FIX/monorepo" \
+  HOME="$FIX" bash "$TARGET" --since-days 3650 --max-files 5 --section efficiency 2>&1)
+check "a bare-string element of a result array is still text" "$OUT" "bash timeouts .............. 1"
+
 # A guard in a SHARED accessor must be load-bearing in MORE THAN ONE section —
 # that is what proves the call sites really are shared rather than merely similar.
 # Each arm removes exactly one guard from one accessor and requires two different
@@ -3665,7 +3680,11 @@ shared_ablate 's/(def content_blocks:.*?)\n  \| objects;/$1;/s' \
   "content_blocks objects guard is load-bearing in two sections" 0 2
 # Drop `strings` from block_text: the object-valued .text reaches join(), which
 # refuses to join an object, aborting the line in every walk that flattens text.
-shared_ablate 's/(def block_text:.*?select\(\.type=="text"\) \| \.text) \| strings\]/$1]/s' \
+# Re-aimed after `block_text` gained its bare-string branch: the old expression
+# matched `| strings]` at the end of the comprehension, which no longer exists.
+# The harness caught that as "perl changed nothing" rather than passing a vacuous
+# arm — a green control is not a live control, so re-ablate after every reshape.
+shared_ablate 's/(def block_text:.*?select\(\.type=="text"\) \| \.text) \| strings\)/$1)/s' \
   "block_text strings guard is load-bearing in two sections" 2 2
 
 # ── ABLATION: each filter must be LOAD-BEARING ────────────────────────────────

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3670,6 +3670,29 @@ check "lattice: a numeric .text payload is preserved" "$OUT" "Bash: <n>"
 check "lattice: an object .text payload is preserved" "$OUT" 'Edit: {"k":"v"}'
 check "lattice: a bare array element is preserved"    "$OUT" "Read: bare elem"
 
+# (5b) The remaining two cells of the `.text` axis: NULL and ABSENT. These are the
+#      one place `element_text` deliberately emits nothing, and that is not a
+#      "drop" — the RECORD is still counted, only the payload text is empty,
+#      because there is no payload. Coercing them would put the literal string
+#      "null" into the message and make a payload-less result look like it
+#      carried content, which is fabrication rather than evidence. Measured:
+#      origin/main counts these 3 records too, so this matches base behaviour.
+#      Pinned in both directions — the records survive, and no "null" is invented.
+mkdir -p "$FIX/nulltext/z"
+cat > "$FIX/nulltext/z/s.jsonl" <<'EOF'
+{"type":"assistant","timestamp":"2026-08-01T10:00:00Z","message":{"content":[{"type":"tool_use","id":"z1","name":"Bash","input":{"command":"a"}}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:01Z","message":{"content":[{"type":"tool_result","tool_use_id":"z1","is_error":true,"content":[{"type":"text","text":null}]}]}}
+{"type":"assistant","timestamp":"2026-08-01T10:00:02Z","message":{"content":[{"type":"tool_use","id":"z2","name":"Edit","input":{"file_path":"/b"}}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:03Z","message":{"content":[{"type":"tool_result","tool_use_id":"z2","is_error":true,"content":[{"type":"text"}]}]}}
+{"type":"assistant","timestamp":"2026-08-01T10:00:04Z","message":{"content":[{"type":"tool_use","id":"z3","name":"Read","input":{"file_path":"/c"}}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:05Z","message":{"content":[{"type":"tool_result","tool_use_id":"z3","is_error":true,"content":[{"type":"text","text":null},{"type":"text","text":"real payload"}]}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/nulltext" CODEX_HOME="$FIX/codex" MONOREPO_DIR="$FIX/monorepo" \
+  HOME="$FIX" bash "$TARGET" --since-days 3650 --max-files 5 --section reliability 2>&1)
+check   "null and absent .text keep their records counted" "$OUT" "tool errors in window: 3"
+check   "a sibling payload beside a null .text survives"   "$OUT" "Read: real payload"
+nocheck "an absent .text is not invented as \"null\""      "$OUT" "Edit: null"
+
 # (6) A bare-string provider refusal inside a final assistant ARRAY. Same rule at
 #     the record position: routing through `content_blocks` discarded it, so a
 #     dead dispatch was filed as `incomplete`.

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3577,6 +3577,60 @@ check "awkward shapes: the dispatch is classified"     "$OUT" 'dispatches of rol
 check "awkward shapes: the dispatch counts as live"    "$OUT" "live ......... 1"
 nocheck "awkward shapes: transcript is not unreadable" "$OUT" "unreadable transcript ....................: 1"
 
+# ── Three shapes the FIRST version of the accessors got wrong (Codex review) ──
+# All three are silent and downward — the exact failure direction these accessors
+# exist to remove — so each is pinned with its own fixture.
+
+# (1) A tool_result whose `content` is null or false. `(.content? // empty)` made
+#     jq emit nothing, so the walk dropped the entire errored result rather than
+#     reaching the scalar `tostring` fallback. Measured: base counted 2, the first
+#     accessor version counted 0. Reading `.content` directly restores it.
+mkdir -p "$FIX/nullcontent/n"
+cat > "$FIX/nullcontent/n/s.jsonl" <<'EOF'
+{"type":"assistant","timestamp":"2026-08-01T10:00:00Z","message":{"content":[{"type":"tool_use","id":"n1","name":"Bash","input":{"command":"x","description":"d"}}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:01Z","message":{"content":[{"type":"tool_result","tool_use_id":"n1","is_error":true,"content":null}]}}
+{"type":"assistant","timestamp":"2026-08-01T10:00:02Z","message":{"content":[{"type":"tool_use","id":"n2","name":"Edit","input":{"file_path":"/y"}}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:03Z","message":{"content":[{"type":"tool_result","tool_use_id":"n2","is_error":true,"content":false}]}}
+EOF
+OUT=$(DISPATCH_HEALTH=on CLAUDE_PROJECTS_DIR="$FIX/nullcontent" CODEX_HOME="$FIX/codex" \
+  MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" bash "$TARGET" \
+  --since-days 3650 --max-files 5 --section reliability 2>&1)
+check "null/false tool_result content stays observable" "$OUT" "tool errors in window: 2"
+
+# (2) A bare string BEFORE the dispatch marker in a content array. Filtering bare
+#     strings out reduced the message to the marker alone, so an interactive
+#     session was falsely classified as a scheduled dispatch — corrupting the
+#     denominator of every per-dispatch rate. Order must be preserved.
+mkdir -p "$FIX/barestring/m"
+cat > "$FIX/barestring/m/s.jsonl" <<'EOF'
+{"type":"user","timestamp":"2026-08-01T10:00:00Z","message":{"content":["please look at this: ",{"type":"text","text":"<scheduled-task name=\"daily-ai-assistant\" file=\"/x/SKILL.md\">\nrun\n</scheduled-task>"}]}}
+{"type":"assistant","timestamp":"2026-08-01T10:00:01Z","message":{"content":[{"type":"tool_use","id":"m1","name":"Bash","input":{"command":"x"}}]}}
+EOF
+OUT=$(DISPATCH_HEALTH=on CLAUDE_PROJECTS_DIR="$FIX/barestring" CODEX_HOME="$FIX/codex" \
+  MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" bash "$TARGET" \
+  --since-days 3650 --max-files 5 --section dispatch 2>&1)
+check "a bare-string prefix is not read as a dispatch marker" "$OUT" \
+  'dispatches of role "daily-ai-assistant": 0'
+check "that session is reported as interactive instead" "$OUT" \
+  "no dispatch record .......................: 1"
+
+# (3) A final assistant record using the documented STRING form of
+#     `message.content` and carrying the provider refusal. `content_blocks`
+#     yields only objects, so the refusal text never reached the classifier and a
+#     dead dispatch was filed as `incomplete` — an outage rendered as "maybe still
+#     running", which is a fail-OPEN in the health signal every other number here
+#     is re-based on.
+mkdir -p "$FIX/strfinal/p"
+cat > "$FIX/strfinal/p/s.jsonl" <<'EOF'
+{"type":"user","timestamp":"2026-08-01T10:00:00Z","message":{"content":[{"type":"text","text":"<scheduled-task name=\"daily-ai-assistant\" file=\"/x/SKILL.md\">\nrun\n</scheduled-task>"}]}}
+{"type":"assistant","timestamp":"2026-08-01T10:00:01Z","message":{"stop_reason":"stop_sequence","content":"You've hit your weekly limit · resets Aug 1 at 1pm (Europe/Copenhagen)"}}
+EOF
+OUT=$(DISPATCH_HEALTH=on CLAUDE_PROJECTS_DIR="$FIX/strfinal" CODEX_HOME="$FIX/codex" \
+  MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" bash "$TARGET" \
+  --since-days 3650 --max-files 5 --section dispatch 2>&1)
+check "a string-form final refusal is classified dead"   "$OUT" "dead ......... 1"
+nocheck "it is not misfiled as incomplete"               "$OUT" "incomplete ... 1"
+
 # A guard in a SHARED accessor must be load-bearing in MORE THAN ONE section —
 # that is what proves the call sites really are shared rather than merely similar.
 # Each arm removes exactly one guard from one accessor and requires two different

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3527,6 +3527,93 @@ nocheck "an oversized signature never reports a zero count" "$OUT" "REAL occurre
 OUT=$(sigrun); check "an inline signature is echoed on its label line" "$OUT" \
   "signature scored (fixed string, case-sensitive):"
 
+# ── SHARED SHAPE ACCESSORS: one fixture, every awkward shape, every section ───
+# Claude's transcript schema is heterogeneous by design, and every walk used to
+# re-derive its own guards against it — so a walk was correct only if its author
+# remembered every case, and the failure when one was forgotten is SILENT and
+# always downward: jq aborts the input line, the call site's `2>/dev/null` eats
+# the error, and the record is dropped.
+#
+# ONE fixture carries every shape that aborts a naive walk, and EVERY section is
+# asserted against it. Before the shared accessors, the already-hardened
+# signature section scored this fixture while reliability read 0 and dispatch
+# reported the whole transcript "unreadable" — the same corpus, three different
+# answers, which is precisely the divergence a shared accessor removes.
+mkdir -p "$FIX/awkward/aw"
+cat > "$FIX/awkward/aw/s.jsonl" <<'EOF'
+{"type":"user","timestamp":"2026-08-01T10:00:00Z","message":{"content":[{"type":"text","text":"<scheduled-task name=\"daily-ai-assistant\" file=\"/x/SKILL.md\">\nrun\n</scheduled-task>"}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:01Z","message":{"content":"a plain string content record"}}
+{"type":"assistant","timestamp":"2026-08-01T10:00:02Z","message":{"content":["bare string block",{"type":"tool_use","id":"a1","name":"Bash","input":{"command":"gh pr view 1","description":"awkward probe"}}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:03Z","message":{"content":["bare string block",{"type":"tool_result","tool_use_id":"a1","is_error":true,"content":[42,{"type":"text","text":"AWKWARDSIG mixed-array failure"}]}]}}
+{"type":"assistant","timestamp":"2026-08-01T10:00:04Z","message":{"content":[{"type":"tool_use","id":"a2","name":"Edit","input":{"file_path":"/y","description":"awkward edit"}}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:05Z","message":{"content":[{"type":"tool_result","tool_use_id":"a2","is_error":true,"content":[{"type":"text","text":99},{"type":"text","text":"AWKWARDSIG nonstring-text failure"}]}]}}
+{"type":"assistant","timestamp":"2026-08-01T10:00:06Z","message":{"content":[{"type":"tool_use","id":"a3","name":"Read","input":{"file_path":"/z","description":"awkward read"}}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:07Z","message":{"content":[{"type":"tool_result","tool_use_id":"a3","is_error":true,"content":[{"type":"text","text":{"nested":"object"}},{"type":"text","text":"AWKWARDSIG objtext failure"}]}]}}
+EOF
+
+# $1 = script under test, $2 = section, $3 = optional signature
+awkrun() {
+  DISPATCH_HEALTH=on CLAUDE_PROJECTS_DIR="$FIX/awkward" CODEX_HOME="$FIX/codex" \
+    MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+    bash "$1" --since-days 3650 --max-files 20 --section "$2" \
+    ${3:+--signature "$3"} 2>&1
+}
+
+echo
+echo "shared shape accessors"
+OUT=$(awkrun "$TARGET" reliability)
+check "awkward shapes: every errored result is counted"    "$OUT" "tool errors in window: 3"
+check "awkward shapes: mixed-array result attributed"      "$OUT" "1 Bash"
+check "awkward shapes: non-string .text result attributed" "$OUT" "1 Edit"
+check "awkward shapes: object .text result attributed"     "$OUT" "1 Read"
+OUT=$(awkrun "$TARGET" signature AWKWARDSIG)
+check "awkward shapes: signature scores all three" "$OUT" "is_error==true): 3"
+# The consequential one. A single bare string in a content array used to abort
+# the dispatch classifier's whole-transcript parse, so a dispatch that really ran
+# was reported as an unreadable transcript — an instrument the improver reads
+# FIRST, to decide whether any other number in the report is trustworthy.
+OUT=$(awkrun "$TARGET" dispatch)
+check "awkward shapes: the dispatch is classified"     "$OUT" 'dispatches of role "daily-ai-assistant": 1'
+check "awkward shapes: the dispatch counts as live"    "$OUT" "live ......... 1"
+nocheck "awkward shapes: transcript is not unreadable" "$OUT" "unreadable transcript ....................: 1"
+
+# A guard in a SHARED accessor must be load-bearing in MORE THAN ONE section —
+# that is what proves the call sites really are shared rather than merely similar.
+# Each arm removes exactly one guard from one accessor and requires two different
+# sections to under-count.
+shared_ablate() { # $1=perl-expr $2=label $3=reliability-after $4=signature-after
+  local ab="$FIX/shared-ablate.sh"
+  cp "$TARGET" "$ab"
+  perl -0pi -e "$1" "$ab"
+  if cmp -s "$TARGET" "$ab"; then
+    bad "shared ablation: $2" "perl changed nothing — the arm proves nothing"
+    return
+  fi
+  local r s
+  r=$(awkrun "$ab" reliability | grep -oE 'tool errors in window: [0-9]+' | head -1)
+  s=$(awkrun "$ab" signature AWKWARDSIG | grep -oE 'is_error==true\): [0-9]+' | head -1)
+  if [ "$r" = "tool errors in window: $3" ] && [ "$s" = "is_error==true): $4" ]; then
+    ok "shared ablation: $2"
+  else
+    bad "shared ablation: $2" "expected reliability=$3 signature=$4; got '$r' / '$s'"
+  fi
+}
+# Drop `objects` from content_blocks: the bare string in the content array is no
+# longer filtered, so indexing it with .type aborts the line in every walk.
+#
+# The two sections lose DIFFERENT amounts, and the asymmetry is the point rather
+# than an inconsistency. Reliability slurps the whole transcript (`jq -Rrs`), so
+# one aborted line takes every record with it: 3 -> 0. The signature walk runs
+# per-line (`jq -Rr`), so only the offending record is lost: 3 -> 2. Slurping is
+# what turns a single awkward block into a whole-transcript blackout, which is
+# also why the dispatch classifier reported "unreadable" rather than a low count.
+shared_ablate 's/(def content_blocks:.*?)\n  \| objects;/$1;/s' \
+  "content_blocks objects guard is load-bearing in two sections" 0 2
+# Drop `strings` from block_text: the object-valued .text reaches join(), which
+# refuses to join an object, aborting the line in every walk that flattens text.
+shared_ablate 's/(def block_text:.*?select\(\.type=="text"\) \| \.text) \| strings\]/$1]/s' \
+  "block_text strings guard is load-bearing in two sections" 2 2
+
 # ── ABLATION: each filter must be LOAD-BEARING ────────────────────────────────
 # A guard that passes when removed is not a guard. Each arm copies the target,
 # removes exactly one filter, asserts the copy actually CHANGED, and requires the
@@ -3563,9 +3650,17 @@ ablate() { # $1=sed-expr $2=label $3=expected-count-after $4=days $5=expected-ch
 }
 # Arm A — drop the is_error filter: the documentation read must become counted
 # (2 -> 3). This is the contamination the section exists to exclude.
-# Anchored at end-of-line so it hits ONLY the signature walk's own filter — the
-# reliability section's `... and .is_error==true)` ends in a paren and is spared.
-ablate 's/\.type=="tool_result" and \.is_error==true$/.type=="tool_result"/' \
+#
+# Anchored on the signature walk's own INDENTATION (14 spaces) and end-of-line.
+# Once every walk was consolidated onto the shared `content_blocks`/`block_text`
+# accessors, all six errored-tool_result filters became textually identical apart
+# from indentation, so the previous end-of-`true` anchor stopped discriminating —
+# and, having been written against the pre-refactor text, stopped matching at all.
+# The harness caught that as "sed changed nothing" rather than passing a vacuous
+# arm. Indentation is the only remaining discriminator: 14 spaces is unique to
+# this walk (the others sit at 8, 10 and 12), and the one-changed-line assertion
+# below fails loudly if a future reindent breaks that uniqueness.
+ablate 's/^              | select(\.type=="tool_result" and \.is_error==true)$/              | select(.type=="tool_result")/' \
   "removing is_error lets a documentation read count" 3
 # Arm B — drop the record-timestamp filter in the 1-day window: the 2026-06-01
 # failure must reappear (1 -> 2), proving mtime is not what bounds the window.

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3646,6 +3646,43 @@ OUT=$(CLAUDE_PROJECTS_DIR="$FIX/barearray" CODEX_HOME="$FIX/codex" MONOREPO_DIR=
   HOME="$FIX" bash "$TARGET" --since-days 3650 --max-files 5 --section efficiency 2>&1)
 check "a bare-string element of a result array is still text" "$OUT" "bash timeouts .............. 1"
 
+# (5) THE SHAPE LATTICE, covered as a matrix rather than one position at a time.
+#     Three review rounds each reported the same defect at a different position,
+#     because each was patched where it was reported. The positions are finite —
+#     an array ELEMENT (bare scalar | block object), a block's `.text` (string |
+#     non-string | absent), and a final assistant record (string | array) — and at
+#     every one of them the rule is the same: COERCE, NEVER DROP. This fixture
+#     pins one payload per shape and requires each to survive to the output.
+mkdir -p "$FIX/lattice/x"
+cat > "$FIX/lattice/x/s.jsonl" <<'EOF'
+{"type":"user","timestamp":"2026-08-01T10:00:00Z","message":{"content":[{"type":"text","text":"<scheduled-task name=\"daily-ai-assistant\" file=\"/x/SKILL.md\">\nrun\n</scheduled-task>"}]}}
+{"type":"assistant","timestamp":"2026-08-01T10:00:01Z","message":{"content":[{"type":"tool_use","id":"x1","name":"Bash","input":{"command":"a"}}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:02Z","message":{"content":[{"type":"tool_result","tool_use_id":"x1","is_error":true,"content":[{"type":"text","text":99}]}]}}
+{"type":"assistant","timestamp":"2026-08-01T10:00:03Z","message":{"content":[{"type":"tool_use","id":"x2","name":"Edit","input":{"file_path":"/b"}}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:04Z","message":{"content":[{"type":"tool_result","tool_use_id":"x2","is_error":true,"content":[{"type":"text","text":{"k":"v"}}]}]}}
+{"type":"assistant","timestamp":"2026-08-01T10:00:05Z","message":{"content":[{"type":"tool_use","id":"x3","name":"Read","input":{"file_path":"/c"}}]}}
+{"type":"user","timestamp":"2026-08-01T10:00:06Z","message":{"content":[{"type":"tool_result","tool_use_id":"x3","is_error":true,"content":["bare elem"]}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/lattice" CODEX_HOME="$FIX/codex" MONOREPO_DIR="$FIX/monorepo" \
+  HOME="$FIX" bash "$TARGET" --since-days 3650 --max-files 5 --section reliability 2>&1)
+check "lattice: every errored result survives"        "$OUT" "tool errors in window: 3"
+check "lattice: a numeric .text payload is preserved" "$OUT" "Bash: <n>"
+check "lattice: an object .text payload is preserved" "$OUT" 'Edit: {"k":"v"}'
+check "lattice: a bare array element is preserved"    "$OUT" "Read: bare elem"
+
+# (6) A bare-string provider refusal inside a final assistant ARRAY. Same rule at
+#     the record position: routing through `content_blocks` discarded it, so a
+#     dead dispatch was filed as `incomplete`.
+mkdir -p "$FIX/arrayrefusal/y"
+cat > "$FIX/arrayrefusal/y/s.jsonl" <<'EOF'
+{"type":"user","timestamp":"2026-08-01T10:00:00Z","message":{"content":[{"type":"text","text":"<scheduled-task name=\"daily-ai-assistant\" file=\"/x/SKILL.md\">\nrun\n</scheduled-task>"}]}}
+{"type":"assistant","timestamp":"2026-08-01T10:00:01Z","message":{"stop_reason":"stop_sequence","content":["You've hit your weekly limit · resets Aug 1 at 1pm (Europe/Copenhagen)"]}}
+EOF
+OUT=$(DISPATCH_HEALTH=on CLAUDE_PROJECTS_DIR="$FIX/arrayrefusal" CODEX_HOME="$FIX/codex" \
+  MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" bash "$TARGET" \
+  --since-days 3650 --max-files 5 --section dispatch 2>&1)
+check "a bare-string refusal in a final array is dead" "$OUT" "dead ......... 1"
+
 # A guard in a SHARED accessor must be load-bearing in MORE THAN ONE section —
 # that is what proves the call sites really are shared rather than merely similar.
 # Each arm removes exactly one guard from one accessor and requires two different
@@ -3680,12 +3717,15 @@ shared_ablate 's/(def content_blocks:.*?)\n  \| objects;/$1;/s' \
   "content_blocks objects guard is load-bearing in two sections" 0 2
 # Drop `strings` from block_text: the object-valued .text reaches join(), which
 # refuses to join an object, aborting the line in every walk that flattens text.
-# Re-aimed after `block_text` gained its bare-string branch: the old expression
-# matched `| strings]` at the end of the comprehension, which no longer exists.
-# The harness caught that as "perl changed nothing" rather than passing a vacuous
-# arm — a green control is not a live control, so re-ablate after every reshape.
-shared_ablate 's/(def block_text:.*?select\(\.type=="text"\) \| \.text) \| strings\)/$1)/s' \
-  "block_text strings guard is load-bearing in two sections" 2 2
+# Now aimed at `scalar_text`, the single coercion every position shares. Removing
+# it lets an object-valued payload reach `join`, which refuses to join an object,
+# so the record is dropped in both sections (3 -> 2 each).
+#
+# This arm has been re-aimed TWICE as the accessors were reshaped, and both times
+# the harness caught it as "perl changed nothing" rather than passing a vacuous
+# control. A green control is not a live control: re-ablate after every reshape.
+shared_ablate 's/def scalar_text: if type=="string" then \. else tostring end;/def scalar_text: .;/s' \
+  "the shared scalar_text coercion is load-bearing in two sections" 2 2
 
 # ── ABLATION: each filter must be LOAD-BEARING ────────────────────────────────
 # A guard that passes when removed is not a guard. Each arm copies the target,


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The telemetry script is how this agent decides whether its own fixes worked. Its readings were quietly unreliable: each walk over the transcript data re-derived its own handling of the awkward shapes the data can take, so a walk was correct only if whoever wrote it remembered every case. When one was missed the reading simply came out **low** — no error, no warning. A missed record doesn't look like a failure, it looks like an improvement, which is the worst possible direction for an instrument used to judge progress.

The same fix had to be discovered twice during the review of #2624 — patched in one place, then found again next door.

The case that matters most: the dispatch check reads a whole session at once, so **one** awkward value made it discard the entire session and report a run that really happened as unreadable. That is the first number this agent looks at each run to decide whether anything else in the report can be trusted.

## What

Handles each shape once, centrally, and routes every reading through it — so a new reading inherits correct handling instead of re-deriving it.

Verified three ways: a new test case carrying every awkward shape, which every section now scores correctly; an ablation showing each shared guard is load-bearing in **two** sections at once; and a controlled before/after over a frozen 92 MB snapshot of the real corpus, which came out identical apart from a timestamp and counts that read a live store. An earlier uncontrolled comparison appeared to show records being recovered — that turned out to be the corpus growing between the two runs, not this change.

Fixes #2628