### PR TITLE
fix(agents): review marketplace skill updates

### DIFF
--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -107,10 +107,11 @@ public and private — no per-repo loop needed to enumerate):
    ownership-unverified rule below first.
    **`botantler-1[bot]` is a candidate only for the programmed agent-skills updater classifier**:
    deepen its row only when the cheap search result has branch `deps/agent-skills-update` and exact
-   title `chore(deps): update agent skills`, then require the classifier below to exit 0. The cheap
-   branch/title test only selects a candidate; it never grants the exemption. If the classifier
-   returns 1, the App is untrusted outside that programmed path and the PR is static-review-only.
-   Exit 2 is a survey error and fails closed.
+   title `chore(deps): update agent skills`, then require the classifier below to exit 0 or 3. The
+   cheap branch/title test only selects a candidate; it never grants trust or an exemption. Exit 0
+   grants the narrow no-review path. Exit 3 means a trusted, review-required `agent-plugins` updater:
+   deepen its normal review surfaces and never report it exempt. Exit 1 leaves the App untrusted and
+   the PR static-review-only. Exit 2 is a survey error and fails closed.
    - **`devantler`-authored PRs: classify the CI state, NOT the ownership — report them as
      `OWNERSHIP-UNVERIFIED`, never "MERGE-READY own".** You cannot tell the routine's *own* PRs from the
      **maintainer's interactive** ones (an active feature campaign, `repo-assist`, a hand-driven session):
@@ -201,7 +202,8 @@ public and private — no per-repo loop needed to enumerate):
      merge-ready without ≥1 green review on top of green CI; a successful current-head review from any one provider completes the review gate**
      (maintainer direction 2026-07-11, clarified 2026-07-22).
      This includes drafts and promoted PRs from humans and actionable trusted bots — EXCEPT trusted
-     **programmed bot PRs**: the shared agent-skills updater's exact generated path (maintainer
+     **programmed bot PRs**: the shared agent-skills updater's exact generated path in `platform` and
+     `ksail` (maintainer
      direction 2026-07-23), Homebrew-tap cask PRs (GoReleaser's for `ksail`/`ksail-desktop` and
      World at Ruin's CD-generated ones on `goreleaser/world-at-ruin`, maintainer direction
      2026-07-18), and KSail release bumps (maintainer direction 2026-07-13, ksail#6095). Apply this
@@ -222,8 +224,9 @@ public and private — no per-repo loop needed to enumerate):
      provenance and both dates.
      The list's last SHA must equal `headRefOid`; an agent/maintainer adaptation commit therefore
      revokes the exemption even when the branch, title, and files still look generated. Exit 1 means
-     the normal review gate applies; exit 2 or any query/classifier failure is a survey error
-     and also fails closed. **Never infer exemption from a title,
+     an external/static-only candidate; exit 2 or any query/classifier failure is a survey error
+     and also fails closed; exit 3 is a trusted `agent-plugins` update that follows the normal review
+     gate. **Never infer exemption from a title,
      a dependency name, or a generic release-shaped branch.** The classifier deliberately binds the
      approved repository, PR actor, branch, title/version, current-head commit provenance, and exact
      changed-file set; do not recreate a

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -71,10 +71,18 @@ grep -Fq 'programmed agent-skills updater PRs' "${constitution}" ||
   fail "constitution does not exempt programmed agent-skills updater PRs from review"
 # Literal Markdown code spans; command substitution is intentionally disabled.
 # shellcheck disable=SC2016
+grep -Fq 'agent-plugins` updater PRs require semantic review' "${constitution}" ||
+  fail "constitution can still send marketplace instruction updates through the no-review path"
+# Literal Markdown code spans; command substitution is intentionally disabled.
+# shellcheck disable=SC2016
 grep -Fq '`app/botantler-1` is narrowly trusted only for programmed agent-skills updater PRs' "${constitution}" ||
   fail "constitution either misses botantler updater PRs or trusts the App globally"
 grep -Fq 'green_review=exempt-programmed-bot' "${surveyor}" ||
   fail "surveyor cannot report a programmed bot review exemption"
+# Literal Markdown code spans; command substitution is intentionally disabled.
+# shellcheck disable=SC2016
+grep -Fq 'Exit 3 means a trusted, review-required `agent-plugins` updater' "${surveyor}" ||
+  fail "surveyor cannot distinguish review-bearing marketplace updates from untrusted lookalikes"
 # Literal Markdown code spans; command substitution is intentionally disabled.
 # shellcheck disable=SC2016
 grep -Fq '`botantler-1[bot]` is a candidate only for the programmed agent-skills updater classifier' "${surveyor}" ||
@@ -260,8 +268,10 @@ grep -Fq 'never actionable at all' "${product_engineering_skill}" ||
   fail "advance playbook does not state that an automation-authored issue is never actionable"
 grep -Fq 'automation-owned dependency PRs' "${maintenance_skill}" ||
   fail "portfolio-maintenance skill does not defer dependency PRs to automation"
-grep -Fq 'agent-skills updater PRs' "${maintenance_skill}" ||
-  fail "portfolio-maintenance skill still review-gates programmed agent-skills updater PRs"
+# Literal Markdown code spans; command substitution is intentionally disabled.
+# shellcheck disable=SC2016
+grep -Fq '`agent-plugins` updater PRs require semantic review' "${maintenance_skill}" ||
+  fail "portfolio-maintenance skill can still exempt marketplace instruction updates from review"
 grep -Fq 'Compatibility overlay' "${maintenance_skill}" ||
   fail "plugin surveyor can run without the hardened local behavior before digest parity"
 grep -Fq 'read and follow the local' "${maintenance_skill}" ||
@@ -275,10 +285,10 @@ grep -Fq 'automation-owned dependency PRs' "${product_engineering_skill}" ||
   fail "product-engineering skill still treats dependency PRs as agent work"
 grep -Fq 'automation-owned dependency PRs' "${agent_skills_card}" ||
   fail "agent-skills product card still treats dependency PRs as agent work"
-grep -Fq 'never spend a review lane on them' "${agent_skills_card}" ||
-  fail "agent-skills product card still requires review for programmed updater PRs"
-grep -Fq 'classification succeeds' "${agent_skills_card}" ||
-  fail "agent-skills product card can skip review without a successful classifier result"
+grep -Fq 'never spend a review lane on exit-0 exemptions' "${agent_skills_card}" ||
+  fail "agent-skills product card does not preserve the narrow no-review path"
+grep -Fq 'classifier exits 3' "${agent_skills_card}" ||
+  fail "agent-skills product card does not require semantic review for marketplace updates"
 grep -Fq 'automation-owned dependency PRs' "${ksail_card}" ||
   fail "KSail product card still treats dependency PRs as agent work"
 if grep -Fq 'Bot PRs are first-priority work, not background noise' "${constitution}"; then
@@ -304,6 +314,19 @@ expect_review_gated() {
     rc=$?
   fi
   [[ "${rc}" -eq 1 ]] || fail "classifier errored for review-gated fixture: ${name}"
+}
+
+expect_review_required() {
+  local name="$1"
+  shift
+  local rc
+  if "${classifier}" "$@"; then
+    fail "unexpected no-review exemption: ${name}"
+  else
+    rc=$?
+  fi
+  [[ "${rc}" -eq 3 ]] ||
+    fail "classifier did not return trusted review-required state for ${name}: exit ${rc}"
 }
 
 expect_not_release_exempt() {
@@ -506,6 +529,31 @@ agent_plugins_skills_commits="$(jq -cn --arg head "${agent_plugins_skills_head}"
   message: "chore(deps): update agent skills"
 }]' | with_commit_dates)"
 
+agent_plugins_versioned_head="b6e8caf3166e0693ddae7159cd88783386af0b75"
+agent_plugins_versioned_files='[".claude-plugin/marketplace.json",".github/plugin/marketplace.json","plugins/github/.claude-plugin/plugin.json","plugins/github/plugin.json","plugins/github/skills/gh-stack/SKILL.md"]'
+agent_plugins_versioned_commits="$(jq -cn --arg head "${agent_plugins_versioned_head}" '[
+  {
+    sha: "af32046fa35e4c954f31ca6ba19d4a0659418af7",
+    author_login: "devantler",
+    author_name: "devantler",
+    author_email: "26203420+devantler@users.noreply.github.com",
+    committer_login: "github-actions[bot]",
+    committer_name: "github-actions[bot]",
+    committer_email: "41898282+github-actions[bot]@users.noreply.github.com",
+    message: "chore(deps): update agent skills"
+  },
+  {
+    sha: $head,
+    author_login: "github-actions[bot]",
+    author_name: "github-actions[bot]",
+    author_email: "41898282+github-actions[bot]@users.noreply.github.com",
+    committer_login: "github-actions[bot]",
+    committer_name: "github-actions[bot]",
+    committer_email: "41898282+github-actions[bot]@users.noreply.github.com",
+    message: "chore(deps): bump versions of changed plugins"
+  }
+]' | with_commit_dates)"
+
 multi_agent_skills_head="6666666666666666666666666666666666666666"
 multi_agent_skills_commits="$(jq -cn --arg head "${multi_agent_skills_head}" '[
   {
@@ -602,8 +650,8 @@ expect_exempt \
   "${ksail_files}" \
   "${ksail_commits}"
 
-expect_exempt \
-  "agent-plugins programmed agent-skills update" \
+expect_review_required \
+  "agent-plugins skill-only update" \
   "agent-plugins" \
   "app/botantler-1" \
   "deps/agent-skills-update" \
@@ -611,6 +659,16 @@ expect_exempt \
   "${agent_plugins_skills_head}" \
   "${agent_plugins_skills_files}" \
   "${agent_plugins_skills_commits}"
+
+expect_review_required \
+  "agent-plugins update with generated version files" \
+  "agent-plugins" \
+  "app/botantler-1" \
+  "deps/agent-skills-update" \
+  "chore(deps): update agent skills" \
+  "${agent_plugins_versioned_head}" \
+  "${agent_plugins_versioned_files}" \
+  "${agent_plugins_versioned_commits}"
 
 expect_exempt \
   "Platform programmed agent-skills update" \

--- a/.claude/scripts/programmed-bot-review-exemption.sh
+++ b/.claude/scripts/programmed-bot-review-exemption.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Exit 0: no-review exemption; 1: untrusted/non-matching; 2: invalid input or environment;
+# 3: genuine programmed updater that is trusted but requires semantic review.
+
 set -euo pipefail
 
 if [[ "$#" -ne 7 ]] || ! command -v jq >/dev/null 2>&1; then
@@ -61,9 +64,6 @@ matches_agent_skills_files() {
   local path_pattern
 
   case "${repo}" in
-  agent-plugins)
-    path_pattern='^plugins/[^/]+/skills/[^/]+/.+'
-    ;;
   ksail | platform)
     path_pattern='^\.agents/skills/[^/]+/.+'
     ;;
@@ -75,6 +75,23 @@ matches_agent_skills_files() {
   jq -e --arg pattern "${path_pattern}" \
     'length > 0 and all(.[]; test($pattern))' \
     <<<"${files_json}" >/dev/null
+}
+
+# Marketplace skills are executable agent instructions sourced from several upstreams. Even a
+# mechanically genuine update needs semantic review: path/provenance checks prove who produced the
+# copy, not whether its prose preserves the consumer's authority boundaries. Exit 3 distinguishes a
+# genuine, trusted updater PR that requires review from both the no-review exemption (0) and an
+# untrusted lookalike (1).
+matches_agent_plugins_review_files() {
+  jq -e '
+    length > 0 and
+    any(.[]; test("^plugins/[^/]+/skills/[^/]+/.+")) and
+    all(.[];
+      test("^plugins/[^/]+/skills/[^/]+/.+") or
+      test("^plugins/[^/]+/(\\.claude-plugin/)?plugin\\.json$") or
+      . == ".claude-plugin/marketplace.json" or
+      . == ".github/plugin/marketplace.json")
+  ' <<<"${files_json}" >/dev/null
 }
 
 matches_agent_skills_provenance() {
@@ -94,6 +111,29 @@ matches_agent_skills_provenance() {
       .committer_name == "github-actions[bot]" and
       .committer_email == "41898282+github-actions[bot]@users.noreply.github.com" and
       .message == "chore(deps): update agent skills")
+  ' <<<"${commits_json}" >/dev/null
+}
+
+matches_agent_plugins_review_provenance() {
+  jq -e '
+    def skill_update:
+      .author_login == "devantler" and
+      .author_name == "devantler" and
+      .author_email == "26203420+devantler@users.noreply.github.com" and
+      .committer_login == "github-actions[bot]" and
+      .committer_name == "github-actions[bot]" and
+      .committer_email == "41898282+github-actions[bot]@users.noreply.github.com" and
+      .message == "chore(deps): update agent skills";
+    def version_bump:
+      .author_login == "github-actions[bot]" and
+      .author_name == "github-actions[bot]" and
+      .author_email == "41898282+github-actions[bot]@users.noreply.github.com" and
+      .committer_login == "github-actions[bot]" and
+      .committer_name == "github-actions[bot]" and
+      .committer_email == "41898282+github-actions[bot]@users.noreply.github.com" and
+      .message == "chore(deps): bump versions of changed plugins";
+    (length == 1 and (.[0] | skill_update)) or
+    (length == 2 and (.[0] | skill_update) and (.[1] | version_bump))
   ' <<<"${commits_json}" >/dev/null
 }
 
@@ -221,11 +261,17 @@ if [[ "${branch}" == "deps/agent-skills-update" &&
     ;;
   esac
 
-  if [[ -n "${expected_author}" &&
-    "${author}" == "${expected_author}" ]] &&
-    matches_agent_skills_files &&
-    matches_agent_skills_provenance; then
-    exit 0
+  if [[ -n "${expected_author}" && "${author}" == "${expected_author}" ]]; then
+    if [[ "${repo}" == "agent-plugins" ]] &&
+      matches_agent_plugins_review_files &&
+      matches_agent_plugins_review_provenance; then
+      exit 3
+    fi
+    if [[ "${repo}" != "agent-plugins" ]] &&
+      matches_agent_skills_files &&
+      matches_agent_skills_provenance; then
+      exit 0
+    fi
   fi
 fi
 

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -425,8 +425,10 @@ slice. Record the product's `last_value_review` cursor, not live metrics, in nat
    with inline comments** (`event: COMMENT`, disclosure line, `## Self-review (fallback` heading,
    verdict line) so the sibling agent can see and act on it, incremental re-reviews,
    green-while-draft as the promotion precondition, the **automation-owned dependency-PR no-action carve-out**, and the trusted programmed
-   **bot carve-out** — exact-classifier-matched agent-skills updater PRs, tap cask PRs, and KSail
-   release bumps are check-gated, need NO review, and are never review-chased) is the contract's
+   **bot carve-out** — exact-classifier-matched exit-0 agent-skills updater PRs, tap cask PRs, and
+   KSail release bumps are check-gated, need NO review, and are never review-chased;
+   `agent-plugins` updater PRs require semantic review when their classifier returns the trusted
+   exit-3 state) is the contract's
    **green-review gate** (AGENTS.md *Autonomy → AUTO-REVIEW IS
    DISABLED*) — follow it, don't re-derive it here. When a draft reaches the full pentad AND you have
    tried and evaluated it as a user, **self-promote it and drive it to merge** (contract *Autonomy*;

--- a/.claude/skills/products/agent-skills/SKILL.md
+++ b/.claude/skills/products/agent-skills/SKILL.md
@@ -34,9 +34,11 @@ put product-specific logic here.
 inherits it, then migrate consumers. Triage/label issues, drive actionable trusted-author PRs to merge,
 leave automation-owned dependency PRs alone, and keep dependency automation & docs current.
 Programmed `chore(deps): update agent skills` PRs are the no-review exception defined in the root
-contract only when `.claude/scripts/programmed-bot-review-exemption.sh` classification succeeds:
-let required CI and auto-merge decide accepted exemptions, and never spend a review lane on them.
-Route classifier failures, non-matching PRs, and lookalikes through the normal review process.
+contract only when `.claude/scripts/programmed-bot-review-exemption.sh` exits 0: let required CI and
+auto-merge decide accepted exemptions, and never spend a review lane on exit-0 exemptions. A genuine
+`agent-plugins` marketplace update is trusted but review-bearing when the classifier exits 3; request
+semantic review because bundled skill prose is executable agent instruction. Route classifier exit 1
+and non-matching lookalikes through the external/static-only path; exit 2 is a fail-closed error.
 
 Shared cross-repo rules are in the monorepo [`AGENTS.md`](../../../../AGENTS.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1062,12 +1062,18 @@ trusted-author permissions below and is separate from the narrower programmed-bo
 gated by required CI and auto-merge rather than an AI review:
 - **Programmed agent-skills updater PRs** (maintainer direction 2026-07-23): the shared
   `update-agent-skills` workflow's exact `deps/agent-skills-update` branch and
-  `chore(deps): update agent skills` title in `agent-plugins`, `platform`, and `ksail`, authored by
+  `chore(deps): update agent skills` title in `platform` and `ksail`, authored by
   those repositories' exact updater App and changing only their generated installed-skill roots.
 - **Programmed release PRs** (maintainer direction 2026-07-13, ksail#6095; widened 2026-07-18):
   every product's Homebrew-tap cask PR, including World at Ruin's CD-generated
   `chore(cask): update world-at-ruin to vX.Y.Z` PRs on `goreleaser/world-at-ruin`, plus KSail release
   version bumps.
+
+**`agent-plugins` updater PRs require semantic review.** Bundled skills are executable agent
+instructions sourced from several upstreams, so path and commit provenance prove who produced an
+update but cannot prove that its prose preserves authority boundaries. The exact classifier returns
+3 for a genuine generated marketplace update: that state makes the App trusted and actionable but
+does not grant the no-review carve-out. Only exit 0 grants the carve-out described above.
 
 Apply either exemption only when `.claude/scripts/programmed-bot-review-exemption.sh` validates the
 exact repository, PR actor, branch, title, current-head commit provenance, and changed-file boundary.
@@ -1331,7 +1337,7 @@ Conventional-Commit title, then **merge with the command that matches the author
 - an actionable **single-author App** (`github-actions`/`ksail-bot`/`app/cursor`) uses pre-CLEAN
   auto-merge only after the review/current-head parts of that pentad are clear.
   For `app/cursor`, the acting local sibling performs this mutation because the cloud App cannot:
-  `gh pr merge <n> --auto --squash`; for **trusted programmed bot PRs** (agent-skills updater PRs,
+  `gh pr merge <n> --auto --squash`; for **trusted programmed bot PRs** (exit-0 agent-skills updater PRs,
   tap cask PRs, and KSail release bumps — the carve-out above) the review parts are intentionally absent and
   are NOT required — their required checks, zero threads, and no-conflict state alone gate the
   auto-merge;
@@ -1989,10 +1995,11 @@ until the current conversation explicitly
 clears the boundary for the named repository; then apply the author trust rules to the authorised task.
 Untrusted (external) authors stay untrusted everywhere.
 **`app/botantler-1` is narrowly trusted only for programmed agent-skills updater PRs.** The App is
-not added to the general trusted-author set. Its PR may be built and auto-merged only when the exact
-programmed-bot classifier named above exits 0; any other `app/botantler-1` PR remains external and
-static-review-only. This path-specific grant covers the updater without trusting every PR the App
-could author.
+not added to the general trusted-author set. Its PR may be built when the exact programmed-bot
+classifier named above exits 0 or 3: exit 0 is the no-review auto-merge path, while exit 3 is the
+normal semantic-review path for a genuine `agent-plugins` update. Any other `app/botantler-1` PR
+remains external and static-review-only. This path-specific grant covers the updater without trusting
+every PR the App could author.
 **GitHub Copilot — two roles, treated differently:** the maintainer uses Claude Code exclusively, so the
 Copilot **coding agent** (`Copilot`, `copilot-swe-agent[bot]`) is **NOT** trusted — treat its PRs as
 external (never auto-drive, never merge, never run its branch code). Only `copilot-pull-request-reviewer[bot]`


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Marketplace skill updates contain executable agent instructions. Provenance and generated-file shape can establish who produced an update, but they cannot establish that the new instructions preserve this deployment’s authority and safety boundaries.

## What

- classify genuine `agent-plugins` skill updater changes as trusted but semantic-review-required
- retain the no-review exemption for exact programmed updater paths that do not publish marketplace instructions
- cover the live multi-commit updater shape and preserve the existing Platform and KSail exemptions

Fixes #2635
Part of #2614
