### PR TITLE
fix(telemetry): mask private keys against a written PEM spec

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -553,8 +553,18 @@ END {
     L[i] = out s
   }
   # Pass B — resolve each line-crossing block by looking for its closing marker.
+  # 🔴 U[] is CLEARED as lines are consumed, and that is load-bearing. A masked
+  # line no longer holds the BEGIN that flagged it, so re-processing it starts a
+  # SECOND search from inside a region that is already handled — and because the
+  # closing marker it would have paired with has itself just been replaced, that
+  # search finds nothing and falls into the unterminated branch, running away
+  # for a full horizon of lines that were never key material.
+  #
+  # Reached by an entirely ordinary input: two BEGINs before one END. Measured
+  # on the un-cleared form — `BEGIN / BEGIN / body / END` followed by six plain
+  # report lines destroyed all six.
   for (i = 1; i <= n; i++) {
-    if (!(i in U)) continue
+    if (!U[i]) continue
     # 🔴 THE SEARCH IS UNBOUNDED, AND THAT IS THE FIX. It used to stop at the
     # same HORIZON the masking uses, which made the classification a GUESS: a
     # COMPLETE key whose END sat beyond the lookahead was misread as
@@ -598,10 +608,11 @@ END {
       # mid-key. 256 lines of base64 is ~16 KB of DER, comfortably past an
       # RSA-16384 key (~170 body lines), so no realistic truncated key reaches
       # the edge. It exists so a stray marker cannot consume the stream.
-      for (j = i + 1; j <= n && (j - i) <= HORIZON; j++) L[j] = mask_line(L[j])
+      for (j = i + 1; j <= n && (j - i) <= HORIZON; j++) { L[j] = mask_line(L[j]); U[j] = 0 }
       continue
     }
-    for (j = i + 1; j < close_at; j++) L[j] = mask_line(L[j])
+    for (j = i + 1; j < close_at; j++) { L[j] = mask_line(L[j]); U[j] = 0 }
+    U[close_at] = 0
     s = L[close_at]
     if (match(s, /-----END [A-Z ]*PRIVATE KEY-----/)) {
       # Everything up to and including the END marker is key material; only the

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -499,7 +499,7 @@ emit_credential_hits() {
 # this must handle, and where each is answered:
 #
 #   1. TERMINATED block of ARBITRARY length  → pass B, closing search unbounded
-#   2. UNTERMINATED block                    → pass B, masked to HORIZON
+#   2. UNTERMINATED block                    → pass B, masked to end of input
 #   3. RFC 1421 `Proc-Type:`/`DEK-Info:` headers and their blank separator
 #                                            → no content test exists to stop on
 #   4. Short final base64 line               → likewise
@@ -511,7 +511,7 @@ emit_credential_hits() {
 # lines inside a window we control. So no branch here asks what a line looks
 # like. Narrow classification is right for a parser and wrong for a redactor.
 AWK_KEY_REDACT='
-BEGIN { PH = "<redacted-key-material>"; HORIZON = 256 }
+BEGIN { PH = "<redacted-key-material>" }
 # Mask a line WITHOUT destroying its structure. Callers tag rows as
 # `D<TAB>tool<TAB>message`, and this filter runs over that tagged stream as well
 # as over the final report — so replacing a whole line does not merely redact
@@ -591,12 +591,12 @@ END {
   # report lines destroyed all six.
   for (i = 1; i <= n; i++) {
     if (!U[i]) continue
-    # 🔴 THE SEARCH IS UNBOUNDED, AND THAT IS THE FIX. It used to stop at the
-    # same HORIZON the masking uses, which made the classification a GUESS: a
-    # COMPLETE key whose END sat beyond the lookahead was misread as
-    # unterminated and masked only to the horizon, so its tail was emitted
-    # verbatim. Measured on the bounded form with HORIZON=64: 36 body lines of a
-    # 100-line RSA-8192 key survived into the output.
+    # 🔴 THE SEARCH IS UNBOUNDED, AND THAT IS THE FIX. It used to stop at a
+    # fixed lookahead, which made the classification a GUESS: a COMPLETE key
+    # whose END sat beyond it was misread as unterminated and masked only that
+    # far, so its tail was emitted verbatim. Measured on the bounded form with
+    # a 64-line lookahead: 36 body lines of a 100-line RSA-8192 key survived
+    # into the output.
     #
     # A bounded lookahead cannot answer an unbounded question. Scanning to end
     # of input makes the terminated/unterminated split EXACT, which is what
@@ -615,7 +615,7 @@ END {
       if (L[j] ~ /-----END [A-Z ]*PRIVATE KEY-----/) { close_at = j; break }
     }
     if (close_at == 0) {
-      # UNTERMINATED block: mask every following line to HORIZON, with NO
+      # UNTERMINATED block: mask every following line to end of input, with NO
       # content test whatsoever. Stopping early on an explicit END is the
       # terminated branch above; there is no other stop condition, by design.
       #
@@ -629,12 +629,28 @@ END {
       # escaped even in the clean case. This asks nothing about what a line
       # looks like, which is what makes it closed rather than merely wider.
       #
-      # HORIZON is 256 lines. It bounds ONLY this branch — a key with no
-      # closing marker anywhere in the stream, i.e. a transcript truncated
-      # mid-key. 256 lines of base64 is ~16 KB of DER, comfortably past an
-      # RSA-16384 key (~170 body lines), so no realistic truncated key reaches
-      # the edge. It exists so a stray marker cannot consume the stream.
-      for (j = i + 1; j <= n && (j - i) <= HORIZON; j++) { L[j] = mask_line(L[j]); U[j] = 0 }
+      # 🔴 THE MASKING IS UNBOUNDED, and that bound is where the LAST leak was.
+      # It used to stop at a 256-line HORIZON, justified as "no realistic
+      # truncated key is that long" and "a stray marker must not consume the
+      # stream". The first half is the same length guess the closing search
+      # above already had to abandon: PEM imposes no payload ceiling, so an
+      # unterminated key longer than the bound emitted its tail verbatim.
+      # Measured on the bounded form: a 300-line unterminated body left 44
+      # survivors, the first at body line 257 — 300 - 256, exactly.
+      #
+      # The second half is real but is the WRONG SIDE OF THE ASYMMETRY. A stray
+      # BEGIN with no END anywhere and a transcript truncated mid-key are the
+      # same input — this branch asks nothing about content, deliberately, so
+      # nothing here can tell them apart. Bounding it therefore does not
+      # separate the two cases; it just picks disclosure over over-masking for
+      # every input past the bound.
+      #
+      # Accepting the runaway costs message text, not evidence: mask_line()
+      # preserves each row tag, so the records stay parsed and counted. That is
+      # the identical trade the unbounded closing search above already makes,
+      # for the identical reason — and it is what makes shape 2 exact, as the
+      # shape-1 fix made shape 1 exact.
+      for (j = i + 1; j <= n; j++) { L[j] = mask_line(L[j]); U[j] = 0 }
       continue
     }
     # ⚠️ The INTERMEDIATE lines are cleared, the CLOSING line is NOT, and the

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -548,17 +548,21 @@ END {
     while (match(s, /-----BEGIN [A-Z ]*PRIVATE KEY-----/)) {
       bs = RSTART; bl = RLENGTH
       head = substr(s, 1, bs - 1)
-      tail = substr(s, bs + bl)
+      # `scan`, deliberately NOT `tail`: pass B owns a global of that name. It
+      # assigns before every use today, so sharing it is not a live defect —
+      # but a value from pass A surviving into pass B is the same class as the
+      # U[] flag below, and this program has paid for that class enough times.
+      scan = substr(s, bs + bl)
       depth = 1; closed = 0
-      while (depth > 0 && match(tail, /-----(BEGIN|END) [A-Z ]*PRIVATE KEY-----/)) {
-        mark = substr(tail, RSTART, RLENGTH)
-        tail = substr(tail, RSTART + RLENGTH)
+      while (depth > 0 && match(scan, /-----(BEGIN|END) [A-Z ]*PRIVATE KEY-----/)) {
+        mark = substr(scan, RSTART, RLENGTH)
+        scan = substr(scan, RSTART + RLENGTH)
         if (mark ~ /^-----BEGIN/) depth++
         else if (--depth == 0) closed = 1
       }
       out = out head PH
       if (closed) {
-        s = tail
+        s = scan
       } else {
         # Unpaired BEGIN: the remainder of this line is key material. Whether
         # the key CONTINUES past this line is decided in pass B.

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -608,8 +608,16 @@ END {
       } else {
         # Unpaired BEGIN: the remainder of this line is key material. Whether
         # the key CONTINUES past this line is decided in pass B.
+        #
+        # 🔴 U[] IS A COUNT, NOT A FLAG, and `depth` is already that count: the
+        # walk above exits with 1 + openers - closers still outstanding on this
+        # line. Storing a boolean collapsed `BEGIN BEGIN` on one physical line
+        # into a single opener, so the pass-B depth walk closed the block at the
+        # FIRST later END instead of the second — and everything after that END
+        # printed verbatim. It is the same nearest-closer defect as 5c/5d,
+        # reached through pass A folding two openers into one line.
         s = ""
-        U[i] = 1
+        U[i] = depth
         break
       }
     }
@@ -670,7 +678,11 @@ END {
     # replacing it. `bdepth`/`bscan`/`bdrop` are named apart from the pass-A
     # `depth`/`scan` on purpose: a value leaking between passes is the same
     # class as the U[] flag below, and this program has paid for it enough.
-    close_at = 0; close_end = 0; bdepth = 1
+    # `bdepth` seeds from U[i] rather than 1, and accumulates U[j] rather than
+    # incrementing, because U[] counts openers — see pass A. A line can carry
+    # more than one, and treating it as a flag under-counts the depth by exactly
+    # the number pass A folded away.
+    close_at = 0; close_end = 0; bdepth = U[i]
     for (j = i + 1; j <= n && close_at == 0; j++) {
       bscan = L[j]; bdrop = 0
       while (match(bscan, /-----END [A-Z ]*PRIVATE KEY-----/)) {
@@ -683,7 +695,7 @@ END {
         bscan = substr(bscan, RSTART + RLENGTH)
         if (--bdepth == 0) { close_at = j; close_end = bdrop; break }
       }
-      if (close_at == 0 && U[j]) bdepth++
+      if (close_at == 0) bdepth += U[j]
     }
     if (close_at == 0) {
       # UNTERMINATED block: mask every following line to end of input, with NO

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -488,18 +488,160 @@ emit_credential_hits() {
       done
 }
 
+# ── PRIVATE-KEY MASKING — the one filter here that can destroy records ────────
+#
+# Written against a SPECIFICATION (RFC 7468 textual encodings, RFC 1421
+# encapsulated headers) rather than against the last review finding. The prior
+# implementations were each induced from whichever PEM shape a reviewer had just
+# produced, and every round produced one the previous fix had not enumerated —
+# greedy pairing, the unterminated case, a bounded closing search, RFC 1421
+# separators, and finally a complete key longer than the lookahead. The shapes
+# this must handle, and where each is answered:
+#
+#   1. TERMINATED block of ARBITRARY length  → pass B, closing search unbounded
+#   2. UNTERMINATED block                    → pass B, masked to HORIZON
+#   3. RFC 1421 `Proc-Type:`/`DEK-Info:` headers and their blank separator
+#                                            → no content test exists to stop on
+#   4. Short final base64 line               → likewise
+#   5. Several markers on ONE physical line  → pass A, match()/substr walk
+#   6. Stray unpaired BEGIN or END           → pass A / the marker sed below
+#   7. Both stream shapes (tagged rows, report) → mask_line() keeps the row tag
+#
+# 🔑 THE GOVERNING ASYMMETRY: a miss DISCLOSES A KEY, an over-mask costs report
+# lines inside a window we control. So no branch here asks what a line looks
+# like. Narrow classification is right for a parser and wrong for a redactor.
+AWK_KEY_REDACT='
+BEGIN { PH = "<redacted-key-material>"; HORIZON = 256 }
+# Mask a line WITHOUT destroying its structure. Callers tag rows as
+# `D<TAB>tool<TAB>message`, and this filter runs over that tagged stream as well
+# as over the final report — so replacing a whole line does not merely redact
+# it, it deletes the record and drops the error from the count. Measured on the
+# sed range this replaces: 4 errors -> 1.
+#
+# Preserving the tool field leaks nothing — it is a tool name, never payload —
+# and it is what makes an over-mask cost MESSAGE TEXT rather than EVIDENCE.
+function mask_line(s) {
+  if (s == "U") return s
+  if (match(s, /^D\t[^\t]*\t/)) return substr(s, 1, RLENGTH) PH
+  return PH
+}
+{ L[NR] = $0 }
+END {
+  n = NR
+  # Pass A — collapse every span COMPLETE ON ONE LINE, pairing each BEGIN with
+  # the NEAREST END. match()/substr, never a quantifier: a regex is
+  # leftmost-longest, so `.*` between the markers runs to the LAST END and
+  # strands a lone BEGIN, whose residual marker then re-opens the range.
+  for (i = 1; i <= n; i++) {
+    s = L[i]; out = ""
+    while (match(s, /-----BEGIN [A-Z ]*PRIVATE KEY-----/)) {
+      bs = RSTART; bl = RLENGTH
+      head = substr(s, 1, bs - 1)
+      rest = substr(s, bs + bl)
+      if (match(rest, /-----END [A-Z ]*PRIVATE KEY-----/)) {
+        out = out head PH
+        s = substr(rest, RSTART + RLENGTH)
+      } else {
+        # Unpaired BEGIN: the remainder of this line is key material. Whether
+        # the key CONTINUES past this line is decided in pass B.
+        out = out head PH
+        s = ""
+        U[i] = 1
+        break
+      }
+    }
+    L[i] = out s
+  }
+  # Pass B — resolve each line-crossing block by looking for its closing marker.
+  for (i = 1; i <= n; i++) {
+    if (!(i in U)) continue
+    # 🔴 THE SEARCH IS UNBOUNDED, AND THAT IS THE FIX. It used to stop at the
+    # same HORIZON the masking uses, which made the classification a GUESS: a
+    # COMPLETE key whose END sat beyond the lookahead was misread as
+    # unterminated and masked only to the horizon, so its tail was emitted
+    # verbatim. Measured on the bounded form with HORIZON=64: 36 body lines of a
+    # 100-line RSA-8192 key survived into the output.
+    #
+    # A bounded lookahead cannot answer an unbounded question. Scanning to end
+    # of input makes the terminated/unterminated split EXACT, which is what
+    # spec shape 1 requires — no fixed bound may apply to a real key block,
+    # because there is no length at which a PEM stops being a PEM.
+    #
+    # The cost is a stray BEGIN pairing with an unrelated END far later, which
+    # over-masks the lines between. That is deliberately accepted rather than
+    # bounded, for two reasons. First, bounding it is exactly the guess that
+    # leaked. Second, mask_line() above makes the over-mask NON-DESTRUCTIVE on
+    # the tagged stream — every record keeps its tag and stays counted, and only
+    # its message text is replaced. The earlier "200 records eaten" measurement
+    # predates that tag preservation; re-measured, the records survive.
+    close_at = 0
+    for (j = i + 1; j <= n; j++) {
+      if (L[j] ~ /-----END [A-Z ]*PRIVATE KEY-----/) { close_at = j; break }
+    }
+    if (close_at == 0) {
+      # UNTERMINATED block: mask every following line to HORIZON, with NO
+      # content test whatsoever. Stopping early on an explicit END is the
+      # terminated branch above; there is no other stop condition, by design.
+      #
+      # ⚠️ THE DEFAULT IS INVERTED ON PURPOSE, and the earlier version is a
+      # cautionary tale. This loop used to mask only lines that "plausibly
+      # continue key material" — a long unbroken base64 run — and that
+      # classifier leaked twice: an RFC 1421 ENCRYPTED PEM puts
+      # `Proc-Type:`/`DEK-Info:` headers and a BLANK separator between BEGIN
+      # and the body, so the loop stopped on line 1 and emitted the whole key;
+      # and a PEM final line is frequently shorter than the length floor, so it
+      # escaped even in the clean case. This asks nothing about what a line
+      # looks like, which is what makes it closed rather than merely wider.
+      #
+      # HORIZON is 256 lines. It bounds ONLY this branch — a key with no
+      # closing marker anywhere in the stream, i.e. a transcript truncated
+      # mid-key. 256 lines of base64 is ~16 KB of DER, comfortably past an
+      # RSA-16384 key (~170 body lines), so no realistic truncated key reaches
+      # the edge. It exists so a stray marker cannot consume the stream.
+      for (j = i + 1; j <= n && (j - i) <= HORIZON; j++) L[j] = mask_line(L[j])
+      continue
+    }
+    for (j = i + 1; j < close_at; j++) L[j] = mask_line(L[j])
+    s = L[close_at]
+    if (match(s, /-----END [A-Z ]*PRIVATE KEY-----/)) {
+      # Everything up to and including the END marker is key material; only the
+      # text after it survives. Capture that tail BEFORE the second match(),
+      # which resets RSTART/RLENGTH.
+      tail = substr(s, RSTART + RLENGTH)
+      # 🔴 The CLOSING line needs the same tag preservation every other masked
+      # line gets. It is the one branch that does not route through
+      # mask_line(), and it was blanking the row tag — so the record stopped
+      # parsing and dropped out of the count, which is precisely the defect
+      # mask_line() exists to prevent, surviving in the path it did not cover.
+      # Measured on a 202-row stray span: 201 of 202 rows kept their tag.
+      # (Same class as the bounded-search defect above: when a guard is added,
+      # check every OTHER path that walks the same structure.)
+      if (match(s, /^D\t[^\t]*\t/)) L[close_at] = substr(s, 1, RLENGTH) PH tail
+      else                          L[close_at] = PH tail
+    }
+  }
+  for (i = 1; i <= n; i++) print L[i]
+}
+'
+
 # Redact credential-shaped strings from ANYTHING this script prints.
 # Every emitted line originates in a transcript, and a failed tool result can
 # carry a token in its error text — so redaction lives at the output boundary
 # rather than in each detector, where one forgotten call-site leaks.
 redact() {
-  # A multi-line key block is masked with a sed RANGE (BEGIN..END), which is
-  # stateful across lines. The obvious alternative — masking any line that looks
-  # like base64 — over-redacts badly: tried against the real corpus it collapsed
-  # 30 distinct guard-denial entries into one unreadable bucket. Destroying real
-  # signal to catch a rare shape is a bad trade, and a redactor that eats the
-  # report is its own kind of failure.
-  sed -E '/-----BEGIN [A-Z ]*PRIVATE KEY-----/,/-----END [A-Z ]*PRIVATE KEY-----/ s/^.*$/<redacted-key-material>/' \
+  # Private-key material is masked by the bounded two-pass walk above, never by
+  # a sed RANGE. A sed range looks for its end address only on a LATER line, so
+  # a key pasted into ONE error message opened a range that never closed and
+  # rewrote every following line to EOF — measured, 4 in-window errors read as
+  # 1. Replacing the WHOLE line then still deleted the record it redacted
+  # (4 -> 3), because callers put structure on these lines. Only the key SPAN
+  # may be replaced. Both sed forms are why the walk exists; do not bring
+  # either back.
+  #
+  # The marker sed rules that follow are NOT dead: pass A leaves a stray
+  # unpaired END untouched (it scans for a BEGIN first), and rule 2 below is
+  # what masks it.
+  awk "$AWK_KEY_REDACT" \
   | sed -E \
     -e 's/(github_pat_[A-Za-z0-9_]{6})[A-Za-z0-9_]+/\1…<redacted>/g' \
     -e 's/(gh[pousr]_[A-Za-z0-9]{4})[A-Za-z0-9]+/\1…<redacted>/g' \

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -504,8 +504,10 @@ emit_credential_hits() {
 #                                            → no content test exists to stop on
 #   4. Short final base64 line               → likewise
 #   5. Several markers on ONE physical line  → pass A, match()/substr walk
+#   5c. NESTED markers ACROSS lines          → pass B, depth over U[] and END
 #   6. Stray unpaired BEGIN or END           → pass A / the marker sed below
 #   7. Both stream shapes (tagged rows, report) → mask_line() keeps the row tag
+#   8. Key material in a tagged row TOOL field  → mask_line() masks it too
 #
 # 🔑 THE GOVERNING ASYMMETRY: a miss DISCLOSES A KEY, an over-mask costs report
 # lines inside a window we control. So no branch here asks what a line looks
@@ -528,8 +530,27 @@ BEGIN { PH = "<redacted-key-material>"; TAB = sprintf("%c", 9); TAG_RE = "^D" TA
 # it, it deletes the record and drops the error from the count. Measured on the
 # sed range this replaces: 4 errors -> 1.
 #
-# Preserving the tool field leaks nothing — it is a tool name, never payload —
-# and it is what makes an over-mask cost MESSAGE TEXT rather than EVIDENCE.
+# 🔴 THE TOOL FIELD IS MASKED TOO, and the earlier claim that it need not be is
+# the one this file paid for. It read "preserving the tool field leaks nothing —
+# it is a tool name, never payload", and that is an assumption about well-formed
+# input asserted inside the one function whose governing rule is to assume
+# nothing about content. It is false: the reliability stream builds that field
+# from `$t.name` straight out of the transcript (see the `D\t` emitter below),
+# with no sanitisation on the way, so `BEGIN / D<TAB><key body><TAB>msg / END`
+# emitted the key body verbatim while dutifully masking the message beside it.
+#
+# What survives is the STRUCTURE only: the `D` tag and both separators. That is
+# all the count needs — the consumer selects on `^D<TAB>` and splits on tabs, so
+# a three-field row still parses and is still counted. The over-mask therefore
+# costs MESSAGE TEXT and TOOL ATTRIBUTION, never a RECORD, and it loses the tool
+# name only on a row whose tool name is already key material.
+#
+# ⚠️ Deliberately NOT a content test on the field. A whitelist of "safe-looking"
+# tool names is not the harmless direction it appears to be: base64 draws from
+# `A-Za-z0-9+/=`, so a key chunk containing none of `+/=` — an ordinary
+# occurrence, not a contrived one — matches any plausible identifier pattern and
+# would be preserved. A test that only ever masks MORE is admissible here; this
+# one would mask less on exactly the input that matters, so it is not that.
 function mask_line(s) {
   # `U` is the UNDATED sentinel: an errored tool result carrying no usable
   # RFC 3339 timestamp is emitted as a bare `U` so it can be counted and
@@ -537,7 +558,7 @@ function mask_line(s) {
   # to redact and nothing to preserve — return it whole. Masking it to PH would
   # destroy the very marker the undated count is derived from.
   if (s == "U") return s
-  if (match(s, TAG_RE)) return substr(s, 1, RLENGTH) PH
+  if (match(s, TAG_RE)) return "D" TAB PH TAB PH
   return PH
 }
 # ⚠️ ACCEPTED MEMORY BOUND. This buffers every emitted line to EOF — the same
@@ -626,9 +647,43 @@ END {
     # the tagged stream — every record keeps its tag and stays counted, and only
     # its message text is replaced. The earlier "200 records eaten" measurement
     # predates that tag preservation; re-measured, the records survive.
-    close_at = 0
-    for (j = i + 1; j <= n; j++) {
-      if (L[j] ~ /-----END [A-Z ]*PRIVATE KEY-----/) { close_at = j; break }
+    #
+    # 🔴 AND IT TRACKS DEPTH, for the same reason pass A does — one dimension
+    # up. Pass A has already consumed every BEGIN marker, so nesting is no
+    # longer visible in the TEXT here; it survives only as U[], the flag marking
+    # a line that ended with an unclosed opener. So the walk reads U[j] as an
+    # opener and each residual END marker as a closer, and closes at depth 0.
+    #
+    # The order within a line is fixed rather than chosen: pass A keeps `head`,
+    # the text BEFORE the unpaired BEGIN, so any END left on a flagged line
+    # necessarily precedes that opener. Closers first, then the opener.
+    #
+    # Without it, `BEGIN1 / body / BEGIN2 / END2 / SECRET / END1` closed the
+    # outer block at END2, cleared U[] for the line of BEGIN2 as a consumed
+    # line, and so never resolved the block of BEGIN2 — SECRET printed
+    # verbatim. The pass-A
+    # same-line nesting fix does not constrain this at all, which is the whole
+    # lesson: fixing one shape of a defect is not fixing the defect.
+    #
+    # It must not RE-BOUND the scan — shape 1 needs it unbounded — so the depth
+    # counter rides along with the existing walk to end of input rather than
+    # replacing it. `bdepth`/`bscan`/`bdrop` are named apart from the pass-A
+    # `depth`/`scan` on purpose: a value leaking between passes is the same
+    # class as the U[] flag below, and this program has paid for it enough.
+    close_at = 0; close_end = 0; bdepth = 1
+    for (j = i + 1; j <= n && close_at == 0; j++) {
+      bscan = L[j]; bdrop = 0
+      while (match(bscan, /-----END [A-Z ]*PRIVATE KEY-----/)) {
+        # Absolute end offset of this marker in L[j], accumulated as `bscan` is
+        # consumed. The closing line is masked UP TO the marker that actually
+        # balanced the depth, not the first one on the line — closing at the
+        # first would mask LESS than the nesting requires, which is the wrong
+        # side of the governing asymmetry.
+        bdrop += RSTART + RLENGTH - 1
+        bscan = substr(bscan, RSTART + RLENGTH)
+        if (--bdepth == 0) { close_at = j; close_end = bdrop; break }
+      }
+      if (close_at == 0 && U[j]) bdepth++
     }
     if (close_at == 0) {
       # UNTERMINATED block: mask every following line to end of input, with NO
@@ -682,22 +737,22 @@ END {
     # before the BEGIN — and `head` still contains the earlier END.)
     for (j = i + 1; j < close_at; j++) { L[j] = mask_line(L[j]); U[j] = 0 }
     s = L[close_at]
-    if (match(s, /-----END [A-Z ]*PRIVATE KEY-----/)) {
-      # Everything up to and including the END marker is key material; only the
-      # text after it survives. Capture that tail BEFORE the second match(),
-      # which resets RSTART/RLENGTH.
-      tail = substr(s, RSTART + RLENGTH)
-      # 🔴 The CLOSING line needs the same tag preservation every other masked
-      # line gets. It is the one branch that does not route through
-      # mask_line(), and it was blanking the row tag — so the record stopped
-      # parsing and dropped out of the count, which is precisely the defect
-      # mask_line() exists to prevent, surviving in the path it did not cover.
-      # Measured on a 202-row stray span: 201 of 202 rows kept their tag.
-      # (Same class as the bounded-search defect above: when a guard is added,
-      # check every OTHER path that walks the same structure.)
-      if (match(s, TAG_RE)) L[close_at] = substr(s, 1, RLENGTH) PH tail
-      else                          L[close_at] = PH tail
-    }
+    # Everything up to and including the BALANCING END marker is key material;
+    # only the text after it survives. `close_end` is the offset of that marker,
+    # computed by the depth walk above — re-matching here would find the FIRST
+    # END on the line, which under nesting is not the one that closed us.
+    tail = substr(s, close_end + 1)
+    # 🔴 The CLOSING line needs the same structural preservation every other
+    # masked line gets. It is the one branch that does not route through
+    # mask_line(), and it was blanking the row tag — so the record stopped
+    # parsing and dropped out of the count, which is precisely the defect
+    # mask_line() exists to prevent, surviving in the path it did not cover.
+    # Measured on a 202-row stray span: 201 of 202 rows kept their tag.
+    # (Same class as the bounded-search defect above: when a guard is added,
+    # check every OTHER path that walks the same structure — which is also why
+    # the tool field is masked here exactly as mask_line() now masks it.)
+    if (match(s, TAG_RE)) L[close_at] = "D" TAB PH TAB PH tail
+    else                  L[close_at] = PH tail
   }
   for (i = 1; i <= n; i++) print L[i]
 }

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -511,7 +511,17 @@ emit_credential_hits() {
 # lines inside a window we control. So no branch here asks what a line looks
 # like. Narrow classification is right for a parser and wrong for a redactor.
 AWK_KEY_REDACT='
-BEGIN { PH = "<redacted-key-material>" }
+# TAG_RE matches the `D<TAB>tool<TAB>` row prefix. It is built from an explicit
+# tab CHARACTER rather than written as the literal /^D\t[^\t]*\t/, because POSIX
+# does not define `\t` INSIDE A BRACKET EXPRESSION. Every awk this runs on today
+# honours it — measured on one-true-awk 20200816 (macOS CI) and on the Linux CI
+# leg, where a `t`-containing tool name like `TodoWrite` matches identically
+# either way — so this is hardening against unspecified behaviour, not a live
+# defect. It is worth doing anyway because the failure mode is SILENT: an awk
+# reading `[^\t]` as "not backslash and not t" would drop the tag from exactly
+# the rows mask_line() exists to keep countable, and a dropped record looks like
+# a clean run rather than an error.
+BEGIN { PH = "<redacted-key-material>"; TAB = sprintf("%c", 9); TAG_RE = "^D" TAB "[^" TAB "]*" TAB }
 # Mask a line WITHOUT destroying its structure. Callers tag rows as
 # `D<TAB>tool<TAB>message`, and this filter runs over that tagged stream as well
 # as over the final report — so replacing a whole line does not merely redact
@@ -527,9 +537,15 @@ function mask_line(s) {
   # to redact and nothing to preserve — return it whole. Masking it to PH would
   # destroy the very marker the undated count is derived from.
   if (s == "U") return s
-  if (match(s, /^D\t[^\t]*\t/)) return substr(s, 1, RLENGTH) PH
+  if (match(s, TAG_RE)) return substr(s, 1, RLENGTH) PH
   return PH
 }
+# ⚠️ ACCEPTED MEMORY BOUND. This buffers every emitted line to EOF — the same
+# trade the private-key spans force, since a block cannot be classified as
+# terminated until its closing marker is found (or proven absent), and that
+# answer is deliberately unbounded above. `MAX_FILES` bounds the report, but a
+# wide window can push hundreds of thousands of tagged rows through here, so the
+# footprint scales with the SELECTED WINDOW, not with the report size.
 { L[NR] = $0 }
 END {
   n = NR
@@ -679,7 +695,7 @@ END {
       # Measured on a 202-row stray span: 201 of 202 rows kept their tag.
       # (Same class as the bounded-search defect above: when a guard is added,
       # check every OTHER path that walks the same structure.)
-      if (match(s, /^D\t[^\t]*\t/)) L[close_at] = substr(s, 1, RLENGTH) PH tail
+      if (match(s, TAG_RE)) L[close_at] = substr(s, 1, RLENGTH) PH tail
       else                          L[close_at] = PH tail
     }
   }

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -611,8 +611,18 @@ END {
       for (j = i + 1; j <= n && (j - i) <= HORIZON; j++) { L[j] = mask_line(L[j]); U[j] = 0 }
       continue
     }
+    # ⚠️ The INTERMEDIATE lines are cleared, the CLOSING line is NOT, and the
+    # asymmetry is the whole point. An intermediate line is replaced wholesale,
+    # so any opener it held is gone and its block is subsumed by this span. The
+    # closing line is only masked UP TO its END marker — a BEGIN sitting AFTER
+    # that marker on the same physical line opens a block that continues past
+    # it and is still unresolved. Clearing the flag there skipped that block
+    # entirely and printed its body verbatim from the next line on.
+    #
+    # (Reported as a 🔴 leak on the first review round of this PR. The
+    # ordering is produced by pass A itself, which keeps `head` — the text
+    # before the BEGIN — and `head` still contains the earlier END.)
     for (j = i + 1; j < close_at; j++) { L[j] = mask_line(L[j]); U[j] = 0 }
-    U[close_at] = 0
     s = L[close_at]
     if (match(s, /-----END [A-Z ]*PRIVATE KEY-----/)) {
       # Everything up to and including the END marker is key material; only the

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -528,23 +528,40 @@ function mask_line(s) {
 { L[NR] = $0 }
 END {
   n = NR
-  # Pass A — collapse every span COMPLETE ON ONE LINE, pairing each BEGIN with
-  # the NEAREST END. match()/substr, never a quantifier: a regex is
-  # leftmost-longest, so `.*` between the markers runs to the LAST END and
-  # strands a lone BEGIN, whose residual marker then re-opens the range.
+  # Pass A — collapse every span COMPLETE ON ONE LINE, closing each BEGIN at the
+  # END that returns nesting DEPTH to zero. match()/substr, never a quantifier:
+  # a regex is leftmost-longest, so `.*` between the markers runs to the LAST END
+  # and strands a lone BEGIN, whose residual marker then re-opens the range.
+  #
+  # 🔴 DEPTH, not the NEAREST END. Pairing with the nearest closer leaked on
+  # `BEGIN1 … BEGIN2 … END2 SECRET END1`: the span ended at END2, so `SECRET
+  # END1` survived pass A, and the stray-marker sed downstream masks only the
+  # marker — the key material beside it reached the output. An ordinary
+  # single-span line masks fully at the same head, which is why a suite without
+  # this shape stays green (shape 5 alone did not constrain it).
+  #
+  # Walking BOTH markers and closing at depth 0 also makes the two-openers-
+  # one-closer case fall to the unterminated branch, where pass B resolves it —
+  # over-masking, which is the direction the governing asymmetry above demands.
   for (i = 1; i <= n; i++) {
     s = L[i]; out = ""
     while (match(s, /-----BEGIN [A-Z ]*PRIVATE KEY-----/)) {
       bs = RSTART; bl = RLENGTH
       head = substr(s, 1, bs - 1)
-      rest = substr(s, bs + bl)
-      if (match(rest, /-----END [A-Z ]*PRIVATE KEY-----/)) {
-        out = out head PH
-        s = substr(rest, RSTART + RLENGTH)
+      tail = substr(s, bs + bl)
+      depth = 1; closed = 0
+      while (depth > 0 && match(tail, /-----(BEGIN|END) [A-Z ]*PRIVATE KEY-----/)) {
+        mark = substr(tail, RSTART, RLENGTH)
+        tail = substr(tail, RSTART + RLENGTH)
+        if (mark ~ /^-----BEGIN/) depth++
+        else if (--depth == 0) closed = 1
+      }
+      out = out head PH
+      if (closed) {
+        s = tail
       } else {
         # Unpaired BEGIN: the remainder of this line is key material. Whether
         # the key CONTINUES past this line is decided in pass B.
-        out = out head PH
         s = ""
         U[i] = 1
         break

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -521,6 +521,11 @@ BEGIN { PH = "<redacted-key-material>"; HORIZON = 256 }
 # Preserving the tool field leaks nothing — it is a tool name, never payload —
 # and it is what makes an over-mask cost MESSAGE TEXT rather than EVIDENCE.
 function mask_line(s) {
+  # `U` is the UNDATED sentinel: an errored tool result carrying no usable
+  # RFC 3339 timestamp is emitted as a bare `U` so it can be counted and
+  # excluded. It holds no tool field and no message text, so there is nothing
+  # to redact and nothing to preserve — return it whole. Masking it to PH would
+  # destroy the very marker the undated count is derived from.
   if (s == "U") return s
   if (match(s, /^D\t[^\t]*\t/)) return substr(s, 1, RLENGTH) PH
   return PH

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -4057,7 +4057,7 @@ longunterm() {
 # horizon the masking uses, so a COMPLETE key longer than that bound was
 # misclassified as unterminated and masked only to the horizon — its tail was
 # emitted verbatim. A bounded lookahead cannot answer an unbounded question.
-OUT=$(longkey | awk "$(extract_awk)")
+OUT=$(longkey | awk "$AWK_PROG")
 nocheck "shape 1: a terminated key LONGER than the horizon is fully masked" "$OUT" "SECRETLINE"
 check   "shape 1: and the record after it survives"                         "$OUT" "AFTER-ROW"
 
@@ -4065,7 +4065,7 @@ check   "shape 1: and the record after it survives"                         "$OU
 # A truncated key is MORE likely in a transcript than a well-formed one,
 # because messages get cut. Requiring a closing marker before masking anything
 # emitted such a body verbatim — a P1 disclosure.
-OUT=$(printf 'timed out: %s\nMIIEvgSECRETBODYaaaa\nQEFAASCBKgSECRETTWO\n' "$RB" | awk "$(extract_awk)")
+OUT=$(printf 'timed out: %s\nMIIEvgSECRETBODYaaaa\nQEFAASCBKgSECRETTWO\n' "$RB" | awk "$AWK_PROG")
 nocheck "shape 2: an unterminated key body is masked"   "$OUT" "SECRETBODY"
 nocheck "shape 2: including its later body lines"       "$OUT" "SECRETTWO"
 
@@ -4074,27 +4074,27 @@ nocheck "shape 2: including its later body lines"       "$OUT" "SECRETTWO"
 # 300 body lines - 256 = 44 survivors, the first at body line 257. PEM imposes
 # no payload ceiling, so no fixed bound can apply to a real key block — the
 # same argument in both branches, now applied in both.
-OUT=$(longunterm | awk "$(extract_awk)")
+OUT=$(longunterm | awk "$AWK_PROG")
 nocheck "shape 2: an unterminated key LONGER than 256 lines is fully masked" "$OUT" "SECRETBODY"
 
 # ── SHAPE 3 — RFC 1421 encrypted-PEM headers and their BLANK separator ────────
 # `Proc-Type:`/`DEK-Info:` and an empty line sit between BEGIN and the body, so
 # any content-shaped continuation test stops dead on the first header line and
 # emits the whole key. Reproduced before the default was inverted.
-OUT=$(printf 'Blocked: %s\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,9A7B2C\n\nMIIEvgIBADANBgkqSECRETBODYxxxx\n' "$RB" | awk "$(extract_awk)")
+OUT=$(printf 'Blocked: %s\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,9A7B2C\n\nMIIEvgIBADANBgkqSECRETBODYxxxx\n' "$RB" | awk "$AWK_PROG")
 nocheck "shape 3: an ENCRYPTED PEM body is masked through its headers" "$OUT" "SECRETBODY"
 nocheck "shape 3: and the DEK-Info header itself does not survive"     "$OUT" "AES-128-CBC"
 
 # ── SHAPE 4 — short final base64 line ────────────────────────────────────────
 # A PEM's last line is frequently only a few characters, so a minimum-length
 # test drops it even when every other line matches.
-OUT=$(printf 'x %s\nMIIEvgIBADANBgkqSECRETONExx\nSHORTTAIL=\n' "$RB" | awk "$(extract_awk)")
+OUT=$(printf 'x %s\nMIIEvgIBADANBgkqSECRETONExx\nSHORTTAIL=\n' "$RB" | awk "$AWK_PROG")
 nocheck "shape 4: a short final PEM line is masked" "$OUT" "SHORTTAIL"
 
 # ── SHAPE 5 — several markers on ONE physical line ───────────────────────────
 # Messages are newline-collapsed before reaching the redactor, so a whole key —
 # or several — can arrive on a single line.
-OUT=$(printf 'a %s SECRETIN %s b %s SECRETTWO\n' "$RB" "$RE" "$RB" | awk "$(extract_awk)")
+OUT=$(printf 'a %s SECRETIN %s b %s SECRETTWO\n' "$RB" "$RE" "$RB" | awk "$AWK_PROG")
 nocheck "shape 5: every span on a shared line is masked" "$OUT" "SECRETIN"
 nocheck "shape 5: including the trailing unpaired one"   "$OUT" "SECRETTWO"
 
@@ -4108,14 +4108,14 @@ nocheck "shape 5: including the trailing unpaired one"   "$OUT" "SECRETTWO"
 # Shape 5 above does NOT constrain this — its markers are sequential, so the
 # nearest closer is also the correct one. The distinguishing input is nesting,
 # which is why the row is separate rather than folded into 5.
-OUT=$(printf 'a %s b %s c %s SECRETNEST %s\n' "$RB" "$RB" "$RE" "$RE" | awk "$(extract_awk)")
+OUT=$(printf 'a %s b %s c %s SECRETNEST %s\n' "$RB" "$RB" "$RE" "$RE" | awk "$AWK_PROG")
 nocheck "shape 5b: a nested span masks through the OUTERMOST closer" "$OUT" "SECRETNEST"
 
 # CONTROL, opposite direction — the fix must not degenerate into "mask to the
 # LAST END on the line", which would pass the row above while destroying every
 # record between two independent keys. Two complete spans must still close
 # individually, so the text between and after them survives.
-OUT=$(printf 'a %s S1 %s KEEPME %s S2 %s TAILKEEP\n' "$RB" "$RE" "$RB" "$RE" | awk "$(extract_awk)")
+OUT=$(printf 'a %s S1 %s KEEPME %s S2 %s TAILKEEP\n' "$RB" "$RE" "$RB" "$RE" | awk "$AWK_PROG")
 nocheck "shape 5b control: independent spans still mask their own bodies" "$OUT" "S1"
 check   "shape 5b control: text BETWEEN two spans survives"               "$OUT" "KEEPME"
 check   "shape 5b control: text AFTER the last span survives"             "$OUT" "TAILKEEP"
@@ -4136,7 +4136,7 @@ nestedfix() {
   printf '%s\n%s\nMIIEvgSECRETNESTED\n%s\n' "$RB" "$RB" "$RE"
   for i in $(seq 1 6); do printf 'SURVIVOR-%d\n' "$i"; done
 }
-OUT=$(nestedfix | awk "$(extract_awk)")
+OUT=$(nestedfix | awk "$AWK_PROG")
 nocheck "shape 6a: two openers before one closer still mask the body" "$OUT" "SECRETNESTED"
 check   "shape 6a: and do NOT eat the report after the key"           "$OUT" "SURVIVOR-6"
 check   "shape 6a: nor the line immediately after it"                 "$OUT" "SURVIVOR-1"
@@ -4160,7 +4160,7 @@ endbeginfix() {
   printf '%s\nMIIEvgSECRETONE\nclose %s then %s\n' "$RB" "$RE" "$RB"
   printf 'MIIEvgSECRETTWO\nMIIEvgSECRETTHREE\n'
 }
-OUT=$(endbeginfix | awk "$(extract_awk)")
+OUT=$(endbeginfix | awk "$AWK_PROG")
 nocheck "shape 6b: a block opening on a CLOSING line is still resolved" "$OUT" "SECRETTWO"
 nocheck "shape 6b: including its later body lines"                      "$OUT" "SECRETTHREE"
 nocheck "shape 6b: and the first block's body stays masked"             "$OUT" "SECRETONE"
@@ -4193,7 +4193,7 @@ nocheck "shape 6: but the marker itself is masked"            "$STRAY" "$PK_E"
 # stopped parsing and dropped out of the count: measured 201 of 202 rows kept.
 S7=$({ printf 'D\tBash\thead %s\n' "$RB"
        for i in $(seq 1 200); do printf 'D\tBash\tRECORD-%03d\n' "$i"; done
-       printf 'D\tBash\ttail %s SURVIVING-TAIL\n' "$RE"; } | awk "$(extract_awk)")
+       printf 'D\tBash\ttail %s SURVIVING-TAIL\n' "$RE"; } | awk "$AWK_PROG")
 S7_ROWS=$(printf '%s\n' "$S7" | grep -c '')
 S7_TAGS=$(printf '%s\n' "$S7" | grep -c "^D$(printf '\t')Bash$(printf '\t')")
 if [ "$S7_ROWS" = 202 ] && [ "$S7_TAGS" = 202 ]; then
@@ -4212,7 +4212,7 @@ check   "shape 7: and text after the closing marker survives"    "$S7" "SURVIVIN
 # Passing code here would put an eval in the one suite whose whole subject is a
 # filter over attacker-controlled text; a function name cannot grow into that.
 unit_ablate() { # $1=sed-expr $2=label $3=fixture-fn $4=needle $5=appear|vanish
-  local ab="$FIX/abl_$$.sh" changed out
+  local ab="$FIX/abl_$$.sh" changed out st
   cp "$TARGET" "$ab"
   sed -i.bak "$1" "$ab"; rm -f "$ab.bak"
   changed=$(diff "$TARGET" "$ab" | grep -c '^<')
@@ -4220,7 +4220,11 @@ unit_ablate() { # $1=sed-expr $2=label $3=fixture-fn $4=needle $5=appear|vanish
     bad "ablation: $2" "sed changed $changed lines, expected 1 — arm is mis-aimed"
     rm -f "$ab"; return
   fi
-  out=$("$3" | awk "$(extract_awk "$ab")" 2>/dev/null); local st=$?
+  # `st` is declared with the locals above and captured on its OWN line. Writing
+  # `local st=$?` here would be a declaration whose own exit status masks the
+  # pipeline's, and the status is what the mis-aimed-arm guard below depends on.
+  out=$("$3" | awk "$(extract_awk "$ab")" 2>/dev/null)
+  st=$?
   rm -f "$ab"
   # 🔴 A `vanish` arm passes whenever the ablated program produces NOTHING —
   # so a sed replacement that breaks the awk regex literal, or any other
@@ -4255,14 +4259,14 @@ closerowfix(){ printf 'D\tBash\thead %s\n' "$RB"; printf 'D\tBash\ttail %s z\n' 
 # recorded here rather than left in a comment. A stray BEGIN with no END now
 # over-masks to end of input — the SAME input as a truncated key, which is why
 # no bound could have separated them.
-OUT=$(strayfix | awk "$(extract_awk)")
+OUT=$(strayfix | awk "$AWK_PROG")
 nocheck "accepted cost: a stray BEGIN over-masks to EOF" "$OUT" "REPORT-LINE-300"
 
 # 🔑 AND WHY THAT PRICE IS PAYABLE — the half that actually justifies the trade.
 # On the TAGGED stream the over-mask costs MESSAGE TEXT, not EVIDENCE:
 # mask_line() keeps `D<TAB>tool<TAB>`, so every record still parses and still
 # counts. Without this row the arm above would read as pure loss.
-OUTR=$(strayrowfix | awk "$(extract_awk)")
+OUTR=$(strayrowfix | awk "$AWK_PROG")
 check "accepted cost: but the over-masked rows keep their tags" \
   "$OUTR" "$(printf 'D\tRead\t<redacted-key-material>')"
 if [ "$(printf '%s\n' "$OUTR" | grep -c "$(printf '^D\t')")" -eq 301 ]; then
@@ -4275,7 +4279,7 @@ fi
 # POSITIVE CONTROL for every "vanish"-signed arm below: the needles must be
 # present in the UNABLATED output, or asserting their absence proves nothing.
 # A diff of two empty outputs reads exactly like "behaviour preserved".
-CTRL2=$(closerowfix | awk "$(extract_awk)")
+CTRL2=$(closerowfix | awk "$AWK_PROG")
 check "positive control: the closing row keeps its tag unablated" "$CTRL2" "$(printf 'D\tBash\t<redacted-key-material> z')"
 
 # POSITIVE CONTROL for the APPEAR-signed arm 2: the needle must be in the
@@ -4337,7 +4341,7 @@ unit_ablate 's|^      for (j = i + 1; j <= n; j++) { L\[j\] = mask_line(L\[j\]);
 # 4. Tag preservation on the CLOSING line — the branch that does not route
 #    through mask_line(). Without it the closing row's tag is blanked and the
 #    record stops parsing.
-unit_ablate 's|^      if (match(s, /\^D\\t\[\^\\t\]\*\\t/)) L\[close_at\] = substr(s, 1, RLENGTH) PH tail$|      if (0) L[close_at] = substr(s, 1, RLENGTH) PH tail|' \
+unit_ablate 's|^      if (match(s, TAG_RE)) L\[close_at\] = substr(s, 1, RLENGTH) PH tail$|      if (0) L[close_at] = substr(s, 1, RLENGTH) PH tail|' \
   "closing-line tag preservation is load-bearing (the record loses its tag without it)" \
   closerowfix "$(printf 'D\tBash\t<redacted-key-material> z')" vanish
 

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -4175,6 +4175,25 @@ nocheck "shape 5d: and the body above it stays masked"                         "
 # destroyed and shape 6b (a block opening after the closer) becomes unreachable.
 check   "shape 5d control: text after the BALANCING closer still survives"      "$OUT" "TAILX"
 
+# ── SHAPE 5 (e) — several openers COLLAPSED onto one physical line ───────────
+# 🔴 A FOURTH disclosure, reported by CodeRabbit against the 5c/5d fix — and it
+# is the same nearest-closer defect once more, reached from a direction neither
+# 5c nor 5d covers. Pass A stops at the first UNPAIRED opener and folds the rest
+# of the line into the mask, so `BEGIN BEGIN` on one line leaves ONE flagged
+# line standing for TWO open blocks. U[] recorded a boolean, so pass B seeded
+# its depth at 1, closed at the FIRST later END, and everything after that END
+# printed verbatim.
+#
+# U[] now carries the COUNT — which pass A already had in `depth`, so the fix
+# stores a value it was computing and discarding.
+collapsefix() { printf '%s %s\nMIIEvgSECRETCOLL\n%s MIIEvgCOLLAPSELEAK %s TAILC\n' "$RB" "$RB" "$RE" "$RE"; }
+OUT=$(collapsefix | awk "$AWK_PROG")
+nocheck "shape 5e: collapsed openers still close at the OUTERMOST marker" "$OUT" "COLLAPSELEAK"
+nocheck "shape 5e: and the body between them stays masked"                "$OUT" "SECRETCOLL"
+# CONTROL, opposite direction — counting openers must not over-count and swallow
+# the tail of a legitimately balanced input.
+check   "shape 5e control: text after the BALANCING closer still survives" "$OUT" "TAILC"
+
 # ── SHAPE 6 (a) — TWO openers before one closer ──────────────────────────────
 # 🔴 Found by reading the shipped program end to end, not by a review round.
 # The second BEGIN sits INSIDE the region the first one's span already masked,
@@ -4455,9 +4474,18 @@ unit_ablate 's|^    for (j = i + 1; j <= n \&\& close_at == 0; j++) {$|    for (
 #     satisfied by an ablation that merely breaks the program: an arm that
 #     produces nothing fails the emptiness guard, and one that over-masks fails
 #     to find the needle.
-unit_ablate 's|^      if (close_at == 0 \&\& U\[j\]) bdepth++$|      if (close_at == 0 \&\& U[j]) bdepth += 0|' \
+unit_ablate 's|^      if (close_at == 0) bdepth += U\[j\]$|      if (close_at == 0) bdepth += 0|' \
   "cross-line nesting depth is load-bearing (a nested key body leaks without it)" \
   crossnestfix "SECRETXNEST" appear
+
+# 1d. U[] carrying the opener COUNT rather than a flag — the shape-5e fix.
+#     Ablate the pass-A store back to the boolean and the collapsed-opener leak
+#     must REAPPEAR. Signed APPEAR. Note this arm ablates pass A while the arm
+#     above ablates pass B: the count is written in one pass and read in the
+#     other, so a single arm could not tell which half is load-bearing.
+unit_ablate 's|^        U\[i\] = depth$|        U[i] = 1|' \
+  "U[] carrying the opener COUNT is load-bearing (collapsed openers leak without it)" \
+  collapsefix "COLLAPSELEAK" appear
 
 # 1c. Masking the closing line to the BALANCING closer rather than the first one
 #     — the shape-5d fix. Ablate back to re-matching the line, and the material

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -4059,6 +4059,28 @@ OUT=$(printf 'a %s SECRETIN %s b %s SECRETTWO\n' "$RB" "$RE" "$RB" | awk "$(extr
 nocheck "shape 5: every span on a shared line is masked" "$OUT" "SECRETIN"
 nocheck "shape 5: including the trailing unpaired one"   "$OUT" "SECRETTWO"
 
+# ── SHAPE 5 (b) — NESTED markers on one physical line ────────────────────────
+# 🔴 P1 disclosure, found by Codex review on #2654. `BEGIN1 … BEGIN2 … END2
+# SECRET END1`: closing the span at the NEAREST END consumed both openers but
+# ended the mask at END2, so `SECRET END1` survived pass A. The stray-marker sed
+# downstream then masked only the marker, and the key material beside it reached
+# the telemetry output.
+#
+# Shape 5 above does NOT constrain this — its markers are sequential, so the
+# nearest closer is also the correct one. The distinguishing input is nesting,
+# which is why the row is separate rather than folded into 5.
+OUT=$(printf 'a %s b %s c %s SECRETNEST %s\n' "$RB" "$RB" "$RE" "$RE" | awk "$(extract_awk)")
+nocheck "shape 5b: a nested span masks through the OUTERMOST closer" "$OUT" "SECRETNEST"
+
+# CONTROL, opposite direction — the fix must not degenerate into "mask to the
+# LAST END on the line", which would pass the row above while destroying every
+# record between two independent keys. Two complete spans must still close
+# individually, so the text between and after them survives.
+OUT=$(printf 'a %s S1 %s KEEPME %s S2 %s TAILKEEP\n' "$RB" "$RE" "$RB" "$RE" | awk "$(extract_awk)")
+nocheck "shape 5b control: independent spans still mask their own bodies" "$OUT" "S1"
+check   "shape 5b control: text BETWEEN two spans survives"               "$OUT" "KEEPME"
+check   "shape 5b control: text AFTER the last span survives"             "$OUT" "TAILKEEP"
+
 # ── SHAPE 6 (a) — TWO openers before one closer ──────────────────────────────
 # 🔴 Found by reading the shipped program end to end, not by a review round.
 # The second BEGIN sits INSIDE the region the first one's span already masked,

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -4044,6 +4044,13 @@ longkey() {
   printf '%s\n' "$RE"
   printf 'AFTER-ROW\n'
 }
+# The same length, with NO closing marker anywhere — shape 2 past the old bound.
+# Deliberately the same 300 lines as `longkey`, so the two shapes differ in
+# exactly one property: whether the block is terminated.
+longunterm() {
+  printf '%s\n' "$RB"
+  for i in $(seq 1 300); do printf 'MIIEvgSECRETBODY-%03d\n' "$i"; done
+}
 
 # ── SHAPE 1 — a TERMINATED block of ARBITRARY length ──────────────────────────
 # 🔴 THE KNOWN-BROKEN ONE. The closing-marker search used to stop at the same
@@ -4061,6 +4068,14 @@ check   "shape 1: and the record after it survives"                         "$OU
 OUT=$(printf 'timed out: %s\nMIIEvgSECRETBODYaaaa\nQEFAASCBKgSECRETTWO\n' "$RB" | awk "$(extract_awk)")
 nocheck "shape 2: an unterminated key body is masked"   "$OUT" "SECRETBODY"
 nocheck "shape 2: including its later body lines"       "$OUT" "SECRETTWO"
+
+# 🔴 AND AT ARBITRARY LENGTH. The masking used to stop at a 256-line horizon,
+# so this shape leaked exactly as shape 1 did before its search was unbounded:
+# 300 body lines - 256 = 44 survivors, the first at body line 257. PEM imposes
+# no payload ceiling, so no fixed bound can apply to a real key block — the
+# same argument in both branches, now applied in both.
+OUT=$(longunterm | awk "$(extract_awk)")
+nocheck "shape 2: an unterminated key LONGER than 256 lines is fully masked" "$OUT" "SECRETBODY"
 
 # ── SHAPE 3 — RFC 1421 encrypted-PEM headers and their BLANK separator ────────
 # `Proc-Type:`/`DEK-Info:` and an empty line sit between BEGIN and the body, so
@@ -4231,29 +4246,83 @@ unit_ablate() { # $1=sed-expr $2=label $3=fixture-fn $4=needle $5=appear|vanish
 
 # Fixture functions for the arms below. Named, not eval'd.
 strayfix()   { printf 'x %s\n' "$RB"; for i in $(seq 1 300); do printf 'REPORT-LINE-%03d\n' "$i"; done; }
+strayrowfix(){ printf 'D\tBash\tx %s\n' "$RB"; for i in $(seq 1 300); do printf 'D\tRead\tREPORT-LINE-%03d\n' "$i"; done; }
 encpemfix()  { printf 'Blocked: %s\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,9A7B2C\n\nMIIEvgIBADANBgkqSECRETBODYxxxx\n' "$RB"; }
 closerowfix(){ printf 'D\tBash\thead %s\n' "$RB"; printf 'D\tBash\ttail %s z\n' "$RE"; }
+
+# ── THE ACCEPTED COST, pinned in BOTH directions ──────────────────────────────
+# Unbounding the unterminated masking buys shape 2 at a price, and the price is
+# recorded here rather than left in a comment. A stray BEGIN with no END now
+# over-masks to end of input — the SAME input as a truncated key, which is why
+# no bound could have separated them.
+OUT=$(strayfix | awk "$(extract_awk)")
+nocheck "accepted cost: a stray BEGIN over-masks to EOF" "$OUT" "REPORT-LINE-300"
+
+# 🔑 AND WHY THAT PRICE IS PAYABLE — the half that actually justifies the trade.
+# On the TAGGED stream the over-mask costs MESSAGE TEXT, not EVIDENCE:
+# mask_line() keeps `D<TAB>tool<TAB>`, so every record still parses and still
+# counts. Without this row the arm above would read as pure loss.
+OUTR=$(strayrowfix | awk "$(extract_awk)")
+check "accepted cost: but the over-masked rows keep their tags" \
+  "$OUTR" "$(printf 'D\tRead\t<redacted-key-material>')"
+if [ "$(printf '%s\n' "$OUTR" | grep -c "$(printf '^D\t')")" -eq 301 ]; then
+  ok "accepted cost: all 301 records survive the over-mask"
+else
+  bad "accepted cost: all 301 records survive the over-mask" \
+      "$(printf '%s\n' "$OUTR" | grep -c "$(printf '^D\t')") of 301 rows kept a tag"
+fi
 
 # POSITIVE CONTROL for every "vanish"-signed arm below: the needles must be
 # present in the UNABLATED output, or asserting their absence proves nothing.
 # A diff of two empty outputs reads exactly like "behaviour preserved".
-CTRL=$(strayfix | awk "$(extract_awk)")
-check "positive control: line past the horizon IS present unablated" "$CTRL" "REPORT-LINE-300"
 CTRL2=$(closerowfix | awk "$(extract_awk)")
 check "positive control: the closing row keeps its tag unablated" "$CTRL2" "$(printf 'D\tBash\t<redacted-key-material> z')"
 
-# 1. The UNBOUNDED closing search — the shape-1 fix. Re-coupling it to HORIZON
-#    restores the misclassification, and the leak is arithmetically exact:
-#    300 body lines - 256 horizon = 44, first at line 257.
-unit_ablate 's|^    for (j = i + 1; j <= n; j++) {$|    for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) {|' \
-  "the UNBOUNDED closing search is load-bearing (a long terminated key leaks without it)" \
-  longkey "MIIEvgSECRETLINE-257" appear
+# POSITIVE CONTROL for the APPEAR-signed arm 2: the needle must be in the
+# FIXTURE, or "it reappeared" is unfalsifiable. That it is ABSENT from the
+# unablated program is the shape-2 row above; this asserts the fixture is not
+# empty of the thing the arm hunts for. (Arm 1 is vanish-signed and its control
+# is the shape-1 `AFTER-ROW` row.)
+check "positive control: the unterminated fixture carries its needle" \
+  "$(longunterm)" "MIIEvgSECRETBODY-257"
 
-# 2. The HORIZON bound on the unterminated branch — signed the OTHER way:
-#    removing it masks MORE, so the arm asserts the far line DISAPPEARS.
-unit_ablate 's|^      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) { L\[j\] = mask_line(L\[j\]); U\[j\] = 0 }$|      for (j = i + 1; j <= n; j++) { L[j] = mask_line(L[j]); U[j] = 0 }|' \
-  "the HORIZON bound is load-bearing (masking runs to EOF without it)" \
-  strayfix "REPORT-LINE-300" vanish
+# ⚠️ Both arms below re-introduce a LITERAL 256 rather than naming HORIZON.
+# The constant was deleted with the bound, and an undefined awk variable is 0 —
+# so `(j - i) <= HORIZON` would be false on the first iteration, and each arm
+# would exercise a loop that never runs instead of the bounded form it claims
+# to test. Arm 1 would then fail confusingly and arm 3 would PASS for entirely
+# the wrong reason.
+
+# 1. The UNBOUNDED closing search — the shape-1 fix. 🔑 THIS ARM CHANGED SIGN
+#    TOO, and the reason is worth more than the arm: the two bounds are NO
+#    LONGER INDEPENDENT. Bounding the closing search still misclassifies a long
+#    terminated key as unterminated — but that branch is now unbounded, so it
+#    masks the key to EOF instead of emitting its tail. Measured: with only
+#    this bound restored, SECRETLINE survivors stay 0 and it is `AFTER-ROW`,
+#    the ordinary record past the key, that disappears (1 -> 0).
+#
+#    So the unterminated branch is now a BACKSTOP for a mis-bounded closing
+#    search: the shape-1 disclosure needs BOTH bounds back, and `unit_ablate`
+#    changes exactly one line by design. What this arm can still prove is that
+#    the closing search decides terminated-vs-unterminated correctly, and the
+#    cost of getting it wrong — now over-masking rather than leaking. Signed
+#    VANISH; its positive control is the shape-1 `AFTER-ROW` row above.
+unit_ablate 's|^    for (j = i + 1; j <= n; j++) {$|    for (j = i + 1; j <= n \&\& (j - i) <= 256; j++) {|' \
+  "the UNBOUNDED closing search is load-bearing (a long terminated key is misclassified without it)" \
+  longkey "AFTER-ROW" vanish
+
+# 2. The UNBOUNDED masking on the unterminated branch — the shape-2 fix, and
+#    the arm whose SIGN REVERSED when the bound came out. It used to assert
+#    that a 256-line horizon was load-bearing, pinning a stray BEGIN's 300th
+#    report line as a SURVIVOR. That pinned the wrong side of the governing
+#    asymmetry: the same bound that spared those report lines emitted 44 lines
+#    of an over-long unterminated key. The two inputs are indistinguishable
+#    here by construction — this branch asks nothing about content — so the
+#    bound never separated them, it only chose disclosure for both. Now signed
+#    APPEAR: restoring the bound must bring the key body back.
+unit_ablate 's|^      for (j = i + 1; j <= n; j++) { L\[j\] = mask_line(L\[j\]); U\[j\] = 0 }$|      for (j = i + 1; j <= n \&\& (j - i) <= 256; j++) { L[j] = mask_line(L[j]); U[j] = 0 }|' \
+  "the UNBOUNDED unterminated masking is load-bearing (a long truncated key leaks without it)" \
+  longunterm "MIIEvgSECRETBODY-257" appear
 
 # 3. Unconditional masking — ablate back to the CONTENT-TESTED form that leaked
 #    twice. The encrypted-PEM body must reappear.
@@ -4261,7 +4330,7 @@ unit_ablate 's|^      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) { L\[
 #    REPLACEMENT emits a bare `/`, which closes the awk regex literal early and
 #    makes the ablated script a syntax error — the arm would then "pass"
 #    because awk produced nothing, not because the guard is load-bearing.
-unit_ablate 's|^      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) { L\[j\] = mask_line(L\[j\]); U\[j\] = 0 }$|      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) { if (L[j] ~ /^[A-Za-z0-9+=]{16,}$/) { L[j] = mask_line(L[j]); U[j] = 0 } else break }|' \
+unit_ablate 's|^      for (j = i + 1; j <= n; j++) { L\[j\] = mask_line(L\[j\]); U\[j\] = 0 }$|      for (j = i + 1; j <= n; j++) { if (L[j] ~ /^[A-Za-z0-9+=]{16,}$/) { L[j] = mask_line(L[j]); U[j] = 0 } else break }|' \
   "unconditional masking is load-bearing (an encrypted-PEM body leaks under a content test)" \
   encpemfix "SECRETBODY" appear
 

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -4120,6 +4120,61 @@ nocheck "shape 5b control: independent spans still mask their own bodies" "$OUT"
 check   "shape 5b control: text BETWEEN two spans survives"               "$OUT" "KEEPME"
 check   "shape 5b control: text AFTER the last span survives"             "$OUT" "TAILKEEP"
 
+# ── SHAPE 5 (c) — NESTED markers ACROSS physical lines ───────────────────────
+# 🔴 P1 disclosure, found by Codex review on #2654 — the SAME defect as 5b, one
+# dimension up, and the fix for 5b did not touch it. Pass A gained a depth
+# counter for markers within one line; the closing search of pass B was still
+# "the first END on any later line". So on
+#
+#     BEGIN1 / body / BEGIN2 / END2 / SECRET / END1
+#
+# the outer block closed at END2, the intermediate lines were masked, U[] was
+# cleared for the line of BEGIN2 as a consumed line, and the block of BEGIN2 was
+# therefore never resolved — SECRET printed verbatim from the next line on.
+#
+# Worth stating plainly, because it is the recurring lesson of this whole file:
+# fixing one SHAPE of a defect is not fixing the DEFECT. 5b passing is exactly
+# what made this look handled.
+#
+# Pass B now reads U[j] as an opener and a residual END as a closer, closing at
+# depth 0 — the pass-A rule lifted to the line-crossing scan, WITHOUT re-bounding
+# it, because shape 1 needs that scan unbounded.
+crossnestfix() { printf '%s\nAAAA\n%s\n%s\nMIIEvgSECRETXNEST\n%s\n' "$RB" "$RB" "$RE" "$RE"; }
+OUT=$(crossnestfix | awk "$AWK_PROG")
+nocheck "shape 5c: a cross-line nested span masks through the OUTERMOST closer" "$OUT" "SECRETXNEST"
+
+# CONTROL, opposite direction — the depth counter must not degenerate into
+# "close at the LAST END in the input", which would pass the row above while
+# merging every pair of independent keys and destroying the records between
+# them. Two complete, SEPARATE cross-line spans must still close individually.
+xindepfix() { printf '%s\nS1\n%s\nKEEPMEX\n%s\nS2\n%s\nTAILKEEPX\n' "$RB" "$RE" "$RB" "$RE"; }
+OUT=$(xindepfix | awk "$AWK_PROG")
+nocheck "shape 5c control: independent cross-line spans mask their own bodies" "$OUT" "S1"
+check   "shape 5c control: text BETWEEN two cross-line spans survives"         "$OUT" "KEEPMEX"
+check   "shape 5c control: text AFTER the last cross-line span survives"       "$OUT" "TAILKEEPX"
+
+# ── SHAPE 5 (d) — several closers on the CLOSING line ────────────────────────
+# 🔴 A THIRD disclosure, found by probing the 5c fix rather than reported by a
+# review round — which is the point of writing the probe. Once nesting is
+# tracked, the closing line may carry MORE THAN ONE END, and only the one that
+# balanced the depth is the real closer. The closing branch re-matched the line
+# and took the FIRST, so everything between the two markers printed verbatim:
+#
+#     BEGIN1 / BEGIN2 / body / END2 <key material> END1 TAIL
+#                              ^ masked to here     ^ leaked
+#
+# Measured on the parent commit: `MIIEvgMIDDLELEAK` survived in full. The walk
+# now records the offset of the BALANCING marker and the closing branch masks to
+# it, so the choice is made once by the code that knows the depth.
+kthendfix() { printf '%s\n%s\nMIIEvgSECRETKTH\n%s MIIEvgMIDDLELEAK %s TAILX\n' "$RB" "$RB" "$RE" "$RE"; }
+OUT=$(kthendfix | awk "$AWK_PROG")
+nocheck "shape 5d: material between two closers on the closing line is masked" "$OUT" "MIDDLELEAK"
+nocheck "shape 5d: and the body above it stays masked"                         "$OUT" "SECRETKTH"
+# CONTROL, opposite direction — masking to the balancing closer must not become
+# "mask the whole closing line", or the tail after a legitimately closed span is
+# destroyed and shape 6b (a block opening after the closer) becomes unreachable.
+check   "shape 5d control: text after the BALANCING closer still survives"      "$OUT" "TAILX"
+
 # ── SHAPE 6 (a) — TWO openers before one closer ──────────────────────────────
 # 🔴 Found by reading the shipped program end to end, not by a review round.
 # The second BEGIN sits INSIDE the region the first one's span already masked,
@@ -4138,8 +4193,36 @@ nestedfix() {
 }
 OUT=$(nestedfix | awk "$AWK_PROG")
 nocheck "shape 6a: two openers before one closer still mask the body" "$OUT" "SECRETNESTED"
-check   "shape 6a: and do NOT eat the report after the key"           "$OUT" "SURVIVOR-6"
-check   "shape 6a: nor the line immediately after it"                 "$OUT" "SURVIVOR-1"
+# 🔑 RE-SIGNED when pass B gained the depth counter (shape 5c), and the reason
+# matters more than the row. Two openers and ONE closer is an UNBALANCED input:
+# depth never returns to zero, so the block is genuinely unterminated and falls
+# to the unterminated branch, which masks to end of input by design.
+#
+# The old rows asserted these lines SURVIVED, which was the nearest-END reading
+# — close the outer block at the only END and declare the input handled. That
+# reading is what leaked on 5c, because it is a GUESS about which opener the
+# lone closer belongs to. PEM does not nest, so there is no correct answer
+# available here; there is only a safe direction and an unsafe one.
+#
+# So the guarantee this row now pins is the ACCEPTED COST, in both directions:
+# the report lines are over-masked (unsafe direction refused), and the records
+# still survive because the input is the tagged stream in production. The
+# record-preservation half is asserted on the tagged variant below, not here.
+nocheck "shape 6a: an unbalanced input over-masks the report (accepted cost)" "$OUT" "SURVIVOR-6"
+nocheck "shape 6a: including the line immediately after it"                   "$OUT" "SURVIVOR-1"
+
+# ...and the half that makes that cost payable: on the TAGGED stream the same
+# over-mask costs message text and tool attribution, never a RECORD.
+nestedrowfix() {
+  printf 'D\tBash\t%s\nD\tBash\t%s\nD\tBash\tMIIEvgSECRETNESTED\nD\tBash\t%s\n' "$RB" "$RB" "$RE"
+  for i in $(seq 1 6); do printf 'D\tRead\tSURVIVOR-%d\n' "$i"; done
+}
+NR6=$(nestedrowfix | awk "$AWK_PROG" | awk -F'\t' '$1 == "D" && NF == 3' | grep -c '')
+if [ "$NR6" = 10 ]; then
+  ok "shape 6a: all 10 records survive the unbalanced over-mask"
+else
+  bad "shape 6a: all 10 records survive the unbalanced over-mask" "$NR6 of 10 rows still parse as D<TAB>tool<TAB>msg"
+fi
 
 # ── SHAPE 6 (b) — a CLOSER and an OPENER on the same physical line ───────────
 # 🔴 The reverse ordering of 6a, and it leaked where 6a did not. Pass A itself
@@ -4195,7 +4278,13 @@ S7=$({ printf 'D\tBash\thead %s\n' "$RB"
        for i in $(seq 1 200); do printf 'D\tBash\tRECORD-%03d\n' "$i"; done
        printf 'D\tBash\ttail %s SURVIVING-TAIL\n' "$RE"; } | awk "$AWK_PROG")
 S7_ROWS=$(printf '%s\n' "$S7" | grep -c '')
-S7_TAGS=$(printf '%s\n' "$S7" | grep -c "^D$(printf '\t')Bash$(printf '\t')")
+# 🔑 The assertion is the STRUCTURE the consumer parses, not the literal tool
+# name. Production selects rows with `^D<TAB>` and splits on tabs, so what has
+# to survive is the `D` tag and both separators — three fields. It was written
+# as `^D<TAB>Bash<TAB>` while the tool field was preserved verbatim; that field
+# is now masked inside a key span (shape 8), and pinning the old literal would
+# have pinned the very disclosure shape 8 exists to close.
+S7_TAGS=$(printf '%s\n' "$S7" | awk -F'\t' '$1 == "D" && NF == 3' | grep -c '')
 if [ "$S7_ROWS" = 202 ] && [ "$S7_TAGS" = 202 ]; then
   ok "shape 7: all 202 tagged rows keep their tag (records stay counted)"
 else
@@ -4203,6 +4292,35 @@ else
 fi
 nocheck "shape 7: while every masked row's message text is gone" "$S7" "RECORD-100"
 check   "shape 7: and text after the closing marker survives"    "$S7" "SURVIVING-TAIL"
+
+# ── SHAPE 8 — key material in the TOOL field of a tagged row ─────────────────
+# 🔴 P1 disclosure, found by Codex review on #2654, and the sharper of that
+# round: it refuted a STATED ASSUMPTION rather than an implementation detail.
+# mask_line() preserved the tool field on the reasoning that it "is a tool name,
+# never payload" — an assumption about well-formed input, asserted inside the
+# one function whose governing rule is to assume nothing about content.
+#
+# It is false. The reliability stream builds that field from `$t.name` straight
+# out of the transcript with no sanitisation, so a key body landing there was
+# emitted verbatim while the message beside it was dutifully masked.
+#
+# The fix keeps STRUCTURE only — `D<TAB>PH<TAB>PH` — which is all the count
+# needs, so the over-mask still costs no record. Deliberately unconditional: a
+# whitelist of safe-looking tool names is not the harmless direction it looks,
+# because base64 draws from `A-Za-z0-9+/=` and a key chunk containing none of
+# `+/=` matches any plausible identifier pattern.
+S8=$(printf '%s\nD\tMIIEvgSECRETINTOOL\tmsgtext\n%s\n' "$RB" "$RE" | awk "$AWK_PROG")
+nocheck "shape 8: key material in a tool field inside a key span is masked" "$S8" "SECRETINTOOL"
+if [ "$(printf '%s\n' "$S8" | awk -F'\t' '$1 == "D" && NF == 3' | grep -c '')" = 1 ]; then
+  ok "shape 8: and the row still parses as three fields (record stays counted)"
+else
+  bad "shape 8: and the row still parses as three fields" "$S8"
+fi
+# CONTROL, opposite direction — masking is scoped to lines INSIDE a key span.
+# A row that merely sits in the same stream keeps its real tool name, or the
+# whole by-tool breakdown would be destroyed by one stray marker upstream.
+S8C=$(printf 'D\tBash\tordinary failure\n' | awk "$AWK_PROG")
+check "shape 8 control: a row outside any key span keeps its tool name" "$S8C" "$(printf 'D\tBash\tordinary failure')"
 
 # ── ablations — each proving ONE branch load-bearing ─────────────────────────
 # Every arm asserts the GUARANTEE stops holding, changes exactly ONE production
@@ -4253,6 +4371,16 @@ strayfix()   { printf 'x %s\n' "$RB"; for i in $(seq 1 300); do printf 'REPORT-L
 strayrowfix(){ printf 'D\tBash\tx %s\n' "$RB"; for i in $(seq 1 300); do printf 'D\tRead\tREPORT-LINE-%03d\n' "$i"; done; }
 encpemfix()  { printf 'Blocked: %s\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,9A7B2C\n\nMIIEvgIBADANBgkqSECRETBODYxxxx\n' "$RB"; }
 closerowfix(){ printf 'D\tBash\thead %s\n' "$RB"; printf 'D\tBash\ttail %s z\n' "$RE"; }
+tooltrapfix(){ printf '%s\nD\tMIIEvgSECRETINTOOL\tmsgtext\n%s\n' "$RB" "$RE"; }
+# A BALANCED nested pair — depth returns to zero, so the span closes normally
+# and the report after it survives. That is what makes it the right fixture for
+# the U[]-clearing arm: `nestedfix` (two openers, one closer) is unbalanced, so
+# its report lines are over-masked by the UNABLATED program too, and a vanish
+# arm on it would pass without the guard ever mattering.
+nestedpairfix(){
+  printf '%s\n%s\nMIIEvgSECRETPAIR\n%s\n%s\n' "$RB" "$RB" "$RE" "$RE"
+  for i in $(seq 1 6); do printf 'SURVIVOR-%d\n' "$i"; done
+}
 
 # ── THE ACCEPTED COST, pinned in BOTH directions ──────────────────────────────
 # Unbounding the unterminated masking buys shape 2 at a price, and the price is
@@ -4268,7 +4396,7 @@ nocheck "accepted cost: a stray BEGIN over-masks to EOF" "$OUT" "REPORT-LINE-300
 # counts. Without this row the arm above would read as pure loss.
 OUTR=$(strayrowfix | awk "$AWK_PROG")
 check "accepted cost: but the over-masked rows keep their tags" \
-  "$OUTR" "$(printf 'D\tRead\t<redacted-key-material>')"
+  "$OUTR" "$(printf 'D\t<redacted-key-material>\t<redacted-key-material>')"
 if [ "$(printf '%s\n' "$OUTR" | grep -c "$(printf '^D\t')")" -eq 301 ]; then
   ok "accepted cost: all 301 records survive the over-mask"
 else
@@ -4280,7 +4408,7 @@ fi
 # present in the UNABLATED output, or asserting their absence proves nothing.
 # A diff of two empty outputs reads exactly like "behaviour preserved".
 CTRL2=$(closerowfix | awk "$AWK_PROG")
-check "positive control: the closing row keeps its tag unablated" "$CTRL2" "$(printf 'D\tBash\t<redacted-key-material> z')"
+check "positive control: the closing row keeps its tag unablated" "$CTRL2" "$(printf 'D\t<redacted-key-material>\t<redacted-key-material> z')"
 
 # POSITIVE CONTROL for the APPEAR-signed arm 2: the needle must be in the
 # FIXTURE, or "it reappeared" is unfalsifiable. That it is ABSENT from the
@@ -4311,9 +4439,32 @@ check "positive control: the unterminated fixture carries its needle" \
 #    the closing search decides terminated-vs-unterminated correctly, and the
 #    cost of getting it wrong — now over-masking rather than leaking. Signed
 #    VANISH; its positive control is the shape-1 `AFTER-ROW` row above.
-unit_ablate 's|^    for (j = i + 1; j <= n; j++) {$|    for (j = i + 1; j <= n \&\& (j - i) <= 256; j++) {|' \
+#
+#    ⚠️ RE-AIMED when the closing search gained its depth counter (shape 5c).
+#    The arm targeted the pre-depth loop header verbatim; that line no longer
+#    exists, so the sed matched nothing and `unit_ablate` correctly reported a
+#    mis-aimed arm rather than a result. Re-aiming, not deleting, is the point:
+#    a guard whose ablation stops compiling is a guard nobody is checking.
+unit_ablate 's|^    for (j = i + 1; j <= n \&\& close_at == 0; j++) {$|    for (j = i + 1; j <= n \&\& close_at == 0 \&\& (j - i) <= 256; j++) {|' \
   "the UNBOUNDED closing search is load-bearing (a long terminated key is misclassified without it)" \
   longkey "AFTER-ROW" vanish
+
+# 1b. The DEPTH COUNTER in that same closing search — the shape-5c fix. Ablate
+#     it back to the nearest-END form by never incrementing on a nested opener,
+#     and the nested body must REAPPEAR. Signed APPEAR, so it cannot be
+#     satisfied by an ablation that merely breaks the program: an arm that
+#     produces nothing fails the emptiness guard, and one that over-masks fails
+#     to find the needle.
+unit_ablate 's|^      if (close_at == 0 \&\& U\[j\]) bdepth++$|      if (close_at == 0 \&\& U[j]) bdepth += 0|' \
+  "cross-line nesting depth is load-bearing (a nested key body leaks without it)" \
+  crossnestfix "SECRETXNEST" appear
+
+# 1c. Masking the closing line to the BALANCING closer rather than the first one
+#     — the shape-5d fix. Ablate back to re-matching the line, and the material
+#     between the two END markers must REAPPEAR. Signed APPEAR.
+unit_ablate 's|^    tail = substr(s, close_end + 1)$|    if (match(s, /-----END [A-Z ]*PRIVATE KEY-----/)) tail = substr(s, RSTART + RLENGTH)|' \
+  "closing at the BALANCING marker is load-bearing (material between two closers leaks without it)" \
+  kthendfix "MIDDLELEAK" appear
 
 # 2. The UNBOUNDED masking on the unterminated branch — the shape-2 fix, and
 #    the arm whose SIGN REVERSED when the bound came out. It used to assert
@@ -4341,16 +4492,34 @@ unit_ablate 's|^      for (j = i + 1; j <= n; j++) { L\[j\] = mask_line(L\[j\]);
 # 4. Tag preservation on the CLOSING line — the branch that does not route
 #    through mask_line(). Without it the closing row's tag is blanked and the
 #    record stops parsing.
-unit_ablate 's|^      if (match(s, TAG_RE)) L\[close_at\] = substr(s, 1, RLENGTH) PH tail$|      if (0) L[close_at] = substr(s, 1, RLENGTH) PH tail|' \
+unit_ablate 's|^    if (match(s, TAG_RE)) L\[close_at\] = "D" TAB PH TAB PH tail$|    if (0) L[close_at] = "D" TAB PH TAB PH tail|' \
   "closing-line tag preservation is load-bearing (the record loses its tag without it)" \
-  closerowfix "$(printf 'D\tBash\t<redacted-key-material> z')" vanish
+  closerowfix "$(printf 'D\t<redacted-key-material>\t<redacted-key-material> z')" vanish
+
+# 4b. Masking the TOOL FIELD inside a key span — the shape-8 fix. Ablate back to
+#     the form that preserved it verbatim, and the key material planted in that
+#     field must REAPPEAR. Signed APPEAR for the same reason as 1b.
+unit_ablate 's|^  if (match(s, TAG_RE)) return "D" TAB PH TAB PH$|  if (match(s, TAG_RE)) return substr(s, 1, RLENGTH) PH|' \
+  "masking the tool field is load-bearing (key material in a tool name leaks without it)" \
+  tooltrapfix "SECRETINTOOL" appear
 
 # 5. Clearing U[] as lines are consumed. Without it a second opener inside an
 #    already-masked span re-enters the unterminated branch and runs away, so the
 #    arm is signed VANISH: removing the guard masks MORE.
+#
+#    ⚠️ FIXTURE RE-AIMED alongside shape 6a. It used `nestedfix` — two openers,
+#    one closer — whose report lines the UNABLATED program now over-masks by
+#    design, since depth never returns to zero. A vanish arm on a needle that is
+#    already absent passes whatever the guard does, which is the exact class of
+#    hollow arm this file keeps having to catch. `nestedpairfix` is BALANCED, so
+#    SURVIVOR-6 is present unablated (asserted immediately below) and its
+#    disappearance is attributable to the removed guard.
+CTRL5=$(nestedpairfix | awk "$AWK_PROG")
+check "positive control: a BALANCED nested span leaves the report intact" "$CTRL5" "SURVIVOR-6"
+nocheck "positive control: while still masking the nested body"           "$CTRL5" "SECRETPAIR"
 unit_ablate 's|^    for (j = i + 1; j < close_at; j++) { L\[j\] = mask_line(L\[j\]); U\[j\] = 0 }$|    for (j = i + 1; j < close_at; j++) { L[j] = mask_line(L[j]) }|' \
   "clearing U[] on consumed lines is load-bearing (a second opener runs away without it)" \
-  nestedfix "SURVIVOR-6" vanish
+  nestedpairfix "SURVIVOR-6" vanish
 
 # ── TIMESTAMP MATRIX — one row per SHAPE, not a case per reported bug ─────────
 # Three consecutive review rounds each reported this defect at a new position:

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -3982,6 +3982,176 @@ relcase control "ordinary failure text" 4 0
 # the row tags: measured 4 -> 1, a 75% under-count from one unlucky message.
 # The whole-line form then still lost the tagged row itself (4 -> 3). Redacting
 # only the key SPAN is what keeps the secret out and the evidence in.
+PK_B=$(printf -- '-----%s %s PRIVATE KEY-----' 'BEGIN' 'RSA')
+PK_E=$(printf -- '-----%s %s PRIVATE KEY-----' 'END' 'RSA')
+relcase privatekey "parse failed: $PK_B AAAA $PK_E trailing" 4 0
+
+# F1b. UNBALANCED markers on one line — an ODD marker count. A regex quantifier
+# is leftmost-LONGEST, so `.*` between the markers ran to the LAST END and left
+# a trailing unpaired BEGIN behind. That residual then re-opened the unbounded
+# range and blanked every following record. Measured: 4 errors -> 1.
+relcase unbalancedkey "x $PK_B y $PK_E z $PK_B w" 4 0
+
+# ── REDACTOR UNIT TESTS — one row per SPEC SHAPE, not per reported bug ────────
+# The reliability walk strips control characters, so a multi-line message
+# arrives at the redactor as ONE line. That makes every cross-line branch
+# UNREACHABLE through `--section reliability`: a fixture written as
+# "multi-line" is silently flattened, and an ablation of the cross-line code
+# then honestly reports "the arm proves nothing". So the redactor is exercised
+# DIRECTLY here, as the unit it is.
+#
+# The shapes below are enumerated from RFC 7468 / RFC 1421 (monorepo#2643), NOT
+# induced from review findings. Five consecutive rounds of induction each
+# produced a shape the previous fix had not thought of; enumerating from the
+# spec is what stops the sixth.
+echo
+echo "redactor unit — the seven PEM shapes (monorepo#2643)"
+
+# Extract the awk program from the target so the unit under test is the SHIPPED
+# one, never a copy that can drift away from it.
+extract_awk() { sed -n "/^AWK_KEY_REDACT='/,/^'\$/p" "${1:-$TARGET}" | sed "1s/^AWK_KEY_REDACT='//; \$d"; }
+RB=$(printf -- '-----%s %s PRIVATE KEY-----' 'BEGIN' 'RSA')
+RE=$(printf -- '-----%s %s PRIVATE KEY-----' 'END' 'RSA')
+# A key body LONGER than the masking horizon (256). Shape 1 is the reason this
+# is 300 lines and not a token 3: the defect it pins only exists past the bound.
+longkey() {
+  printf '%s\n' "$RB"
+  for i in $(seq 1 300); do printf 'MIIEvgSECRETLINE-%03d\n' "$i"; done
+  printf '%s\n' "$RE"
+  printf 'AFTER-ROW\n'
+}
+
+# ── SHAPE 1 — a TERMINATED block of ARBITRARY length ──────────────────────────
+# 🔴 THE KNOWN-BROKEN ONE. The closing-marker search used to stop at the same
+# horizon the masking uses, so a COMPLETE key longer than that bound was
+# misclassified as unterminated and masked only to the horizon — its tail was
+# emitted verbatim. A bounded lookahead cannot answer an unbounded question.
+OUT=$(longkey | awk "$(extract_awk)")
+nocheck "shape 1: a terminated key LONGER than the horizon is fully masked" "$OUT" "SECRETLINE"
+check   "shape 1: and the record after it survives"                         "$OUT" "AFTER-ROW"
+
+# ── SHAPE 2 — UNTERMINATED block (no closing marker anywhere) ─────────────────
+# A truncated key is MORE likely in a transcript than a well-formed one,
+# because messages get cut. Requiring a closing marker before masking anything
+# emitted such a body verbatim — a P1 disclosure.
+OUT=$(printf 'timed out: %s\nMIIEvgSECRETBODYaaaa\nQEFAASCBKgSECRETTWO\n' "$RB" | awk "$(extract_awk)")
+nocheck "shape 2: an unterminated key body is masked"   "$OUT" "SECRETBODY"
+nocheck "shape 2: including its later body lines"       "$OUT" "SECRETTWO"
+
+# ── SHAPE 3 — RFC 1421 encrypted-PEM headers and their BLANK separator ────────
+# `Proc-Type:`/`DEK-Info:` and an empty line sit between BEGIN and the body, so
+# any content-shaped continuation test stops dead on the first header line and
+# emits the whole key. Reproduced before the default was inverted.
+OUT=$(printf 'Blocked: %s\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,9A7B2C\n\nMIIEvgIBADANBgkqSECRETBODYxxxx\n' "$RB" | awk "$(extract_awk)")
+nocheck "shape 3: an ENCRYPTED PEM body is masked through its headers" "$OUT" "SECRETBODY"
+nocheck "shape 3: and the DEK-Info header itself does not survive"     "$OUT" "AES-128-CBC"
+
+# ── SHAPE 4 — short final base64 line ────────────────────────────────────────
+# A PEM's last line is frequently only a few characters, so a minimum-length
+# test drops it even when every other line matches.
+OUT=$(printf 'x %s\nMIIEvgIBADANBgkqSECRETONExx\nSHORTTAIL=\n' "$RB" | awk "$(extract_awk)")
+nocheck "shape 4: a short final PEM line is masked" "$OUT" "SHORTTAIL"
+
+# ── SHAPE 5 — several markers on ONE physical line ───────────────────────────
+# Messages are newline-collapsed before reaching the redactor, so a whole key —
+# or several — can arrive on a single line.
+OUT=$(printf 'a %s SECRETIN %s b %s SECRETTWO\n' "$RB" "$RE" "$RB" | awk "$(extract_awk)")
+nocheck "shape 5: every span on a shared line is masked" "$OUT" "SECRETIN"
+nocheck "shape 5: including the trailing unpaired one"   "$OUT" "SECRETTWO"
+
+# ── SHAPE 6 — stray unpaired markers ─────────────────────────────────────────
+# A lone END is NOT handled by the awk walk (pass A scans for a BEGIN first);
+# the marker sed rule in redact() is what masks it. Asserting it here through
+# the walk alone would pin coverage that lives elsewhere — so this row goes
+# through the whole `--section reliability` path, which runs both.
+relcase strayend "prose mentioning $PK_E with no opener" 4 0
+
+# ── SHAPE 7 — BOTH stream shapes: a tagged row keeps its record ──────────────
+# 🔴 The over-mask must cost MESSAGE TEXT, never EVIDENCE. On the tagged stream
+# each row is one message with newlines already collapsed, so masking following
+# rows is pure measurement loss — bounded to that loss only because every masked
+# row keeps its `D<TAB>tool<TAB>` tag and stays counted.
+#
+# This also pins the CLOSING-line branch, which is the one path that does not
+# route through mask_line(). It was blanking that row's tag, so the record
+# stopped parsing and dropped out of the count: measured 201 of 202 rows kept.
+S7=$({ printf 'D\tBash\thead %s\n' "$RB"
+       for i in $(seq 1 200); do printf 'D\tBash\tRECORD-%03d\n' "$i"; done
+       printf 'D\tBash\ttail %s SURVIVING-TAIL\n' "$RE"; } | awk "$(extract_awk)")
+S7_ROWS=$(printf '%s\n' "$S7" | grep -c '')
+S7_TAGS=$(printf '%s\n' "$S7" | grep -c "^D$(printf '\t')Bash$(printf '\t')")
+if [ "$S7_ROWS" = 202 ] && [ "$S7_TAGS" = 202 ]; then
+  ok "shape 7: all 202 tagged rows keep their tag (records stay counted)"
+else
+  bad "shape 7: all 202 tagged rows keep their tag" "rows=$S7_ROWS tags=$S7_TAGS, expected 202/202"
+fi
+nocheck "shape 7: while every masked row's message text is gone" "$S7" "RECORD-100"
+check   "shape 7: and text after the closing marker survives"    "$S7" "SURVIVING-TAIL"
+
+# ── ablations — each proving ONE branch load-bearing ─────────────────────────
+# Every arm asserts the GUARANTEE stops holding, changes exactly ONE production
+# line, and is SIGNED in the correct direction. An arm that expects a needle to
+# reappear cannot detect a guard whose removal masks MORE, and vice versa.
+unit_ablate() { # $1=sed-expr $2=label $3=input-cmd $4=needle $5=appear|vanish
+  local ab="$FIX/abl_$$.sh" changed out
+  cp "$TARGET" "$ab"
+  sed -i.bak "$1" "$ab"; rm -f "$ab.bak"
+  changed=$(diff "$TARGET" "$ab" | grep -c '^<')
+  if [ "$changed" -ne 1 ]; then
+    bad "ablation: $2" "sed changed $changed lines, expected 1 — arm is mis-aimed"
+    rm -f "$ab"; return
+  fi
+  out=$(eval "$3" | awk "$(extract_awk "$ab")")
+  rm -f "$ab"
+  if [ "$5" = appear ]; then
+    if printf '%s' "$out" | grep -qF -- "$4"; then ok "ablation: $2"
+    else bad "ablation: $2" "expected '$4' to REAPPEAR without the branch; it did not"; fi
+  else
+    if printf '%s' "$out" | grep -qF -- "$4"; then
+      bad "ablation: $2" "'$4' survived without the branch — the arm proves nothing"
+    else ok "ablation: $2"; fi
+  fi
+}
+
+# POSITIVE CONTROL for every "vanish"-signed arm below: the needles must be
+# present in the UNABLATED output, or asserting their absence proves nothing.
+# A diff of two empty outputs reads exactly like "behaviour preserved".
+CTRL=$({ printf 'x %s\n' "$RB"; for i in $(seq 1 300); do printf 'REPORT-LINE-%03d\n' "$i"; done; } | awk "$(extract_awk)")
+check "positive control: line past the horizon IS present unablated" "$CTRL" "REPORT-LINE-300"
+
+# 1. The UNBOUNDED closing search — the shape-1 fix. Re-coupling it to HORIZON
+#    restores the misclassification, and the leak is arithmetically exact:
+#    300 body lines - 256 horizon = 44, first at line 257.
+unit_ablate 's|^    for (j = i + 1; j <= n; j++) {$|    for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) {|' \
+  "the UNBOUNDED closing search is load-bearing (a long terminated key leaks without it)" \
+  'longkey' "MIIEvgSECRETLINE-257" appear
+
+# 2. The HORIZON bound on the unterminated branch — signed the OTHER way:
+#    removing it masks MORE, so the arm asserts the far line DISAPPEARS.
+unit_ablate 's|^      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) L\[j\] = mask_line(L\[j\])$|      for (j = i + 1; j <= n; j++) L[j] = mask_line(L[j])|' \
+  "the HORIZON bound is load-bearing (masking runs to EOF without it)" \
+  '{ printf "x %s\n" "$RB"; for i in $(seq 1 300); do printf "REPORT-LINE-%03d\n" "$i"; done; }' \
+  "REPORT-LINE-300" vanish
+
+# 3. Unconditional masking — ablate back to the CONTENT-TESTED form that leaked
+#    twice. The encrypted-PEM body must reappear.
+#    NOTE: the replacement class deliberately omits `/`; a `\/` in a sed
+#    REPLACEMENT emits a bare `/`, which closes the awk regex literal early and
+#    makes the ablated script a syntax error — the arm would then "pass"
+#    because awk produced nothing, not because the guard is load-bearing.
+unit_ablate 's|^      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) L\[j\] = mask_line(L\[j\])$|      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) { if (L[j] ~ /^[A-Za-z0-9+=]{16,}$/) L[j] = mask_line(L[j]); else break }|' \
+  "unconditional masking is load-bearing (an encrypted-PEM body leaks under a content test)" \
+  'printf "Blocked: %s\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,9A7B2C\n\nMIIEvgIBADANBgkqSECRETBODYxxxx\n" "$RB"' \
+  "SECRETBODY" appear
+
+# 4. Tag preservation on the CLOSING line — the branch that does not route
+#    through mask_line(). Without it the closing row's tag is blanked and the
+#    record stops parsing.
+unit_ablate 's|^      if (match(s, /\^D\\t\[\^\\t\]\*\\t/)) L\[close_at\] = substr(s, 1, RLENGTH) PH tail$|      if (0) L[close_at] = substr(s, 1, RLENGTH) PH tail|' \
+  "closing-line tag preservation is load-bearing (the record loses its tag without it)" \
+  '{ printf "D\tBash\thead %s\n" "$RB"; printf "D\tBash\ttail %s z\n" "$RE"; }' \
+  "$(printf 'D\tBash\t<redacted-key-material> z')" vanish
+
 # ── TIMESTAMP MATRIX — one row per SHAPE, not a case per reported bug ─────────
 # Three consecutive review rounds each reported this defect at a new position:
 # the type was unchecked, then a non-date string, then a malformed prefix. Each

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -4010,6 +4010,30 @@ echo "redactor unit — the seven PEM shapes (monorepo#2643)"
 # Extract the awk program from the target so the unit under test is the SHIPPED
 # one, never a copy that can drift away from it.
 extract_awk() { sed -n "/^AWK_KEY_REDACT='/,/^'\$/p" "${1:-$TARGET}" | sed "1s/^AWK_KEY_REDACT='//; \$d"; }
+
+# 🔴 PIN THE EXTRACTION ITSELF, BEFORE ANY SHAPE ROW DEPENDS ON IT.
+# `awk ""` is valid: it exits 0 and prints nothing. Every shape row below is an
+# ABSENCE assertion (`nocheck` — "the sentinel must not appear"), and absence is
+# exactly what an empty program produces, so a broken extraction would report
+# the whole section green with NO program under test.
+#
+# The extraction keys on the literal text `AWK_KEY_REDACT='` and a lone closing
+# quote line in the target, so an ordinary rename or requoting in
+# agent-telemetry.sh breaks it SILENTLY — the failure mode is green tests, not
+# an error. `unit_ablate` below already guards this class for the ablation arms;
+# the direct rows carry the primary coverage and need it more.
+#
+# Testing for `mask_line` rather than mere non-emptiness is deliberate: a
+# partial extraction that captured only the leading comment block would be
+# non-empty and still be no program at all.
+AWK_PROG=$(extract_awk)
+if [ -n "$AWK_PROG" ] && printf '%s' "$AWK_PROG" | grep -q 'mask_line'; then
+  ok "redactor unit: the awk program really extracts from the shipped script"
+else
+  bad "redactor unit: the awk program really extracts from the shipped script" \
+      "extraction produced ${#AWK_PROG} bytes with no mask_line() — every absence row below would pass vacuously"
+fi
+
 RB=$(printf -- '-----%s %s PRIVATE KEY-----' 'BEGIN' 'RSA')
 RE=$(printf -- '-----%s %s PRIVATE KEY-----' 'END' 'RSA')
 # A key body LONGER than the masking horizon (256). Shape 1 is the reason this

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -4080,6 +4080,30 @@ nocheck "shape 6a: two openers before one closer still mask the body" "$OUT" "SE
 check   "shape 6a: and do NOT eat the report after the key"           "$OUT" "SURVIVOR-6"
 check   "shape 6a: nor the line immediately after it"                 "$OUT" "SURVIVOR-1"
 
+# ── SHAPE 6 (b) — a CLOSER and an OPENER on the same physical line ───────────
+# 🔴 The reverse ordering of 6a, and it leaked where 6a did not. Pass A itself
+# produces this shape: it keeps `head` — the text before the BEGIN — and `head`
+# still contains the earlier END. So the line is simultaneously the closing
+# line of one block and the opening line of the next.
+#
+# 6a's fix cleared the open-block flag on every line a span consumed, and
+# clearing it on the CLOSING line skipped the block that opens after the marker
+# — its body printed verbatim from the next line on. An intermediate line is
+# replaced wholesale so its flag is genuinely spent; a closing line is masked
+# only up to its marker, so its flag is not. That asymmetry is the fix.
+#
+# Worth stating plainly: 6a and 6b are the same defect class approached from
+# two directions, and the guard for one CREATED the other. Neither row alone
+# constrains the program — they have to be read as a pair.
+endbeginfix() {
+  printf '%s\nMIIEvgSECRETONE\nclose %s then %s\n' "$RB" "$RE" "$RB"
+  printf 'MIIEvgSECRETTWO\nMIIEvgSECRETTHREE\n'
+}
+OUT=$(endbeginfix | awk "$(extract_awk)")
+nocheck "shape 6b: a block opening on a CLOSING line is still resolved" "$OUT" "SECRETTWO"
+nocheck "shape 6b: including its later body lines"                      "$OUT" "SECRETTHREE"
+nocheck "shape 6b: and the first block's body stays masked"             "$OUT" "SECRETONE"
+
 # ── SHAPE 6 — stray unpaired markers ─────────────────────────────────────────
 # A lone END is NOT handled by the awk walk (pass A scans for a BEGIN first);
 # the marker sed rule in redact() is what masks it. Asserting it here through
@@ -4135,8 +4159,20 @@ unit_ablate() { # $1=sed-expr $2=label $3=fixture-fn $4=needle $5=appear|vanish
     bad "ablation: $2" "sed changed $changed lines, expected 1 — arm is mis-aimed"
     rm -f "$ab"; return
   fi
-  out=$("$3" | awk "$(extract_awk "$ab")")
+  out=$("$3" | awk "$(extract_awk "$ab")" 2>/dev/null); local st=$?
   rm -f "$ab"
+  # 🔴 A `vanish` arm passes whenever the ablated program produces NOTHING —
+  # so a sed replacement that breaks the awk regex literal, or any other
+  # syntax error, reads exactly like "the guard was load-bearing". Three of the
+  # five arms are vanish-signed, so this would have silently hollowed out most
+  # of the ablation coverage. Require the ablated program to have RUN before
+  # judging its output: non-zero status or empty output is a mis-aimed arm, not
+  # a result. (Same class as the arm-changed-exactly-one-line check above: an
+  # ablation is only evidence if the ablated thing still executes.)
+  if [ "$st" -ne 0 ] || [ -z "$out" ]; then
+    bad "ablation: $2" "ablated program did not run (status=$st, ${#out} bytes out) — arm cannot judge"
+    return
+  fi
   if [ "$5" = appear ]; then
     if printf '%s' "$out" | grep -qF -- "$4"; then ok "ablation: $2"
     else bad "ablation: $2" "expected '$4' to REAPPEAR without the branch; it did not"; fi

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -4059,12 +4059,43 @@ OUT=$(printf 'a %s SECRETIN %s b %s SECRETTWO\n' "$RB" "$RE" "$RB" | awk "$(extr
 nocheck "shape 5: every span on a shared line is masked" "$OUT" "SECRETIN"
 nocheck "shape 5: including the trailing unpaired one"   "$OUT" "SECRETTWO"
 
+# ── SHAPE 6 (a) — TWO openers before one closer ──────────────────────────────
+# 🔴 Found by reading the shipped program end to end, not by a review round.
+# The second BEGIN sits INSIDE the region the first one's span already masked,
+# so by the time it is reconsidered its own line no longer holds a marker AND
+# the closing marker it would have paired with has been replaced too. The
+# search then finds nothing, falls into the unterminated branch, and runs away
+# for a full horizon of lines that were never key material. Measured on the
+# un-cleared form: six plain report lines after the key, all destroyed.
+#
+# This is the same class as the two defects above — a state flag that outlives
+# the text it described — which is why the row is here rather than left to a
+# reviewer to rediscover.
+nestedfix() {
+  printf '%s\n%s\nMIIEvgSECRETNESTED\n%s\n' "$RB" "$RB" "$RE"
+  for i in $(seq 1 6); do printf 'SURVIVOR-%d\n' "$i"; done
+}
+OUT=$(nestedfix | awk "$(extract_awk)")
+nocheck "shape 6a: two openers before one closer still mask the body" "$OUT" "SECRETNESTED"
+check   "shape 6a: and do NOT eat the report after the key"           "$OUT" "SURVIVOR-6"
+check   "shape 6a: nor the line immediately after it"                 "$OUT" "SURVIVOR-1"
+
 # ── SHAPE 6 — stray unpaired markers ─────────────────────────────────────────
 # A lone END is NOT handled by the awk walk (pass A scans for a BEGIN first);
 # the marker sed rule in redact() is what masks it. Asserting it here through
 # the walk alone would pin coverage that lives elsewhere — so this row goes
 # through the whole `--section reliability` path, which runs both.
 relcase strayend "prose mentioning $PK_E with no opener" 4 0
+# ⚠️ relcase asserts COUNTS only, so on its own it proves the stray marker does
+# not destroy records — NOT that it is masked. Those are different guarantees,
+# and reading the first as the second is how a control ends up described by the
+# property it was written to defend rather than the one it instantiates. Assert
+# the masking explicitly, on the same fixture the row above just built.
+STRAY=$(PORTFOLIO_PATHS="$FIX/relloss_strayend" CLAUDE_PROJECTS_DIR="$FIX/relloss_strayend" \
+        CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+        bash "$TARGET" --since-days 1 --section reliability 2>/dev/null)
+check   "shape 6: the stray-END row still reaches the report" "$STRAY" "prose mentioning"
+nocheck "shape 6: but the marker itself is masked"            "$STRAY" "$PK_E"
 
 # ── SHAPE 7 — BOTH stream shapes: a tagged row keeps its record ──────────────
 # 🔴 The over-mask must cost MESSAGE TEXT, never EVIDENCE. On the tagged stream
@@ -4092,7 +4123,10 @@ check   "shape 7: and text after the closing marker survives"    "$S7" "SURVIVIN
 # Every arm asserts the GUARANTEE stops holding, changes exactly ONE production
 # line, and is SIGNED in the correct direction. An arm that expects a needle to
 # reappear cannot detect a guard whose removal masks MORE, and vice versa.
-unit_ablate() { # $1=sed-expr $2=label $3=input-cmd $4=needle $5=appear|vanish
+# $3 is the NAME of a fixture function, never a string of shell to evaluate.
+# Passing code here would put an eval in the one suite whose whole subject is a
+# filter over attacker-controlled text; a function name cannot grow into that.
+unit_ablate() { # $1=sed-expr $2=label $3=fixture-fn $4=needle $5=appear|vanish
   local ab="$FIX/abl_$$.sh" changed out
   cp "$TARGET" "$ab"
   sed -i.bak "$1" "$ab"; rm -f "$ab.bak"
@@ -4101,7 +4135,7 @@ unit_ablate() { # $1=sed-expr $2=label $3=input-cmd $4=needle $5=appear|vanish
     bad "ablation: $2" "sed changed $changed lines, expected 1 — arm is mis-aimed"
     rm -f "$ab"; return
   fi
-  out=$(eval "$3" | awk "$(extract_awk "$ab")")
+  out=$("$3" | awk "$(extract_awk "$ab")")
   rm -f "$ab"
   if [ "$5" = appear ]; then
     if printf '%s' "$out" | grep -qF -- "$4"; then ok "ablation: $2"
@@ -4113,25 +4147,31 @@ unit_ablate() { # $1=sed-expr $2=label $3=input-cmd $4=needle $5=appear|vanish
   fi
 }
 
+# Fixture functions for the arms below. Named, not eval'd.
+strayfix()   { printf 'x %s\n' "$RB"; for i in $(seq 1 300); do printf 'REPORT-LINE-%03d\n' "$i"; done; }
+encpemfix()  { printf 'Blocked: %s\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,9A7B2C\n\nMIIEvgIBADANBgkqSECRETBODYxxxx\n' "$RB"; }
+closerowfix(){ printf 'D\tBash\thead %s\n' "$RB"; printf 'D\tBash\ttail %s z\n' "$RE"; }
+
 # POSITIVE CONTROL for every "vanish"-signed arm below: the needles must be
 # present in the UNABLATED output, or asserting their absence proves nothing.
 # A diff of two empty outputs reads exactly like "behaviour preserved".
-CTRL=$({ printf 'x %s\n' "$RB"; for i in $(seq 1 300); do printf 'REPORT-LINE-%03d\n' "$i"; done; } | awk "$(extract_awk)")
+CTRL=$(strayfix | awk "$(extract_awk)")
 check "positive control: line past the horizon IS present unablated" "$CTRL" "REPORT-LINE-300"
+CTRL2=$(closerowfix | awk "$(extract_awk)")
+check "positive control: the closing row keeps its tag unablated" "$CTRL2" "$(printf 'D\tBash\t<redacted-key-material> z')"
 
 # 1. The UNBOUNDED closing search — the shape-1 fix. Re-coupling it to HORIZON
 #    restores the misclassification, and the leak is arithmetically exact:
 #    300 body lines - 256 horizon = 44, first at line 257.
 unit_ablate 's|^    for (j = i + 1; j <= n; j++) {$|    for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) {|' \
   "the UNBOUNDED closing search is load-bearing (a long terminated key leaks without it)" \
-  'longkey' "MIIEvgSECRETLINE-257" appear
+  longkey "MIIEvgSECRETLINE-257" appear
 
 # 2. The HORIZON bound on the unterminated branch — signed the OTHER way:
 #    removing it masks MORE, so the arm asserts the far line DISAPPEARS.
-unit_ablate 's|^      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) L\[j\] = mask_line(L\[j\])$|      for (j = i + 1; j <= n; j++) L[j] = mask_line(L[j])|' \
+unit_ablate 's|^      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) { L\[j\] = mask_line(L\[j\]); U\[j\] = 0 }$|      for (j = i + 1; j <= n; j++) { L[j] = mask_line(L[j]); U[j] = 0 }|' \
   "the HORIZON bound is load-bearing (masking runs to EOF without it)" \
-  '{ printf "x %s\n" "$RB"; for i in $(seq 1 300); do printf "REPORT-LINE-%03d\n" "$i"; done; }' \
-  "REPORT-LINE-300" vanish
+  strayfix "REPORT-LINE-300" vanish
 
 # 3. Unconditional masking — ablate back to the CONTENT-TESTED form that leaked
 #    twice. The encrypted-PEM body must reappear.
@@ -4139,18 +4179,23 @@ unit_ablate 's|^      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) L\[j\
 #    REPLACEMENT emits a bare `/`, which closes the awk regex literal early and
 #    makes the ablated script a syntax error — the arm would then "pass"
 #    because awk produced nothing, not because the guard is load-bearing.
-unit_ablate 's|^      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) L\[j\] = mask_line(L\[j\])$|      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) { if (L[j] ~ /^[A-Za-z0-9+=]{16,}$/) L[j] = mask_line(L[j]); else break }|' \
+unit_ablate 's|^      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) { L\[j\] = mask_line(L\[j\]); U\[j\] = 0 }$|      for (j = i + 1; j <= n \&\& (j - i) <= HORIZON; j++) { if (L[j] ~ /^[A-Za-z0-9+=]{16,}$/) { L[j] = mask_line(L[j]); U[j] = 0 } else break }|' \
   "unconditional masking is load-bearing (an encrypted-PEM body leaks under a content test)" \
-  'printf "Blocked: %s\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,9A7B2C\n\nMIIEvgIBADANBgkqSECRETBODYxxxx\n" "$RB"' \
-  "SECRETBODY" appear
+  encpemfix "SECRETBODY" appear
 
 # 4. Tag preservation on the CLOSING line — the branch that does not route
 #    through mask_line(). Without it the closing row's tag is blanked and the
 #    record stops parsing.
 unit_ablate 's|^      if (match(s, /\^D\\t\[\^\\t\]\*\\t/)) L\[close_at\] = substr(s, 1, RLENGTH) PH tail$|      if (0) L[close_at] = substr(s, 1, RLENGTH) PH tail|' \
   "closing-line tag preservation is load-bearing (the record loses its tag without it)" \
-  '{ printf "D\tBash\thead %s\n" "$RB"; printf "D\tBash\ttail %s z\n" "$RE"; }' \
-  "$(printf 'D\tBash\t<redacted-key-material> z')" vanish
+  closerowfix "$(printf 'D\tBash\t<redacted-key-material> z')" vanish
+
+# 5. Clearing U[] as lines are consumed. Without it a second opener inside an
+#    already-masked span re-enters the unterminated branch and runs away, so the
+#    arm is signed VANISH: removing the guard masks MORE.
+unit_ablate 's|^    for (j = i + 1; j < close_at; j++) { L\[j\] = mask_line(L\[j\]); U\[j\] = 0 }$|    for (j = i + 1; j < close_at; j++) { L[j] = mask_line(L[j]) }|' \
+  "clearing U[] on consumed lines is load-bearing (a second opener runs away without it)" \
+  nestedfix "SURVIVOR-6" vanish
 
 # ── TIMESTAMP MATRIX — one row per SHAPE, not a case per reported bug ─────────
 # Three consecutive review rounds each reported this defect at a new position:


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The telemetry miner's private-key redactor was deciding whether a key block was complete by looking a fixed distance ahead. A key longer than that distance was misread as truncated and only partly masked — so the tail of a real private key could reach the report. Measured: 44 lines of a 300-line key.

This is the component five consecutive review rounds each found a new defect in. Each fix handled the shapes we had thought of. This one is written against the RFCs instead, so the shapes are enumerated up front rather than discovered one review at a time.

## What

Both fixed-distance limits are gone. Whether a key block is complete is now decided by reading to the end of the input, and a key that never ends is masked to the end of the input too — so neither answer depends on a guess about how long a key can be. There is no such limit in the format, which is why every version that assumed one leaked eventually.

The cost is deliberate and is now covered by tests in both directions: a stray key marker in ordinary text will over-mask the lines after it. That is the safe direction — masked records keep their identity and stay counted, so the cost is lost message text and lost tool attribution, never a lost record.

Proving this surfaced further disclosures in the same area, all fixed here. Four of them turned out to be **one** defect wearing four shapes: whenever key markers were nested, the redactor stopped masking at the wrong marker and printed the key material past it. Fixing each shape as it was reported is what produced four rounds; this change instead pins the single property that makes all four impossible, so a fifth shape has nothing left to exploit. A fifth defect was an assumption rather than an oversight — one field was preserved on the stated grounds that it "can only be a tool name", when it is copied straight out of the transcript and can be anything.

Along the way: one masking path was blanking a record's identifying tag, quietly dropping it from the error count, and several tests were re-deriving the program under test instead of using the one the suite validates, so they could have passed against nothing.

Behaviour is unchanged for every non-key line — real-corpus error counts are identical before and after, with both corruption canaries at zero.

Fixes #2643
