### PR TITLE
fix(branch-cleanup): stop the pre-delete worktree re-check failing open

### DIFF
--- a/.claude/scripts/branch-cleanup.sh
+++ b/.claude/scripts/branch-cleanup.sh
@@ -367,7 +367,15 @@ if [ "$DO_LOCAL" -eq 1 ]; then
         echo "$SLUG: keep '$b' — worktree enumeration failed; refusing to delete (fail-closed)" >&2
         l_keep=$((l_keep+1)); errors=$((errors+1)); continue
       fi
-      if printf '%s\n' "$wt_list" | grep -Fxq "branch refs/heads/$b"; then
+      # Feed grep directly instead of through a pipe. This script runs under
+      # `pipefail`, and `grep -Fxq` exits at the first match — so with a pipe the
+      # still-writing `printf` takes SIGPIPE (141) and pipefail reports THAT as
+      # the pipeline status, turning "is checked out" into "is checked out
+      # nowhere" and deleting the branch this very check exists to protect.
+      # Size-dependent, hence easy to miss: correct up to ~2 worktree entries,
+      # wrong from ~5 up. Do NOT "simplify" this back into a pipeline, and do
+      # not fix such a case by dropping pipefail (monorepo#2674).
+      if grep -Fxq "branch refs/heads/$b" <<<"$wt_list"; then
         echo "$SLUG: keep '$b' — checked out by a worktree since the snapshot" >&2
         l_keep=$((l_keep+1)); continue
       fi

--- a/.claude/scripts/branch-cleanup.test.sh
+++ b/.claude/scripts/branch-cleanup.test.sh
@@ -411,6 +411,74 @@ report "apply recorded the remote deletion sha and MERGED status" \
 # Silence unused-var lint for the open_sha we only needed for push tip creation.
 : "$open_sha" "$local_sha"
 
+# --- 13. the pre-delete worktree re-check must survive a realistic list -----
+# monorepo#2674. The local delete loop re-reads `git worktree list --porcelain`
+# immediately before `update-ref -d`, to catch a worktree that claimed the
+# branch AFTER the keep-set snapshot. That predicate was a pipeline ending in
+# `grep -Fxq`, and this script runs under `pipefail`: grep exits at the matching
+# line, the still-writing `printf` takes SIGPIPE (141), and pipefail reports 141
+# as the pipeline status — so a branch that IS checked out reads as checked out
+# NOWHERE and gets deleted, leaving that worktree on a dangling HEAD.
+#
+# It is a SIZE-dependent failure, which is why it survived review: the predicate
+# is correct for a one- or two-entry list and wrong from about five entries up.
+# A `git` shim on PATH returns the real enumeration for the keep-set snapshot
+# and a larger, later one for the re-check — exactly the race the re-check
+# exists to cover, and the only way to isolate it from the primary keep-set.
+wt_shim_dir="$tmp/wtshim"; mkdir -p "$wt_shim_dir"
+real_git=$(command -v git)
+cat >"$tmp/bin/git" <<SHIM
+#!/usr/bin/env bash
+if [ "\$1" = "worktree" ] && [ "\$2" = "list" ] && [ -n "\${WT_SHIM_STATE:-}" ]; then
+  n=\$(cat "\$WT_SHIM_STATE" 2>/dev/null || echo 0); echo \$((n+1)) >"\$WT_SHIM_STATE"
+  if [ "\$n" -ge 1 ] && [ -s "\${WT_SHIM_INJECT:-/nonexistent}" ]; then
+    cat "\$WT_SHIM_INJECT"; exit 0
+  fi
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$tmp/bin/git"
+
+# A worktree list of realistic size. The target branch sits near the FRONT,
+# as a real match usually does — that is what leaves the writer with work to do.
+mk_wt_list() {   # $1 = branch to include ("" for none)
+  local target="$1" i
+  printf 'worktree %s\nHEAD %s\nbranch refs/heads/main\n\n' "$work" "$(git -C "$work" rev-parse main)"
+  [ -n "$target" ] && printf 'worktree %s/live\nHEAD %s\nbranch refs/heads/%s\n\n' "$tmp" "$(git -C "$work" rev-parse main)" "$target"
+  for i in $(seq 1 40); do
+    printf 'worktree %s/.claude/worktrees/sess-%s\nHEAD %s\nbranch refs/heads/claude/other-session-%s\n\n' \
+      "$work" "$i" "$(git -C "$work" rev-parse main)" "$i"
+  done
+}
+
+# ARM 1 — the guard: branch IS in the later list, so it must be KEPT.
+wt_sha=$(mk_remote_branch "claude/wt-reclaim-2674")
+git -C "$work" checkout main >/dev/null
+: >"$OPEN_HEADS_FILE"
+printf '%s\tMERGED\t%s\n' "claude/wt-reclaim-2674" "$wt_sha" >"$PR_EVIDENCE_FILE"
+export WT_SHIM_STATE="$wt_shim_dir/count" WT_SHIM_INJECT="$wt_shim_dir/list"
+: >"$WT_SHIM_STATE"; mk_wt_list "claude/wt-reclaim-2674" >"$WT_SHIM_INJECT"
+manifest="$tmp/manifest-2674a"; : >"$manifest"
+out="$("$helper" "$work" "monorepo" "$manifest" apply 2>&1)" && rc=0 || rc=$?
+report "worktree re-check keeps a branch claimed after the snapshot (#2674)" \
+  "$($real_git -C "$work" rev-parse --verify --quiet "refs/heads/claude/wt-reclaim-2674" >/dev/null && echo yes || echo no)" \
+  "rc=$rc out=$out"
+
+# ARM 2 — control: same shim, same size, branch ABSENT from the later list, so
+# the branch SHOULD be deleted. Without this, a harness that never deletes
+# anything would pass arm 1 vacuously.
+ctl_sha=$(mk_remote_branch "claude/wt-control-2674")
+git -C "$work" checkout main >/dev/null
+printf '%s\tMERGED\t%s\n' "claude/wt-control-2674" "$ctl_sha" >"$PR_EVIDENCE_FILE"
+: >"$WT_SHIM_STATE"; mk_wt_list "" >"$WT_SHIM_INJECT"
+manifest="$tmp/manifest-2674b"; : >"$manifest"
+out="$("$helper" "$work" "monorepo" "$manifest" apply 2>&1)" && rc=0 || rc=$?
+report "control: an unclaimed branch is still deleted at the same list size (#2674)" \
+  "$($real_git -C "$work" rev-parse --verify --quiet "refs/heads/claude/wt-control-2674" >/dev/null && echo no || echo yes)" \
+  "rc=$rc out=$out"
+unset WT_SHIM_STATE WT_SHIM_INJECT
+rm -f "$tmp/bin/git"
+
 if [[ "$fail" -ne 0 ]]; then
   echo "branch-cleanup contract: FAILED"
   exit 1

--- a/.claude/scripts/branch-cleanup.test.sh
+++ b/.claude/scripts/branch-cleanup.test.sh
@@ -430,7 +430,13 @@ real_git=$(command -v git)
 cat >"$tmp/bin/git" <<SHIM
 #!/usr/bin/env bash
 if [ "\$1" = "worktree" ] && [ "\$2" = "list" ] && [ -n "\${WT_SHIM_STATE:-}" ]; then
-  n=\$(cat "\$WT_SHIM_STATE" 2>/dev/null || echo 0); echo \$((n+1)) >"\$WT_SHIM_STATE"
+  # The counter file is TRUNCATED (not written to 0) between arms, so the first
+  # read yields the empty string — and \`[ "" -ge 1 ]\` is not merely false in
+  # bash, it prints "integer expression expected" to stderr. That stderr is
+  # captured into the assertion's \$out, where it would sit next to a genuine
+  # failure message and read like part of it. Default it explicitly.
+  n=\$(cat "\$WT_SHIM_STATE" 2>/dev/null || echo 0); n=\${n:-0}
+  echo \$((n+1)) >"\$WT_SHIM_STATE"
   if [ "\$n" -ge 1 ] && [ -s "\${WT_SHIM_INJECT:-/nonexistent}" ]; then
     cat "\$WT_SHIM_INJECT"; exit 0
   fi


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`branch-cleanup.sh` deletes local branches. The last thing it does before each delete is re-read the live worktree list, to catch a branch a session claimed since the keep-set snapshot. That check could never return true, so the protection it provides has never existed.

The consequence is a branch deleted out from under a running session, leaving that worktree on a dangling HEAD — which is precisely the outcome the code comment above the line says it is preventing.

## What

The check ran under `pipefail` and piped into a quiet `grep`. `grep` stops at the first match while the writer is still going, the writer dies of `SIGPIPE`, and `pipefail` reports *that* as the answer — so "is checked out" came back as "is checked out nowhere". It now feeds grep directly.

It is size-dependent, which is why it read as correct: fine for a one- or two-entry worktree list, wrong from about five entries up. This host enumerates roughly 124.

Scope, stated plainly: this is the **secondary** re-check. The primary keep-set is built earlier and is unaffected, so the exposure was a worktree appearing *after* the snapshot — the exact race this line covers. A defence-in-depth layer that was fully non-functional, not an unguarded delete path.

The new test drives the real script with a `git` shim that returns a bigger worktree list at the re-check than at the snapshot. Before the fix it fails, with `line 370: printf: write error: Broken pipe` in the output; after it passes. A second arm deletes an *unclaimed* branch at the same list size and passes either way, so the first arm cannot pass vacuously.

Same root cause as #2673, different file and a live safety impact rather than a test-harness one, so it ships separately. 80 further instances of the shape remain across other scripts and are tracked on the issue.

Fixes #2674
