### PR TITLE
fix(surveyor): stop counting an empty CodeRabbit reply container as a green review

### DIFF
--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -247,13 +247,24 @@ public and private — no per-repo loop needed to enumerate):
      still applies its creation-record test before acting on any `devantler` row.
      Fetch `headRefOid` while deepening the PR. Report `cr@<sha>` for a finding-free CodeRabbit
      review completion at the current head even without `APPROVED`: accept a current-head review
-     object, or CodeRabbit's substantive auto-generated summary comment
+     object **whose own `body` is non-empty**, or CodeRabbit's substantive auto-generated summary comment
      (`<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`) updated after the
      authenticated request and naming `headRefOid`, only when its threads, review-body sections, and
      explicit ancillary problem count are all zero. **Never count an auto-generated command reply, acknowledgement, quota notice, or service shell as a review completion**; reject the summary too when
      its body says the review did not run. The qualifying review object `submitted_at` must be later than the latest authenticated CodeRabbit request marker for that head, just as the summary's
      `updated_at` must be later; this prevents a same-SHA retry from reusing its original review.
      An authenticated fingerprint-matching **`body_findings=0-resolved@<sha>` counts as zero for CodeRabbit success** even when the identical section is repeated in the later review.
+     🔴 **An EMPTY review object is a reply container, not a review — `body: ""` never satisfies the gate.**
+     GitHub wraps a reply to an existing review thread in its own review object, so CodeRabbit
+     acknowledging a resolved finding ("confirmed. The revised text correctly identifies…") lands as a
+     review that is authored by `coderabbitai[bot]`, anchored to the CURRENT head, and carries zero
+     finding sections — passing every "no findings at head" test while representing no review at all.
+     Measured on platform#2973 (2026-08-05): a `bodylen=0` container at `afa4445220` was reported
+     `cr@afa4445220` while that head's own CodeRabbit status read `Review skipped: automatic reviews
+     are disabled`; the real review, one head earlier, was `bodylen=2755`. Corroborate with the head's
+     CodeRabbit commit status, which reads `Review completed` for a review that ran and
+     `Review skipped: …` or `Review rate limited` when none did — and note that `state=success`
+     accompanies all three, so the `description` is the discriminator, never the state.
      Report an older completion as `cr-stale@<sha>`. A
      **current-head CodeRabbit review that carries findings** (a `COMMENTED`/`CHANGES_REQUESTED`
      review with unresolved threads or actionable comments) is `cr-findings@<sha>` — report its

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -247,7 +247,8 @@ public and private — no per-repo loop needed to enumerate):
      still applies its creation-record test before acting on any `devantler` row.
      Fetch `headRefOid` while deepening the PR. Report `cr@<sha>` for a finding-free CodeRabbit
      review completion at the current head even without `APPROVED`: accept a current-head review
-     object **whose own `body` is non-empty**, or CodeRabbit's substantive auto-generated summary comment
+     object **whose own `body` is non-empty AND whose head carries a CodeRabbit commit status whose
+     `description` begins `Review completed`** — both conjuncts, never the body alone — or CodeRabbit's substantive auto-generated summary comment
      (`<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`) updated after the
      authenticated request and naming `headRefOid`, only when its threads, review-body sections, and
      explicit ancillary problem count are all zero. **Never count an auto-generated command reply, acknowledgement, quota notice, or service shell as a review completion**; reject the summary too when
@@ -261,10 +262,16 @@ public and private — no per-repo loop needed to enumerate):
      finding sections — passing every "no findings at head" test while representing no review at all.
      Measured on platform#2973 (2026-08-05): a `bodylen=0` container at `afa4445220` was reported
      `cr@afa4445220` while that head's own CodeRabbit status read `Review skipped: automatic reviews
-     are disabled`; the real review, one head earlier, was `bodylen=2755`. Corroborate with the head's
-     CodeRabbit commit status, which reads `Review completed` for a review that ran and
-     `Review skipped: …` or `Review rate limited` when none did — and note that `state=success`
-     accompanies all three, so the `description` is the discriminator, never the state.
+     are disabled`; the real review, one head earlier, was `bodylen=2755`. 🔴 **The status conjunct is
+     REQUIRED, not advisory.** A non-empty body plus an exclusion list is still a blocklist: any
+     unlisted non-review response — a thread reply that happens to carry text, a setup note, an
+     unrecognised service message — satisfies it. The head's CodeRabbit commit status reads
+     `Review completed` for a review that ran and `Review skipped: …` or `Review rate limited` when
+     none did — and note that `state=success` accompanies all three, so
+     the `description` is the discriminator, never the state.
+     Keep the exclusions as defense in depth; the status is what makes
+     the test positive rather than merely not-negative. A head carrying **no** CodeRabbit status at all
+     fails closed to `none`.
      Report an older completion as `cr-stale@<sha>`. A
      **current-head CodeRabbit review that carries findings** (a `COMMENTED`/`CHANGES_REQUESTED`
      review with unresolved threads or actionable comments) is `cr-findings@<sha>` — report its

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -247,8 +247,10 @@ public and private — no per-repo loop needed to enumerate):
      still applies its creation-record test before acting on any `devantler` row.
      Fetch `headRefOid` while deepening the PR. Report `cr@<sha>` for a finding-free CodeRabbit
      review completion at the current head even without `APPROVED`: accept a current-head review
-     object **whose own `body` is non-empty AND whose head carries a CodeRabbit commit status whose
-     `description` begins `Review completed`** — both conjuncts, never the body alone — or CodeRabbit's substantive auto-generated summary comment
+     object **whose own `body` BEGINS WITH the recognised CodeRabbit review-artifact marker
+     `**Actionable comments posted:`** — a positive identification of the matched object as a review,
+     never merely a non-empty body — **and** whose head also carries a CodeRabbit commit status whose
+     `description` begins `Review completed`, or CodeRabbit's substantive auto-generated summary comment
      (`<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`) updated after the
      authenticated request and naming `headRefOid`, only when its threads, review-body sections, and
      explicit ancillary problem count are all zero. **Never count an auto-generated command reply, acknowledgement, quota notice, or service shell as a review completion**; reject the summary too when
@@ -262,15 +264,21 @@ public and private — no per-repo loop needed to enumerate):
      finding sections — passing every "no findings at head" test while representing no review at all.
      Measured on platform#2973 (2026-08-05): a `bodylen=0` container at `afa4445220` was reported
      `cr@afa4445220` while that head's own CodeRabbit status read `Review skipped: automatic reviews
-     are disabled`; the real review, one head earlier, was `bodylen=2755`. 🔴 **The status conjunct is
-     REQUIRED, not advisory.** A non-empty body plus an exclusion list is still a blocklist: any
-     unlisted non-review response — a thread reply that happens to carry text, a setup note, an
-     unrecognised service message — satisfies it. The head's CodeRabbit commit status reads
-     `Review completed` for a review that ran and `Review skipped: …` or `Review rate limited` when
-     none did — and note that `state=success` accompanies all three, so
+     are disabled`; the real review, one head earlier, was `bodylen=2755`.
+     🔴 **Identify the OBJECT positively; the status only proves a run completed.** A non-empty body
+     plus an exclusion list is a blocklist — any unlisted non-review response (a thread reply that
+     happens to carry text, a setup note, an unrecognised service message) satisfies it. Nor does
+     pairing it with the head's status close the hole, because the two are **independent facts**: a
+     run completing and *some* object carrying text can both be true while the matched object is
+     still a reply container. Measured on monorepo#2677 (2026-08-05): head `0b2c759530` carried a
+     `bodylen=0` container at 16:22:58Z **and** a genuine `bodylen=5573` review at 16:33:34Z under one
+     `Review completed` status — had the container carried text, a status conjunct would have blessed
+     it. So match the artifact itself: every real CodeRabbit review body observed across monorepo and
+     platform begins `**Actionable comments posted: N**`. The status stays a **required corroborator**
+     of run-completion — it reads `Review completed` for a review that ran and `Review skipped: …` or
+     `Review rate limited` when none did, and note that `state=success` accompanies all three, so
      the `description` is the discriminator, never the state.
-     Keep the exclusions as defense in depth; the status is what makes
-     the test positive rather than merely not-negative. A head carrying **no** CodeRabbit status at all
+     Keep the exclusions as defense in depth. A head carrying **no** CodeRabbit status at all
      fails closed to `none`.
      Report an older completion as `cr-stale@<sha>`. A
      **current-head CodeRabbit review that carries findings** (a `COMMENTED`/`CHANGES_REQUESTED`

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -86,16 +86,21 @@ grep -Fq 'green_review=exempt-programmed-bot' "${surveyor}" ||
 # work. Measured live on platform#2973.
 # Literal Markdown code spans; command substitution is intentionally disabled.
 # shellcheck disable=SC2016
-grep -Fq 'object **whose own `body` is non-empty AND whose head carries a CodeRabbit commit status whose' "${surveyor}" ||
+grep -Fq 'object **whose own `body` BEGINS WITH the recognised CodeRabbit review-artifact marker' "${surveyor}" ||
   fail "surveyor can count an empty CodeRabbit reply container as a green review"
 grep -Fq 'An EMPTY review object is a reply container, not a review' "${surveyor}" ||
   fail "surveyor does not name the empty-review-container trap"
-# A non-empty body plus an exclusion list is a blocklist: an unlisted non-review response
-# (a thread reply carrying text, a setup note, an unrecognised service message) passes it
-# while no review ran. Only the head's own `Review completed` status makes the test
-# positive, so it has to be a required conjunct rather than described corroboration.
-grep -Fq 'REQUIRED, not advisory.**' "${surveyor}" ||
-  fail "surveyor treats the CodeRabbit status as advisory, so a non-empty non-review body still passes"
+# A non-empty body is not enough, and neither is pairing it with the head's status: a run
+# completing and *some* object carrying text are independent facts, so a non-empty reply
+# container can satisfy both while no review of that object exists. Measured on
+# monorepo#2677, where one head carried a bodylen=0 container AND a real review under a
+# single `Review completed` status. The object must be identified positively instead.
+# Literal Markdown code spans; command substitution is intentionally disabled.
+# shellcheck disable=SC2016
+grep -Fq '`**Actionable comments posted:`' "${surveyor}" ||
+  fail "surveyor does not positively identify a CodeRabbit review artifact, so a non-empty non-review body still passes"
+grep -Fq 'the status only proves a run completed' "${surveyor}" ||
+  fail "surveyor treats the head status as proof the matched object is a substantive review"
 # Literal Markdown code spans; command substitution is intentionally disabled.
 # shellcheck disable=SC2016
 grep -Fq 'fails closed to `none`' "${surveyor}" ||

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -86,10 +86,20 @@ grep -Fq 'green_review=exempt-programmed-bot' "${surveyor}" ||
 # work. Measured live on platform#2973.
 # Literal Markdown code spans; command substitution is intentionally disabled.
 # shellcheck disable=SC2016
-grep -Fq 'object **whose own `body` is non-empty**' "${surveyor}" ||
+grep -Fq 'object **whose own `body` is non-empty AND whose head carries a CodeRabbit commit status whose' "${surveyor}" ||
   fail "surveyor can count an empty CodeRabbit reply container as a green review"
 grep -Fq 'An EMPTY review object is a reply container, not a review' "${surveyor}" ||
   fail "surveyor does not name the empty-review-container trap"
+# A non-empty body plus an exclusion list is a blocklist: an unlisted non-review response
+# (a thread reply carrying text, a setup note, an unrecognised service message) passes it
+# while no review ran. Only the head's own `Review completed` status makes the test
+# positive, so it has to be a required conjunct rather than described corroboration.
+grep -Fq 'REQUIRED, not advisory.**' "${surveyor}" ||
+  fail "surveyor treats the CodeRabbit status as advisory, so a non-empty non-review body still passes"
+# Literal Markdown code spans; command substitution is intentionally disabled.
+# shellcheck disable=SC2016
+grep -Fq 'fails closed to `none`' "${surveyor}" ||
+  fail "surveyor does not fail closed when the head carries no CodeRabbit status"
 # Literal Markdown code spans; command substitution is intentionally disabled.
 # shellcheck disable=SC2016
 grep -Fq 'the `description` is the discriminator, never the state' "${surveyor}" ||

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -79,6 +79,21 @@ grep -Fq '`app/botantler-1` is narrowly trusted only for programmed agent-skills
   fail "constitution either misses botantler updater PRs or trusts the App globally"
 grep -Fq 'green_review=exempt-programmed-bot' "${surveyor}" ||
   fail "surveyor cannot report a programmed bot review exemption"
+# An empty review object is the container GitHub creates for a reply to an existing
+# review thread. It is authored by the bot, anchored to the current head, and has zero
+# findings — so a green-review test that does not require a substantive body reports a
+# clean review on a PR that had none, and a run following the digest merges unreviewed
+# work. Measured live on platform#2973.
+# Literal Markdown code spans; command substitution is intentionally disabled.
+# shellcheck disable=SC2016
+grep -Fq 'object **whose own `body` is non-empty**' "${surveyor}" ||
+  fail "surveyor can count an empty CodeRabbit reply container as a green review"
+grep -Fq 'An EMPTY review object is a reply container, not a review' "${surveyor}" ||
+  fail "surveyor does not name the empty-review-container trap"
+# Literal Markdown code spans; command substitution is intentionally disabled.
+# shellcheck disable=SC2016
+grep -Fq 'the `description` is the discriminator, never the state' "${surveyor}" ||
+  fail "surveyor can read a CodeRabbit status state=success as proof a review ran"
 # Literal Markdown code spans; command substitution is intentionally disabled.
 # shellcheck disable=SC2016
 grep -Fq 'Exit 3 means a trusted, review-required `agent-plugins` updater' "${surveyor}" ||


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The survey can report a PR as having a clean CodeRabbit review when no review ran at all — so a run following the digest promotes and merges unreviewed work.

It happened live today on platform#2973: the digest said `green_review=cr@afa4445220`, while that head`s own CodeRabbit status read `Review skipped: automatic reviews are disabled`. The object it matched was CodeRabbit replying "confirmed" to a thread I had just resolved. Only re-querying the reviews list directly before promoting caught it.

## What

A review object now counts only when its own body is non-empty — an empty one is the container GitHub creates to hold a reply to an existing thread, not a review. The head`s CodeRabbit commit status is named as corroboration, along with the trap that `state=success` accompanies "completed", "skipped" and "rate limited" alike, so the description is what distinguishes them.

Pinned by two contract assertions, proven RED before GREEN.

Worth flagging: this composes with #2676 into a false green. Keyed on state plus author plus "no findings", both bugs read green on a PR that had zero reviews at its head.

Fixes #2620