### PR TITLE
fix(agents): read the CodeRabbit status description, not its state

### DIFF
--- a/.claude/plugin-consumption/agentic-engineering-surveyor-diff.md
+++ b/.claude/plugin-consumption/agentic-engineering-surveyor-diff.md
@@ -50,6 +50,12 @@ plugin carries them (or an explicit, tested subset):
    `**Reviewed commit:**` marker), fails closed when unattributable, and is **not** cleared by a
    newer `Didn't find any major issues` comment. Without this the pentad reads fully clear over an
    open P2 — measured on monorepo#2559.
+4c. **CodeRabbit commit-status description discriminator** (monorepo#2676) — the `CodeRabbit` status
+   is `state: success` for a completed review, for `Review skipped: automatic reviews are disabled`,
+   and for a rate-limit refusal alike. Auto-review is disabled deployment-wide, so the skipped form
+   is the default state of every head: the status corroborates run-completion only when its
+   `description` begins `Review completed`, and never satisfies the gate on its own. Without this a
+   state-only check reports every never-reviewed PR as green.
 5. **Sequential review coordination state** — authenticated single-phase request marker posted with
    the trigger (the two-phase reservation was retired on measurement 2026-07-25), pending request,
    monotonic artifact-backed or evidenced-expiry no-gate progression,

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -98,6 +98,25 @@ grep -Fq 'Missing or delayed pre-merge output never blocks promotion' "${constit
   fail "absent ancillary CodeRabbit output can still block a reviewed PR"
 grep -Fq 'fold it into `body_findings`' "${surveyor}" ||
   fail "an explicit CodeRabbit pre-merge problem is not preserved as a review finding"
+
+# The `CodeRabbit` commit status carries `state: success` for three different outcomes — a completed
+# review, a review that never ran because auto-review is disabled, and a rate-limited refusal
+# (monorepo#2676). Auto-review is disabled portfolio-wide, so the skipped form is the DEFAULT state
+# of every head: a green keyed on the state alone marks every never-reviewed PR as reviewed. These
+# guards keep the `description` discriminator, and the status's corroborator-not-satisfier role, in
+# all three overlays that describe the swept surfaces.
+assert_prose "${constitution}" 'Review skipped: automatic reviews are disabled' \
+  "constitution does not name the not-run CodeRabbit status description"
+assert_prose "${constitution}" 'the `description` is the only discriminator' \
+  "constitution does not make the status description the discriminator"
+assert_prose "${constitution}" 'required corroborator, never a satisfier' \
+  "the CodeRabbit commit status can satisfy the green-review gate on its own"
+assert_prose "${surveyor}" 'Review skipped: automatic reviews are disabled' \
+  "surveyor lost the not-run CodeRabbit status marker"
+assert_prose "${surveyor}" 'the `description` is the discriminator, never the state' \
+  "surveyor can read a skipped CodeRabbit review as a green"
+assert_prose "${maintenance_skill}" 'Review skipped: automatic reviews are disabled' \
+  "portfolio-maintenance is blind to the not-run CodeRabbit status"
 for contract_file in "${constitution}" "${surveyor}" "${maintenance_skill}"; do
   if grep -Fq 'premerge=' "${contract_file}"; then
     fail "standalone CodeRabbit pre-merge readiness state remains in ${contract_file}"

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -99,9 +99,10 @@ grep -Fq 'Missing or delayed pre-merge output never blocks promotion' "${constit
 grep -Fq 'fold it into `body_findings`' "${surveyor}" ||
   fail "an explicit CodeRabbit pre-merge problem is not preserved as a review finding"
 
-# The `CodeRabbit` commit status carries `state: success` for three different outcomes — a completed
-# review, a review that never ran because auto-review is disabled, and a rate-limited refusal
-# (monorepo#2676). Auto-review is disabled portfolio-wide, so the skipped form is the DEFAULT state
+# With `reviews.fail_commit_status: false`, the `CodeRabbit` commit status carries `state: success`
+# for three different outcomes — a completed review, a review that never ran because auto-review is
+# disabled, and a rate-limited refusal (monorepo#2676). Auto-review is disabled portfolio-wide, so
+# the skipped form is the DEFAULT state
 # of every head: a green keyed on the state alone marks every never-reviewed PR as reviewed. These
 # guards keep the `description` discriminator, and the status's corroborator-not-satisfier role, in
 # all three overlays that describe the swept surfaces.

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -117,6 +117,10 @@ assert_prose "${surveyor}" 'the `description` is the discriminator, never the st
   "surveyor can read a skipped CodeRabbit review as a green"
 assert_prose "${maintenance_skill}" 'Review skipped: automatic reviews are disabled' \
   "portfolio-maintenance is blind to the not-run CodeRabbit status"
+# The parity checklist gates deletion of the local surveyor overlay, so a deployment-hardened rule
+# absent from it is one the overlay removal drops silently.
+assert_prose "${parity_checklist}" 'CodeRabbit commit-status description discriminator' \
+  "removing the surveyor overlay would silently drop the status discriminator"
 for contract_file in "${constitution}" "${surveyor}" "${maintenance_skill}"; do
   if grep -Fq 'premerge=' "${contract_file}"; then
     fail "standalone CodeRabbit pre-merge readiness state remains in ${contract_file}"

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -190,8 +190,9 @@ Configure the plugin surveyor from this repo's `AGENTS.md` contract sections (*P
   identical section repeats.
   🔴 **Corroborate with the head's `CodeRabbit` commit status, and read its `description`, not its
   `state`.** `state` is `success` for a completed review, for `Review skipped: automatic reviews are
-  disabled` (the default state of every head, since auto-review is disabled portfolio-wide), and for
-  `Review rate limited` alike, so a state-only check reads every never-reviewed PR as green. Only a
+  disabled` (the default state of every head, since auto-review is disabled portfolio-wide), and —
+  while `fail_commit_status: false` is in force — for a rate-limit refusal alike, so a state-only
+  check reads every never-reviewed PR as green. Only a
   `description` beginning `Review completed` evidences a run, and it corroborates the artifact rather
   than replacing it.
   Report an older completion as stale, and a current-head CodeRabbit review carrying

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -188,6 +188,12 @@ Configure the plugin surveyor from this repo's `AGENTS.md` contract sections (*P
   reply/acknowledgement, quota notice, service shell, or summary saying the review did not run.
   Treat an authenticated fingerprint-matching `body_findings=0-resolved@<sha>` as zero when the
   identical section repeats.
+  🔴 **Corroborate with the head's `CodeRabbit` commit status, and read its `description`, not its
+  `state`.** `state` is `success` for a completed review, for `Review skipped: automatic reviews are
+  disabled` (the default state of every head, since auto-review is disabled portfolio-wide), and for
+  `Review rate limited` alike, so a state-only check reads every never-reviewed PR as green. Only a
+  `description` beginning `Review completed` evidences a run, and it corroborates the artifact rather
+  than replacing it.
   Report an older completion as stale, and a current-head CodeRabbit review carrying
   findings as `cr-findings@<sha>`. For Codex, sweep
   paginated `issues/<n>/comments` plus `pulls/<n>/reviews`/review threads for the latest actual

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -993,8 +993,10 @@ the green can be newer than the finding, so recency decides nothing here.
 🔴 **The `CodeRabbit` commit status is `success` when NO review ran — the `description` is the only
 discriminator.** Auto-review is disabled portfolio-wide, so
 `success — Review skipped: automatic reviews are disabled` is the **default state of every head**,
-carrying zero reviews, zero inline comments and no summary; `Review rate limited` is `success` too
-(see *Local review round*). A green keyed on `context == "CodeRabbit" && state == "success"`
+carrying zero reviews, zero inline comments and no summary; a rate-limit refusal publishes `success`
+too while `reviews.fail_commit_status: false` is in force (see *Local review round*, whose
+`CodeRabbit / failure` wording describes the same refusal with that lever off). A green keyed on
+`context == "CodeRabbit" && state == "success"`
 therefore marks **every never-reviewed PR as reviewed** — a fail-open on the promotion gate reachable
 by following the surface list literally. So read the `description`, never the `state`:
 `Review completed` is the only value that evidences a run, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -970,7 +970,7 @@ green reads as "no review". Rows are in lane-priority order:**
 
 | Lane | Clean/green artifact | Findings artifact | Key to match |
 |---|---|---|---|
-| **CodeRabbit** (`coderabbitai[bot]`) | current-head review completion with no actionable thread/body/ancillary finding; `APPROVED` is sufficient but not required | review object/body/comment with an actionable finding | REST `commit_id` == head, or the auto-generated summary comment updated after the authenticated request, naming the head, and carrying no rate-limit/service marker |
+| **CodeRabbit** (`coderabbitai[bot]`) | current-head review completion with no actionable thread/body/ancillary finding; `APPROVED` is sufficient but not required | review object/body/comment with an actionable finding | REST `commit_id` == head, or the auto-generated summary comment updated after the authenticated request, naming the head, and carrying no rate-limit/service marker; the head's `CodeRabbit` commit status corroborates that a review RAN only when its `description` begins `Review completed` |
 | **Codex** (`chatgpt-codex-connector[bot]`) | **issue COMMENT** — `Codex Review: Didn't find any major issues` + `**Reviewed commit:** <sha>` (10-char, no `commit_id` field) | review object, `state: COMMENTED`, inline threads — **OR an issue COMMENT carrying a `## Review finding` section** (see below) | clean pass: comment body sha vs `headRefOid[0:10]`; comment-form finding: full 40-char sha in its blob permalinks |
 | **Cursor Bugbot** (`cursor[bot]`) | **CHECK-RUN named `Cursor Bugbot`** (app slug `cursor`), `conclusion: success` — *no review object, no comment* | same check-run with **`conclusion: neutral` AND `output.title: "Bugbot Review"`**, findings as INLINE review comments from `cursor[bot]` on `pulls/<n>/comments` | check-run at `commits/<headRefOid>/check-runs` |
 
@@ -989,6 +989,18 @@ is precisely why the marker-based sweep missed it. **`Didn't find any major issu
 the green can be newer than the finding, so recency decides nothing here.
 
 **CodeRabbit success is about its review result, not GitHub's approval event:** **a finding-free current-head CodeRabbit review completion is `cr@<sha>` even without `APPROVED`**. Accept either its current-head review object submitted after the latest authenticated request for that head or its substantive auto-generated summary comment (`<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`) updated after that request and naming the head. Reject auto-generated command replies/acknowledgements and any summary carrying a rate-limit, quota, or service marker saying the review did not run. Only then check all CodeRabbit threads, review-body finding sections, and explicit ancillary problems for that review; an authenticated fingerprint-matching `body_findings=0-resolved@<sha>` record counts as zero when the identical section repeats. Any unresolved/new finding or stale completion is not green.
+
+🔴 **The `CodeRabbit` commit status is `success` when NO review ran — the `description` is the only
+discriminator.** Auto-review is disabled portfolio-wide, so
+`success — Review skipped: automatic reviews are disabled` is the **default state of every head**,
+carrying zero reviews, zero inline comments and no summary; `Review rate limited` is `success` too
+(see *Local review round*). A green keyed on `context == "CodeRabbit" && state == "success"`
+therefore marks **every never-reviewed PR as reviewed** — a fail-open on the promotion gate reachable
+by following the surface list literally. So read the `description`, never the `state`:
+`Review completed` is the only value that evidences a run, and
+`Review skipped: automatic reviews are disabled` is a not-run marker in the same family as a
+rate-limit marker. The status is a **required corroborator, never a satisfier** — it proves only that
+*a* run completed, so a green still needs the real artifact its row names, positively identified.
 
 ⚠️ **Bugbot's green is a status check, NOT a review object and NOT a comment** — a gate or survey that
 sweeps only `pulls/<n>/reviews` and `issues/<n>/comments` is **structurally blind** to it and will


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The `CodeRabbit` commit status reads `success` whether a review ran, was skipped, or was refused on quota. Auto-review is disabled across this deployment, so `success — "Review skipped: automatic reviews are disabled"` is the state of **every** pull-request head before anyone asks for a review. A promotion check that treats that status as a green therefore waves through PRs nobody has reviewed.

## What

Records the discriminator — only a description of `Review completed` evidences a review, and the status corroborates a real review artifact rather than replacing one — in the three places that describe the reviewed surfaces, and adds six guards so the distinction cannot be lost again.

Fixes #2676