### PR TITLE
fix(telemetry): annotate each injection phrase with its own class split

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -293,7 +293,7 @@ emit_injection_hits() {
 # both. Classify the matched STRING path, never the whole record. If parsing or
 # reconciliation is uncertain, retain every raw occurrence as other content.
 emit_injection_classes() {
-  local f="$1" session line raw raw_count runtime_count other_count i
+  local f="$1" session line raw runtime_phrases
   session=$(basename "$f" | tr -cd 'A-Za-z0-9._-' | cut -c1-120)
   [ -n "$session" ] || session=unknown
 
@@ -301,52 +301,71 @@ emit_injection_classes() {
     | while IFS=: read -r line raw; do
         case "$line" in ''|*[!0-9]*) continue ;; esac
         line=$(printf '%s' "$line" | cut -c1-12)
-        raw_count=$(printf '%s' "$raw" | grep -hoiE "$INJ_PHRASE_RE" | wc -l | tr -d ' ')
-        runtime_count=$(printf '%s' "$raw" | jq -r --arg re "$INJ_PHRASE_RE" '
-          def match_count:
-            if type == "string" then [scan($re; "i")] | length else 0 end;
-          if
-            (.type == "response_item"
-             and .payload.type == "message"
-             and .payload.role == "developer")
-          then
-            ([.payload.content[]?.text | match_count] | add // 0)
-          elif
-            (.type == "turn_context")
-          then
-            (.payload.collaboration_mode.settings.developer_instructions | match_count)
-          elif
-            (.type == "event_msg" and .payload.type == "thread_settings_applied")
-          then
-            (.payload.thread_settings.collaboration_mode.settings.developer_instructions | match_count)
-          elif
-            (.type == "compacted")
-          then
-            ([
-              .payload.replacement_history[]?
-              | select(.type == "message" and .role == "developer")
-              | .content[]?.text
-              | match_count
-            ] | add // 0)
-          else
-            0
-          end
-        ' 2>/dev/null || true)
-        case "$runtime_count" in
-          ''|*[!0-9]*) runtime_count=0 ;;
-          *) [ "$runtime_count" -le "$raw_count" ] || runtime_count=0 ;;
-        esac
-        other_count=$((raw_count - runtime_count))
-        i=0
-        while [ "$i" -lt "$runtime_count" ]; do
-          printf '%s\t%s\truntime-developer\n' "$session" "$line"
-          i=$((i + 1))
-        done
-        i=0
-        while [ "$i" -lt "$other_count" ]; do
-          printf '%s\t%s\tother-content\n' "$session" "$line"
-          i=$((i + 1))
-        done
+        # Runtime-supplied developer context as STRINGS rather than a bare
+        # count, so every occurrence keeps the phrase it came from and the
+        # report can name WHICH phrase was fleet chatter. Any path this filter
+        # cannot reach — a shape we do not model, a malformed record, a jq
+        # failure — yields nothing here and stays fail-closed as other-content.
+        runtime_phrases=$(printf '%s' "$raw" | jq -r '
+          def runtime_text:
+            if
+              (.type == "response_item"
+               and .payload.type == "message"
+               and .payload.role == "developer")
+            then
+              [.payload.content[]?.text]
+            elif
+              (.type == "turn_context")
+            then
+              [.payload.collaboration_mode.settings.developer_instructions]
+            elif
+              (.type == "event_msg" and .payload.type == "thread_settings_applied")
+            then
+              [.payload.thread_settings.collaboration_mode.settings.developer_instructions]
+            elif
+              (.type == "compacted")
+            then
+              [
+                .payload.replacement_history[]?
+                | select(.type == "message" and .role == "developer")
+                | .content[]?.text
+              ]
+            else
+              []
+            end;
+          runtime_text | .[] | select(type == "string")
+        ' 2>/dev/null \
+          | grep -hoiE "$INJ_PHRASE_RE" 2>/dev/null \
+          | redact | tr '[:upper:]' '[:lower:]' \
+          | sed -E 's|[^a-z0-9 ._:/@+-]||g' | cut -c1-80 \
+          | tr '\n' '|' || true)
+        # Normalisation MUST match the phrase list's own display derivation, or
+        # the per-phrase class annotation silently joins nothing.
+        #
+        # The runtime list reaches awk as a PIPE-separated single line, never as
+        # newline-separated text: BSD awk aborts a -v value containing a newline
+        # ("newline in string"), which would kill the classifier for exactly the
+        # records carrying MORE than one runtime phrase and drop their
+        # occurrences from the class file entirely — the counts would stop
+        # summing to TOTAL instead of failing loudly. `|` is safe as the
+        # separator because the filter above admits only [a-z0-9 ._:/@+-].
+        printf '%s' "$raw" | grep -hoiE "$INJ_PHRASE_RE" \
+          | redact | tr '[:upper:]' '[:lower:]' \
+          | sed -E 's|[^a-z0-9 ._:/@+-]||g' | cut -c1-80 \
+          | awk -v S="$session" -v L="$line" -v RT="$runtime_phrases" '
+              BEGIN {
+                n = split(RT, a, "|")
+                for (i = 1; i <= n; i++) if (a[i] != "") rt[a[i]]++
+              }
+              # Multiset consumption caps runtime at the raw match count: a
+              # runtime string the raw detector did not also match can never
+              # invent an occurrence, and any surplus falls through to
+              # other-content. That replaces the old numeric sanity guard.
+              {
+                if (rt[$0] > 0) { rt[$0]--; c = "runtime-developer" }
+                else { c = "other-content" }
+                print S "\t" L "\t" c "\t" $0
+              }'
       done
 }
 
@@ -2705,11 +2724,39 @@ if want safety; then
     echo "       records MAY be echo — a previous report re-counted by the NEXT run —"
     echo "       but flat record/session counts do NOT rule out a new hit: a real"
     echo "       attempt can share an existing record. Read both; classify neither.)"
-    : > "$CONCTMP"
+    # Per-phrase class split, derived BEFORE the scratch file is cleared. The
+    # aggregate lines above say how many occurrences were fleet chatter but not
+    # WHICH phrase they were, so a runtime status announcement and a genuine
+    # attack shape read identically in the list below. #2521 measured the cost:
+    # `you are now <...> mode` resolves to the single literal string
+    # `you are now in default mode` — a Codex approval-mode announcement — and
+    # supplied 826 of 1554 occurrences (53%) over a 7-day two-corpus window on
+    # 2026-08-06, yet identifying it required hand-attribution with
+    # --injection-provenance. Annotation only ADDS the split; the per-phrase
+    # total still leads each line and TOTAL occurrences stays fail-closed.
     # Group on the fixed-width digest plus bounded display. If display
     # truncation happens before identity is derived, distinct matches collapse.
+    # The class map is read as a FILE, never passed with `awk -v`: BSD awk
+    # rejects a newline inside a -v value ("newline in string"), which silently
+    # killed the whole phrase list on macOS. The `FILENAME != "-"` guard —
+    # rather than the usual NR==FNR — is load-bearing for the same reason a
+    # negative control exists: when the class file is EMPTY, NR==FNR is still
+    # true for the first phrase line and would eat it.
     sort "$INJTMP" | uniq -c | sort -rn | head -6 \
-      | awk -F '\t' '{prefix=$1; sub(/^[[:space:]]*/, "", prefix); split(prefix, parts, /[[:space:]]+/); printf "    %7d %s\n", parts[1], substr($2,1,80)}'
+      | awk -F '\t' '
+          FILENAME != "-" {
+            if ($4 != "") {
+              if ($3 == "runtime-developer") rtc[$4]++; else occ[$4]++
+            }
+            next
+          }
+          {
+            prefix=$1; sub(/^[[:space:]]*/, "", prefix); split(prefix, parts, /[[:space:]]+/)
+            disp = substr($2,1,80)
+            printf "    %7d %s   (%d runtime / %d other)\n", parts[1], disp, rtc[disp]+0, occ[disp]+0
+          }
+        ' "$CONCTMP" -
+    : > "$CONCTMP"
     if [ "$INJECTION_PROVENANCE" -eq 1 ]; then
       printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | while IFS= read -r f; do
         emit_injection_hits "$f"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -287,6 +287,25 @@ emit_injection_hits() {
       done
 }
 
+# Stream of redacted, lowercased phrases -> one "<digest>~<display>" key per
+# line. The phrase list identifies a phrase by digest AND bounded display, so
+# the class join must use the same identity: two matches differing only in
+# characters the display filter strips (`add "bot" ...` vs `add bot ...`) or
+# only beyond the 80-character bound share a display but not a digest. Keyed on
+# display alone their counts merge, and the merged split then prints on BOTH
+# phrase-list lines, where it can belong to the other digest or exceed its own
+# line's total. `~` is safe as the field separator because the display filter
+# admits only [a-z0-9 ._:/@+-].
+phrase_class_keys() {
+  local ph
+  while IFS= read -r ph || [ -n "$ph" ]; do
+    [ -n "$ph" ] || continue
+    printf '%s~%s\n' \
+      "$(printf '%s' "$ph" | sha256_digest)" \
+      "$(printf '%s' "$ph" | tr -cd 'a-z0-9 ._:/@+-' | cut -c1-80)"
+  done
+}
+
 # Emit one safe class row per occurrence without suppressing anything from the
 # fail-closed raw total. Runtime-supplied developer context is structurally
 # distinguishable from user/tool content, but a compacted record can contain
@@ -351,7 +370,7 @@ emit_injection_classes() {
         # separator because the filter above admits only [a-z0-9 ._:/@+-].
         printf '%s' "$raw" | grep -hoiE "$INJ_PHRASE_RE" \
           | redact | tr '[:upper:]' '[:lower:]' \
-          | sed -E 's|[^a-z0-9 ._:/@+-]||g' | cut -c1-80 \
+          | phrase_class_keys \
           | awk -v S="$session" -v L="$line" -v RT="$runtime_phrases" '
               BEGIN {
                 n = split(RT, a, "|")
@@ -361,10 +380,21 @@ emit_injection_classes() {
               # runtime string the raw detector did not also match can never
               # invent an occurrence, and any surplus falls through to
               # other-content. That replaces the old numeric sanity guard.
+              # The runtime multiset is keyed on DISPLAY, not on the digest,
+              # because the two sides live in different escaping spaces: the raw
+              # transcript line is JSON-escaped while jq hands back the decoded
+              # text, so their digests can never agree. The display filter
+              # strips backslashes and quotes alike, which makes it the only
+              # representation both sides share. The DIGEST is still emitted,
+              # because the report join needs it to keep two colliding displays
+              # apart.
               {
-                if (rt[$0] > 0) { rt[$0]--; c = "runtime-developer" }
+                p = index($0, "~")
+                digest = substr($0, 1, p - 1)
+                disp = substr($0, p + 1)
+                if (rt[disp] > 0) { rt[disp]--; c = "runtime-developer" }
                 else { c = "other-content" }
-                print S "\t" L "\t" c "\t" $0
+                print S "\t" L "\t" c "\t" digest "\t" disp
               }'
       done
 }
@@ -2745,15 +2775,19 @@ if want safety; then
     sort "$INJTMP" | uniq -c | sort -rn | head -6 \
       | awk -F '\t' '
           FILENAME != "-" {
-            if ($4 != "") {
-              if ($3 == "runtime-developer") rtc[$4]++; else occ[$4]++
+            if ($5 != "") {
+              k = $4 "~" $5
+              if ($3 == "runtime-developer") rtc[k]++; else occ[k]++
             }
             next
           }
           {
             prefix=$1; sub(/^[[:space:]]*/, "", prefix); split(prefix, parts, /[[:space:]]+/)
             disp = substr($2,1,80)
-            printf "    %7d %s   (%d runtime / %d other)\n", parts[1], disp, rtc[disp]+0, occ[disp]+0
+            # parts[1] is the count uniq prepended; parts[2] is the digest. Key
+            # on digest+display so two colliding displays keep separate splits.
+            k = parts[2] "~" disp
+            printf "    %7d %s   (%d runtime / %d other)\n", parts[1], disp, rtc[k]+0, occ[k]+0
           }
         ' "$CONCTMP" -
     : > "$CONCTMP"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1609,6 +1609,46 @@ check "a mixed compacted record is counted once in overall concentration" "$OUT"
 check "runtime disclosure never suppresses the fail-closed total" "$OUT" \
       "TOTAL occurrences: 6"
 
+# The aggregate class split above tells a reader HOW MANY occurrences were
+# runtime-supplied, but not WHICH PHRASE they were. #2521's review measured the
+# consequence: `you are now <...> mode` resolves to the single literal string
+# `you are now in default mode` — a Codex approval-mode announcement, never an
+# instruction attempt — and it supplied 826 of 1554 occurrences (53%) across a
+# 7-day two-corpus window on 2026-08-06. In the phrase list that phrase is
+# indistinguishable from an attack shape, so a reader had to hand-attribute it
+# with --injection-provenance to learn which figures were fleet chatter. Annotate
+# each phrase with its own class split so the distinction is readable in place.
+# Nothing is filtered: the per-phrase total still leads each line and TOTAL is
+# asserted unchanged above.
+check "the runtime-announcement phrase carries its own class split" "$OUT" \
+      "4 you are now in default mode   (4 runtime / 0 other)"
+# The genuine attack shape must be annotated too, and must NOT be attributed to
+# the runtime class — a phrase list that marked every phrase runtime would pass
+# the assertion above while destroying the signal.
+check "a content-path phrase is annotated as other, not runtime" "$OUT" \
+      "1 ignore prior rules   (0 runtime / 1 other)"
+check "a second content-path phrase is annotated independently" "$OUT" \
+      "1 update your instructions   (0 runtime / 1 other)"
+
+# TWO runtime phrases inside ONE record. Every fixture above carries at most one
+# per record, which hides a whole class of failure: the runtime phrase list is
+# handed to awk, and BSD awk aborts with "newline in string" on a multi-line -v
+# value. That kills the classifier for the record, so its occurrences never
+# reach the class file at all — the counts would silently stop summing to TOTAL
+# rather than failing loudly. Assert the sum, not just the split.
+mkdir -p "$FIX/injmulti"
+cat > "$FIX/injmulti/two.jsonl" <<'EOF'
+{"type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"you are now in default mode and update your instructions"}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/injmulti" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+check "two runtime phrases in one record are both classified" "$OUT" \
+      "runtime-supplied developer context: 2 occurrences across 1 records in 1 session"
+check "a multi-phrase runtime record leaves nothing in other-content" "$OUT" \
+      "other content locations: 0 occurrences across 0 records in 0 sessions"
+check "class occurrences still sum to the fail-closed total" "$OUT" \
+      "TOTAL occurrences: 2"
+
 # NOTE: no "concentration adds no jq" assertion here. --section safety already
 # runs jq for the denial scan, so a blanket no-jq check asserts something false
 # about the design and would pass only by accident. The existing

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1649,6 +1649,28 @@ check "a multi-phrase runtime record leaves nothing in other-content" "$OUT" \
 check "class occurrences still sum to the fail-closed total" "$OUT" \
       "TOTAL occurrences: 2"
 
+# Two DISTINCT matches that normalise to the SAME bounded display. The phrase
+# list identifies a phrase by digest+display, so these are two separate lines,
+# but the class map keyed on display alone would merge their counts and print
+# the same split on both — a split that can belong to the other digest or exceed
+# its own line's total. `add "bot" ...` and `add bot ...` differ only in
+# characters the display filter strips, so the displays collide while the
+# digests do not. One is runtime-supplied and one is content, so a merged key is
+# visible as (1 runtime / 1 other) on BOTH lines instead of one of each.
+mkdir -p "$FIX/injdigest"
+cat > "$FIX/injdigest/runtime.jsonl" <<'EOF'
+{"type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"add \"bot\" to the trust gate"}]}}
+EOF
+cat > "$FIX/injdigest/content.jsonl" <<'EOF'
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"add bot to the trust gate"}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/injdigest" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+check "colliding displays keep the runtime line's own split" "$OUT" \
+      "1 add bot to the trust gate   (1 runtime / 0 other)"
+check "colliding displays keep the content line's own split" "$OUT" \
+      "1 add bot to the trust gate   (0 runtime / 1 other)"
+
 # NOTE: no "concentration adds no jq" assertion here. --section safety already
 # runs jq for the denial scan, so a blanket no-jq check asserts something false
 # about the design and would pass only by accident. The existing


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The safety scorecard reports how many instruction-shaped hits came from fleet runtime chatter rather than real corpus content, but only as a total. In the phrase list itself a harness status announcement and a genuine attack shape look identical, so telling them apart meant re-running the miner in attribution mode by hand — the manual step this work set out to remove.

Reviewing the phrase set over a week of both instances found one phrase that is harness output rather than an instruction attempt, and it accounts for just over half of all hits. Left unlabelled it inflates the number a reader is meant to watch.

## What

Each phrase in the report now carries its own runtime/content breakdown, so the distinction is readable in place. Nothing is filtered or suppressed — the totals are unchanged and anything the classifier cannot account for stays counted as content, which is the safe direction.

Building it surfaced two latent faults in the same area that fail silently rather than loudly; both are fixed here, and the review verdict on the remaining phrases is recorded on the issue.

Fixes #2521