### PR TITLE
fix(scripts): refuse repair when a submodule path resolves to the superproject gitdir

### DIFF
--- a/.claude/scripts/submodule-init.sh
+++ b/.claude/scripts/submodule-init.sh
@@ -147,8 +147,14 @@ repair() {
   # place by a different route, so test the RESOLVED gitdir rather than the presence of a `.git` entry
   # (an existence check is subsumed by this one and provably never fires on its own). Fail closed: the
   # blast radius is the parent repo and every session sharing it (monorepo#2694).
-  super_mdir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
-  if [ -n "$super_mdir" ] && same_dir "$mdir" "$super_mdir"; then
+  # No `|| true` and no silent fallback: `same_dir` fails closed on an empty path, which here would
+  # SKIP the guard rather than trip it, so a failed probe must stop the run instead of quietly
+  # disabling the check. `errexit` covers a non-zero rev-parse; the emptiness test covers a
+  # zero-exit-no-output result.
+  super_mdir=$(git rev-parse --path-format=absolute --git-common-dir)
+  [ -n "$super_mdir" ] ||
+    die "cannot resolve the superproject's gitdir — refusing to repair '$path' rather than skip the parent-escape check"
+  if same_dir "$mdir" "$super_mdir"; then
     die "'$path' resolves to the SUPERPROJECT's gitdir ('$mdir'), not its own — refusing to repair, because that would redirect the parent repository's checkout at '$path'. Populate the submodule first: git submodule update --init '$path'"
   fi
 

--- a/.claude/scripts/submodule-init.sh
+++ b/.claude/scripts/submodule-init.sh
@@ -155,7 +155,7 @@ repair() {
   [ -n "$super_mdir" ] ||
     die "cannot resolve the superproject's gitdir — refusing to repair '$path' rather than skip the parent-escape check"
   if same_dir "$mdir" "$super_mdir"; then
-    die "'$path' resolves to the SUPERPROJECT's gitdir ('$mdir'), not its own — refusing to repair, because that would redirect the parent repository's checkout at '$path'. Populate the submodule first: git submodule update --init '$path'"
+    die "'$path' resolves to the SUPERPROJECT's gitdir ('$mdir'), not its own — refusing to repair, because that would redirect the parent repository's checkout at '$path'. The directory has content but no usable '.git', so nothing here is a real submodule checkout: remove its stray contents, then re-run 'submodule-init.sh $path' to populate it at the pinned commit"
   fi
 
   git config -f "$mdir/config" extensions.worktreeConfig true

--- a/.claude/scripts/submodule-init.sh
+++ b/.claude/scripts/submodule-init.sh
@@ -132,11 +132,25 @@ check_existing_worktrees() {
 # Move the stray shared core.worktree into each worktree's own per-worktree config. Idempotent.
 repair() {
   local path=$1
-  local mdir tree
+  local mdir tree super_mdir
+
   mdir=$(module_dir "$path")
   tree=$(module_tree "$path")
   { [ -n "$mdir" ] && [ -d "$mdir" ] && [ -n "$tree" ]; } ||
     die "git does not report a gitdir for '$path' (not an initialised submodule?)"
+
+  # `git -C <dir>` walks UP when <dir> is not itself a repository, so a REGISTERED submodule path that
+  # is non-empty but NOT initialised resolves to the SUPERPROJECT's gitdir — and repair would then pin
+  # `core.worktree` in the PARENT repository's per-worktree config, redirecting the parent's own main
+  # checkout at this directory. `is_populated` cannot catch it: it only asks whether the directory has
+  # entries, and one leftover file is enough. A `.git` that exists but points outward reaches the same
+  # place by a different route, so test the RESOLVED gitdir rather than the presence of a `.git` entry
+  # (an existence check is subsumed by this one and provably never fires on its own). Fail closed: the
+  # blast radius is the parent repo and every session sharing it (monorepo#2694).
+  super_mdir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  if [ -n "$super_mdir" ] && same_dir "$mdir" "$super_mdir"; then
+    die "'$path' resolves to the SUPERPROJECT's gitdir ('$mdir'), not its own — refusing to repair, because that would redirect the parent repository's checkout at '$path'. Populate the submodule first: git submodule update --init '$path'"
+  fi
 
   git config -f "$mdir/config" extensions.worktreeConfig true
   # Pin the tree this gitdir is actually checked out in — not a path we guessed.

--- a/.claude/scripts/submodule-init.test.sh
+++ b/.claude/scripts/submodule-init.test.sh
@@ -372,6 +372,79 @@ out="$(cd "$c11/super" && "$helper" --check 2>&1)" && rc=0 || rc=$?
 report "empty-init: --check still SKIPS a legitimately deinitialised submodule" \
   "$([[ $rc -eq 0 ]] && echo yes || echo no)" "rc=$rc $out"
 
+
+# 12. monorepo#2694 — a registered submodule that is NON-EMPTY but NOT INITIALISED (no `.git`) must
+#     never make `repair` write into the SUPERPROJECT's config. `is_populated` only asks "is the
+#     directory non-empty", so a leftover file is enough to route such a path into `repair`; there
+#     `git -C <path> rev-parse --git-common-dir` walks UP and returns the superproject's gitdir, and
+#     repair then pins `core.worktree` in the PARENT repo's per-worktree config — redirecting the
+#     parent's main checkout at the submodule directory.
+#
+#     Measured on the live host 2026-08-06: the monorepo main checkout resolved to
+#     `<monorepo>/.claude/worktrees/<slug>/platform`, `git status` reported 182 phantom deletions, and
+#     the contract-mandated end-of-tick `branch-cleanup.sh` fail-closed on EVERY tick as a result.
+#     The blast radius is the parent repository and every session sharing it, which is why this fails
+#     closed rather than best-effort repairing.
+c12="$tmp/c12"
+mk_super "$c12"
+git -C "$c12/super" submodule --quiet deinit -f sub >/dev/null
+# The state that bit: not empty, but carrying no `.git` — so `is_populated` says yes and git escapes up.
+echo leftover >"$c12/super/sub/leftover.txt"
+
+report "parent-escape precondition: the submodule dir is non-empty" \
+  "$([[ -n "$(ls -A "$c12/super/sub" 2>/dev/null)" ]] && echo yes || echo no)"
+report "parent-escape precondition: it has no .git of its own" \
+  "$([[ ! -e "$c12/super/sub/.git" ]] && echo yes || echo no)"
+# PRECONDITION that makes the whole case meaningful: git really does resolve this path to the PARENT.
+# If some future git stopped escaping upward, the assertions below would pass vacuously.
+c12_escaped="$(cd "$c12/super/sub" && git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+report "parent-escape precondition: git -C on it resolves to the SUPERPROJECT gitdir" \
+  "$([[ "$c12_escaped" -ef "$c12/super/.git" ]] && echo yes || echo no)" "got=$c12_escaped"
+
+out="$(cd "$c12/super" && "$helper" sub 2>&1)" && rc=0 || rc=$?
+
+# THE discriminating assertion — this is the production harm, and it is what goes RED without the fix.
+c12_parent_key="$(git config -f "$c12/super/.git/config.worktree" core.worktree 2>/dev/null || true)"
+report "parent-escape: never writes core.worktree into the SUPERPROJECT's per-worktree config" \
+  "$([[ -z "$c12_parent_key" ]] && echo yes || echo no)" "parent core.worktree=${c12_parent_key:-<unset>}"
+
+# The same harm stated as the user-visible symptom (#2694 AC-1): the parent still resolves to itself.
+c12_top="$(git -C "$c12/super" rev-parse --show-toplevel 2>/dev/null || true)"
+report "parent-escape: the superproject still resolves to its OWN root" \
+  "$([[ -n "$c12_top" && "$c12_top" -ef "$c12/super" ]] && echo yes || echo no)" "toplevel=$c12_top"
+
+report "parent-escape: the run FAILS rather than reporting success" \
+  "$([[ $rc -ne 0 ]] && echo yes || echo no)" "rc=$rc $out"
+report "parent-escape: it never reports 'isolated ✓'" \
+  "$(grep -q 'isolated ✓' <<<"$out" && echo no || echo yes)" "$out"
+
+# NEGATIVE CONTROL — the fix must refuse only the escaping case, not every repair. A genuinely
+# initialised submodule must still be repaired and probed exactly as case 3 requires.
+c12b="$tmp/c12b"
+mk_super "$c12b"
+out="$(cd "$c12b/super" && "$helper" sub 2>&1)" && rc=0 || rc=$?
+report "parent-escape negative control: a properly initialised submodule still repairs (exit 0)" \
+  "$([[ $rc -eq 0 ]] && echo yes || echo no)" "rc=$rc $out"
+report "parent-escape negative control: its core.worktree is still pinned to the submodule's own path" \
+  "$([[ "$(git config -f "$c12b/super/.git/modules/sub/config.worktree" core.worktree 2>/dev/null || true)" == "$(abspath "$c12b/super/sub")" ]] && echo yes || echo no)"
+
+
+# 12c. The second guard, and why it is not redundant with the `.git`-existence check: a `.git` that
+#      EXISTS but points at the superproject passes that check while still resolving outward. Same
+#      harm, different route — so it gets its own reproduction rather than riding on 12's.
+c12c="$tmp/c12c"
+mk_super "$c12c"
+git -C "$c12c/super" submodule --quiet deinit -f sub >/dev/null
+printf 'gitdir: %s\n' "$(abspath "$c12c/super")/.git" >"$c12c/super/sub/.git"
+report "outward-.git precondition: the .git entry exists (an existence check would NOT catch this)" \
+  "$([[ -e "$c12c/super/sub/.git" ]] && echo yes || echo no)"
+out="$(cd "$c12c/super" && "$helper" sub 2>&1)" && rc=0 || rc=$?
+c12c_parent_key="$(git config -f "$c12c/super/.git/config.worktree" core.worktree 2>/dev/null || true)"
+report "outward-.git: never writes core.worktree into the SUPERPROJECT's per-worktree config" \
+  "$([[ -z "$c12c_parent_key" ]] && echo yes || echo no)" "parent core.worktree=${c12c_parent_key:-<unset>}"
+report "outward-.git: the failure names the SUPERPROJECT gitdir" \
+  "$(grep -q "SUPERPROJECT's gitdir" <<<"$out" && echo yes || echo no)" "rc=$rc $out"
+
 if [[ $fail -ne 0 ]]; then
   echo "submodule-init self-test: FAILURES above" >&2
   exit 1


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The helper every agent run is told to use instead of a bare `git submodule update --init` could
silently break the **parent** repository. Handed a registered submodule directory that is non-empty
but not actually initialised, it wrote the wrong setting into the monorepo's own git config and
pointed the monorepo's main checkout at that submodule directory — then exited reporting success.

This happened for real on the agent host this morning: the monorepo checkout resolved to a submodule
folder, `git status` showed 182 files as deleted that were not, and the end-of-tick branch cleanup
every run is required to perform had been failing closed on **every** tick as a result. Because the
helper reported success, nothing surfaced it.

## What

The helper now checks the git directory it actually resolved and refuses when that turns out to be
the parent repository's, instead of writing into it. The refusal says what to do next. A correctly
initialised submodule repairs exactly as before.

The live symptom on the host was repaired separately; this stops it recurring.

Fixes #2694