### PR TITLE
fix(agents): require a CodeRabbit review object to be identified as a review

### DIFF
--- a/.claude/plugin-consumption/agentic-engineering-surveyor-diff.md
+++ b/.claude/plugin-consumption/agentic-engineering-surveyor-diff.md
@@ -56,6 +56,12 @@ plugin carries them (or an explicit, tested subset):
    is the default state of every head: the status corroborates run-completion only when its
    `description` begins `Review completed`, and never satisfies the gate on its own. Without this a
    state-only check reports every never-reviewed PR as green.
+4d. **CodeRabbit review-object positive identification** (monorepo#2620 / #2713) — a review object
+   counts only when its body begins `**Actionable comments posted:`; an empty object is a reply
+   container, never a review, whatever its `commit_id`. Measured over the 60 most recently merged
+   monorepo PRs: 16 of 19 objects at a merged head were empty, and two PRs merged with no substantive
+   review at the merged commit. Without this a bare `commit_id == head` match reports a non-review as
+   a green.
 5. **Sequential review coordination state** — authenticated single-phase request marker posted with
    the trigger (the two-phase reservation was retired on measurement 2026-07-25), pending request,
    monotonic artifact-backed or evidenced-expiry no-gate progression,

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -146,6 +146,10 @@ assert_prose "${constitution}" 'an empty object is a reply container, never a re
 # drifting apart again in the direction that caused this defect.
 assert_prose "${surveyor}" 'Actionable comments posted:' \
   "surveyor lost the positive identification of a CodeRabbit review object"
+# The parity checklist gates deletion of the local surveyor overlay, so a rule absent from it is one
+# the overlay removal drops silently — the same guard pattern as 4c above.
+assert_prose "${parity_checklist}" 'CodeRabbit review-object positive identification' \
+  "removing the surveyor overlay would silently drop the review-object identification"
 if grep -Fq 'pre-merge summary parsing' "${parity_checklist}"; then
   fail "plugin-parity checklist can reintroduce the removed pre-merge gate"
 fi

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -127,6 +127,25 @@ for contract_file in "${constitution}" "${surveyor}" "${maintenance_skill}"; do
     fail "standalone CodeRabbit pre-merge readiness state remains in ${contract_file}"
   fi
 done
+
+# monorepo#2620 established that an EMPTY CodeRabbit review object is a reply container, not a review.
+# Its fix (#2677) landed only in the surveyor overlay, leaving the contract — the surface every lane
+# reads, and the normative statement of the gate — accepting a bare `commit_id == head` match.
+# Measured over the 60 most recently merged monorepo PRs (2026-08-07): 16 of 19 CodeRabbit review
+# objects sitting at a merged head were empty, and monorepo#2607 and #2658 merged with an empty
+# container as the ONLY head-matching artifact and no Codex or Bugbot green. The gate's own predicate
+# matched a non-review, on the one control standing between an unreviewed change and main.
+#
+# Each assertion pins one COMPLETE operand: `assert_prose` flattens the file first, so the phrase is
+# matched against the words rather than the column the prose happens to wrap at.
+assert_prose "${constitution}" 'positively identified as a review' \
+  "constitution accepts a CodeRabbit review object without identifying it as a review"
+assert_prose "${constitution}" 'an empty object is a reply container, never a review' \
+  "constitution does not reject an empty CodeRabbit reply container at head"
+# The surveyor already carries the guard (#2677). Pinning it here too keeps the two surfaces from
+# drifting apart again in the direction that caused this defect.
+assert_prose "${surveyor}" 'Actionable comments posted:' \
+  "surveyor lost the positive identification of a CodeRabbit review object"
 if grep -Fq 'pre-merge summary parsing' "${parity_checklist}"; then
   fail "plugin-parity checklist can reintroduce the removed pre-merge gate"
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1000,6 +1000,14 @@ more often than a review. The surveyor has required this positive identification
 the contract did not, and that asymmetry is what let it through — so **never weaken this to a bare
 `commit_id` match again.**
 
+⚠️ **And do not "repair" it by counting inline comments at head instead** — that reads as the obvious
+alternative and is wrong. An inline review comment's `commit_id` tracks the commit its diff position
+currently anchors to, and GitHub **re-anchors it forward** as the head advances, so old comments
+follow the PR. On #2658 all 11 inline comments at the merged head belonged to review objects from
+*earlier* heads, while the two objects actually at that head carried none. Attribute a review by its
+own object or its summary comment; an inline comment's `commit_id` says where it points **now**, never
+when it was made.
+
 🔴 **The `CodeRabbit` commit status is `success` when NO review ran — the `description` is the only
 discriminator.** Auto-review is disabled portfolio-wide, so
 `success — Review skipped: automatic reviews are disabled` is the **default state of every head**,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -970,7 +970,7 @@ green reads as "no review". Rows are in lane-priority order:**
 
 | Lane | Clean/green artifact | Findings artifact | Key to match |
 |---|---|---|---|
-| **CodeRabbit** (`coderabbitai[bot]`) | current-head review completion with no actionable thread/body/ancillary finding; `APPROVED` is sufficient but not required | review object/body/comment with an actionable finding | REST `commit_id` == head, or the auto-generated summary comment updated after the authenticated request, naming the head, and carrying no rate-limit/service marker; the head's `CodeRabbit` commit status corroborates that a review RAN only when its `description` begins `Review completed` |
+| **CodeRabbit** (`coderabbitai[bot]`) | current-head review completion with no actionable thread/body/ancillary finding; `APPROVED` is sufficient but not required | review object/body/comment with an actionable finding | REST `commit_id` == head **on an object positively identified as a review** (body begins `**Actionable comments posted:`), or the auto-generated summary comment updated after the authenticated request, naming the head, and carrying no rate-limit/service marker; the head's `CodeRabbit` commit status corroborates that a review RAN only when its `description` begins `Review completed` |
 | **Codex** (`chatgpt-codex-connector[bot]`) | **issue COMMENT** — `Codex Review: Didn't find any major issues` + `**Reviewed commit:** <sha>` (10-char, no `commit_id` field) | review object, `state: COMMENTED`, inline threads — **OR an issue COMMENT carrying a `## Review finding` section** (see below) | clean pass: comment body sha vs `headRefOid[0:10]`; comment-form finding: full 40-char sha in its blob permalinks |
 | **Cursor Bugbot** (`cursor[bot]`) | **CHECK-RUN named `Cursor Bugbot`** (app slug `cursor`), `conclusion: success` — *no review object, no comment* | same check-run with **`conclusion: neutral` AND `output.title: "Bugbot Review"`**, findings as INLINE review comments from `cursor[bot]` on `pulls/<n>/comments` | check-run at `commits/<headRefOid>/check-runs` |
 
@@ -988,7 +988,17 @@ sha in its blob permalinks** — the finding comment carries **no** `**Reviewed 
 is precisely why the marker-based sweep missed it. **`Didn't find any major issues` never clears a P2**:
 the green can be newer than the finding, so recency decides nothing here.
 
-**CodeRabbit success is about its review result, not GitHub's approval event:** **a finding-free current-head CodeRabbit review completion is `cr@<sha>` even without `APPROVED`**. Accept either its current-head review object submitted after the latest authenticated request for that head or its substantive auto-generated summary comment (`<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`) updated after that request and naming the head. Reject auto-generated command replies/acknowledgements and any summary carrying a rate-limit, quota, or service marker saying the review did not run. Only then check all CodeRabbit threads, review-body finding sections, and explicit ancillary problems for that review; an authenticated fingerprint-matching `body_findings=0-resolved@<sha>` record counts as zero when the identical section repeats. Any unresolved/new finding or stale completion is not green.
+**CodeRabbit success is about its review result, not GitHub's approval event:** **a finding-free current-head CodeRabbit review completion is `cr@<sha>` even without `APPROVED`**. Accept either its current-head review object submitted after the latest authenticated request for that head **and positively identified as a review** — its body begins `**Actionable comments posted:`, because **an empty object is a reply container, never a review**, whatever its `commit_id` — or its substantive auto-generated summary comment (`<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`) updated after that request and naming the head. Reject auto-generated command replies/acknowledgements and any summary carrying a rate-limit, quota, or service marker saying the review did not run. Only then check all CodeRabbit threads, review-body finding sections, and explicit ancillary problems for that review; an authenticated fingerprint-matching `body_findings=0-resolved@<sha>` record counts as zero when the identical section repeats. Any unresolved/new finding or stale completion is not green.
+
+🔴 **The empty-container half is not pedantry — it is the dominant shape, and it has reached `main`.**
+Measured over the 60 most recently merged monorepo PRs (2026-08-07): of the CodeRabbit review objects
+sitting at a merged head, **16 of 19 were empty**, and **9 of the 12** PRs carrying any object at head
+had **no real review object there at all**. Two — monorepo#2607 and #2658 — merged with an empty
+container as the *only* head-matching artifact and no Codex or Bugbot green, i.e. with no substantive
+review at the commit that merged. A `commit_id == head` test alone therefore matches a non-review far
+more often than a review. The surveyor has required this positive identification since #2620/#2677;
+the contract did not, and that asymmetry is what let it through — so **never weaken this to a bare
+`commit_id` match again.**
 
 🔴 **The `CodeRabbit` commit status is `success` when NO review ran — the `description` is the only
 discriminator.** Auto-review is disabled portfolio-wide, so


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The green-review gate is the one control standing between an unreviewed change and `main`. It was
accepting artifacts that are not reviews.

CodeRabbit wraps thread replies in review objects that carry **no body**. The contract matched those
on `commit_id == head` alone, so a pull request with no review at its merged commit could read as
reviewed. Measured across the sixty most recently merged pull requests here: **two merged with no
substantive review at the commit that merged**, and empty containers outnumber real reviews at head
roughly five to one.

The rule was already fixed once, in the surveyor. It never reached `AGENTS.md` — the surface every
lane actually reads — so the other lanes stayed exposed. That gap between one instance and the shared
contract is the real defect here.

## What

A CodeRabbit review object now counts only when it is identifiable as a review. An empty object is a
reply container and satisfies nothing, whatever commit it points at. The lane table and the prose both
say so, and a contract test pins them together so they cannot drift apart again.

**Tightening only** — this removes a fail-open and adds no new way to satisfy the gate. The other
satisfiers (the summary comment, Codex, Cursor Bugbot) are untouched, so it withholds a false green
without blocking a genuinely reviewed pull request.

One shape is deliberately left alone: CodeRabbit sometimes reports a real result in a comment form the
contract rejects, which makes a reviewed change read as unreviewed. That is the opposite error, it is
rare, and accepting a new artifact form is a loosening that belongs in its own change with its own
evidence.

Fixes #2713
Part of #2578
