### PR TITLE
perf(agents): read a lane's quota refusal instead of rediscovering it by request

### DIFF
--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -211,7 +211,9 @@ printf '%s' "${green_body}" | grep -Fq "${expected_head:0:10}" ||
   fail "fixture clean-pass comment no longer names the same head; ordering trap not reproduced"
 
 # The contract must be a required PR check, including when its own workflow wiring changes.
-# A provider's rate limit is account-wide and time-boxed, so it is one fact per run, not one per PR.
+# A provider's rate limit is time-boxed and SHORT, so it is one fact PER HEAD, re-read per PR — never
+# one fact per run. The window measurably clears in ~28 minutes, so a run-wide latch skips the free
+# CodeRabbit lane over an expired refusal and spends the weekly-limited Codex lane instead.
 # Measured 2026-08-08: 54 review requests -> 16 real CodeRabbit reviews, 17 rate-limit refusals, and
 # on #2720 all 8 CodeRabbit requests were rate-limited across five rounds because lane priority
 # re-asked it every time. These pin the probe, that it is a READ, and that the gate is untouched.
@@ -223,11 +225,20 @@ assert_prose "${constitution}" 'Do NOT latch that refusal for the whole run' \
   "a short-lived quota refusal could be latched run-wide, burning the weekly Codex lane"
 assert_prose "${constitution}" 'the window cleared inside ~28 minutes' \
   "the measured quota-window duration that refutes a run-wide latch is not recorded"
+# The probe's LIMIT must be stated, or a reader takes it for a stronger guarantee than it is and is
+# surprised by the one unavoidable refusal per fresh head.
+assert_prose "${constitution}" 'cannot prevent the **first** refusal at' \
+  "the probe's fresh-head limit is unstated, so it reads as preventing every refusal"
+# ...and the obvious remedy for that limit must stay closed. A portfolio-wide TTL covers the fresh
+# head and re-creates the latch: measured 2026-08-08, 14 minutes of inherited state already inverted
+# the lane order on #2727 while CodeRabbit was serving at that head.
+assert_prose "${constitution}" 'may never **replace** the per-head read' \
+  "a portfolio-wide quota observation could replace the per-head read, re-creating the latch"
 # The optimisation must not become a way around the gate, nor a shortcut into the local fallback.
 assert_prose "${constitution}" 'never WHETHER A REVIEW IS REQUIRED' \
   "the lane probe could be read as relaxing the green-review gate"
 assert_prose "${constitution}" 'never** evidence for the *Local review round* fallback on its own' \
-  "a run-level quota window could be misread as satisfying the local-review-round evidence bar"
+  "a per-head quota refusal could be misread as satisfying the local-review-round evidence bar"
 
 grep -Fq 'review-provider-loop-contract: ${{ steps.filter.outputs.review-provider-loop-contract }}' "${workflow}" ||
   fail "CI does not export the review-provider contract change filter"

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -248,6 +248,12 @@ assert_prose "${constitution}" 'A refusal is scoped to its ROUND, never to the h
 # durable old refusal reads as current forever and the skip never expires.
 assert_prose "${constitution}" 'a refusal justifies skipping only when THIS round has already posted a CodeRabbit request marker' \
   "refusal provenance is not tied to a request marker, so a durable old refusal can read as current"
+# The OPERATIVE instruction must carry the round qualification itself. Stating the skip unconditionally
+# and qualifying it 35 lines later means an agent acts on the unqualified form first and advances to a
+# metered lane before ever reaching the refinement -- the same-SHA restart is then skipped in practice
+# however correct the later prose is. A rule is what its operative sentence says.
+assert_prose "${constitution}" 'A refusal you cannot attribute to this round is **not** a reason to skip' \
+  "the operative skip instruction is unqualified, so a durable prior-round refusal skips CodeRabbit before the round test is reached"
 # ...and the marker test must NOT be claimed mechanical on its payload alone. At an unchanged SHA the
 # previous round's marker is indistinguishable from this round's by head, provider, comment id or
 # timestamp, so a durable refusal postdates the OLD marker just as well and the restarted round's

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -226,9 +226,9 @@ printf '%s' "${green_body}" | grep -Fq "${expected_head:0:10}" ||
 # CodeRabbit lane over an expired refusal and spends the weekly-limited Codex lane instead.
 # Measured 2026-08-08: 54 review requests -> 16 real CodeRabbit reviews, 17 rate-limit refusals. On
 # #2720 specifically: 14 CodeRabbit requests across 12 DISTINCT heads, 10 of them refused — but only
-# 2 were same-head repeats. Because the rule preserves each round's first request, those 2 are the
-# ONLY waste this probe removes; the other 12 are unavoidable first attempts. The measurement must
-# keep the two apart or the case for the probe is inflated by refusals it never prevents.
+# 2 were second-or-later requests WITHIN ONE ROUND (classified against the restarting artifact, not
+# merely by repeated head). Those 2 are the only waste this probe removes; the other 12 each open a
+# round, whose first request the rule preserves. Keep the two apart or the case is inflated.
 # These pin the probe, that it is a READ, and that the gate is untouched.
 assert_prose "${constitution}" 'READ a lane'"'"'s quota state before spending a request on it' \
   "constitution does not require reading a lane's quota state before spending a request"
@@ -250,8 +250,13 @@ assert_prose "${constitution}" 'may never **replace** the per-head read' \
 # The measured waste must separate a round's unavoidable FIRST request from a within-round repeat.
 # Counting every refusal as waste overstates what the probe buys and hides whether the marker logic
 # still permits the repeats that ARE preventable.
-assert_prose "${constitution}" 'only 2 were same-head repeats' \
+assert_prose "${constitution}" 'second-or-later requests within the same round' \
   "the measured waste is not split into within-round repeats vs unavoidable first attempts"
+# ...and the split must be classified by ROUND, not by repeated head. A same-SHA refutation opens a
+# new round at an unchanged head, so a head-based count can book two protected first attempts as one
+# saved repeat. The two tests coincided on #2720; that is luck, not equivalence.
+assert_prose "${constitution}" 'Classify by ROUND, not by repeated head' \
+  "the waste metric could count repeated heads instead of within-round repeats, overstating the saving"
 # ...and the retired overstatement must be GONE, not merely supplemented.
 assert_absent "${constitution}" "#2720's eight requests were repeats inside five rounds" \
   "the retired '#2720's eight requests were repeats inside five rounds' overstatement still stands"

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -248,6 +248,14 @@ assert_prose "${constitution}" 'A refusal is scoped to its ROUND, never to the h
 # durable old refusal reads as current forever and the skip never expires.
 assert_prose "${constitution}" 'a refusal justifies skipping only when THIS round has already posted a CodeRabbit request marker' \
   "refusal provenance is not tied to a request marker, so a durable old refusal can read as current"
+# ...and the marker test must NOT be claimed mechanical on its payload alone. At an unchanged SHA the
+# previous round's marker is indistinguishable from this round's by head, provider, comment id or
+# timestamp, so a durable refusal postdates the OLD marker just as well and the restarted round's
+# mandatory first CodeRabbit request is skipped — the same-SHA refutation path this section protects.
+assert_prose "${constitution}" 'do NOT identify its round' \
+  "the marker payload is presented as round-identifying, so a same-SHA restart reuses the old round's marker"
+assert_prose "${constitution}" 'newest RESTARTING ARTIFACT at that head' \
+  "no round boundary is derivable, so the marker test cannot distinguish a restarted round"
 assert_prose "${constitution}" 'a refusal never pre-empts the FIRST CodeRabbit request of a round' \
   "a stale refusal could still pre-empt a round's first CodeRabbit request"
 # The optimisation must not become a way around the gate, nor a shortcut into the local fallback.

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -215,12 +215,14 @@ printf '%s' "${green_body}" | grep -Fq "${expected_head:0:10}" ||
 # Measured 2026-08-08: 54 review requests -> 16 real CodeRabbit reviews, 17 rate-limit refusals, and
 # on #2720 all 8 CodeRabbit requests were rate-limited across five rounds because lane priority
 # re-asked it every time. These pin the probe, that it is a READ, and that the gate is untouched.
-assert_prose "${constitution}" 'Establish a lane'"'"'s quota state ONCE PER RUN, by reading' \
-  "constitution does not require a per-run lane quota probe"
+assert_prose "${constitution}" 'READ a lane'"'"'s quota state before spending a request on it' \
+  "constitution does not require reading a lane's quota state before spending a request"
 assert_prose "${constitution}" 'readable with NO write' \
   "the quota probe is not required to be a read rather than a spent request"
-assert_prose "${constitution}" 'start the ladder at Codex on every PR that run' \
-  "a known CodeRabbit quota window does not redirect the ladder for the run"
+assert_prose "${constitution}" 'Do NOT latch that refusal for the whole run' \
+  "a short-lived quota refusal could be latched run-wide, burning the weekly Codex lane"
+assert_prose "${constitution}" 'the window cleared inside ~28 minutes' \
+  "the measured quota-window duration that refutes a run-wide latch is not recorded"
 # The optimisation must not become a way around the gate, nor a shortcut into the local fallback.
 assert_prose "${constitution}" 'never WHETHER A REVIEW IS REQUIRED' \
   "the lane probe could be read as relaxing the green-review gate"

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -234,6 +234,15 @@ assert_prose "${constitution}" 'cannot prevent the **first** refusal at' \
 # the lane order on #2727 while CodeRabbit was serving at that head.
 assert_prose "${constitution}" 'may never **replace** the per-head read' \
   "a portfolio-wide quota observation could replace the per-head read, re-creating the latch"
+# The status is a NEGATIVE filter. Measured 2026-08-08: a run read the never-reviewed default at
+# 19:29:29Z, asked on that basis, and was refused 16s later — the default promised nothing. Left
+# unqualified, "serving state is readable" licenses the same inversion from the other direction.
+assert_prose "${constitution}" 'it can never show the lane serving' \
+  "the quota read could be taken as positive evidence that CodeRabbit is serving"
+# ...and a refusal must not outlive its round, or a same-SHA restart after a refutation can never
+# return to the free lane — the refutation path deliberately creates no new commit.
+assert_prose "${constitution}" 'A refusal is scoped to its ROUND, never to the head forever' \
+  "a one-off refusal at a head could permanently skip CodeRabbit there, inverting the lane order"
 # The optimisation must not become a way around the gate, nor a shortcut into the local fallback.
 assert_prose "${constitution}" 'never WHETHER A REVIEW IS REQUIRED' \
   "the lane probe could be read as relaxing the green-review gate"

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -243,6 +243,13 @@ assert_prose "${constitution}" 'it can never show the lane serving' \
 # return to the free lane — the refutation path deliberately creates no new commit.
 assert_prose "${constitution}" 'A refusal is scoped to its ROUND, never to the head forever' \
   "a one-off refusal at a head could permanently skip CodeRabbit there, inverting the lane order"
+# ...and that scoping must key on WHICH REQUEST produced the refusal. Scoping it to "observed in this
+# round" is circular: the mandatory pre-trigger read is itself an observation in the new round, so a
+# durable old refusal reads as current forever and the skip never expires.
+assert_prose "${constitution}" 'a refusal justifies skipping only when THIS round has already posted a CodeRabbit request marker' \
+  "refusal provenance is not tied to a request marker, so a durable old refusal can read as current"
+assert_prose "${constitution}" 'a refusal never pre-empts the FIRST CodeRabbit request of a round' \
+  "a stale refusal could still pre-empt a round's first CodeRabbit request"
 # The optimisation must not become a way around the gate, nor a shortcut into the local fallback.
 assert_prose "${constitution}" 'never WHETHER A REVIEW IS REQUIRED' \
   "the lane probe could be read as relaxing the green-review gate"

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -211,6 +211,22 @@ printf '%s' "${green_body}" | grep -Fq "${expected_head:0:10}" ||
   fail "fixture clean-pass comment no longer names the same head; ordering trap not reproduced"
 
 # The contract must be a required PR check, including when its own workflow wiring changes.
+# A provider's rate limit is account-wide and time-boxed, so it is one fact per run, not one per PR.
+# Measured 2026-08-08: 54 review requests -> 16 real CodeRabbit reviews, 17 rate-limit refusals, and
+# on #2720 all 8 CodeRabbit requests were rate-limited across five rounds because lane priority
+# re-asked it every time. These pin the probe, that it is a READ, and that the gate is untouched.
+assert_prose "${constitution}" 'Establish a lane'"'"'s quota state ONCE PER RUN, by reading' \
+  "constitution does not require a per-run lane quota probe"
+assert_prose "${constitution}" 'readable with NO write' \
+  "the quota probe is not required to be a read rather than a spent request"
+assert_prose "${constitution}" 'start the ladder at Codex on every PR that run' \
+  "a known CodeRabbit quota window does not redirect the ladder for the run"
+# The optimisation must not become a way around the gate, nor a shortcut into the local fallback.
+assert_prose "${constitution}" 'never WHETHER A REVIEW IS REQUIRED' \
+  "the lane probe could be read as relaxing the green-review gate"
+assert_prose "${constitution}" 'never** evidence for the *Local review round* fallback on its own' \
+  "a run-level quota window could be misread as satisfying the local-review-round evidence bar"
+
 grep -Fq 'review-provider-loop-contract: ${{ steps.filter.outputs.review-provider-loop-contract }}' "${workflow}" ||
   fail "CI does not export the review-provider contract change filter"
 grep -Fq '.claude/plugin-consumption/agentic-engineering-surveyor-diff.md' "${workflow}" ||

--- a/.claude/scripts/review-provider-loop-contract.test.sh
+++ b/.claude/scripts/review-provider-loop-contract.test.sh
@@ -28,6 +28,16 @@ assert_prose() {
     fail "${message}"
 }
 
+# The mirror of assert_prose. A presence-only suite cannot see a RETIRED claim that survived, so a
+# correction reads as applied while the wrong text still stands (monorepo#2733). `if` is required:
+# a bare `grep -q … && fail` returns 1 on the PASSING path, and `set -e` would abort the run there.
+assert_absent() {
+  local file="$1" phrase="$2" message="$3"
+  if tr '\n' ' ' <"${file}" | tr -s '[:space:]' ' ' | grep -Fq -- "${phrase}"; then
+    fail "${message}"
+  fi
+}
+
 grep -Fq 'CodeRabbit > Codex > Cursor Bugbot' "${constitution}" ||
   fail "constitution does not preserve the provider order"
 grep -Fq 'STOP on the first successful current-head review' "${constitution}" ||
@@ -214,9 +224,12 @@ printf '%s' "${green_body}" | grep -Fq "${expected_head:0:10}" ||
 # A provider's rate limit is time-boxed and SHORT, so it is one fact PER HEAD, re-read per PR — never
 # one fact per run. The window measurably clears in ~28 minutes, so a run-wide latch skips the free
 # CodeRabbit lane over an expired refusal and spends the weekly-limited Codex lane instead.
-# Measured 2026-08-08: 54 review requests -> 16 real CodeRabbit reviews, 17 rate-limit refusals, and
-# on #2720 all 8 CodeRabbit requests were rate-limited across five rounds because lane priority
-# re-asked it every time. These pin the probe, that it is a READ, and that the gate is untouched.
+# Measured 2026-08-08: 54 review requests -> 16 real CodeRabbit reviews, 17 rate-limit refusals. On
+# #2720 specifically: 14 CodeRabbit requests across 12 DISTINCT heads, 10 of them refused — but only
+# 2 were same-head repeats. Because the rule preserves each round's first request, those 2 are the
+# ONLY waste this probe removes; the other 12 are unavoidable first attempts. The measurement must
+# keep the two apart or the case for the probe is inflated by refusals it never prevents.
+# These pin the probe, that it is a READ, and that the gate is untouched.
 assert_prose "${constitution}" 'READ a lane'"'"'s quota state before spending a request on it' \
   "constitution does not require reading a lane's quota state before spending a request"
 assert_prose "${constitution}" 'readable with NO write' \
@@ -234,6 +247,14 @@ assert_prose "${constitution}" 'cannot prevent the **first** refusal at' \
 # the lane order on #2727 while CodeRabbit was serving at that head.
 assert_prose "${constitution}" 'may never **replace** the per-head read' \
   "a portfolio-wide quota observation could replace the per-head read, re-creating the latch"
+# The measured waste must separate a round's unavoidable FIRST request from a within-round repeat.
+# Counting every refusal as waste overstates what the probe buys and hides whether the marker logic
+# still permits the repeats that ARE preventable.
+assert_prose "${constitution}" 'only 2 were same-head repeats' \
+  "the measured waste is not split into within-round repeats vs unavoidable first attempts"
+# ...and the retired overstatement must be GONE, not merely supplemented.
+assert_absent "${constitution}" "#2720's eight requests were repeats inside five rounds" \
+  "the retired '#2720's eight requests were repeats inside five rounds' overstatement still stands"
 # The status is a NEGATIVE filter. Measured 2026-08-08: a run read the never-reviewed default at
 # 19:29:29Z, asked on that basis, and was refused 16s later — the default promised nothing. Left
 # unqualified, "serving state is readable" licenses the same inversion from the other direction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1199,8 +1199,14 @@ result at the current head — self-promotion is forbidden before that. Request 
   carries it in its `description` — `Review rate limited` (a quota refusal),
   `Review skipped: automatic reviews are disabled` (the never-reviewed default), or `Review completed`
   (a run happened). So **before each CodeRabbit trigger, read that description on that PR's head**; if
-  it already reads as a quota refusal, do not post the trigger for that round — advance to Codex for
-  that PR and record the usual `cr:no-gate@<sha>`.
+  it reads as a quota refusal **that this round itself produced** — by the round-provenance test below,
+  which is part of this instruction rather than a later refinement of it — do not post the trigger for
+  that round: advance to Codex for that PR and record the usual `cr:no-gate@<sha>`.
+  **A refusal you cannot attribute to this round is **not** a reason to skip — ask.** The status is
+  durable and outlives the quota window, so an unqualified reading of this paragraph sends a same-SHA
+  restart (a refutation that changes no files) straight to the **weekly-limited** lane while the
+  **free** one has long recovered. An operative sentence is what actually gets executed, so the
+  qualification belongs here, not only in the elaboration below.
   🔴 **This read is a NEGATIVE filter only. It can show the lane refusing HERE; it can never show the
   lane serving.** The never-reviewed default means only that nothing has been tried at this head — it
   is a reason to *ask*, never evidence the lane is up. Reading it as "serving" licenses the same

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1239,9 +1239,19 @@ result at the current head — self-promotion is forbidden before that. Request 
   at CodeRabbit* after findings — most sharply when a finding is **refuted without changing files**,
   which restarts at the *same* SHA by design and must not create an empty commit. That PR would then
   advance straight to the **weekly-limited** lane on every subsequent round while the **free** one had
-  long recovered. So on a new round at the same head — after a fix, a refutation, or a later run —
-  re-read the status and ask CodeRabbit again unless the refusal was observed **in this round**. The
-  read is free; that is what makes re-asking cheap rather than wasteful.
+  long recovered.
+  **Scope it by WHICH REQUEST produced the refusal, never by when you read it.** "Unless the refusal
+  was observed in this round" is circular and does not work: the mandatory pre-trigger read *is* an
+  observation in the new round, and the status is durable, so the old refusal reads as current every
+  time and the skip fires forever — the exact behaviour this paragraph forbids. Attribute it instead:
+  **a refusal justifies skipping only when THIS round has already posted a CodeRabbit request marker
+  at this head and the refusal postdates that marker.** The markers carry an id and a timestamp for
+  exactly this, so the test is mechanical rather than a judgement about "rounds".
+  The consequence is deliberate and worth stating plainly: **a refusal never pre-empts the FIRST
+  CodeRabbit request of a round.** What the probe kills is re-asking a head *within* a round after it
+  has already answered — which is where the measured waste was, since #2720's eight requests were
+  repeats inside five rounds. The read is free; that is what makes re-asking cheap rather than
+  wasteful.
   ⚠️ **This changes WHICH LANE IS ASKED FIRST, never WHETHER A REVIEW IS REQUIRED.** The green-review
   gate is untouched: every PR still needs one successful current-head review from some lane, or a
   qualifying local review round. Skipping a lane that is *demonstrably refusing at that head* is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1245,8 +1245,22 @@ result at the current head — self-promotion is forbidden before that. Request 
   observation in the new round, and the status is durable, so the old refusal reads as current every
   time and the skip fires forever — the exact behaviour this paragraph forbids. Attribute it instead:
   **a refusal justifies skipping only when THIS round has already posted a CodeRabbit request marker
-  at this head and the refusal postdates that marker.** The markers carry an id and a timestamp for
-  exactly this, so the test is mechanical rather than a judgement about "rounds".
+  at this head and the refusal postdates that marker.**
+  🔴 **A marker's id and timestamp alone do NOT identify its round — derive the boundary, or this
+  test fails in exactly the case it was written for.** At an unchanged SHA the previous round's
+  marker is indistinguishable from this round's: head, provider, comment id and timestamp are all
+  equally "at this head", and a durable refusal postdates the *old* marker just as well as it would
+  a new one. Read literally, the test then skips the restarted round's mandatory first CodeRabbit
+  request — the same-SHA refutation path, which is the one case the paragraph above exists to
+  protect. A payload carrying only `<sha>` and `provider=` cannot answer a question about rounds.
+  **The boundary is the newest RESTARTING ARTIFACT at that head, and the loop already emits one.**
+  A restart follows findings, and findings are fixed-or-refuted with their threads resolved before
+  it, so the newest authenticated disclosed resolution reply at that head is what opens the new
+  round. The test is therefore: **skip only when a CodeRabbit request marker at this head is NEWER
+  than that artifact, and the refusal postdates that marker.** Where no findings have arrived at
+  this head there has been only one round and no artifact, so the marker test stands unqualified.
+  This mirrors the same-head Codex retry rule below, which likewise supersedes findings by
+  "threads resolved → later re-request → later clean marker" rather than by timestamps alone.
   The consequence is deliberate and worth stating plainly: **a refusal never pre-empts the FIRST
   CodeRabbit request of a round.** What the probe kills is re-asking a head *within* a round after it
   has already answered — which is where the measured waste was, since #2720's eight requests were

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1210,6 +1210,20 @@ result at the current head — self-promotion is forbidden before that. Request 
   and spend the **weekly-limited** Codex quota in its place — inverting the maintainer's own reason for
   the lane order (spend the cheapest-to-exhaust lane first). Re-read per PR instead; the read is free,
   which is the entire point.
+  ⚠️ **Know exactly what this probe does and does not buy.** It cannot prevent the **first** refusal at
+  a **fresh** head: a new SHA carries only the never-reviewed default until some request is spent, so
+  the probe has nothing to read there. What it prevents is every **repeat** at a head already known to
+  be refusing — which is the bulk of the measured waste, since the eight wasted #2720 requests were
+  five rounds of re-asking heads that had already answered.
+  **That residual is accepted deliberately, and the obvious "fix" for it is worse.** Carrying a
+  portfolio-wide refusal forward with a TTL would cover the fresh-head case, and it re-creates the
+  latch this rule exists to forbid: measured 2026-08-08, an agent took #2722's 19:03Z refusal as
+  portfolio-wide, skipped CodeRabbit on #2727 at 19:17Z, and spent the **weekly-limited** Codex lane —
+  while #2727's own head status read `Review skipped: automatic reviews are disabled` and CodeRabbit
+  was in fact serving. Fourteen minutes of inherited state was already too much, against a window that
+  clears in ~28. So a portfolio-wide observation may **inform** how patiently you wait; it may never
+  **replace** the per-head read, and it may never skip a head whose own status says the lane was never
+  asked. One spent request per fresh head is the price of not inverting the lane order.
   ⚠️ **This changes WHICH LANE IS ASKED FIRST, never WHETHER A REVIEW IS REQUIRED.** The green-review
   gate is untouched: every PR still needs one successful current-head review from some lane, or a
   qualifying local review round. Skipping a lane that is *demonstrably refusing at that head* is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1188,6 +1188,30 @@ result at the current head — self-promotion is forbidden before that. Request 
   maintainer instruction. This carve-out covers **only** an exact-match review trigger; every other
   comment you author keeps its inline disclosure line.
 
+- **Establish a lane's quota state ONCE PER RUN, by reading — never by spending a request per PR.**
+  A provider's rate limit is **account-wide and time-boxed**, so during a limited window the answer is
+  identical for every PR in the portfolio. Rediscovering it per PR per round is the single largest
+  source of wasted review requests: measured 2026-08-08 over 8 recent monorepo PRs, **54 review
+  requests produced 16 actual CodeRabbit reviews**, with **17 rate-limit refusals** — and on #2720
+  **all 8 CodeRabbit requests were rate-limited** across five rounds, each round re-requesting
+  CodeRabbit first because that is what lane priority says. Every one of those cost a trigger comment,
+  an ack read, a status read and a marker write to learn a fact the run already had.
+  **CodeRabbit's serving state is readable with NO write**: the head's `CodeRabbit` commit status
+  carries it in its `description` — `Review rate limited` (a quota refusal),
+  `Review skipped: automatic reviews are disabled` (the never-reviewed default), or `Review completed`
+  (a run happened). So before the run's **first** CodeRabbit trigger, read that description on any head
+  the run has already fetched; if it is a quota refusal, record `cr:quota-window` **for the run** and
+  **start the ladder at Codex on every PR that run**, posting no CodeRabbit trigger at all. Re-probe
+  only when a CodeRabbit request does later succeed, or at the start of the next run.
+  ⚠️ **This changes WHICH LANE IS ASKED FIRST, never WHETHER A REVIEW IS REQUIRED.** The green-review
+  gate is untouched: every PR still needs one successful current-head review from some lane, or a
+  qualifying local review round. Skipping a lane that is *demonstrably refusing* is exactly the
+  "advance on a service failure" the loop already prescribes — this only makes the discovery free. A
+  lane that is **serving** is never skipped, and a run-level `cr:quota-window` is **never** evidence
+  for the *Local review round* fallback on its own: that still requires all three lanes tried at the
+  current head, per its own admissible-evidence rule.
+  The per-PR `cr:no-gate@<sha>` marker is unaffected — it records a provider that genuinely ran and
+  completed without a gate-satisfying artifact, which is a different fact from a quota window.
 - **Only one provider request may be active at a time.** Never fan out or request two reviewers
   concurrently. The priority above sets the order: request one, wait for its substantive outcome,
   then either stop on success, restart after fixes, or advance after a provider/service failure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1195,12 +1195,20 @@ result at the current head — self-promotion is forbidden before that. Request 
   rate-limited** across five rounds, each round re-requesting CodeRabbit first because that is what
   lane priority says. Every one cost a trigger comment, an ack read, a status read and a marker write
   to learn something a free read already knew.
-  **CodeRabbit's serving state is readable with NO write**: the head's `CodeRabbit` commit status
+  **A CodeRabbit REFUSAL is readable with NO write**: the head's `CodeRabbit` commit status
   carries it in its `description` — `Review rate limited` (a quota refusal),
   `Review skipped: automatic reviews are disabled` (the never-reviewed default), or `Review completed`
   (a run happened). So **before each CodeRabbit trigger, read that description on that PR's head**; if
-  it already reads as a quota refusal, do not post the trigger — advance to Codex for that PR and
-  record the usual `cr:no-gate@<sha>`.
+  it already reads as a quota refusal, do not post the trigger for that round — advance to Codex for
+  that PR and record the usual `cr:no-gate@<sha>`.
+  🔴 **This read is a NEGATIVE filter only. It can show the lane refusing HERE; it can never show the
+  lane serving.** The never-reviewed default means only that nothing has been tried at this head — it
+  is a reason to *ask*, never evidence the lane is up. Reading it as "serving" licenses the same
+  inversion from the opposite direction, and it is measured: on 2026-08-08 a run read
+  `Review skipped: automatic reviews are disabled` at 19:29:29Z, correctly asked CodeRabbit on that
+  basis, and was refused **16 seconds later**. The request was still right — asking is how a fresh
+  head learns — but the status had promised nothing, so treat a green-looking default as *unknown*,
+  and never let it override a refusal observed at this same head in this same round.
   🔴 **Do NOT latch that refusal for the whole run — the window is SHORT, and measured.** It is
   tempting to conclude that a rate limit is account-wide and therefore one fact per run. **It is not:**
   on 2026-08-08 monorepo#2722 was requested at 15:10:09Z and refused `Review rate limited` at
@@ -1219,11 +1227,21 @@ result at the current head — self-promotion is forbidden before that. Request 
   portfolio-wide refusal forward with a TTL would cover the fresh-head case, and it re-creates the
   latch this rule exists to forbid: measured 2026-08-08, an agent took #2722's 19:03Z refusal as
   portfolio-wide, skipped CodeRabbit on #2727 at 19:17Z, and spent the **weekly-limited** Codex lane —
-  while #2727's own head status read `Review skipped: automatic reviews are disabled` and CodeRabbit
-  was in fact serving. Fourteen minutes of inherited state was already too much, against a window that
-  clears in ~28. So a portfolio-wide observation may **inform** how patiently you wait; it may never
-  **replace** the per-head read, and it may never skip a head whose own status says the lane was never
-  asked. One spent request per fresh head is the price of not inverting the lane order.
+  while #2727's own head status said the lane had never been asked *there*. That is the whole defect:
+  the skip was justified by another PR's refusal rather than by any evidence about this head. Fourteen
+  minutes of inherited state was already too much, against a window that clears in ~28. So a
+  portfolio-wide observation may **inform** how patiently you wait; it may never **replace** the
+  per-head read, and it may never skip a head whose own status says the lane was never asked. One
+  spent request per fresh head is the price of not inverting the lane order.
+  🔴 **A refusal is scoped to its ROUND, never to the head forever.** The skip above applies to the
+  request round in which it was read. A head's status is durable, so an unconditional "this head once
+  refused, therefore never ask again" would outlive the quota window and break the mandated *restart
+  at CodeRabbit* after findings — most sharply when a finding is **refuted without changing files**,
+  which restarts at the *same* SHA by design and must not create an empty commit. That PR would then
+  advance straight to the **weekly-limited** lane on every subsequent round while the **free** one had
+  long recovered. So on a new round at the same head — after a fix, a refutation, or a later run —
+  re-read the status and ask CodeRabbit again unless the refusal was observed **in this round**. The
+  read is free; that is what makes re-asking cheap rather than wasteful.
   ⚠️ **This changes WHICH LANE IS ASKED FIRST, never WHETHER A REVIEW IS REQUIRED.** The green-review
   gate is untouched: every PR still needs one successful current-head review from some lane, or a
   qualifying local review round. Skipping a lane that is *demonstrably refusing at that head* is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1270,12 +1270,18 @@ result at the current head — self-promotion is forbidden before that. Request 
   The consequence is deliberate and worth stating plainly: **a refusal never pre-empts the FIRST
   CodeRabbit request of a round.** What the probe kills is re-asking a head *within* a round after it
   has already answered. **Size that saving honestly — most refusals are NOT what it eliminates.**
-  Re-measured on #2720 (2026-08-08): **14 CodeRabbit requests across 12 distinct heads, 10 of them
-  refused — but only 2 were same-head repeats.** Those 2 are the whole saving; the other 12 are each
-  a round's unavoidable first attempt, which this rule deliberately preserves. Counting all 14, or
-  all 10 refusals, as waste this probe removes would credit it with preventing exactly the requests
-  it is written to protect. The read is free; that is what makes that first attempt cheap rather than
-  wasteful.
+  Re-measured on #2720 (2026-08-08): **14 CodeRabbit requests, 10 of them refused — and exactly 2 were
+  second-or-later requests within the same round.** Those 2 are the saving; the other 12 each open a
+  round, and this rule preserves a round's first request on purpose. Counting all 14, or all 10
+  refusals, would credit the probe with preventing exactly the requests it is written to protect.
+  ⚠️ **Classify by ROUND, not by repeated head — the two are not the same test.** A same-SHA fix or
+  refutation opens a new round at an unchanged head, so two requests on one head can be two rounds'
+  protected first attempts rather than a saved repeat; a head-based count silently overstates. Apply
+  the same boundary the skip test uses — the newest restarting artifact at that head — and count only
+  second-or-later requests inside one round. On #2720 both pairs (`0f16c3192e`, `a90875e3ac`) carry no
+  resolution reply between their two requests, so each pair is genuinely one round; the head-based
+  count happened to agree there, which is exactly why it cannot be trusted in general. The read is
+  free; that is what makes a round's first attempt cheap rather than wasteful.
   ⚠️ **This changes WHICH LANE IS ASKED FIRST, never WHETHER A REVIEW IS REQUIRED.** The green-review
   gate is untouched: every PR still needs one successful current-head review from some lane, or a
   qualifying local review round. Skipping a lane that is *demonstrably refusing at that head* is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1188,30 +1188,35 @@ result at the current head — self-promotion is forbidden before that. Request 
   maintainer instruction. This carve-out covers **only** an exact-match review trigger; every other
   comment you author keeps its inline disclosure line.
 
-- **Establish a lane's quota state ONCE PER RUN, by reading — never by spending a request per PR.**
-  A provider's rate limit is **account-wide and time-boxed**, so during a limited window the answer is
-  identical for every PR in the portfolio. Rediscovering it per PR per round is the single largest
-  source of wasted review requests: measured 2026-08-08 over 8 recent monorepo PRs, **54 review
-  requests produced 16 actual CodeRabbit reviews**, with **17 rate-limit refusals** — and on #2720
-  **all 8 CodeRabbit requests were rate-limited** across five rounds, each round re-requesting
-  CodeRabbit first because that is what lane priority says. Every one of those cost a trigger comment,
-  an ack read, a status read and a marker write to learn a fact the run already had.
+- **READ a lane's quota state before spending a request on it — the status says so for free.**
+  Rediscovering a refusal by *posting a trigger* is the single largest source of wasted review
+  requests: measured 2026-08-08 over 8 recent monorepo PRs, **54 review requests produced 16 actual
+  CodeRabbit reviews**, with **17 rate-limit refusals** — and on #2720 **all 8 CodeRabbit requests were
+  rate-limited** across five rounds, each round re-requesting CodeRabbit first because that is what
+  lane priority says. Every one cost a trigger comment, an ack read, a status read and a marker write
+  to learn something a free read already knew.
   **CodeRabbit's serving state is readable with NO write**: the head's `CodeRabbit` commit status
   carries it in its `description` — `Review rate limited` (a quota refusal),
   `Review skipped: automatic reviews are disabled` (the never-reviewed default), or `Review completed`
-  (a run happened). So before the run's **first** CodeRabbit trigger, read that description on any head
-  the run has already fetched; if it is a quota refusal, record `cr:quota-window` **for the run** and
-  **start the ladder at Codex on every PR that run**, posting no CodeRabbit trigger at all. Re-probe
-  only when a CodeRabbit request does later succeed, or at the start of the next run.
+  (a run happened). So **before each CodeRabbit trigger, read that description on that PR's head**; if
+  it already reads as a quota refusal, do not post the trigger — advance to Codex for that PR and
+  record the usual `cr:no-gate@<sha>`.
+  🔴 **Do NOT latch that refusal for the whole run — the window is SHORT, and measured.** It is
+  tempting to conclude that a rate limit is account-wide and therefore one fact per run. **It is not:**
+  on 2026-08-08 monorepo#2722 was requested at 15:10:09Z and refused `Review rate limited` at
+  15:10:24Z, while monorepo#2723 was requested at 15:38:07Z and returned `Review completed` at
+  15:42:48Z — **the window cleared inside ~28 minutes.** A run-wide latch would therefore skip the
+  **free, unmetered** CodeRabbit lane for the rest of a run over a refusal that had already expired,
+  and spend the **weekly-limited** Codex quota in its place — inverting the maintainer's own reason for
+  the lane order (spend the cheapest-to-exhaust lane first). Re-read per PR instead; the read is free,
+  which is the entire point.
   ⚠️ **This changes WHICH LANE IS ASKED FIRST, never WHETHER A REVIEW IS REQUIRED.** The green-review
   gate is untouched: every PR still needs one successful current-head review from some lane, or a
-  qualifying local review round. Skipping a lane that is *demonstrably refusing* is exactly the
-  "advance on a service failure" the loop already prescribes — this only makes the discovery free. A
-  lane that is **serving** is never skipped, and a run-level `cr:quota-window` is **never** evidence
+  qualifying local review round. Skipping a lane that is *demonstrably refusing at that head* is
+  exactly the "advance on a service failure" the loop already prescribes — this only makes the
+  discovery free. A lane that is **serving** is never skipped, and a quota refusal is **never** evidence
   for the *Local review round* fallback on its own: that still requires all three lanes tried at the
   current head, per its own admissible-evidence rule.
-  The per-PR `cr:no-gate@<sha>` marker is unaffected — it records a provider that genuinely ran and
-  completed without a gate-satisfying artifact, which is a different fact from a quota window.
 - **Only one provider request may be active at a time.** Never fan out or request two reviewers
   concurrently. The priority above sets the order: request one, wait for its substantive outcome,
   then either stop on success, restart after fixes, or advance after a provider/service failure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1189,12 +1189,13 @@ result at the current head — self-promotion is forbidden before that. Request 
   comment you author keeps its inline disclosure line.
 
 - **READ a lane's quota state before spending a request on it — the status says so for free.**
-  Rediscovering a refusal by *posting a trigger* is the single largest source of wasted review
-  requests: measured 2026-08-08 over 8 recent monorepo PRs, **54 review requests produced 16 actual
-  CodeRabbit reviews**, with **17 rate-limit refusals** — and on #2720 **all 8 CodeRabbit requests were
-  rate-limited** across five rounds, each round re-requesting CodeRabbit first because that is what
-  lane priority says. Every one cost a trigger comment, an ack read, a status read and a marker write
-  to learn something a free read already knew.
+  Rediscovering a refusal by *posting a trigger* costs a trigger comment, an ack read, a status read
+  and a marker write to learn something a free read already knew. Measured 2026-08-08 over 8 recent
+  monorepo PRs: **54 review requests produced 16 actual CodeRabbit reviews**, with **17 rate-limit
+  refusals**. On #2720 alone: **14 CodeRabbit requests across 12 distinct heads, 10 of them refused**,
+  each round re-requesting CodeRabbit first because that is what lane priority says. **Only the
+  same-head repeats are recoverable** — see the sizing note below, which is deliberately narrower than
+  those totals.
   **A CodeRabbit REFUSAL is readable with NO write**: the head's `CodeRabbit` commit status
   carries it in its `description` — `Review rate limited` (a quota refusal),
   `Review skipped: automatic reviews are disabled` (the never-reviewed default), or `Review completed`
@@ -1227,8 +1228,7 @@ result at the current head — self-promotion is forbidden before that. Request 
   ⚠️ **Know exactly what this probe does and does not buy.** It cannot prevent the **first** refusal at
   a **fresh** head: a new SHA carries only the never-reviewed default until some request is spent, so
   the probe has nothing to read there. What it prevents is every **repeat** at a head already known to
-  be refusing — which is the bulk of the measured waste, since the eight wasted #2720 requests were
-  five rounds of re-asking heads that had already answered.
+  be refusing — a **minority** of the measured waste, not the bulk of it: on #2720, 2 of 14 requests.
   **That residual is accepted deliberately, and the obvious "fix" for it is worse.** Carrying a
   portfolio-wide refusal forward with a TTL would cover the fresh-head case, and it re-creates the
   latch this rule exists to forbid: measured 2026-08-08, an agent took #2722's 19:03Z refusal as
@@ -1269,8 +1269,12 @@ result at the current head — self-promotion is forbidden before that. Request 
   "threads resolved → later re-request → later clean marker" rather than by timestamps alone.
   The consequence is deliberate and worth stating plainly: **a refusal never pre-empts the FIRST
   CodeRabbit request of a round.** What the probe kills is re-asking a head *within* a round after it
-  has already answered — which is where the measured waste was, since #2720's eight requests were
-  repeats inside five rounds. The read is free; that is what makes re-asking cheap rather than
+  has already answered. **Size that saving honestly — most refusals are NOT what it eliminates.**
+  Re-measured on #2720 (2026-08-08): **14 CodeRabbit requests across 12 distinct heads, 10 of them
+  refused — but only 2 were same-head repeats.** Those 2 are the whole saving; the other 12 are each
+  a round's unavoidable first attempt, which this rule deliberately preserves. Counting all 14, or
+  all 10 refusals, as waste this probe removes would credit it with preventing exactly the requests
+  it is written to protect. The read is free; that is what makes that first attempt cheap rather than
   wasteful.
   ⚠️ **This changes WHICH LANE IS ASKED FIRST, never WHETHER A REVIEW IS REQUIRED.** The green-review
   gate is untouched: every PR still needs one successful current-head review from some lane, or a


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Asking a review bot for a review is slow and metered, and many of those requests came back with
nothing. Measured across 8 recent PRs: **54 review requests produced 16 actual reviews**, with 17
refused because CodeRabbit was rate-limited.

Each refusal was discovered by *spending* a request, to learn something the pull request's own
status already said for free.

## What

Before asking CodeRabbit, a run now reads that free status on the pull request it is about to ask
about. If it already says "refused here, this round", the run moves to the next reviewer for **that**
pull request instead of knocking on a door it can see is locked.

**Sized honestly:** this only removes *repeat* asks at a head that already answered. Each round's
first ask is deliberately preserved, so on the PR we measured in detail it recovers 2 of 14
requests — a minority of the refusals, not all of them. That count is of repeat asks *within one
round*, checked against the round boundary rather than merely landing on the same commit twice. Claiming more would credit it with preventing exactly
the requests it exists to protect.

Deliberately narrow in the other direction too, because the wider version is what went wrong while
writing this: a refusal seen on one pull request is **not** carried over to others. That window
clears in under half an hour, and assuming otherwise skips the free reviewer in favour of the one
with a weekly limit. The change also states plainly what the free read cannot tell you — it can show
a reviewer refusing, never that one is available.

No change to the quality bar: every PR still needs a real green review before it can be promoted.
This only changes which reviewer is asked first when one of them is visibly refusing.

Fixes #2725
