### PR TITLE
docs(agents): state the measured dispatch drop rate instead of a nominal hourly tick

### DIFF
--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -46,6 +46,15 @@ assert_engineer_prose() {
     *) fail "$2" ;;
   esac
 }
+# A presence-only guard passes happily while the claim it replaced is still sitting
+# three paragraphs up, so a corrected fact needs BOTH halves pinned: the new statement
+# present AND the superseded one absent. Every contradiction found in this contract so
+# far survived exactly that way.
+refute_prose() {
+  case "${constitution_flat}" in
+    *"$1"*) fail "$2" ;;
+  esac
+}
 
 grep -Fq '### Agent definition locations' "${constitution}" ||
   fail "consumer does not define Agent definition locations"
@@ -300,6 +309,26 @@ assert_prose '`lastRunAt` as its marker; the `SKILL.md` description is not sched
   "runtime-local delivery can mistake Claude loader prose for deployed cadence"
 assert_prose 'A missing or ambiguous store, missing baseline, marker that did not advance, or incomplete recurrence rule is `UNKNOWN`, never `MATCH`.' \
   "runtime-local delivery does not fail closed on incomplete persistence evidence"
+
+# --- Scheduled cadence is not delivered cadence (#2716) -----------------------
+# The schedule fires hourly in both machine-local lanes; only ONE of them keeps it.
+# The Claude runtime refuses a dispatch that would overlap the previous run of the
+# same task and drops it silently, so a third of ticks never happen — while Codex
+# starts the overlapping run instead. A run that plans off "the next tick" is
+# therefore wrong about a third of the time on one lane and right on the other,
+# which is the undeliberate instance asymmetry this contract must state outright.
+assert_prose '`per_task_limit`' \
+  "cadence does not name the mechanism by which Claude dispatches are dropped"
+assert_prose 'Claude dispatched 108/161' \
+  "cadence does not state the measured Claude dispatch shortfall"
+assert_prose 'Codex dispatched 161/161' \
+  "cadence does not state the Codex control that makes the shortfall a lane asymmetry"
+assert_prose 'never time anything off' \
+  "cadence does not tell a run to stop planning against the next scheduled tick"
+# The superseded absolute. Left in place it reads as the operative rule, because it is
+# stated as a flat invariant while the correction reads as a caveat about it.
+refute_prose 'next scheduled tick is always one hour later' \
+  "cadence still asserts an unconditional hourly next tick alongside its own refutation"
 
 # --- The merged spend mandate -------------------------------------------------
 # Spend is a dimension of the Agentic Engineer. The consumer must supply the Spend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2738,7 +2738,8 @@ normal overlap rather than evidence that a slot is free.
 | **Codex** — `codex/*`, hourly at `:10` | Every hour at `:10` | 07:00, 19:00 |
 | **Cursor** — `cursor/*`, uneven hours at `:30` | 01:30 … 23:30 | — |
 
-Both machine-local Agentic Engineer lanes dispatch **every hour**. Cursor keeps its every-2-hours
+Both machine-local Agentic Engineer lanes are **scheduled** every hour — for what the Claude lane
+actually keeps, see *Scheduled is not delivered* below. Cursor keeps its every-2-hours
 cloud cadence, centered between the two machine-local offsets on uneven hours. The Agent Improver
 keeps its 4×/day rotation (00 Claude, 07 Codex, 12 Claude, 19 Codex) as additional `:00` starts; those
 slots no longer replace an Agentic Engineer tick. This table covers the two scheduled engineering
@@ -2759,9 +2760,22 @@ case is safe by construction — same namespace, same deterministic branch name,
 is refused (see *Claim protocol* rule 4) — so it needs no handling beyond never force-pushing a claim
 branch.
 
-**Your Agentic Engineer's next scheduled tick is always one hour later.** The Agent Improver's four
-daily starts are additional work, not replacement slots. That hour is the gap **between runs, not a
-per-run time budget**; it bounds a carry-forward without telling an active run to stop early. Each run works
+🔴 **Scheduled is not delivered — on the Claude lane about a third of ticks never happen.** Measured
+across one identical window (2026-08-02T03:50Z → 2026-08-08T19:50Z, **161 scheduled slots per lane**):
+**Codex dispatched 161/161**, because that scheduler starts a run even when the previous one is still
+open — one run whose record stayed open for 240 minutes did not block any of the four ticks behind it.
+**Claude dispatched 108/161**: its scheduler refuses any dispatch that would overlap the previous run
+of the same task and records it as `per_task_limit`, so **53 ticks — 32.9% — were dropped**, silently,
+producing no artifact anywhere. That is the second consecutive measurement of the same behaviour
+(36.6% over 2026-08-01→08-07), so it is the lane's normal state, not an incident, and the effective
+Claude interval is **~1.5 hours**. The Agent Improver is unaffected: the Claude store records **zero**
+dropped improver dispatches, and the Codex scheduler refuses none.
+**So never time anything off "the next tick."** A carry-forward, a claim-expiry judgement, or a "the
+next run will collect this" decision is wrong about a third of the time on Claude, and always in the
+direction of waiting **longer** than planned — so prefer finishing inside the current run over handing
+work to a tick that may not come. The Agent Improver's four daily starts are additional work, not
+replacement slots. The scheduled interval is the gap **between runs, not a per-run time budget**; it
+bounds a carry-forward without telling an active run to stop early. Each run works
 *The work-selection ladder* top-down — **breakage → every open PR you own or trust, drafts included →
 security issues → bugs → the oldest actionable issue** — capturing new
 non-trivial finds as issues (see *Issue-driven*).


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The contract tells every run that its next scheduled tick is an hour away. On the Claude lane that is
wrong about a third of the time, and nothing anywhere records it.

Measured over one identical window — 161 scheduled slots per lane, 2026-08-02 to 2026-08-08 — Codex
ran all 161 of its ticks and Claude ran 108. The Claude scheduler declines any tick that would overlap
the run before it, and drops it without leaving a trace. That is the second measurement of the same
behaviour in a row, so it is how the lane normally works, not a bad week.

It matters because runs plan around that number: deciding to leave something for the next run, or
judging when someone else's claim on a piece of work has expired. Both are wrong in the same
direction — the wait is longer than expected.

## What

The Cadence section now says what actually happens on each lane and tells a run to finish work inside
the current run rather than hand it to a tick that may not come.

The guard pins both halves — the new statement present *and* the old absolute gone. A presence-only
check passes while the sentence it replaced is still sitting three paragraphs up, which is how every
contradiction found in this contract so far survived.

Part of #2716