### PR TITLE
fix(telemetry): count dispatches that ran, not cron slots

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -3590,6 +3590,21 @@ if want drift; then
     ' "$store" 2>/dev/null
   }
 
+  # Newest skip record. Coverage alone does not prove the scheduler was RUNNING in
+  # the window: an enabled schedule record plus old skips, with the scheduler having
+  # stopped dispatching entirely, yields floor-covered and zero drops — which would
+  # publish "0.0%" and present a total outage as a window of successful opportunities.
+  # That is the same absence-read-as-health error as a fabricated zero, so the rate
+  # additionally requires positive evidence of activity INSIDE the window: either a
+  # dispatch marker (`lastRunAt`) or a skip record landing in it.
+  claude_store_skip_latest() {
+    local store="$1" id="$2"
+    [ -f "$store" ] || return 0
+    jq -r --arg id "$id" '
+      [ .recordedSkips[$id][]? | (.at // empty) ] | if length == 0 then empty else max end
+    ' "$store" 2>/dev/null
+  }
+
   claude_store_schedule() {
     local store="$1" id="$2" pointer="$3" cron parsed hours minute
     cron=$(claude_store_field "$store" "$id" "$pointer" cronExpression)
@@ -3816,8 +3831,22 @@ if want drift; then
       # What CAN be detected is the impossible outcome it produces: more dropped slots
       # than the window could schedule. That is proof the assumption failed, so it
       # fails closed instead of publishing a rate above 100%.
+      #
+      # Coverage is also not liveness. An enabled record plus old skips, with the
+      # scheduler no longer dispatching, is floor-covered with zero drops — and would
+      # publish "0.0%", presenting a total outage as a window of successful
+      # opportunities. So the rate additionally requires positive evidence that the
+      # scheduler was active INSIDE the window: a dispatch marker (`lastRunAt`) or a
+      # skip record landing in it. Without either, the denominator describes slots
+      # nothing was even attempting to fill.
       RATE_TOTAL=$(( CLAUDE_ENG_SLOTS_DAY * SINCE_DAYS ))
+      SKIP_LATEST=$(claude_store_skip_latest "$CLAUDE_SCHEDULE_STORE" daily-ai-assistant)
+      ACTIVE_IN_WINDOW=0
+      [[ "$CLAUDE_ENGINEER_MARKER" =~ ^[0-9]+$ ]] \
+        && [ $(( CLAUDE_ENGINEER_MARKER * 1000 )) -ge "$SKIP_SINCE_MS" ] && ACTIVE_IN_WINDOW=1
+      [ -n "$SKIP_LATEST" ] && [ "$SKIP_LATEST" -ge "$SKIP_SINCE_MS" ] && ACTIVE_IN_WINDOW=1
       if [ "$SKIP_FLOOR" -le "$SKIP_SINCE_MS" ] \
+         && [ "$ACTIVE_IN_WINDOW" -eq 1 ] \
          && [ "$CLAUDE_ENG_SLOTS_DAY" -gt 0 ] \
          && [ "$CLAUDE_DROPPED" -le "$RATE_TOTAL" ]; then
         RATE=$(awk -v d="$CLAUDE_DROPPED" -v t="$RATE_TOTAL" \
@@ -3826,6 +3855,8 @@ if want drift; then
       elif [ -n "$RATE_TOTAL" ] && [ "$CLAUDE_ENG_SLOTS_DAY" -gt 0 ] \
            && [ "$CLAUDE_DROPPED" -gt "$RATE_TOTAL" ]; then
         echo "    claude engineer dropped dispatches: $CLAUDE_DROPPED slot(s) (per_task_limit), drop rate: UNKNOWN (more drops than the window schedules — cadence changed within it)"
+      elif [ "$ACTIVE_IN_WINDOW" -ne 1 ]; then
+        echo "    claude engineer dropped dispatches: $CLAUDE_DROPPED slot(s) (per_task_limit), drop rate: UNKNOWN (no dispatch or skip inside the window — scheduler not proven active)"
       else
         echo "    claude engineer dropped dispatches: $CLAUDE_DROPPED slot(s) (per_task_limit), drop rate: UNKNOWN (skip records do not span the window)"
       fi

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -3521,6 +3521,48 @@ if want drift; then
     ' "$store" 2>/dev/null
   }
 
+  # ── dropped dispatches ──────────────────────────────────────────────────────
+  # A cron expansion counts SCHEDULED SLOTS. The Claude runtime declines any
+  # dispatch that would overlap the previous run of the same task and records the
+  # refusal as `per_task_limit`, so a slot is not a run. Measured on the live
+  # store: 58 of 168 slots dropped over 2026-08-02→08-09 (34.5%), corroborating
+  # 52/142 (36.6%) and 108/161 (32.9%) from two earlier windows.
+  #
+  # The store writes one record per POLL TICK — roughly every 60s for as long as
+  # the task stays blocked — so raw records overstate badly: 1067 records for 58
+  # real drops, ~18x. Only a record landing in the cron's OWN minute is a dropped
+  # dispatch; every later record in that hour re-refuses a tick already counted.
+  # Distinct-slot counting (truncate to the hour) also absorbs the duplicate that
+  # appears when two poll ticks land inside the same due minute.
+  claude_store_skip_slots() {
+    local store="$1" id="$2" minute="$3" since_ms="$4"
+    [ -f "$store" ] || return 0
+    jq -r --arg id "$id" --argjson minute "$minute" --argjson since "$since_ms" '
+      [ .recordedSkips[$id][]?
+        | (.at // empty)
+        | select(. >= $since)
+        | (. / 1000 | floor)
+        | select(((. % 3600) / 60 | floor) == $minute)
+        | (. - (. % 3600))
+      ] | unique | length
+    ' "$store" 2>/dev/null
+  }
+
+  # Earliest skip record, used ONLY to decide whether a rate may be stated. A
+  # denominator of "slots in the window" is only honest when the store's records
+  # actually span that window; if the earliest record falls INSIDE the window the
+  # store cannot account for the earlier slots, and dividing anyway would invent
+  # a low rate out of short retention. Empty means no skip surface at all — which
+  # is UNKNOWN, never zero, since absence on a surface is a claim about that
+  # surface only.
+  claude_store_skip_floor() {
+    local store="$1" id="$2"
+    [ -f "$store" ] || return 0
+    jq -r --arg id "$id" '
+      [ .recordedSkips[$id][]? | (.at // empty) ] | if length == 0 then empty else min end
+    ' "$store" 2>/dev/null
+  }
+
   claude_store_schedule() {
     local store="$1" id="$2" pointer="$3" cron parsed hours minute
     cron=$(claude_store_field "$store" "$id" "$pointer" cronExpression)
@@ -3650,6 +3692,25 @@ if want drift; then
     "$CODEX_IMPROVER_POINTER_ACTUAL" "$CODEX_IMPROVER_STORE_ACTUAL" \
     "$CODEX_IMPROVER_LOADER" "$CODEX_AUTOMATION_STORE" "$CODEX_IMPROVER_MARKER" "$CODEX_IMPROVER_BASELINE"
 
+  # Defined before the aggregate gate, not inside it: the per-lane drop reporting
+  # below runs even when the gate fails, and a helper defined only on the success
+  # path left that path computing an EMPTY slot count — which silently downgraded a
+  # measurable drop rate to UNKNOWN. Caught by evaluating the change on the live
+  # store, where the gate does fail; every test fixture measures cleanly, so no
+  # fixture could have exposed it.
+  expand_schedules() {
+    awk -F'@' '
+      NF == 2 {
+        if ($1 == "*") {
+          for (hour = 0; hour <= 23; hour++) print hour ":" $2
+        } else {
+          count = split($1, hours, ",")
+          for (i = 1; i <= count; i++) print hours[i] ":" $2
+        }
+      }
+    '
+  }
+
   if schedule_measured "$CLAUDE_LOADER" "$CLAUDE_ENGINEER_EXPECTED" "$CLAUDE_ENGINEER_ACTUAL" \
        "$CLAUDE_ENGINEER_MARKER" "$CLAUDE_ENGINEER_BASELINE" \
      && schedule_measured "$CLAUDE_IMPROVER_LOADER" "$CLAUDE_IMPROVER_EXPECTED" "$CLAUDE_IMPROVER_ACTUAL" \
@@ -3658,18 +3719,7 @@ if want drift; then
        "$CODEX_ENGINEER_MARKER" "$CODEX_ENGINEER_BASELINE" \
      && schedule_measured "$CODEX_IMPROVER_LOADER" "$CODEX_IMPROVER_EXPECTED" "$CODEX_IMPROVER_ACTUAL" \
        "$CODEX_IMPROVER_MARKER" "$CODEX_IMPROVER_BASELINE"; then
-    expand_schedules() {
-      awk -F'@' '
-        NF == 2 {
-          if ($1 == "*") {
-            for (hour = 0; hour <= 23; hour++) print hour ":" $2
-          } else {
-            count = split($1, hours, ",")
-            for (i = 1; i <= count; i++) print hours[i] ":" $2
-          }
-        }
-      '
-    }
+    :
     ALL_SLOTS=$(printf '%s\n' "$CLAUDE_ENGINEER_ACTUAL" "$CLAUDE_IMPROVER_ACTUAL" \
       "$CODEX_ENGINEER_ACTUAL" "$CODEX_IMPROVER_ACTUAL" | expand_schedules)
     COLLISIONS=$(printf '%s\n' "$ALL_SLOTS" | awk '
@@ -3684,10 +3734,67 @@ if want drift; then
     ENGINEER_DISPATCHES=$(printf '%s\n' "$CLAUDE_ENGINEER_ACTUAL" "$CODEX_ENGINEER_ACTUAL" \
       | expand_schedules | awk 'NF { count++ } END { print count + 0 }')
     echo "    local simultaneous starts/day: $COLLISIONS"
-    echo "    local engineer dispatches/day: $ENGINEER_DISPATCHES"
+    # "slots scheduled", not "dispatches": this number is the cron expanded, and a
+    # scheduled slot is not a run. The old label read as an actual dispatch count,
+    # which matters because this deployment states hypothesis volume floors in
+    # DISPATCHES — so a floor could be cleared by slots that never ran.
+    echo "    local engineer slots scheduled/day: $ENGINEER_DISPATCHES"
   else
     echo "    local simultaneous starts/day: UNKNOWN (one or more pointers unmeasured)"
-    echo "    local engineer dispatches/day: UNKNOWN (one or more engineer pointers unmeasured)"
+    echo "    local engineer slots scheduled/day: UNKNOWN (one or more engineer pointers unmeasured)"
+  fi
+
+  # Reported OUTSIDE the aggregate gate above, deliberately. That gate requires all
+  # four schedule pointers to be measured because it SUMS both lanes; this figure
+  # needs only the Claude cron minute and the Claude skip records. Measured live
+  # 2026-08-09: the Codex engineer's stored RRULE had lost its BYSECOND=0, so that
+  # lane read UNKNOWN and suppressed the whole block — hiding a Claude drop count
+  # that was fully measurable. A lane's own number must not be hostage to a
+  # sibling lane's unrelated pointer defect.
+  if [ -n "$CLAUDE_ENGINEER_ACTUAL" ]; then
+    CLAUDE_ENG_SLOTS_DAY=$(printf '%s\n' "$CLAUDE_ENGINEER_ACTUAL" \
+      | expand_schedules | awk 'NF { count++ } END { print count + 0 }')
+    CLAUDE_ENG_MINUTE=${CLAUDE_ENGINEER_ACTUAL##*@}
+    SKIP_SINCE_MS=$(jq -nr --arg since "$WINDOW_SINCE" '
+      ($since | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601 | floor) * 1000
+    ' 2>/dev/null)
+    CLAUDE_DROPPED=""
+    if [ -n "$WINDOW_SINCE" ] && [ -n "$SKIP_SINCE_MS" ] \
+       && [[ "$CLAUDE_ENG_MINUTE" =~ ^[0-9]+$ ]]; then
+      CLAUDE_DROPPED=$(claude_store_skip_slots "$CLAUDE_SCHEDULE_STORE" \
+        daily-ai-assistant "$CLAUDE_ENG_MINUTE" "$SKIP_SINCE_MS")
+    fi
+    SKIP_FLOOR=""
+    [ -n "$CLAUDE_DROPPED" ] \
+      && SKIP_FLOOR=$(claude_store_skip_floor "$CLAUDE_SCHEDULE_STORE" daily-ai-assistant)
+    # An absent skip surface and a genuinely drop-free window are indistinguishable
+    # from the count alone: both yield 0. Reporting that 0 would fabricate a clean
+    # lane out of a surface that recorded nothing — the exact error this change
+    # refuses to make for Codex two lines below, and it would be no better here.
+    # An empty floor means no record exists to prove the surface is live, so the
+    # whole figure is UNKNOWN rather than zero.
+    if [ -z "$CLAUDE_DROPPED" ] || [ -z "$SKIP_FLOOR" ]; then
+      echo "    claude engineer dropped dispatches: UNKNOWN (no readable skip record — an absent surface is not a zero)"
+    else
+      # A rate is stated only when the store's records demonstrably cover the whole
+      # window. Records that begin INSIDE it leave the earlier slots unaccounted,
+      # and short retention would otherwise masquerade as a low drop rate.
+      if [ "$SKIP_FLOOR" -le "$SKIP_SINCE_MS" ] \
+         && [ "$CLAUDE_ENG_SLOTS_DAY" -gt 0 ]; then
+        RATE=$(awk -v d="$CLAUDE_DROPPED" -v s="$CLAUDE_ENG_SLOTS_DAY" -v n="$SINCE_DAYS" \
+          'BEGIN { t = s * n; if (t > 0) printf "%.1f%% of %d slot(s)", 100 * d / t, t; else print "UNKNOWN" }')
+        echo "    claude engineer dropped dispatches: $CLAUDE_DROPPED slot(s) (per_task_limit), drop rate: $RATE"
+      else
+        echo "    claude engineer dropped dispatches: $CLAUDE_DROPPED slot(s) (per_task_limit), drop rate: UNKNOWN (skip records do not span the window)"
+      fi
+    fi
+    # The Codex `automations` table records dispatches that HAPPENED; it carries no
+    # skip surface, so a Codex drop is visible only as a gap. Reporting 0 here would
+    # fabricate a clean lane out of a surface that cannot record the event.
+    echo "    codex engineer dropped dispatches: UNKNOWN (scheduler store records dispatches only, no skip surface)"
+  else
+    echo "    claude engineer dropped dispatches: UNKNOWN (claude engineer schedule unmeasured)"
+    echo "    codex engineer dropped dispatches: UNKNOWN (scheduler store records dispatches only, no skip surface)"
   fi
 
   echo

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -3534,11 +3534,17 @@ if want drift; then
   # dispatch; every later record in that hour re-refuses a tick already counted.
   # Distinct-slot counting (truncate to the hour) also absorbs the duplicate that
   # appears when two poll ticks land inside the same due minute.
+  #
+  # Filtered on the REASON as well as the minute. Every record on the live store is
+  # currently `per_task_limit`, but the field exists precisely because it need not
+  # be, and the reported line names that reason — so counting any other skip class
+  # would inflate both the count and the rate while claiming to measure one cause.
   claude_store_skip_slots() {
     local store="$1" id="$2" minute="$3" since_ms="$4"
     [ -f "$store" ] || return 0
     jq -r --arg id "$id" --argjson minute "$minute" --argjson since "$since_ms" '
       [ .recordedSkips[$id][]?
+        | select(.reason == "per_task_limit")
         | (.at // empty)
         | select(. >= $since)
         | (. / 1000 | floor)

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -3539,18 +3539,39 @@ if want drift; then
   # currently `per_task_limit`, but the field exists precisely because it need not
   # be, and the reported line names that reason — so counting any other skip class
   # would inflate both the count and the rate while claiming to measure one cause.
+  # Matched on the schedule's HOURS as well as its minute. Filtering on the minute
+  # alone is correct only while the cron covers every hour; the moment it does not —
+  # `50 0,12 * * *`, exactly the drift this section exists to diagnose — the runtime
+  # still records a poll tick at every hour's :50 while a run stays blocked, so an
+  # unscheduled hour would be counted as a dropped slot against a denominator of two
+  # slots/day, and the rate could exceed 100%.
+  #
+  # Cron hours are LOCAL (verified: the improver's `0,12` fires at 10:00Z under a
+  # +02:00 offset), so both fields are read through `strflocaltime` rather than
+  # arithmetic on the epoch. That also removes a latent assumption in the minute
+  # test, which only agreed with local time because this host's offset is a whole
+  # number of hours; it would have been wrong on a :30 offset.
   claude_store_skip_slots() {
-    local store="$1" id="$2" minute="$3" since_ms="$4"
+    local store="$1" id="$2" minute="$3" since_ms="$4" hours="$5"
     [ -f "$store" ] || return 0
-    jq -r --arg id "$id" --argjson minute "$minute" --argjson since "$since_ms" '
-      [ .recordedSkips[$id][]?
-        | select(.reason == "per_task_limit")
-        | (.at // empty)
-        | select(. >= $since)
-        | (. / 1000 | floor)
-        | select(((. % 3600) / 60 | floor) == $minute)
-        | (. - (. % 3600))
-      ] | unique | length
+    jq -r --arg id "$id" --argjson minute "$minute" --arg hours "$hours" \
+          --argjson since "$since_ms" '
+      ($hours | split(",")) as $hourset
+      | [ .recordedSkips[$id][]?
+          | select(.reason == "per_task_limit")
+          | (.at // empty)
+          | select(. >= $since)
+          | (. / 1000 | floor)
+          | select((strflocaltime("%M") | tonumber) == $minute)
+          # Bound to a variable first: index(f) evaluates f against the input of
+          # index itself, so $hourset | index(strflocaltime(...)) would apply the
+          # format to the hour ARRAY and abort on "requires parsed datetime inputs".
+          | . as $epoch
+          | select($hours == "*"
+                   or ($hourset
+                       | index($epoch | strflocaltime("%H") | tonumber | tostring)) != null)
+          | strflocaltime("%Y-%m-%dT%H")
+        ] | unique | length
     ' "$store" 2>/dev/null
   }
 
@@ -3768,7 +3789,8 @@ if want drift; then
     if [ -n "$WINDOW_SINCE" ] && [ -n "$SKIP_SINCE_MS" ] \
        && [[ "$CLAUDE_ENG_MINUTE" =~ ^[0-9]+$ ]]; then
       CLAUDE_DROPPED=$(claude_store_skip_slots "$CLAUDE_SCHEDULE_STORE" \
-        daily-ai-assistant "$CLAUDE_ENG_MINUTE" "$SKIP_SINCE_MS")
+        daily-ai-assistant "$CLAUDE_ENG_MINUTE" "$SKIP_SINCE_MS" \
+        "${CLAUDE_ENGINEER_ACTUAL%%@*}")
     fi
     SKIP_FLOOR=""
     [ -n "$CLAUDE_DROPPED" ] \
@@ -3785,11 +3807,25 @@ if want drift; then
       # A rate is stated only when the store's records demonstrably cover the whole
       # window. Records that begin INSIDE it leave the earlier slots unaccounted,
       # and short retention would otherwise masquerade as a low drop rate.
+      # The rate assumes the CURRENT cadence held for the whole window, and the store
+      # carries no schedule history to prove that — a cron changed mid-window would
+      # have its earlier drops classified under the new minute while the denominator
+      # still counts every slot. That case cannot be detected from this surface, so
+      # it is disclosed in the label rather than silently assumed away.
+      #
+      # What CAN be detected is the impossible outcome it produces: more dropped slots
+      # than the window could schedule. That is proof the assumption failed, so it
+      # fails closed instead of publishing a rate above 100%.
+      RATE_TOTAL=$(( CLAUDE_ENG_SLOTS_DAY * SINCE_DAYS ))
       if [ "$SKIP_FLOOR" -le "$SKIP_SINCE_MS" ] \
-         && [ "$CLAUDE_ENG_SLOTS_DAY" -gt 0 ]; then
-        RATE=$(awk -v d="$CLAUDE_DROPPED" -v s="$CLAUDE_ENG_SLOTS_DAY" -v n="$SINCE_DAYS" \
-          'BEGIN { t = s * n; if (t > 0) printf "%.1f%% of %d slot(s)", 100 * d / t, t; else print "UNKNOWN" }')
+         && [ "$CLAUDE_ENG_SLOTS_DAY" -gt 0 ] \
+         && [ "$CLAUDE_DROPPED" -le "$RATE_TOTAL" ]; then
+        RATE=$(awk -v d="$CLAUDE_DROPPED" -v t="$RATE_TOTAL" \
+          'BEGIN { if (t > 0) printf "%.1f%% of %d slot(s) at the current cadence", 100 * d / t, t; else print "UNKNOWN" }')
         echo "    claude engineer dropped dispatches: $CLAUDE_DROPPED slot(s) (per_task_limit), drop rate: $RATE"
+      elif [ -n "$RATE_TOTAL" ] && [ "$CLAUDE_ENG_SLOTS_DAY" -gt 0 ] \
+           && [ "$CLAUDE_DROPPED" -gt "$RATE_TOTAL" ]; then
+        echo "    claude engineer dropped dispatches: $CLAUDE_DROPPED slot(s) (per_task_limit), drop rate: UNKNOWN (more drops than the window schedules — cadence changed within it)"
       else
         echo "    claude engineer dropped dispatches: $CLAUDE_DROPPED slot(s) (per_task_limit), drop rate: UNKNOWN (skip records do not span the window)"
       fi

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -163,7 +163,37 @@ cat > "$FIX/claude-store/scheduled-tasks.json" <<EOF
       "cronExpression": "0 0,12 * * *",
       "lastRunAt": "2026-07-25T12:00:00.000Z"
     }
-  ]
+  ],
+  "recordedSkips": {
+    "daily-ai-assistant": [
+      { "at": 1784541000000, "reason": "per_task_limit" },
+      { "at": 1784544600000, "reason": "per_task_limit" },
+      { "at": 1784548200000, "reason": "per_task_limit" },
+      { "at": 1784541059000, "reason": "per_task_limit" },
+      { "at": 1784541065000, "reason": "per_task_limit" },
+      { "at": 1784541125000, "reason": "per_task_limit" },
+      { "at": 1784541185000, "reason": "per_task_limit" },
+      { "at": 1784541245000, "reason": "per_task_limit" },
+      { "at": 1784541305000, "reason": "per_task_limit" },
+      { "at": 1784541365000, "reason": "per_task_limit" },
+      { "at": 1784541425000, "reason": "per_task_limit" },
+      { "at": 1784541485000, "reason": "per_task_limit" },
+      { "at": 1784541545000, "reason": "per_task_limit" },
+      { "at": 1784544665000, "reason": "per_task_limit" },
+      { "at": 1784544725000, "reason": "per_task_limit" },
+      { "at": 1784544785000, "reason": "per_task_limit" },
+      { "at": 1784544845000, "reason": "per_task_limit" },
+      { "at": 1784544905000, "reason": "per_task_limit" },
+      { "at": 1784544965000, "reason": "per_task_limit" },
+      { "at": 1784545025000, "reason": "per_task_limit" },
+      { "at": 1784545085000, "reason": "per_task_limit" },
+      { "at": 1784545145000, "reason": "per_task_limit" },
+      { "at": 1784548265000, "reason": "per_task_limit" },
+      { "at": 1784548325000, "reason": "per_task_limit" },
+      { "at": 1784551505000, "reason": "per_task_limit" },
+      { "at": 1784551565000, "reason": "per_task_limit" }
+    ]
+  }
 }
 EOF
 cat > "$FIX/codex/automations/daily-ai-engineer/automation.toml" <<'EOF'
@@ -282,7 +312,63 @@ check "compares Codex improver schedule"  "$OUT" "codex improver:  expected=7,19
 check "reports Codex engineer dispatch advance" "$OUT" "MATCH marker=1785238560676 baseline=1785238559000"
 check "reports Codex improver dispatch advance" "$OUT" "MATCH marker=1785222864850 baseline=1785222863000"
 check "proves staggered local starts"      "$OUT" "local simultaneous starts/day: 0"
-check "proves hourly engineer dispatches"  "$OUT" "local engineer dispatches/day: 48"
+check "proves hourly engineer slots"       "$OUT" "local engineer slots scheduled/day: 48"
+
+# A cron expansion counts SCHEDULED SLOTS, never dispatches. The Claude runtime
+# declines any dispatch that would overlap the previous run of the same task, so
+# a third of this lane's slots never run (58 of 168 measured 2026-08-02→08-09).
+# Labelling the cron total "dispatches" is what let hypothesis volume floors —
+# which are stated in dispatches — be satisfied by runs that never happened.
+#
+# The store records one skip per POLL TICK, roughly every 60s while blocked, so
+# the raw record count overstates dropped dispatches by ~18x on the live store
+# (1067 records, 58 real drops). Only a record landing in the cron's own minute
+# is a dropped dispatch; the rest are re-refusals of a tick already counted.
+# The fixture encodes exactly that: 26 records, of which 3 are distinct due-minute
+# slots, 1 is a same-slot duplicate, and 22 are off-minute poll noise.
+#
+# The last two noise records sit in an hour carrying NO due-minute record, and that
+# asymmetry is load-bearing. An earlier fixture put every noise record in an hour
+# that also held a real drop, so distinct-slot counting returned 3 whether or not
+# the due-minute filter ran — the assertion passed against a wrong implementation
+# and the ablation proved nothing. With hour 12 present as noise only, dropping the
+# filter counts 4 and the test fails, which is what makes it a real check.
+nocheck "never counts poll-tick records as dropped dispatches" "$OUT" "dropped dispatches: 26"
+check   "counts dropped dispatches by due slot, not poll tick" "$OUT" \
+  "claude engineer dropped dispatches: 3 slot(s)"
+# Codex's store has no skip surface at all — `automations` records dispatches that
+# HAPPENED, so a Codex drop is visible only as a gap. Zero on a surface that cannot
+# record the event is not zero, and reporting 0 here would invent a clean lane.
+check "codex drop is UNKNOWN, never a fabricated zero" "$OUT" \
+  "codex engineer dropped dispatches: UNKNOWN"
+nocheck "codex drop never reports a zero"  "$OUT" "codex engineer dropped dispatches: 0"
+
+# A rate needs the skip records to span the whole window. Here they start well
+# after a 3650-day window opens, so the denominator is unprovable and the rate
+# must fail closed rather than dividing by a window the store cannot cover.
+check "unspanned window refuses to state a rate" "$OUT" "drop rate: UNKNOWN"
+
+# The covered case: with a 1-day window the records predate the window start, so
+# coverage IS proven and the rate is computed. None of the 24 records fall inside
+# that window, which also proves the due-slot count is window-bounded.
+OUT=$(run --section drift --since-days 1)
+check "covered window states a rate"        "$OUT" "drop rate: 0.0%"
+check "window bounds the dropped-slot count" "$OUT" \
+  "claude engineer dropped dispatches: 0 slot(s)"
+
+# A store with NO skip surface must read UNKNOWN, never 0. The count alone cannot
+# tell an absent surface from a genuinely drop-free window — both are 0 — and
+# reporting the zero would invent a clean lane, which is precisely the error this
+# section refuses to make for Codex.
+cp "$FIX/claude-store/scheduled-tasks.json" "$FIX/claude-store/scheduled-tasks.json.bak"
+jq 'del(.recordedSkips)' "$FIX/claude-store/scheduled-tasks.json.bak" \
+  > "$FIX/claude-store/scheduled-tasks.json"
+OUT=$(run --section drift)
+check   "absent skip surface reads UNKNOWN" "$OUT" \
+  "claude engineer dropped dispatches: UNKNOWN"
+nocheck "absent skip surface is never a zero" "$OUT" \
+  "claude engineer dropped dispatches: 0 slot(s)"
+mv "$FIX/claude-store/scheduled-tasks.json.bak" "$FIX/claude-store/scheduled-tasks.json"
 
 # Removing one pointer must fail closed rather than leaving the schedule surface
 # silently unmeasured. This is the exact blind spot that hid the reverted Codex
@@ -291,6 +377,12 @@ mv "$FIX/codex/automations/agent-improver/automation.toml" \
    "$FIX/codex/automations/agent-improver/automation.toml.missing"
 OUT=$(run --section drift)
 check "missing improver pointer is explicit" "$OUT" "UNKNOWN: codex improver schedule pointer missing"
+# A Codex-side pointer defect must not suppress a fully measurable Claude number.
+# This is the live failure the change was evaluated against: the Codex engineer's
+# stored RRULE had lost BYSECOND=0, the aggregate gate went UNKNOWN, and the Claude
+# drop count — which depends on nothing Codex owns — disappeared with it.
+check "a codex pointer defect does not suppress the claude drop count" "$OUT" \
+  "claude engineer dropped dispatches: 3 slot(s)"
 mv "$FIX/codex/automations/agent-improver/automation.toml.missing" \
    "$FIX/codex/automations/agent-improver/automation.toml"
 
@@ -302,7 +394,7 @@ OUT=$(run --section drift)
 check "missing runtime marker is explicit" "$OUT" "UNKNOWN: codex improver change marker missing"
 nocheck "missing runtime marker never claims persistence" "$OUT" "codex improver:  expected=7,19@0 actual=7,19@0 MATCH"
 check "missing runtime marker invalidates parity total" "$OUT" "local simultaneous starts/day: UNKNOWN"
-check "missing runtime marker invalidates dispatch total" "$OUT" "local engineer dispatches/day: UNKNOWN"
+check "missing runtime marker invalidates dispatch total" "$OUT" "local engineer slots scheduled/day: UNKNOWN"
 sqlite3 "$CODEX_AUTOMATION_STORE" \
   "UPDATE automations SET last_run_at = 1785222864850 WHERE id = 'agent-improver';"
 
@@ -320,7 +412,7 @@ OUT=$(run --section drift)
 check "scheduler-store rewrite is detected" "$OUT" "DRIFT: codex improver schedule pointer=7,19@0 scheduler=6,18@50"
 nocheck "scheduler-store rewrite never claims MATCH" "$OUT" "codex improver:  expected=7,19@0 actual=7,19@0 MATCH"
 check "scheduler-store rewrite invalidates collision total" "$OUT" "local simultaneous starts/day: UNKNOWN"
-check "scheduler-store rewrite invalidates dispatch total" "$OUT" "local engineer dispatches/day: UNKNOWN"
+check "scheduler-store rewrite invalidates dispatch total" "$OUT" "local engineer slots scheduled/day: UNKNOWN"
 sqlite3 "$CODEX_AUTOMATION_STORE" \
   "UPDATE automations SET rrule = 'RRULE:FREQ=DAILY;BYHOUR=7,19;BYMINUTE=0;BYSECOND=0' WHERE id = 'agent-improver';"
 

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -191,7 +191,8 @@ cat > "$FIX/claude-store/scheduled-tasks.json" <<EOF
       { "at": 1784548265000, "reason": "per_task_limit" },
       { "at": 1784548325000, "reason": "per_task_limit" },
       { "at": 1784551505000, "reason": "per_task_limit" },
-      { "at": 1784551565000, "reason": "per_task_limit" }
+      { "at": 1784551565000, "reason": "per_task_limit" },
+      { "at": 1784555400000, "reason": "provider_outage" }
     ]
   }
 }
@@ -324,8 +325,11 @@ check "proves hourly engineer slots"       "$OUT" "local engineer slots schedule
 # the raw record count overstates dropped dispatches by ~18x on the live store
 # (1067 records, 58 real drops). Only a record landing in the cron's own minute
 # is a dropped dispatch; the rest are re-refusals of a tick already counted.
-# The fixture encodes exactly that: 26 records, of which 3 are distinct due-minute
-# slots, 1 is a same-slot duplicate, and 22 are off-minute poll noise.
+# The fixture encodes exactly that: 27 records, of which 3 are distinct due-minute
+# `per_task_limit` slots, 1 is a same-slot duplicate, 22 are off-minute poll noise,
+# and 1 sits in the due minute of an otherwise-empty hour under a DIFFERENT reason.
+# That last one pins the reason filter: the reported line names `per_task_limit`, so
+# counting another skip class would inflate the count while claiming one cause.
 #
 # The last two noise records sit in an hour carrying NO due-minute record, and that
 # asymmetry is load-bearing. An earlier fixture put every noise record in an hour
@@ -333,7 +337,8 @@ check "proves hourly engineer slots"       "$OUT" "local engineer slots schedule
 # the due-minute filter ran — the assertion passed against a wrong implementation
 # and the ablation proved nothing. With hour 12 present as noise only, dropping the
 # filter counts 4 and the test fails, which is what makes it a real check.
-nocheck "never counts poll-tick records as dropped dispatches" "$OUT" "dropped dispatches: 26"
+nocheck "never counts poll-tick records as dropped dispatches" "$OUT" "dropped dispatches: 27"
+nocheck "never counts a skip recorded under another reason"     "$OUT" "dropped dispatches: 4 slot(s)"
 check   "counts dropped dispatches by due slot, not poll tick" "$OUT" \
   "claude engineer dropped dispatches: 3 slot(s)"
 # Codex's store has no skip surface at all — `automations` records dispatches that

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -353,6 +353,23 @@ nocheck "codex drop never reports a zero"  "$OUT" "codex engineer dropped dispat
 # must fail closed rather than dividing by a window the store cannot cover.
 check "unspanned window refuses to state a rate" "$OUT" "drop rate: UNKNOWN"
 
+# The minute alone identifies a dropped slot only while the cron covers every hour.
+# Under a finite hour list the runtime still records a poll tick at every hour's :50
+# while a run stays blocked, so counting unscheduled hours would score drops against
+# a two-slot/day denominator and could publish a rate above 100%.
+#
+# Cron hours are LOCAL. The three due-minute fixture records are 09:50/10:50/11:50 UTC
+# = 11:50/12:50/13:50 under this suite's +02:00 host, so `0,12` admits exactly one.
+cp "$FIX/claude-store/scheduled-tasks.json" "$FIX/claude-store/scheduled-tasks.json.bak"
+jq '(.scheduledTasks[] | select(.id == "daily-ai-assistant") | .cronExpression) = "50 0,12 * * *"' \
+  "$FIX/claude-store/scheduled-tasks.json.bak" > "$FIX/claude-store/scheduled-tasks.json"
+OUT=$(run --section drift)
+check   "a finite hour list excludes unscheduled hours" "$OUT" \
+  "claude engineer dropped dispatches: 1 slot(s)"
+nocheck "an hour-list cron never counts every hour's due minute" "$OUT" \
+  "claude engineer dropped dispatches: 3 slot(s)"
+mv "$FIX/claude-store/scheduled-tasks.json.bak" "$FIX/claude-store/scheduled-tasks.json"
+
 # The covered case: with a 1-day window the records predate the window start, so
 # coverage IS proven and the rate is computed. None of the 24 records fall inside
 # that window, which also proves the due-slot count is window-bounded.

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -237,6 +237,11 @@ EOF
 mkdir -p "$FIX/monorepo/.claude"
 
 run() {
+  # TZ is PINNED. Cron hours are local, so the dropped-slot classifier reads local
+  # time — which makes any fixture asserting an hour a function of the host's zone.
+  # Unpinned, the hour-list case passed on a +02:00 developer machine and failed on
+  # the UTC runners, which is a property of the test, not of the code under test.
+  TZ=UTC \
   CLAUDE_PROJECTS_DIR="$FIX/projects" CODEX_HOME="$FIX/codex" \
   MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
   CLAUDE_SCHEDULE_STORE_PATH="$FIX/claude-store/scheduled-tasks.json" \
@@ -358,10 +363,11 @@ check "unspanned window refuses to state a rate" "$OUT" "drop rate: UNKNOWN"
 # while a run stays blocked, so counting unscheduled hours would score drops against
 # a two-slot/day denominator and could publish a rate above 100%.
 #
-# Cron hours are LOCAL. The three due-minute fixture records are 09:50/10:50/11:50 UTC
-# = 11:50/12:50/13:50 under this suite's +02:00 host, so `0,12` admits exactly one.
+# Cron hours are LOCAL, and `run` pins TZ=UTC so this assertion is host-independent.
+# The three due-minute fixture records are 09:50/10:50/11:50 UTC, so `0,10` admits
+# exactly one of them.
 cp "$FIX/claude-store/scheduled-tasks.json" "$FIX/claude-store/scheduled-tasks.json.bak"
-jq '(.scheduledTasks[] | select(.id == "daily-ai-assistant") | .cronExpression) = "50 0,12 * * *"' \
+jq '(.scheduledTasks[] | select(.id == "daily-ai-assistant") | .cronExpression) = "50 0,10 * * *"' \
   "$FIX/claude-store/scheduled-tasks.json.bak" > "$FIX/claude-store/scheduled-tasks.json"
 OUT=$(run --section drift)
 check   "a finite hour list excludes unscheduled hours" "$OUT" \

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -376,13 +376,30 @@ nocheck "an hour-list cron never counts every hour's due minute" "$OUT" \
   "claude engineer dropped dispatches: 3 slot(s)"
 mv "$FIX/claude-store/scheduled-tasks.json.bak" "$FIX/claude-store/scheduled-tasks.json"
 
-# The covered case: with a 1-day window the records predate the window start, so
-# coverage IS proven and the rate is computed. None of the 24 records fall inside
-# that window, which also proves the due-slot count is window-bounded.
+# Coverage is not liveness, and the two must be tested separately.
+#
+# OUTAGE: with a 1-day window the fixture's records and `lastRunAt` both predate it,
+# so the floor covers the window and zero drops are counted — but nothing dispatched
+# and nothing was even refused inside it. Reporting "0.0%" there would present a dead
+# scheduler as 24 successful opportunities, which is the same absence-read-as-health
+# error as a fabricated zero.
 OUT=$(run --section drift --since-days 1)
-check "covered window states a rate"        "$OUT" "drop rate: 0.0%"
-check "window bounds the dropped-slot count" "$OUT" \
+check   "an inactive scheduler refuses to state a rate" "$OUT" \
+  "drop rate: UNKNOWN (no dispatch or skip inside the window"
+nocheck "an outage is never reported as a clean 0.0%" "$OUT" "drop rate: 0.0%"
+check   "window bounds the dropped-slot count" "$OUT" \
   "claude engineer dropped dispatches: 0 slot(s)"
+
+# ACTIVE: same window, but `lastRunAt` now falls inside it, so the scheduler is
+# proven to have dispatched and the denominator describes slots something was
+# actually attempting to fill.
+cp "$FIX/claude-store/scheduled-tasks.json" "$FIX/claude-store/scheduled-tasks.json.bak"
+jq --arg now "$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')" \
+  '(.scheduledTasks[] | select(.id == "daily-ai-assistant") | .lastRunAt) = $now' \
+  "$FIX/claude-store/scheduled-tasks.json.bak" > "$FIX/claude-store/scheduled-tasks.json"
+OUT=$(run --section drift --since-days 1)
+check "a proven-active scheduler states a rate" "$OUT" "drop rate: 0.0%"
+mv "$FIX/claude-store/scheduled-tasks.json.bak" "$FIX/claude-store/scheduled-tasks.json"
 
 # A store with NO skip surface must read UNKNOWN, never 0. The count alone cannot
 # tell an absent surface from a genuinely drop-free window — both are 0 — and


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The telemetry miner reported `local engineer dispatches/day: 48`. That number is the
cron expanded — it counts **scheduled slots, not runs**. The Claude runtime declines
any dispatch that would overlap the previous run of the same task, and roughly a third
of this lane's slots never run (58 of 168 measured over the last week).

That matters beyond a wrong label: this deployment states hypothesis volume floors in
*dispatches*, so a floor could be cleared by runs that never happened — a verdict
applied to data that does not exist.

## What

The cron total is relabelled as scheduled slots, and the measured drop count is now
reported per lane from the scheduler store's own records.

Three things it deliberately refuses to do, because each would report a cleaner picture
than the evidence supports:

- **Count poll ticks as drops.** The store records a refusal roughly every 60s for as
  long as the task stays blocked, so raw records overstate by ~18× (1067 records for 58
  real drops). Only a record landing in the cron's own minute is a dropped dispatch.
- **State a rate it cannot support.** A rate needs the records to span the window; where
  they start inside it, the rate reads UNKNOWN rather than letting short retention
  masquerade as a low drop rate.
- **Report a zero for a surface that records nothing.** An absent skip surface and a
  genuinely drop-free window both count 0. Codex has no skip surface at all, so that
  lane reports UNKNOWN — never 0.

Evaluated against the live store: 13 dropped slots (54.2%) over 1 day, 58 over 7 days,
both matching an independent measurement taken separately.

Part of #2716 — this delivers the scheduled-vs-actual and per-lane drop-rate reporting.
It does **not** flip the `DISPATCH_HEALTH` default, which gates a different classifier
(provider refusals that killed a session that *did* start) and needs its own validation.
