### PR TITLE
fix(telemetry): let the parser decide which image payloads the credential mask may blank

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1156,9 +1156,11 @@ strip_ansi() {
 # the line. Both are conservative: a false veto merely scans a record the table
 # excluded, which is the safe direction. The vetoes are anchored on `type` keys
 # and key-colon pairs, so the `/` a payload is allowed to carry cannot
-# trigger them. What remains uncovered is a record combining an escaped key with
-# a duplicate key so the totals coincide; it is recorded rather than closed,
-# because closing it costs a whole-line rewrite per record.
+# trigger them. `\u` is the only escape that can spell a letter, so no other
+# escape opens this route. The residual is a key whose own text defeats the
+# veto's `[^"]*` span — one containing an escaped quote as well as a `\u` —
+# which is recorded rather than closed, because closing it means re-deriving
+# every excluded span from the parse and rewriting the line per record.
 #
 # The counting runs inside the SAME `jq -R` pass that already asks the parse
 # question, so this adds no process and no second read of the line.
@@ -3376,10 +3378,14 @@ if want safety; then
     echo "       directions, so read it as a pointer, never as a second count."
     echo "       UNDER: the table scans DECODED strings, so an escaped-quote"
     echo "       match is counted there with no locator line here. OVER: complete"
-    echo "       base64 image payloads are excluded from this scan too, but that"
-    echo "       exclusion is matched textually while the table computes it by"
-    echo "       parsing, so rarer JSON spellings still slip through and point at"
-    echo "       encoded image bytes the table never counted (monorepo#2741)."
+    echo "       base64 image payloads are excluded from this scan too. The"
+    echo "       parser decides which records that exclusion may apply to, so a"
+    echo "       record whose spelling it cannot vouch for is scanned rather"
+    echo "       than blanked — but WHERE the payload sits is still found"
+    echo "       textually, so rarer JSON spellings can point at encoded image"
+    echo "       bytes the table never counted (monorepo#2741). Where the two"
+    echo "       cannot be reconciled the record is scanned, so the exclusion"
+    echo "       errs toward showing a pointer rather than hiding one."
     echo "       Concentration is CONTEXT, never a verdict.)"
     : > "$CREDCONC"
     echo "    (empty = clean. A HIGH-SIGNAL shape count means rotate the credential AND"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1090,7 +1090,7 @@ strip_ansi() {
 # because the alternation needs `|`.
 #
 # 🔴 The mask requires a record that parses — the first of two conditions the
-# parser imposes, the second being key precedence immediately below. The table
+# parser imposes, the second being key precedence below. The table
 # itself applies this one: it runs `$raw | fromjson | decoded_strings`
 # and falls back to `catch $raw` — so a record that fails to parse is scanned
 # WHOLE and its credentials ARE counted, image payload or not. Masking such a
@@ -1143,27 +1143,41 @@ strip_ansi() {
 #
 # The agreement test is a COUNT: how many times the marker is spelled in the raw
 # line, against how many objects the parser actually sees carrying it. Equality
-# is what licenses the mask. A duplicate key breaks equality in whichever
-# direction it resolves, so the record is declined and scanned — and, crucially,
-# a record whose LAST value is `input_image` still counts 1 == 1 and is still
-# masked. Declining every repeated key would be safe but would silence a payload
-# the table genuinely dropped, so the test is precedence-aware rather than
-# duplicate-averse.
+# is what licenses the mask. A duplicate key that resolves AWAY from
+# `input_image` leaves the text saying it once and the parser seeing it zero
+# times, so the record is declined and scanned — while one that resolves TO
+# `input_image` still counts 1 == 1 and is still masked. Declining every
+# repeated key would be safe but would silence a payload the table genuinely
+# dropped, so the test is precedence-aware rather than duplicate-averse.
+#
+# The raw marker is tested FIRST, before the count and the veto, and that
+# ordering is load-bearing rather than cosmetic. Both expressions below require
+# the literal marker, so a line without it cannot be masked whichever byte is
+# prepended — making the rest of the question unobservable. Skipping it there
+# leaves the common case (no marker anywhere) at one cheap test instead of a
+# scan plus a veto, which matters because this filter sees every line of every
+# session file and those lines run to megabytes. Note the guard must key on the
+# RAW marker and NOT on a zero parsed count: the parsed count is zero in exactly
+# the duplicate-key case that has to be declined.
 #
 # Two RESPELLING vetoes close the way two divergences could cancel out and leave
-# the counts equal. Only a `\u` escape can spell `input_image` or the `type` key
-# some other way, so a `\u` inside a `type` VALUE, or inside any KEY, declines
-# the line. Both are conservative: a false veto merely scans a record the table
-# excluded, which is the safe direction. The vetoes are anchored on `type` keys
-# and key-colon pairs, so the `/` a payload is allowed to carry cannot
-# trigger them. `\u` is the only escape that can spell a letter, so no other
-# escape opens this route. The residual is a key whose own text defeats the
-# veto's `[^"]*` span — one containing an escaped quote as well as a `\u` —
-# which is recorded rather than closed, because closing it means re-deriving
-# every excluded span from the parse and rewriting the line per record.
+# the counts equal — one object hiding the marker from the text while another
+# hides it from the parser. `\u` is the only JSON escape that can spell a
+# letter, so respelling is the only route in, and a `\u` inside a `type` VALUE
+# or inside a KEY declines the line. That closes the route rather than merely
+# narrowing it: a token that must DECODE to `type` or to `input_image` can
+# differ from its plain spelling only by `\u` escapes of those same letters, so
+# it can never also contain the escaped quote that would end the veto's `[^"]*`
+# span early. Both vetoes are conservative anyway — a false one merely scans a
+# record the table excluded, which is the safe direction.
+#
+# What this does NOT do is make the textual locator agree with the parse in
+# general; it removes one specific way they can disagree. Deriving the excluded
+# spans from the parse instead is the durable fix, tracked on monorepo#2741
+# together with the perf constraint in monorepo#2740.
 #
 # The counting runs inside the SAME `jq -R` pass that already asks the parse
-# question, so this adds no process and no second read of the line.
+# question, so this adds no process and no second read of the file.
 CRED_MASK_ELIGIBLE=$(printf '\001')
 CRED_MASK_DECLINED=$(printf '\002')
 # The marker as the raw line spells it, and the two respelling vetoes. Held as
@@ -1176,17 +1190,16 @@ cred_mask_image_payloads() {
      --arg marker "$CRED_MASK_MARKER_RE" --arg respell "$CRED_MASK_RESPELL_RE" \
      '. as $raw
       | (try ($raw | fromjson) catch null) as $doc
-      | if $doc == null then $no + $raw
-        elif ([$raw | scan($marker)] | length)
-               == ([$doc | .. | objects | select(.type? == "input_image")] | length)
+      | (if $doc != null
+             and ($raw | test($marker))
+             and ([$raw | scan($marker)] | length)
+                 == ([$doc | .. | objects | select(.type == "input_image")] | length)
              and ($raw | test($respell) | not)
-        then $ok + $raw
-        else $no + $raw
-        end' 2>/dev/null \
+          then $ok else $no end) + $raw' 2>/dev/null \
   | sed -E \
     -e "/^${CRED_MASK_ELIGIBLE}/{" \
-    -e 's#("type"[[:space:]]*:[[:space:]]*"input_image"[^{}]*"image_url"[[:space:]]*:[[:space:]]*")[dD][aA][tT][aA]:[iI][mM][aA][gG][eE](\\?/|\\u002[fF])[A-Za-z0-9.+=;-]*;[bB][aA][sS][eE]64,([A-Za-z0-9+]|\\?/|\\u002[fF])*={0,2}(")#\1 \4#g' \
-    -e 's#("image_url"[[:space:]]*:[[:space:]]*")[dD][aA][tT][aA]:[iI][mM][aA][gG][eE](\\?/|\\u002[fF])[A-Za-z0-9.+=;-]*;[bB][aA][sS][eE]64,([A-Za-z0-9+]|\\?/|\\u002[fF])*={0,2}("[^{}]*"type"[[:space:]]*:[[:space:]]*"input_image")#\1 \4#g' \
+    -e 's#('"$CRED_MASK_MARKER_RE"'[^{}]*"image_url"[[:space:]]*:[[:space:]]*")[dD][aA][tT][aA]:[iI][mM][aA][gG][eE](\\?/|\\u002[fF])[A-Za-z0-9.+=;-]*;[bB][aA][sS][eE]64,([A-Za-z0-9+]|\\?/|\\u002[fF])*={0,2}(")#\1 \4#g' \
+    -e 's#("image_url"[[:space:]]*:[[:space:]]*")[dD][aA][tT][aA]:[iI][mM][aA][gG][eE](\\?/|\\u002[fF])[A-Za-z0-9.+=;-]*;[bB][aA][sS][eE]64,([A-Za-z0-9+]|\\?/|\\u002[fF])*={0,2}("[^{}]*'"$CRED_MASK_MARKER_RE"')#\1 \4#g' \
     -e '}' \
     -e "s/^[${CRED_MASK_ELIGIBLE}${CRED_MASK_DECLINED}]//"
 }
@@ -3383,9 +3396,7 @@ if want safety; then
     echo "       record whose spelling it cannot vouch for is scanned rather"
     echo "       than blanked — but WHERE the payload sits is still found"
     echo "       textually, so rarer JSON spellings can point at encoded image"
-    echo "       bytes the table never counted (monorepo#2741). Where the two"
-    echo "       cannot be reconciled the record is scanned, so the exclusion"
-    echo "       errs toward showing a pointer rather than hiding one."
+    echo "       bytes the table never counted (monorepo#2741)."
     echo "       Concentration is CONTEXT, never a verdict.)"
     : > "$CREDCONC"
     echo "    (empty = clean. A HIGH-SIGNAL shape count means rotate the credential AND"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -1089,8 +1089,9 @@ strip_ansi() {
 # `\t` and `\"` and mask values the table does not exclude. `#` is the delimiter
 # because the alternation needs `|`.
 #
-# 🔴 The mask applies ONLY to records that parse, because that is the condition
-# the table itself applies. The table runs `$raw | fromjson | decoded_strings`
+# 🔴 The mask requires a record that parses — the first of two conditions the
+# parser imposes, the second being key precedence immediately below. The table
+# itself applies this one: it runs `$raw | fromjson | decoded_strings`
 # and falls back to `catch $raw` — so a record that fails to parse is scanned
 # WHOLE and its credentials ARE counted, image payload or not. Masking such a
 # record would leave a counted table row with no concentration entry and no
@@ -1130,17 +1131,62 @@ strip_ansi() {
 # backslash would mask exactly that value and leave a counted row with no
 # locator. `,` and `"` stay excluded for the same reason — they would run the
 # match past the end of the value the table evaluated.
-CRED_MASK_PARSEABLE=$(printf '\001')
-CRED_MASK_UNPARSEABLE=$(printf '\002')
+#
+# 🔴 PARSE-SUCCESS IS NOT THE WHOLE GATE — KEY PRECEDENCE DECIDES TOO. JSON
+# permits a repeated key and `fromjson` keeps the LAST occurrence, so
+# `{"type":"input_image","type":"input_file","image_url":"data:image/…"}` has an
+# effective type of `input_file`: the table does NOT exclude that value and
+# COUNTS any credential in it, while the text still says `input_image` at the
+# first key and the expressions below would mask it. That is a counted row with
+# no locator — the unsafe direction. So the parser decides WHETHER the textual
+# expressions may run at all; they only ever LOCATE.
+#
+# The agreement test is a COUNT: how many times the marker is spelled in the raw
+# line, against how many objects the parser actually sees carrying it. Equality
+# is what licenses the mask. A duplicate key breaks equality in whichever
+# direction it resolves, so the record is declined and scanned — and, crucially,
+# a record whose LAST value is `input_image` still counts 1 == 1 and is still
+# masked. Declining every repeated key would be safe but would silence a payload
+# the table genuinely dropped, so the test is precedence-aware rather than
+# duplicate-averse.
+#
+# Two RESPELLING vetoes close the way two divergences could cancel out and leave
+# the counts equal. Only a `\u` escape can spell `input_image` or the `type` key
+# some other way, so a `\u` inside a `type` VALUE, or inside any KEY, declines
+# the line. Both are conservative: a false veto merely scans a record the table
+# excluded, which is the safe direction. The vetoes are anchored on `type` keys
+# and key-colon pairs, so the `/` a payload is allowed to carry cannot
+# trigger them. What remains uncovered is a record combining an escaped key with
+# a duplicate key so the totals coincide; it is recorded rather than closed,
+# because closing it costs a whole-line rewrite per record.
+#
+# The counting runs inside the SAME `jq -R` pass that already asks the parse
+# question, so this adds no process and no second read of the line.
+CRED_MASK_ELIGIBLE=$(printf '\001')
+CRED_MASK_DECLINED=$(printf '\002')
+# The marker as the raw line spells it, and the two respelling vetoes. Held as
+# constants so the textual question and the sed expressions below cannot drift
+# apart in how they spell the same key.
+CRED_MASK_MARKER_RE='"type"[[:space:]]*:[[:space:]]*"input_image"'
+CRED_MASK_RESPELL_RE='"type"[[:space:]]*:[[:space:]]*"[^"]*\\u|"[^"]*\\u[^"]*"[[:space:]]*:'
 cred_mask_image_payloads() {
-  jq -R -r --arg ok "$CRED_MASK_PARSEABLE" --arg no "$CRED_MASK_UNPARSEABLE" \
-     'if (try (fromjson | true) catch false) then $ok + . else $no + . end' 2>/dev/null \
+  jq -R -r --arg ok "$CRED_MASK_ELIGIBLE" --arg no "$CRED_MASK_DECLINED" \
+     --arg marker "$CRED_MASK_MARKER_RE" --arg respell "$CRED_MASK_RESPELL_RE" \
+     '. as $raw
+      | (try ($raw | fromjson) catch null) as $doc
+      | if $doc == null then $no + $raw
+        elif ([$raw | scan($marker)] | length)
+               == ([$doc | .. | objects | select(.type? == "input_image")] | length)
+             and ($raw | test($respell) | not)
+        then $ok + $raw
+        else $no + $raw
+        end' 2>/dev/null \
   | sed -E \
-    -e "/^${CRED_MASK_PARSEABLE}/{" \
+    -e "/^${CRED_MASK_ELIGIBLE}/{" \
     -e 's#("type"[[:space:]]*:[[:space:]]*"input_image"[^{}]*"image_url"[[:space:]]*:[[:space:]]*")[dD][aA][tT][aA]:[iI][mM][aA][gG][eE](\\?/|\\u002[fF])[A-Za-z0-9.+=;-]*;[bB][aA][sS][eE]64,([A-Za-z0-9+]|\\?/|\\u002[fF])*={0,2}(")#\1 \4#g' \
     -e 's#("image_url"[[:space:]]*:[[:space:]]*")[dD][aA][tT][aA]:[iI][mM][aA][gG][eE](\\?/|\\u002[fF])[A-Za-z0-9.+=;-]*;[bB][aA][sS][eE]64,([A-Za-z0-9+]|\\?/|\\u002[fF])*={0,2}("[^{}]*"type"[[:space:]]*:[[:space:]]*"input_image")#\1 \4#g' \
     -e '}' \
-    -e "s/^[${CRED_MASK_PARSEABLE}${CRED_MASK_UNPARSEABLE}]//"
+    -e "s/^[${CRED_MASK_ELIGIBLE}${CRED_MASK_DECLINED}]//"
 }
 # Portable mtime listing. GNU `stat -f` means --file-system (it SUCCEEDS and
 # prints filesystem status), so a `stat -f … || stat -c …` fallback never fires

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1041,6 +1041,41 @@ printf '%s\n' '{"type":"response_item","payload":{"type":"custom_tool_call_outpu
 # by both review lanes, which is why it is fixed here rather than deferred.
 printf '%s\n' '{"type":"response_item","payload":{"type":"custom_tool_call_output","output":[{"type":"input_image","image_url":"data:image/png;charset=utf-8;base64,'"${_B64RUN}"'/__AWS__BB"}]}}' \
   >> "$FIX/blobimgnc/codex/sessions/s.jsonl"
+# Lines 14 and 15 — a DUPLICATE `type` key, the two orders. JSON permits the
+# repeat and `fromjson` keeps the LAST occurrence, so key precedence — not text
+# order — decides what the table sees. A mask that matches the marker textually
+# reads the FIRST occurrence and can therefore reach the opposite verdict.
+#
+# Line 14 is the unsafe direction and the reason this pair exists: the effective
+# type is `input_file`, so the table does NOT exclude the value and COUNTS the
+# credential in it, while the raw text still says `input_image` at the first key.
+# Masking here leaves a counted table row with no locator — a triager told
+# something was found and given nothing to look at.
+printf '%s\n' '{"type":"response_item","payload":{"type":"custom_tool_call_output","output":[{"type":"input_image","type":"input_file","image_url":"data:image/png;base64,'"${_B64RUN}"'/__AWS__BB"}]}}' \
+  >> "$FIX/blobimgnc/codex/sessions/s.jsonl"
+# Line 15 is the same construct with the winning value reversed: the effective
+# type IS `input_image`, the table excludes the value, and the mask must too.
+# It is what stops the fix from being "decline anything with a repeated key",
+# which would be safe but would silence a payload the table genuinely dropped.
+printf '%s\n' '{"type":"response_item","payload":{"type":"custom_tool_call_output","output":[{"type":"input_file","type":"input_image","image_url":"data:image/png;base64,'"${_B64RUN}"'/__AWS__BB"}]}}' \
+  >> "$FIX/blobimgnc/codex/sessions/s.jsonl"
+# 🔴 Line 16 — TWO divergences on one line that cancel in the COUNT. The first
+# object repeats `type` and resolves away from `input_image` (text says it once,
+# the parser sees it zero times); the second spells its `type` KEY with a `\u`
+# escape and resolves TO `input_image` (text zero, parser one). The totals are
+# 1 == 1, so counting alone licenses the mask and the textual expression then
+# matches the FIRST object — blanking the credential the table counts.
+#
+# This is the case the respelling veto exists for, and it is the only one that
+# distinguishes the veto from dead code: every single-object respelling is
+# already caught by the count. Verified by ablation — with the veto removed this
+# line masks and the locator below disappears.
+#
+# ONLY the first object carries the credential, and that asymmetry is what gives
+# the assertion teeth: with a token in both payloads, a mask firing on either
+# one leaves the other visible and the output looks identical.
+printf '%s\n' '{"type":"response_item","payload":{"type":"custom_tool_call_output","output":[{"type":"input_image","type":"input_file","image_url":"data:image/png;base64,'"${_B64RUN}"'/__AWS__BB"},{"ty'"${_BS}"'u0070e":"input_image","image_url":"data:image/png;base64,'"${_B64RUN}"'"}]}}' \
+  >> "$FIX/blobimgnc/codex/sessions/s.jsonl"
 sed -i.bak "s|__FIX__|$FIX|g" "$FIX/blobimgnc/codex/sessions/s.jsonl" && rm -f "$FIX/blobimgnc/codex/sessions/s.jsonl.bak"
 subst "$FIX/blobimgnc/codex/sessions/s.jsonl"
 # Control: the appended lines really do carry literal escapes. Without this,
@@ -1059,6 +1094,31 @@ _L11=$(sed -n '11p' "$FIX/blobimgnc/codex/sessions/s.jsonl")
 if grep -qE -- '"image_url":"data:image/png;base64,[A-Za-z0-9+/]*"' <<<"$_L11"; then
   ok "control: line 11 carries an unremarkable, complete data URL"
 else bad "control: line 11 carries an unremarkable, complete data URL" "$_L11"; fi
+# Control: lines 14/15 really carry a REPEATED `type` on disk, and `fromjson`
+# really resolves each to its LAST occurrence. Both halves matter — without the
+# textual check a normalising tool upstream could have collapsed the duplicate,
+# and without the parse check the pair asserts nothing about precedence. The two
+# together are what make the next two assertions a test of parser-vs-text
+# disagreement rather than of two ordinary records.
+_L14=$(sed -n '14p' "$FIX/blobimgnc/codex/sessions/s.jsonl")
+_L15=$(sed -n '15p' "$FIX/blobimgnc/codex/sessions/s.jsonl")
+if [ "$(printf '%s' "$_L14" | jq -r '.payload.output[0].type')" = "input_file" ] &&
+   [ "$(printf '%s' "$_L15" | jq -r '.payload.output[0].type')" = "input_image" ] &&
+   grep -q '"type":"input_image","type":"input_file"' <<<"$_L14" &&
+   grep -q '"type":"input_file","type":"input_image"' <<<"$_L15"; then
+  ok "control: the duplicate-key fixtures parse to their LAST type value"
+else bad "control: the duplicate-key fixtures parse to their LAST type value" "$_L14"; fi
+# Control: line 16 really carries BOTH constructs and they really cancel — the
+# marker is spelled once, the parser sees exactly one `input_image` object, and
+# it is the SECOND one (so the textual match lands on the wrong object). Without
+# this the assertion below could pass on a line where the counts never collided.
+_L16=$(sed -n '16p' "$FIX/blobimgnc/codex/sessions/s.jsonl")
+if [ "$(grep -o '"type":"input_image"' <<<"$_L16" | wc -l | tr -d ' ')" = "1" ] &&
+   [ "$(printf '%s' "$_L16" | jq -r '[.payload.output[]|select(.type=="input_image")]|length')" = "1" ] &&
+   [ "$(printf '%s' "$_L16" | jq -r '.payload.output[0].type')" = "input_file" ] &&
+   grep -q 'u0070e' <<<"$_L16"; then
+  ok "control: line 16's two divergences cancel in the marker count"
+else bad "control: line 16's two divergences cancel in the marker count" "$_L16"; fi
 OUT=$(CLAUDE_PROJECTS_DIR="$FIX/blobimgnc/projects" CODEX_HOME="$FIX/blobimgnc/codex" \
       MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
       bash "$TARGET" --since-days 3650 --section safety --credential-provenance 2>&1)
@@ -1144,6 +1204,26 @@ else bad "an ANSI-wrapped image payload keeps its locator, as the table counts i
 if grep -q 'line=13 record=response_item shape=aws-access-key-id' <<<"$CRED"; then
   bad "a MIME-parameterised data URL under input_image is masked" "$CRED"
 else ok "a MIME-parameterised data URL under input_image is masked"; fi
+# 🔴 Line 14 — key precedence, the UNSAFE direction. The raw text opens with
+# `"type":"input_image"`, so a textual marker match says "exclude"; `fromjson`
+# keeps the later `input_file`, so the table does NOT exclude and COUNTS the
+# credential. Masking it would leave a counted row with no locator. (#2742)
+if grep -q 'line=14 record=response_item shape=aws-access-key-id' <<<"$CRED"; then
+  ok "a duplicate-key record whose effective type is input_file keeps its locator"
+else bad "a duplicate-key record whose effective type is input_file keeps its locator" "$CRED"; fi
+# Line 15 — the same construct resolving the other way. The effective type IS
+# `input_image`, so the table excludes the value and the mask must still fire.
+# This is what keeps the fix from degenerating into "decline any repeated key",
+# which would be safe but would silence a payload the table genuinely dropped.
+if grep -q 'line=15 record=response_item shape=aws-access-key-id' <<<"$CRED"; then
+  bad "a duplicate-key record whose effective type is input_image is masked" "$CRED"
+else ok "a duplicate-key record whose effective type is input_image is masked"; fi
+# 🔴 Line 16 — the marker count agrees while the objects diverge, so counting
+# alone would license the mask and blank a credential the table counts. Only the
+# respelling veto declines it. Removing that veto fails exactly this assertion.
+if grep -q 'line=16 record=response_item shape=aws-access-key-id' <<<"$CRED"; then
+  ok "a record whose two key divergences cancel in the count keeps its locator"
+else bad "a record whose two key divergences cancel in the count keeps its locator" "$CRED"; fi
 
 # (4) 🔴 A value with BOTH a blob occurrence AND a plain one must NOT be
 # labelled. The label's stated rule is that ambiguity falls through to the plain

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -1102,8 +1102,8 @@ else bad "control: line 11 carries an unremarkable, complete data URL" "$_L11"; 
 # disagreement rather than of two ordinary records.
 _L14=$(sed -n '14p' "$FIX/blobimgnc/codex/sessions/s.jsonl")
 _L15=$(sed -n '15p' "$FIX/blobimgnc/codex/sessions/s.jsonl")
-if [ "$(printf '%s' "$_L14" | jq -r '.payload.output[0].type')" = "input_file" ] &&
-   [ "$(printf '%s' "$_L15" | jq -r '.payload.output[0].type')" = "input_image" ] &&
+if [ "$(jq -r '.payload.output[0].type' <<<"$_L14")" = "input_file" ] &&
+   [ "$(jq -r '.payload.output[0].type' <<<"$_L15")" = "input_image" ] &&
    grep -q '"type":"input_image","type":"input_file"' <<<"$_L14" &&
    grep -q '"type":"input_file","type":"input_image"' <<<"$_L15"; then
   ok "control: the duplicate-key fixtures parse to their LAST type value"
@@ -1114,8 +1114,8 @@ else bad "control: the duplicate-key fixtures parse to their LAST type value" "$
 # this the assertion below could pass on a line where the counts never collided.
 _L16=$(sed -n '16p' "$FIX/blobimgnc/codex/sessions/s.jsonl")
 if [ "$(grep -o '"type":"input_image"' <<<"$_L16" | wc -l | tr -d ' ')" = "1" ] &&
-   [ "$(printf '%s' "$_L16" | jq -r '[.payload.output[]|select(.type=="input_image")]|length')" = "1" ] &&
-   [ "$(printf '%s' "$_L16" | jq -r '.payload.output[0].type')" = "input_file" ] &&
+   [ "$(jq -r '[.payload.output[]|select(.type=="input_image")]|length' <<<"$_L16")" = "1" ] &&
+   [ "$(jq -r '.payload.output[0].type' <<<"$_L16")" = "input_file" ] &&
    grep -q 'u0070e' <<<"$_L16"; then
   ok "control: line 16's two divergences cancel in the marker count"
 else bad "control: line 16's two divergences cancel in the marker count" "$_L16"; fi


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The credential report could tell whoever triages it that something was found and then point at nothing. A transcript record can name one content type in its raw text while the parser reads a different one, and the two halves of the report disagreed about which is real — so a genuine credential got hidden from the locator while still being counted in the table. That is the wrong direction for a leak detector: silence where evidence should be.

## What

The parser now decides which image payloads may be hidden from the raw scan; the text-matching step only finds where they are. Records the two cannot agree on are scanned rather than hidden, so an undecidable case errs toward showing evidence. Three new regression records pin both directions, including one that only the narrower of the two new checks catches.

No behaviour change for any record already handled correctly — the twelve previously pinned cases are unchanged.

Fixes #2742
Part of #2522