### PR TITLE
fix(telemetry): classify runtime task-output polling

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -2592,6 +2592,13 @@ if want efficiency; then
     # and only count when the target is not a loopback address.
     FETCH_RE='(^|[^[:alnum:]_-])(curl|wget)([[:space:]]|$)'
     LOCALHOST_RE='(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|::1)'
+    # Claude background tasks expose completion through runtime-owned output
+    # files. Reading one after a sleep is therefore a redundant poll even though
+    # the read is local. Require both an executed file-reader command and the
+    # runtime path shape so an arbitrary project tasks/*.output file does not
+    # inherit this classification.
+    TASK_READ_RE='(^[[:space:]]*|[;&|][[:space:]]*)(/usr/bin/|/bin/)?(cat|tail|head|wc)([[:space:]]|$)'
+    TASK_OUTPUT_RE='/(private/)?tmp/claude-[0-9]+/[^[:space:];|&]+/tasks/[[:alnum:]_-]+\.output([^[:alnum:]_.-]|$)'
     # Shell-level detachment. `nohup … &`, `setsid`, or a trailing `&` returns the
     # tool call immediately, so the agent is NOT foreground-blocked — that is a
     # compliant way to arm a watcher, and the `run_in_background` flag alone
@@ -2630,10 +2637,11 @@ if want efficiency; then
     # rejects outright ("illegal primary in regular expression"). ENVIRON hands
     # the string over verbatim, which is what keeps ONE regex definition usable
     # by both grep -E and awk instead of forcing a second, drifting copy.
-    export SLEEP_RE REMOTE_RE FETCH_RE LOCALHOST_RE DETACH_RE LOOP_RE
+    export SLEEP_RE REMOTE_RE FETCH_RE LOCALHOST_RE TASK_READ_RE TASK_OUTPUT_RE DETACH_RE LOOP_RE
     WT=$(boundary_lines | strip_heredocs $'\003\004' | awk '
       BEGIN { sre = ENVIRON["SLEEP_RE"]; rre = ENVIRON["REMOTE_RE"]
               fre = ENVIRON["FETCH_RE"]; lhre = ENVIRON["LOCALHOST_RE"]
+              trre = ENVIRON["TASK_READ_RE"]; tore = ENVIRON["TASK_OUTPUT_RE"]
               dre = ENVIRON["DETACH_RE"]; lre = ENVIRON["LOOP_RE"] }
       # Only EXECUTED text can be a poll. A shell comment or a quoted literal
       # that merely mentions a tool (`sleep 5 # check gh later`, or this suite
@@ -2668,6 +2676,13 @@ if want efficiency; then
         if (e ~ rre) return 1
         if (e ~ fre && e !~ lhre) return 1
         return 0
+      }
+      # A runtime task-output read is executed local text, not a remote call.
+      # Keep it separate so the remote-adjacent baseline remains comparable.
+      function is_task_output_poll(s,   e) {
+        e = s
+        sub(/(^|[[:space:]])#.*$/, "", e)
+        return (e ~ trre && e ~ tore)
       }
       # UNIT: a sleeping LINE, exactly as count_sleeps counts it (grep -c counts
       # matching lines). Counting sleeping COMMANDS instead would make this split
@@ -2747,6 +2762,16 @@ if want efficiency; then
         for (j = i + 1; j <= nlines; j++) if (is_remote(lines[j])) return 1
         return 0
       }
+      function task_output_after(i,   j, tail, rgn) {
+        rgn = loop_region(i)
+        if (rgn != "" && is_task_output_poll(rgn)) return 1
+        if (match(lines[i], sre)) {
+          tail = substr(lines[i], RSTART + RLENGTH)
+          if (is_task_output_poll(tail)) return 1
+        }
+        for (j = i + 1; j <= nlines; j++) if (is_task_output_poll(lines[j])) return 1
+        return 0
+      }
       # A pending sleep is resolved by the FIRST remote poll in the next command,
       # wherever it sits in that command — position only constrains the command
       # the sleep itself belongs to, which it has already left.
@@ -2763,9 +2788,10 @@ if want efficiency; then
         e = exec_text(buf)
         return (e ~ dre) ? "BG" : "FG"
       }
-      function classify(   i, irem, ec) {
+      function classify(   i, irem, itask, ec) {
         if (!started) return
         irem = is_remote(buf)
+        itask = is_task_output_poll(buf)
         ec = eff_cls()
         # Resolve sleeps left pending by the PREVIOUS command first: they slept
         # without a remote poll after them, so this command decides the bucket.
@@ -2773,6 +2799,7 @@ if want efficiency; then
         # make that call, and the intent is what this metric measures.
         if (pending) {
           if (irem) { n_next += pending; if (pcls=="FG") { fg_rem += pending; fg_next += pending } }
+          else if (itask) { n_task_next += pending; if (pcls=="FG") { fg_task += pending; fg_task_next += pending } }
           else        n_none += pending
           pending = 0
         }
@@ -2785,6 +2812,7 @@ if want efficiency; then
           if (lines[i] !~ sre) continue
           n_tot++
           if (remote_after(i)) { n_same++; if (ec=="FG") fg_rem++ }
+          else if (task_output_after(i)) { n_task_same++; if (ec=="FG") fg_task++ }
           else                 { pending++; pcls = ec }
         }
         nlines = 0; buf = ""; started = 0
@@ -2799,11 +2827,13 @@ if want efficiency; then
                  started = 1; addline(substr($0, i+1)); next }
                  { if (started) addline($0) }
       END { classify(); resolve()
-            printf "%d %d %d %d %d %d", n_tot, n_same, n_next, n_none, fg_rem, fg_next }')
+            printf "%d %d %d %d %d %d %d %d %d %d", n_tot, n_same, n_next, n_task_same, n_task_next, n_none, fg_rem, fg_next, fg_task, fg_task_next }')
     # `read`, not `set --`: the latter would clobber the script's positional
     # parameters. (A here-string is a bash/zsh extension — fine under this
     # file's bash shebang, and never to be copied into a /bin/sh script.)
-    read -r WT_TOT WT_SAME WT_NEXT WT_NONE WT_FGREM WT_FGNEXT <<< "$WT"
+    read -r WT_TOT WT_SAME WT_NEXT WT_TASK_SAME WT_TASK_NEXT WT_NONE WT_FGREM WT_FGNEXT WT_FGTASK WT_FGTASK_NEXT <<< "$WT"
+    WT_NOREMOTE=$((WT_TASK_SAME + WT_TASK_NEXT + WT_NONE))
+    WT_FGALL=$((WT_FGREM + WT_FGTASK))
     # The total is the SUM of the classes, not a separate scan. That makes
     # class-vs-total drift impossible instead of detectable — and a drift
     # warning over a sum would be a vacuous guard, which is worse than none.
@@ -2836,23 +2866,31 @@ if want efficiency; then
     echo "  wait target (WHAT the sleep waits on — the contract's actual line):"
     echo "    ├ remote poll, same command .. ${WT_SAME}   [busy-wait]"
     echo "    ├ remote poll, next command .. ${WT_NEXT}   [busy-wait, UNCHAINED]"
-    echo "    └ no remote poll adjacent .... ${WT_NONE}   [local timer — PERMITTED]"
-    echo "  ⇒ FOREGROUND ∧ remote-adjacent . ${WT_FGREM}   [THE BUSY-WAIT VIOLATION]"
+    echo "    ├ no remote poll adjacent .... ${WT_NOREMOTE}   [not a compliance verdict]"
+    echo "    │  ├ background-task output poll, same command .. ${WT_TASK_SAME}   [redundant wait]"
+    echo "    │  ├ background-task output poll, next command .. ${WT_TASK_NEXT}   [redundant wait, UNCHAINED]"
+    echo "    │  └ no recognised poll adjacent .............. ${WT_NONE}   [local-timer candidate]"
+    echo "  ⇒ FOREGROUND ∧ recognised-poll-adjacent ... ${WT_FGALL}   [PRIMARY BUSY-WAIT ESTIMATE]"
+    echo "  ⇒ FOREGROUND ∧ remote-adjacent . ${WT_FGREM}   [baseline-continuity component]"
+    echo "  ⇒ FOREGROUND ∧ task-output-adjacent ${WT_FGTASK}   [redundant runtime-task poll]"
+    echo "          of which UNCHAINED (task-output, fg) ${WT_FGTASK_NEXT}"
     # The aggregate remote-next bucket mixes in compliant BACKGROUND watchers and
     # unattributed Codex sleeps, so it moves when neither the rule nor foreground
     # behaviour changed. Only this foreground-only figure tests the unchained-wait
     # tightening — trend THIS, never the aggregate.
     echo "      of which UNCHAINED (fg) ... ${WT_FGNEXT}   [tests the #2262 rule]"
     if [ "$SF_COUNT" -gt 0 ]; then
-      echo "    per-session (Claude, n=${SF_COUNT}): $(awk -v a="$WT_FGREM" -v b="$SF_COUNT" 'BEGIN{printf "%.2f", a/b}')/session   ← the metric to trend"
+      echo "    per-session (Claude, n=${SF_COUNT}): $(awk -v a="$WT_FGALL" -v b="$SF_COUNT" 'BEGIN{printf "%.2f", a/b}')/session   ← the recognised-poll metric to trend"
+      echo "    remote-only continuity (n=${SF_COUNT}): $(awk -v a="$WT_FGREM" -v b="$SF_COUNT" 'BEGIN{printf "%.2f", a/b}')/session"
     fi
     if [ "$WT_TOT" != "$SLEEPS" ]; then
       echo "    ⚠️  wait-target total ${WT_TOT} != launch-mode total ${SLEEPS} —"
       echo "        the two passes disagree; treat BOTH as unreliable this run."
     fi
-    echo "    NOTE: 'no remote poll adjacent' is the CONTRACT-PERMITTED case (a"
-    echo "          bare sleep bounding a local process the agent started), so a"
-    echo "          high number there is not waste. The two remote buckets ARE"
+    echo "    NOTE: 'no remote poll adjacent' is not a compliance verdict: it"
+    echo "          contains redundant polls of runtime-owned task output as well"
+    echo "          as bare sleeps bounding local processes. The task-output row"
+    echo "          separates the recognised redundant local class. The two remote buckets ARE"
     echo "          the busy-wait the latency discipline forbids; 'next command'"
     echo "          is the unchained form the PreToolUse hook cannot see, which"
     echo "          is what monorepo#2262 tightened the constitution against."
@@ -2880,9 +2918,9 @@ if want efficiency; then
     echo "          run_in_background says how Bash started the command, never"
     echo "          why the sleep exists. The contract permits a FOREGROUND bare"
     echo "          sleep only as a local timer for a process whose completion"
-    echo "          NOTHING WILL REPORT — not merely one the agent started, so a"
-    echo "          sleep polling a backgrounded task's own output file is a"
-    echo "          violation this adjacency test does not see (monorepo#2752)."
+    echo "          NOTHING WILL REPORT — not merely one the agent started. Polls"
+    echo "          of runtime-owned background-task output are split above from"
+    echo "          otherwise unrecognised local timers."
     echo "          A BACKGROUND sleep can still be a redundant"
     echo "          poll alongside foreground polling. So a foreground count is"
     echo "          a busy-wait CANDIDATE, not a violation, and a background"

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -2597,9 +2597,8 @@ if want efficiency; then
     # the read is local. The reader and runtime path must occur in that order in
     # one shell segment, with no redirection before the path: independent matches
     # would misread `cat local > task.output` as polling the task.
-    TASK_READ_RE='(^[[:space:]]*|[;&|][[:space:]]*)(/usr/bin/|/bin/)?(cat|tail|head|wc)([[:space:]]|$)'
+    TASK_SEGMENT_RE='^[[:space:]]*(/usr/bin/|/bin/)?(cat|tail|head|wc)([[:space:]]|$)'
     TASK_OUTPUT_PATH_RE='/(private/)?tmp/claude-[0-9]+/[^[:space:];|&]+/tasks/[[:alnum:]_-]+\.output'
-    TASK_OUTPUT_RE="${TASK_OUTPUT_PATH_RE}([^[:alnum:]_.-]|$)"
     # Shell-level detachment. `nohup … &`, `setsid`, or a trailing `&` returns the
     # tool call immediately, so the agent is NOT foreground-blocked — that is a
     # compliant way to arm a watcher, and the `run_in_background` flag alone
@@ -2638,13 +2637,13 @@ if want efficiency; then
     # rejects outright ("illegal primary in regular expression"). ENVIRON hands
     # the string over verbatim, which is what keeps ONE regex definition usable
     # by both grep -E and awk instead of forcing a second, drifting copy.
-    export SLEEP_RE REMOTE_RE FETCH_RE LOCALHOST_RE TASK_READ_RE TASK_OUTPUT_PATH_RE TASK_OUTPUT_RE DETACH_RE LOOP_RE
+    export SLEEP_RE REMOTE_RE FETCH_RE LOCALHOST_RE TASK_SEGMENT_RE TASK_OUTPUT_PATH_RE DETACH_RE LOOP_RE
     WT=$(boundary_lines | strip_heredocs $'\003\004' | awk '
       BEGIN { sre = ENVIRON["SLEEP_RE"]; rre = ENVIRON["REMOTE_RE"]
               fre = ENVIRON["FETCH_RE"]; lhre = ENVIRON["LOCALHOST_RE"]
-              trre = ENVIRON["TASK_READ_RE"]; topath = ENVIRON["TASK_OUTPUT_PATH_RE"]
-              tore = ENVIRON["TASK_OUTPUT_RE"]
-              dre = ENVIRON["DETACH_RE"]; lre = ENVIRON["LOOP_RE"] }
+              tsre = ENVIRON["TASK_SEGMENT_RE"]; topath = ENVIRON["TASK_OUTPUT_PATH_RE"]
+              dre = ENVIRON["DETACH_RE"]; lre = ENVIRON["LOOP_RE"]
+              sq = sprintf("%c", 39); dq = sprintf("%c", 34) }
       # Only EXECUTED text can be a poll. A shell comment or a quoted literal
       # that merely mentions a tool (`sleep 5 # check gh later`, or this suite
       # generating its own fixtures) is data, not a command — and counting it let
@@ -2681,16 +2680,90 @@ if want efficiency; then
       }
       # A runtime task-output read is executed local text, not a remote call.
       # Keep it separate so the remote-adjacent baseline remains comparable.
-      function is_task_output_poll(s,   e, raw, qre) {
-        e = exec_text(s)
-        if (e ~ (trre "[^;|&<>]*" tore)) return 1
-        # exec_text intentionally blanks quoted prose, but a quoted path after
-        # an executable reader is still an operand. Match that narrow raw shape
-        # separately while keeping separators and redirections out of the gap.
-        raw = s
-        sub(/(^|[[:space:]])#.*$/, "", raw)
-        qre = "[\"\047]"
-        return (raw ~ (trre "[^;|&<>]*" qre topath qre))
+      function task_boundary(c) {
+        return (c == "" || c ~ /[[:space:]<>]/)
+      }
+      # Quote state at the end of s. Backslash escapes apply outside single
+      # quotes; this is enough to distinguish a shell separator from the same
+      # byte carried inside prose without pretending to implement a shell.
+      function quote_state(s,   i, c, q, esc) {
+        q = ""; esc = 0
+        for (i = 1; i <= length(s); i++) {
+          c = substr(s, i, 1)
+          if (esc) { esc = 0; continue }
+          if (c == "\\" && q != sq) { esc = 1; continue }
+          if (q == "") { if (c == sq || c == dq) q = c }
+          else if (c == q) q = ""
+        }
+        return q
+      }
+      # Is the candidate path a redirection target that does not open it for
+      # reading? Output redirects write it; << and <<< consume delimiter/data
+      # text. One < opens the file and is deliberately allowed.
+      function is_nonread_target(prefix,   t, c, n) {
+        t = prefix
+        sub(/[[:space:]]*$/, "", t)
+        c = substr(t, length(t), 1)
+        if (c == sq || c == dq) {
+          t = substr(t, 1, length(t) - 1)
+          sub(/[[:space:]]*$/, "", t)
+        }
+        c = substr(t, length(t), 1)
+        if (c == ">") return 1
+        if (c != "<") return 0
+        n = 0
+        while (length(t) > n && substr(t, length(t) - n, 1) == "<") n++
+        return (n > 1)
+      }
+      # One unquoted shell segment. Requiring the reader at segment start keeps
+      # a quoted example such as `example; cat path` as data, while the path walk
+      # accepts exact quoted or unquoted tokens and input-redirection targets.
+      function task_segment(seg,   scan, base, p, pend, prefix, prev, after, q, afterq) {
+        if (!match(seg, tsre)) return 0
+        base = RSTART + RLENGTH - 1
+        scan = substr(seg, base + 1)
+        while (match(scan, topath)) {
+          p = base + RSTART
+          pend = p + RLENGTH - 1
+          prefix = substr(seg, 1, p - 1)
+          prev = substr(seg, p - 1, 1)
+          after = substr(seg, pend + 1, 1)
+          q = quote_state(prefix)
+          if (q != "") {
+            afterq = substr(seg, pend + 2, 1)
+            if (prev == q && after == q && task_boundary(afterq) && !is_nonread_target(prefix)) return 1
+          } else if ((prev == "" || prev ~ /[[:space:]<]/) && task_boundary(after) && !is_nonread_target(prefix)) {
+            return 1
+          }
+          base = pend
+          scan = substr(seg, base + 1)
+        }
+        return 0
+      }
+      # Split only on executable shell separators. Separators inside quotes are
+      # ordinary data, which is the distinction the raw regex could not make.
+      function is_task_output_poll(s,   i, c, q, esc, seg, prev) {
+        q = ""; esc = 0; seg = ""
+        for (i = 1; i <= length(s); i++) {
+          c = substr(s, i, 1)
+          prev = (i > 1) ? substr(s, i - 1, 1) : ""
+          if (esc) { seg = seg c; esc = 0; continue }
+          if (c == "\\" && q != sq) { seg = seg c; esc = 1; continue }
+          if (q != "") {
+            seg = seg c
+            if (c == q) q = ""
+            continue
+          }
+          if (c == sq || c == dq) { q = c; seg = seg c; continue }
+          if (c == "#" && (i == 1 || prev ~ /[[:space:]]/)) break
+          if (c ~ /[;&|]/) {
+            if (task_segment(seg)) return 1
+            seg = ""
+            continue
+          }
+          seg = seg c
+        }
+        return task_segment(seg)
       }
       # UNIT: a sleeping LINE, exactly as count_sleeps counts it (grep -c counts
       # matching lines). Counting sleeping COMMANDS instead would make this split

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -2598,7 +2598,8 @@ if want efficiency; then
     # one shell segment, with no redirection before the path: independent matches
     # would misread `cat local > task.output` as polling the task.
     TASK_READ_RE='(^[[:space:]]*|[;&|][[:space:]]*)(/usr/bin/|/bin/)?(cat|tail|head|wc)([[:space:]]|$)'
-    TASK_OUTPUT_RE='/(private/)?tmp/claude-[0-9]+/[^[:space:];|&]+/tasks/[[:alnum:]_-]+\.output([^[:alnum:]_.-]|$)'
+    TASK_OUTPUT_PATH_RE='/(private/)?tmp/claude-[0-9]+/[^[:space:];|&]+/tasks/[[:alnum:]_-]+\.output'
+    TASK_OUTPUT_RE="${TASK_OUTPUT_PATH_RE}([^[:alnum:]_.-]|$)"
     # Shell-level detachment. `nohup … &`, `setsid`, or a trailing `&` returns the
     # tool call immediately, so the agent is NOT foreground-blocked — that is a
     # compliant way to arm a watcher, and the `run_in_background` flag alone
@@ -2637,11 +2638,12 @@ if want efficiency; then
     # rejects outright ("illegal primary in regular expression"). ENVIRON hands
     # the string over verbatim, which is what keeps ONE regex definition usable
     # by both grep -E and awk instead of forcing a second, drifting copy.
-    export SLEEP_RE REMOTE_RE FETCH_RE LOCALHOST_RE TASK_READ_RE TASK_OUTPUT_RE DETACH_RE LOOP_RE
+    export SLEEP_RE REMOTE_RE FETCH_RE LOCALHOST_RE TASK_READ_RE TASK_OUTPUT_PATH_RE TASK_OUTPUT_RE DETACH_RE LOOP_RE
     WT=$(boundary_lines | strip_heredocs $'\003\004' | awk '
       BEGIN { sre = ENVIRON["SLEEP_RE"]; rre = ENVIRON["REMOTE_RE"]
               fre = ENVIRON["FETCH_RE"]; lhre = ENVIRON["LOCALHOST_RE"]
-              trre = ENVIRON["TASK_READ_RE"]; tore = ENVIRON["TASK_OUTPUT_RE"]
+              trre = ENVIRON["TASK_READ_RE"]; topath = ENVIRON["TASK_OUTPUT_PATH_RE"]
+              tore = ENVIRON["TASK_OUTPUT_RE"]
               dre = ENVIRON["DETACH_RE"]; lre = ENVIRON["LOOP_RE"] }
       # Only EXECUTED text can be a poll. A shell comment or a quoted literal
       # that merely mentions a tool (`sleep 5 # check gh later`, or this suite
@@ -2679,9 +2681,16 @@ if want efficiency; then
       }
       # A runtime task-output read is executed local text, not a remote call.
       # Keep it separate so the remote-adjacent baseline remains comparable.
-      function is_task_output_poll(s,   e) {
+      function is_task_output_poll(s,   e, raw, qre) {
         e = exec_text(s)
-        return (e ~ (trre "[^;|&<>]*" tore))
+        if (e ~ (trre "[^;|&<>]*" tore)) return 1
+        # exec_text intentionally blanks quoted prose, but a quoted path after
+        # an executable reader is still an operand. Match that narrow raw shape
+        # separately while keeping separators and redirections out of the gap.
+        raw = s
+        sub(/(^|[[:space:]])#.*$/, "", raw)
+        qre = "[\"\047]"
+        return (raw ~ (trre "[^;|&<>]*" qre topath qre))
       }
       # UNIT: a sleeping LINE, exactly as count_sleeps counts it (grep -c counts
       # matching lines). Counting sleeping COMMANDS instead would make this split

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -2594,9 +2594,9 @@ if want efficiency; then
     LOCALHOST_RE='(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|::1)'
     # Claude background tasks expose completion through runtime-owned output
     # files. Reading one after a sleep is therefore a redundant poll even though
-    # the read is local. Require both an executed file-reader command and the
-    # runtime path shape so an arbitrary project tasks/*.output file does not
-    # inherit this classification.
+    # the read is local. The reader and runtime path must occur in that order in
+    # one shell segment, with no redirection before the path: independent matches
+    # would misread `cat local > task.output` as polling the task.
     TASK_READ_RE='(^[[:space:]]*|[;&|][[:space:]]*)(/usr/bin/|/bin/)?(cat|tail|head|wc)([[:space:]]|$)'
     TASK_OUTPUT_RE='/(private/)?tmp/claude-[0-9]+/[^[:space:];|&]+/tasks/[[:alnum:]_-]+\.output([^[:alnum:]_.-]|$)'
     # Shell-level detachment. `nohup … &`, `setsid`, or a trailing `&` returns the
@@ -2680,9 +2680,8 @@ if want efficiency; then
       # A runtime task-output read is executed local text, not a remote call.
       # Keep it separate so the remote-adjacent baseline remains comparable.
       function is_task_output_poll(s,   e) {
-        e = s
-        sub(/(^|[[:space:]])#.*$/, "", e)
-        return (e ~ trre && e ~ tore)
+        e = exec_text(s)
+        return (e ~ (trre "[^;|&<>]*" tore))
       }
       # UNIT: a sleeping LINE, exactly as count_sleeps counts it (grep -c counts
       # matching lines). Counting sleeping COMMANDS instead would make this split

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -2554,6 +2554,41 @@ if grep -qE 'background-task output poll, same command \.+ 1' <<<"$OUT" \
    && grep -qE 'FOREGROUND.*recognised-poll-adjacent \.+ 1' <<<"$OUT"; then
   ok "a sleep polling runtime-owned task output is scored as a busy-wait"
 else bad "a sleep polling runtime-owned task output is scored as a busy-wait" "$(printf '%s' "$OUT" | grep -E 'background-task|remote poll|no remote')"; fi
+
+# Quoting an executable operand does not turn it into prose. The generic
+# literal stripper deliberately blanks quoted data, so the task-output matcher
+# must recognise a quoted reader operand before applying that broad filter.
+mkdir -p "$FIX/wttaskquoted"
+cat > "$FIX/wttaskquoted/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tq1","name":"Bash","input":{"command":"sleep 10 && cat \"/private/tmp/claude-501/-Users-example-project/tasks/task-quoted.output\""}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttaskquoted" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  bad "the quoted task-output fixture completes" "telemetry exited $rc: $OUT"
+fi
+if grep -qE 'background-task output poll, same command \.+ 1' <<<"$OUT"; then
+  ok "a quoted runtime task-output operand remains a recognised read"
+else bad "a quoted runtime task-output operand remains a recognised read" "$(printf '%s' "$OUT" | grep -E 'background-task|recognised poll')"; fi
+
+# A quoted command example is data, not an executable reader. Preserving quoted
+# operands narrowly must not undo the existing protection against prose that
+# merely mentions both a reader and a runtime-shaped path.
+mkdir -p "$FIX/wttaskquotedprose"
+cat > "$FIX/wttaskquotedprose/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tqp1","name":"Bash","input":{"command":"sleep 10 && printf '%s\\n' 'cat \"/private/tmp/claude-501/-Users-example-project/tasks/task-prose.output\"'"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttaskquotedprose" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  bad "the quoted task-output prose fixture completes" "telemetry exited $rc: $OUT"
+fi
+if grep -qE 'background-task output poll, same command \.+ 0' <<<"$OUT" \
+   && grep -qE 'no recognised poll adjacent \.+ 1' <<<"$OUT"; then
+  ok "quoted prose naming a task-output read remains non-executable data"
+else bad "quoted prose naming a task-output read remains non-executable data" "$(printf '%s' "$OUT" | grep -E 'background-task|recognised poll')"; fi
 if grep -qE 'no remote poll adjacent \.+ 1   \[not a compliance verdict\]' <<<"$OUT" \
    && ! grep -qF '[local timer — PERMITTED]' <<<"$OUT"; then
   ok "the no-remote bucket no longer claims every local read is permitted"

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -2577,7 +2577,7 @@ else bad "a quoted runtime task-output operand remains a recognised read" "$(pri
 # merely mentions both a reader and a runtime-shaped path.
 mkdir -p "$FIX/wttaskquotedprose"
 cat > "$FIX/wttaskquotedprose/s.jsonl" <<'EOF'
-{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tqp1","name":"Bash","input":{"command":"sleep 10 && printf '%s\\n' 'cat \"/private/tmp/claude-501/-Users-example-project/tasks/task-prose.output\"'"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tqp1","name":"Bash","input":{"command":"sleep 10 && printf '%s\\n' 'example; cat \"/private/tmp/claude-501/-Users-example-project/tasks/task-prose.output\"'"}}]}}
 EOF
 OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttaskquotedprose" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
       bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
@@ -2589,6 +2589,39 @@ if grep -qE 'background-task output poll, same command \.+ 0' <<<"$OUT" \
    && grep -qE 'no recognised poll adjacent \.+ 1' <<<"$OUT"; then
   ok "quoted prose naming a task-output read remains non-executable data"
 else bad "quoted prose naming a task-output read remains non-executable data" "$(printf '%s' "$OUT" | grep -E 'background-task|recognised poll')"; fi
+
+# Input redirection still consumes the runtime file. Excluding every angle
+# bracket avoids output-target false positives but also loses this real read.
+mkdir -p "$FIX/wttaskinputredirect"
+cat > "$FIX/wttaskinputredirect/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tir1","name":"Bash","input":{"command":"sleep 10 && wc -l < /private/tmp/claude-501/-Users-example-project/tasks/task-input.output"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttaskinputredirect" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  bad "the task-output input-redirection fixture completes" "telemetry exited $rc: $OUT"
+fi
+if grep -qE 'background-task output poll, same command \.+ 1' <<<"$OUT"; then
+  ok "an input-redirection runtime task-output path remains a recognised read"
+else bad "an input-redirection runtime task-output path remains a recognised read" "$(printf '%s' "$OUT" | grep -E 'background-task|recognised poll')"; fi
+
+# A here-string feeds the path text itself to stdin; it does not open that path.
+# The single-input-redirect allowance must not treat << or <<< targets as reads.
+mkdir -p "$FIX/wttaskherestring"
+cat > "$FIX/wttaskherestring/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"ths1","name":"Bash","input":{"command":"sleep 10 && wc -l <<< /private/tmp/claude-501/-Users-example-project/tasks/task-here.output"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttaskherestring" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  bad "the task-output here-string fixture completes" "telemetry exited $rc: $OUT"
+fi
+if grep -qE 'background-task output poll, same command \.+ 0' <<<"$OUT" \
+   && grep -qE 'no recognised poll adjacent \.+ 1' <<<"$OUT"; then
+  ok "a here-string containing a task-output path is not a file read"
+else bad "a here-string containing a task-output path is not a file read" "$(printf '%s' "$OUT" | grep -E 'background-task|recognised poll')"; fi
 if grep -qE 'no remote poll adjacent \.+ 1   \[not a compliance verdict\]' <<<"$OUT" \
    && ! grep -qF '[local timer — PERMITTED]' <<<"$OUT"; then
   ok "the no-remote bucket no longer claims every local read is permitted"
@@ -2632,6 +2665,23 @@ if grep -qE 'background-task output poll, same command \.+ 0' <<<"$OUT" \
    && grep -qE 'no recognised poll adjacent \.+ 1' <<<"$OUT"; then
   ok "a task-output filename lookalike does not count as runtime completion evidence"
 else bad "a task-output filename lookalike does not count as runtime completion evidence" "$(printf '%s' "$OUT" | grep -E 'background-task|recognised poll')"; fi
+
+# Shell backup suffixes are different files too. The exact path boundary must
+# accept only a real token terminator, not arbitrary punctuation after .output.
+mkdir -p "$FIX/wttasktilde"
+cat > "$FIX/wttasktilde/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tt1","name":"Bash","input":{"command":"sleep 10 && cat /private/tmp/claude-501/-Users-example-project/tasks/task-123.output~"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttasktilde" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  bad "the task-output tilde-lookalike fixture completes" "telemetry exited $rc: $OUT"
+fi
+if grep -qE 'background-task output poll, same command \.+ 0' <<<"$OUT" \
+   && grep -qE 'no recognised poll adjacent \.+ 1' <<<"$OUT"; then
+  ok "a tilde-suffixed task-output lookalike is not exact completion evidence"
+else bad "a tilde-suffixed task-output lookalike is not exact completion evidence" "$(printf '%s' "$OUT" | grep -E 'background-task|recognised poll')"; fi
 
 # The reader and runtime path must belong to the same input operation. A
 # command that reads an ordinary file and writes it to a runtime-shaped output

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -2546,6 +2546,10 @@ cat > "$FIX/wttaskoutput/s.jsonl" <<'EOF'
 EOF
 OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttaskoutput" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
       bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  bad "the same-command task-output fixture completes" "telemetry exited $rc: $OUT"
+fi
 if grep -qE 'background-task output poll, same command \.+ 1' <<<"$OUT" \
    && grep -qE 'FOREGROUND.*recognised-poll-adjacent \.+ 1' <<<"$OUT"; then
   ok "a sleep polling runtime-owned task output is scored as a busy-wait"
@@ -2568,6 +2572,10 @@ cat > "$FIX/wttasknext/s.jsonl" <<'EOF'
 EOF
 OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttasknext" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
       bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  bad "the next-command task-output fixture completes" "telemetry exited $rc: $OUT"
+fi
 if grep -qE 'background-task output poll, next command \.+ 1' <<<"$OUT"; then
   ok "an unchained sleep before runtime task output is scored as a redundant wait"
 else bad "an unchained sleep before runtime task output is scored as a redundant wait" "$(printf '%s' "$OUT" | grep -E 'background-task|remote poll|no remote')"; fi
@@ -2581,10 +2589,33 @@ cat > "$FIX/wttasklookalike/s.jsonl" <<'EOF'
 EOF
 OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttasklookalike" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
       bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  bad "the task-output lookalike fixture completes" "telemetry exited $rc: $OUT"
+fi
 if grep -qE 'background-task output poll, same command \.+ 0' <<<"$OUT" \
    && grep -qE 'no recognised poll adjacent \.+ 1' <<<"$OUT"; then
   ok "a task-output filename lookalike does not count as runtime completion evidence"
 else bad "a task-output filename lookalike does not count as runtime completion evidence" "$(printf '%s' "$OUT" | grep -E 'background-task|recognised poll')"; fi
+
+# The reader and runtime path must belong to the same input operation. A
+# command that reads an ordinary file and writes it to a runtime-shaped output
+# path is not polling that task; independent command-buffer matches inflate the
+# metric by treating the redirection target as a reader operand.
+mkdir -p "$FIX/wttaskredirect"
+cat > "$FIX/wttaskredirect/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tr1","name":"Bash","input":{"command":"sleep 10 && cat README.md > /private/tmp/claude-501/-Users-example-project/tasks/task-789.output"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttaskredirect" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  bad "the task-output redirection fixture completes" "telemetry exited $rc: $OUT"
+fi
+if grep -qE 'background-task output poll, same command \.+ 0' <<<"$OUT" \
+   && grep -qE 'no recognised poll adjacent \.+ 1' <<<"$OUT"; then
+  ok "a runtime-shaped redirection target does not count as a task-output read"
+else bad "a runtime-shaped redirection target does not count as a task-output read" "$(printf '%s' "$OUT" | grep -E 'background-task|recognised poll')"; fi
 
 # The UNCHAINED form: the PreToolUse hook blocks `sleep N && poll`, and sessions
 # adapt by splitting it across two tool calls. Same busy-wait, invisible to the

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -2535,6 +2535,57 @@ if grep -qE 'no remote poll adjacent \.+ 1' <<<"$OUT"; then
   ok "a sleep bounding a local process is scored PERMITTED, not a violation"
 else bad "a sleep bounding a local process is scored PERMITTED, not a violation" "$(printf '%s' "$OUT" | grep -E 'remote poll|no remote')"; fi
 
+# Polling the runtime-owned output file of a background task is not the local
+# timer above: the runtime itself reports task completion, so sleeping before
+# reading that file is the redundant wait this metric exists to expose. The
+# production break this catches is dropping the runtime-output recogniser,
+# which would put the wait back in the flattering PERMITTED bucket.
+mkdir -p "$FIX/wttaskoutput"
+cat > "$FIX/wttaskoutput/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"sleep 10 && cat /private/tmp/claude-501/-Users-example-project/tasks/task-123.output"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttaskoutput" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if grep -qE 'background-task output poll, same command \.+ 1' <<<"$OUT" \
+   && grep -qE 'FOREGROUND.*recognised-poll-adjacent \.+ 1' <<<"$OUT"; then
+  ok "a sleep polling runtime-owned task output is scored as a busy-wait"
+else bad "a sleep polling runtime-owned task output is scored as a busy-wait" "$(printf '%s' "$OUT" | grep -E 'background-task|remote poll|no remote')"; fi
+if grep -qE 'no remote poll adjacent \.+ 1   \[not a compliance verdict\]' <<<"$OUT" \
+   && ! grep -qF '[local timer — PERMITTED]' <<<"$OUT"; then
+  ok "the no-remote bucket no longer claims every local read is permitted"
+else bad "the no-remote bucket no longer claims every local read is permitted" "$(printf '%s' "$OUT" | grep -E 'background-task|remote poll|no remote')"; fi
+if ! grep -qF 'violation this adjacency test does not see' <<<"$OUT"; then
+  ok "the report no longer claims runtime-task polls are invisible"
+else bad "the report no longer claims runtime-task polls are invisible" "stale gap note remained"; fi
+
+# The same redundant wait can be split across tool calls, just like the remote
+# unchained form below. Dropping the next-command task-output branch must make
+# this fixture fall back to the unclassified local bucket.
+mkdir -p "$FIX/wttasknext"
+cat > "$FIX/wttasknext/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tn1","name":"Bash","input":{"command":"sleep 10"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tn2","name":"Bash","input":{"command":"tail -n 20 /private/tmp/claude-501/-Users-example-project/tasks/task-456.output"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttasknext" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if grep -qE 'background-task output poll, next command \.+ 1' <<<"$OUT"; then
+  ok "an unchained sleep before runtime task output is scored as a redundant wait"
+else bad "an unchained sleep before runtime task output is scored as a redundant wait" "$(printf '%s' "$OUT" | grep -E 'background-task|remote poll|no remote')"; fi
+
+# The suffix is part of the runtime artifact shape. A prefix-only recogniser
+# would classify task-123.output.backup as completion evidence and inflate the
+# busy-wait metric with arbitrary local files.
+mkdir -p "$FIX/wttasklookalike"
+cat > "$FIX/wttasklookalike/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tl1","name":"Bash","input":{"command":"sleep 10 && cat /private/tmp/claude-501/-Users-example-project/tasks/task-123.output.backup"}}]}}
+EOF
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/wttasklookalike" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section efficiency 2>&1)
+if grep -qE 'background-task output poll, same command \.+ 0' <<<"$OUT" \
+   && grep -qE 'no recognised poll adjacent \.+ 1' <<<"$OUT"; then
+  ok "a task-output filename lookalike does not count as runtime completion evidence"
+else bad "a task-output filename lookalike does not count as runtime completion evidence" "$(printf '%s' "$OUT" | grep -E 'background-task|recognised poll')"; fi
+
 # The UNCHAINED form: the PreToolUse hook blocks `sleep N && poll`, and sessions
 # adapt by splitting it across two tool calls. Same busy-wait, invisible to the
 # hook — this is the shape monorepo#2262 tightened the constitution against, and


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The efficiency report classified every sleep without an adjacent remote command as a permitted local timer. Runtime background-task output reads are local, but sleeping before reading them is still redundant polling because the runtime reports task completion.

## What changed

- Parse quote and escape state so only executable shell separators split commands.
- Recognise exact quoted or unquoted Claude runtime task-output paths read by cat, tail, head, or wc, including single-input-redirection reads.
- Exclude quoted prose, output redirection targets, here-doc/here-string data, suffix lookalikes, and paths outside the exact shell token.
- Split same-command and next-command task-output polling from unrecognised local timers.
- Preserve the remote-only metric as a continuity component and add a combined recognised-poll primary metric.

## Evidence

The current seven-day window contains 20 recognised task-output waits: 12 same-command and 8 next-command. Fifteen are foreground waits. The one-day window contains seven foreground task-output waits.

## Verification

- RED/GREEN fixture cycles cover quoted and unquoted operands, separators inside quoted prose, ordinary and input-redirection reads, output redirections, here-strings, filename suffix lookalikes, unchained next-command reads, stale-report wording, and combined totals.
- agent-telemetry.test.sh: 581 passed, 0 failed.
- bash syntax and shellcheck pass.
- agent-role delivery contract passes.
- Runtime exercise reports 1d combined recognised polling at 2.02 per Claude session and 7d at 1.72, while preserving remote-only values of 1.89 and 1.68.

Fixes #2752