### PR TITLE
fix(agents): make each Agent Improver read the sibling instance's hypothesis ledger

### DIFF
--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -254,15 +254,21 @@ grep -Fq 'Agent Improver scorecard store' "${constitution}" ||
 grep -Fq 'open verification-hypothesis store' "${constitution}" ||
   fail "Memory does not name the Agent Improver hypothesis store"
 
-# Naming the two stores is NOT the same as requiring a run to read across them. Each of the three
-# assertions below pins a distinct clause, so deleting any one of them fails on its own line rather
-# than being masked by the others.
-grep -Fq "reads the SIBLING instance's scorecard and hypothesis store" "${constitution}" ||
-  fail "Memory does not require the Agent Improver to read the sibling instance's store"
-grep -Fq "sibling's pending hypothesis binds your signature-overlap decisions" "${constitution}" ||
-  fail "Memory does not bind signature-overlap decisions on a sibling's PENDING hypothesis"
-grep -Fq 'Settled is not the same as inconclusive' "${constitution}" ||
-  fail "Memory does not carve NO-VERDICT/NOT-YET-DUE out of the no-re-measure rule, so pending hypotheses could be frozen"
+# Naming the two stores is NOT the same as requiring a run to read across them. Each assertion below
+# pins a distinct clause, so deleting one fails on its own line rather than being masked by another.
+# These use assert_prose (whitespace-flattened) and carry the ORDERING and the SEMANTICS, not just a
+# recognisable prefix or heading: a prefix-only pin stays green while the clause that gives it meaning
+# is deleted, which is a fixture that proves nothing.
+assert_prose "reads the SIBLING instance's scorecard and hypothesis store too, before it scores or opens any hypothesis" \
+  "Memory does not require the sibling-store cross-read BEFORE scoring or opening a hypothesis (the ordering is the rule)"
+assert_prose "sibling's pending hypothesis binds your signature-overlap decisions" \
+  "Memory does not bind signature-overlap decisions on a sibling's PENDING hypothesis"
+assert_prose 'a signature the sibling has already **settled** is **not re-measured**' \
+  "Memory does not forbid re-measuring a signature the sibling has already settled"
+assert_prose 'whatever direction that verdict took and whichever window produced it' \
+  "Memory does not extend the no-re-measure rule to negative verdicts and earlier windows, so both could be re-measured"
+assert_prose 'A sibling `NO-VERDICT`, `NOT-YET-DUE`, or an explicitly unmet measurement floor is **unsettled**, and those stay measurable' \
+  "Memory does not classify NO-VERDICT/NOT-YET-DUE/unmet-floor as unsettled, so pending hypotheses could be frozen"
 
 for authority_row in \
   '| **Prose tightening**' \

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -280,6 +280,21 @@ assert_prose 'cross-*reading* them is mandatory, cross-*publishing* them is not 
 assert_prose "The sibling's file remains **its** single source of truth — read it, never write it" \
   "Memory does not keep the sibling store read-only, so a run could write to another instance's ledger"
 
+# WHITELIST, not another named clause. Four review rounds each found "clause N is unpinned" — a
+# blacklist that never converges, because the next round just names clause N+1. The named assertions
+# above stay for their specific failure messages; this one closes the CLASS by pinning the whole block
+# verbatim, so ANY deletion or alteration inside it fails, including a clause nobody thought to name.
+# Extracted by ANCHOR rather than line number so unrelated edits elsewhere in AGENTS.md cannot shift it.
+sibling_fixture="${repo_root}/.claude/scripts/fixtures/agent-improver-sibling-ledger.txt"
+[ -r "${sibling_fixture}" ] ||
+  fail "sibling-ledger fixture is missing: ${sibling_fixture}"
+sibling_block="$(awk '/^   🔴 \*\*Each Agent Improver run reads the SIBLING/{f=1} f{print} /read it, never$/{if(f){print "   write it."; exit}}' "${constitution}")"
+[ -n "${sibling_block}" ] ||
+  fail "Could not locate the sibling-ledger block in AGENTS.md — its opening anchor was removed or reworded"
+if ! printf '%s\n' "${sibling_block}" | diff -q - "${sibling_fixture}" >/dev/null 2>&1; then
+  fail "The sibling-ledger block no longer matches its fixture. Intentional edits must update .claude/scripts/fixtures/agent-improver-sibling-ledger.txt in the same commit; run: diff <(awk '/Each Agent Improver run reads the SIBLING/,/write it\./' AGENTS.md) ${sibling_fixture}"
+fi
+
 for authority_row in \
   '| **Prose tightening**' \
   '| **Prose loosening**' \

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -288,7 +288,17 @@ assert_prose "The sibling's file remains **its** single source of truth — read
 sibling_fixture="${repo_root}/.claude/scripts/fixtures/agent-improver-sibling-ledger.txt"
 [ -r "${sibling_fixture}" ] ||
   fail "sibling-ledger fixture is missing: ${sibling_fixture}"
-sibling_block="$(awk '/^   🔴 \*\*Each Agent Improver run reads the SIBLING/{f=1} f{print} /read it, never$/{if(f){print "   write it."; exit}}' "${constitution}")"
+# Read the REAL terminating line; never fabricate it. An earlier version printed a literal
+# "   write it." after seeing "read it, never" and exited, so qualifying the rule on its continuation
+# line (e.g. "write it unless its verdict is stale.") produced the ORIGINAL text and the diff passed —
+# a fail-open in the very check meant to close the class. The named assertion misses it too, because
+# the flattened prefix "read it, never write it" is still a substring of the weakened sentence.
+sibling_block="$(awk '
+  /^   🔴 \*\*Each Agent Improver run reads the SIBLING/ { f = 1 }
+  f { print }
+  f && stop { exit }
+  f && /read it, never$/ { stop = 1 }
+' "${constitution}")"
 [ -n "${sibling_block}" ] ||
   fail "Could not locate the sibling-ledger block in AGENTS.md — its opening anchor was removed or reworded"
 if ! printf '%s\n' "${sibling_block}" | diff -q - "${sibling_fixture}" >/dev/null 2>&1; then

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -269,6 +269,16 @@ assert_prose 'whatever direction that verdict took and whichever window produced
   "Memory does not extend the no-re-measure rule to negative verdicts and earlier windows, so both could be re-measured"
 assert_prose 'A sibling `NO-VERDICT`, `NOT-YET-DUE`, or an explicitly unmet measurement floor is **unsettled**, and those stay measurable' \
   "Memory does not classify NO-VERDICT/NOT-YET-DUE/unmet-floor as unsettled, so pending hypotheses could be frozen"
+# Without the escape below a settled verdict becomes PERMANENT: the signature could change, or new
+# evidence arrive, and the hypothesis could still never be measured again.
+assert_prose 'until new evidence or a changed signature invalidates it' \
+  "Memory does not let new evidence or a changed signature invalidate a settled sibling verdict, so verdicts would be permanent"
+# The confidentiality half is privacy-critical and is NOT covered by the read/verdict assertions above:
+# every one of them still passes with the cross-publishing and read-only prohibitions deleted.
+assert_prose 'cross-*reading* them is mandatory, cross-*publishing* them is not permitted, and nothing read this way enters a repository artifact or public comment' \
+  "Memory does not prohibit cross-publishing the sibling store or leaking it into a repository artifact or public comment"
+assert_prose "The sibling's file remains **its** single source of truth — read it, never write it" \
+  "Memory does not keep the sibling store read-only, so a run could write to another instance's ledger"
 
 for authority_row in \
   '| **Prose tightening**' \

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -254,6 +254,16 @@ grep -Fq 'Agent Improver scorecard store' "${constitution}" ||
 grep -Fq 'open verification-hypothesis store' "${constitution}" ||
   fail "Memory does not name the Agent Improver hypothesis store"
 
+# Naming the two stores is NOT the same as requiring a run to read across them. Each of the three
+# assertions below pins a distinct clause, so deleting any one of them fails on its own line rather
+# than being masked by the others.
+grep -Fq "reads the SIBLING instance's scorecard and hypothesis store" "${constitution}" ||
+  fail "Memory does not require the Agent Improver to read the sibling instance's store"
+grep -Fq "sibling's pending hypothesis binds your signature-overlap decisions" "${constitution}" ||
+  fail "Memory does not bind signature-overlap decisions on a sibling's PENDING hypothesis"
+grep -Fq 'Settled is not the same as inconclusive' "${constitution}" ||
+  fail "Memory does not carve NO-VERDICT/NOT-YET-DUE out of the no-re-measure rule, so pending hypotheses could be frozen"
+
 for authority_row in \
   '| **Prose tightening**' \
   '| **Prose loosening**' \

--- a/.claude/scripts/fixtures/agent-improver-sibling-ledger.txt
+++ b/.claude/scripts/fixtures/agent-improver-sibling-ledger.txt
@@ -1,0 +1,27 @@
+   🔴 **Each Agent Improver run reads the SIBLING instance's scorecard and hypothesis store too, before
+   it scores or opens any hypothesis — naming the two stores is not the same as wiring them together.**
+   Each run boots into its own store, so without this cross-read a hypothesis opened by one instance can
+   never be scored, closed, or respected by the other, and the ledger splits in half. Measured
+   2026-08-11 and stated as an **aggregate on purpose** — the inventories themselves are private runtime
+   state, so this paragraph must not quote them: of roughly fifteen open hypotheses across the two
+   instances, **exactly one was shared**; every other one was visible to only the instance that opened
+   it. That cost two things the same day. **A duplicated heavy measurement:** one instance's ledger
+   carried a provenance question as *"needs attribution next run"* that the other had **already
+   attributed hours earlier**. **And an unsatisfiable constraint:** the `agent-improvement` skill's
+   step 5 says to
+   continue only with work that cannot affect a pending hypothesis's tracked signature — yet one
+   instance held a pending gate over a signature the *other* instance was independently tracking, with
+   no path between them. An instance cannot honour a gate
+   it has no path to read, so that rule was unenforceable across instances **by construction**. So: a
+   **sibling's pending hypothesis binds your signature-overlap decisions** exactly as your own does, and
+   a signature the sibling has already **settled** is **not re-measured** — record its verdict and move
+   on — **whatever direction that verdict took and whichever window produced it**, until new evidence or
+   a changed signature invalidates it. Scoping this to "attributed in the current window" would have
+   left a sibling's *negative* verdict, and any still-valid verdict from an earlier window, free to be
+   measured again — which is the duplication this paragraph exists to stop.
+   ⚠️ **Settled is not the same as inconclusive.** A sibling `NO-VERDICT`, `NOT-YET-DUE`, or an
+   explicitly unmet measurement floor is **unsettled**, and those stay measurable — freezing them would
+   starve exactly the hypotheses still waiting for the data that would close them. ⚠️ Both stores stay **private runtime state**: cross-*reading* them is
+   mandatory, cross-*publishing* them is not permitted, and nothing read this way enters a repository
+   artifact or public comment. The sibling's file remains **its** single source of truth — read it, never
+   write it.

--- a/.claude/scripts/fixtures/agent-improver-sibling-ledger.txt
+++ b/.claude/scripts/fixtures/agent-improver-sibling-ledger.txt
@@ -24,4 +24,4 @@
    starve exactly the hypotheses still waiting for the data that would close them. ⚠️ Both stores stay **private runtime state**: cross-*reading* them is
    mandatory, cross-*publishing* them is not permitted, and nothing read this way enters a repository
    artifact or public comment. The sibling's file remains **its** single source of truth — read it, never
-   write it.
+   write it. The

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3101,8 +3101,7 @@ step:
    two things the same day. **A duplicated heavy measurement:** Claude's ledger carried #19 as *"needs
    attribution next run"* while the Codex run at **05:29Z had already attributed it** (one real
    instruction-shaped cross-agent handoff, correctly rejected; every other dominant hit traced to loaded
-   definition, memory, telemetry-report or current-run echo) — and provenance is the miner's most
-   expensive section. **And an unsatisfiable constraint:** the `agent-improvement` skill's step 5 says to
+   definition, memory, telemetry-report or current-run echo). **And an unsatisfiable constraint:** the `agent-improvement` skill's step 5 says to
    continue only with work that cannot affect a pending hypothesis's tracked signature, yet Codex's
    memory reads *"Do not change polling classification before those gates"* for its #29/#30 while
    Claude's own **#10b tracks foreground polling** — the same signature. An instance cannot honour a gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3096,16 +3096,16 @@ step:
    it scores or opens any hypothesis — naming the two stores is not the same as wiring them together.**
    Each run boots into its own store, so without this cross-read a hypothesis opened by one instance can
    never be scored, closed, or respected by the other, and the ledger splits in half. Measured
-   2026-08-11: of ~15 open hypotheses, **exactly one (#28) appeared in both** — Claude held 5/10b/11/14/
-   15/16/18/19/21/27/28 and Codex held 28/29/30/31/32, so **#29–#32 were invisible to Claude**. That cost
-   two things the same day. **A duplicated heavy measurement:** Claude's ledger carried #19 as *"needs
-   attribution next run"* while the Codex run at **05:29Z had already attributed it** (one real
-   instruction-shaped cross-agent handoff, correctly rejected; every other dominant hit traced to loaded
-   definition, memory, telemetry-report or current-run echo). **And an unsatisfiable constraint:** the
-   `agent-improvement` skill's step 5 says to
-   continue only with work that cannot affect a pending hypothesis's tracked signature, yet Codex's
-   memory reads *"Do not change polling classification before those gates"* for its #29/#30 while
-   Claude's own **#10b tracks foreground polling** — the same signature. An instance cannot honour a gate
+   2026-08-11 and stated as an **aggregate on purpose** — the inventories themselves are private runtime
+   state, so this paragraph must not quote them: of roughly fifteen open hypotheses across the two
+   instances, **exactly one was shared**; every other one was visible to only the instance that opened
+   it. That cost two things the same day. **A duplicated heavy measurement:** one instance's ledger
+   carried a provenance question as *"needs attribution next run"* that the other had **already
+   attributed hours earlier**. **And an unsatisfiable constraint:** the `agent-improvement` skill's
+   step 5 says to
+   continue only with work that cannot affect a pending hypothesis's tracked signature — yet one
+   instance held a pending gate over a signature the *other* instance was independently tracking, with
+   no path between them. An instance cannot honour a gate
    it has no path to read, so that rule was unenforceable across instances **by construction**. So: a
    **sibling's pending hypothesis binds your signature-overlap decisions** exactly as your own does, and
    a signature the sibling has already **settled** is **not re-measured** — record its verdict and move

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3101,7 +3101,8 @@ step:
    two things the same day. **A duplicated heavy measurement:** Claude's ledger carried #19 as *"needs
    attribution next run"* while the Codex run at **05:29Z had already attributed it** (one real
    instruction-shaped cross-agent handoff, correctly rejected; every other dominant hit traced to loaded
-   definition, memory, telemetry-report or current-run echo). **And an unsatisfiable constraint:** the `agent-improvement` skill's step 5 says to
+   definition, memory, telemetry-report or current-run echo). **And an unsatisfiable constraint:** the
+   `agent-improvement` skill's step 5 says to
    continue only with work that cannot affect a pending hypothesis's tracked signature, yet Codex's
    memory reads *"Do not change polling classification before those gates"* for its #29/#30 while
    Claude's own **#10b tracks foreground polling** — the same signature. An instance cannot honour a gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3108,8 +3108,14 @@ step:
    Claude's own **#10b tracks foreground polling** — the same signature. An instance cannot honour a gate
    it has no path to read, so that rule was unenforceable across instances **by construction**. So: a
    **sibling's pending hypothesis binds your signature-overlap decisions** exactly as your own does, and
-   a signature the sibling has already attributed in the current window is **not re-measured** — record
-   its verdict and move on. ⚠️ Both stores stay **private runtime state**: cross-*reading* them is
+   a signature the sibling has already **settled** is **not re-measured** — record its verdict and move
+   on — **whatever direction that verdict took and whichever window produced it**, until new evidence or
+   a changed signature invalidates it. Scoping this to "attributed in the current window" would have
+   left a sibling's *negative* verdict, and any still-valid verdict from an earlier window, free to be
+   measured again — which is the duplication this paragraph exists to stop.
+   ⚠️ **Settled is not the same as inconclusive.** A sibling `NO-VERDICT`, `NOT-YET-DUE`, or an
+   explicitly unmet measurement floor is **unsettled**, and those stay measurable — freezing them would
+   starve exactly the hypotheses still waiting for the data that would close them. ⚠️ Both stores stay **private runtime state**: cross-*reading* them is
    mandatory, cross-*publishing* them is not permitted, and nothing read this way enters a repository
    artifact or public comment. The sibling's file remains **its** single source of truth — read it, never
    write it. The

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3091,7 +3091,28 @@ step:
    `/Users/homelab-mac-mini/.codex/automations/agent-improver/memory.md`.
    The **open verification-hypothesis store** is
    `/Users/homelab-mac-mini/.claude/projects/-Users-homelab-mac-mini-git-personal-monorepo/memory/agent-improver-routine.md`
-   for Claude and the `Hypotheses / next run` section of the Codex Agent Improver memory file. The
+   for Claude and the `Hypotheses / next run` section of the Codex Agent Improver memory file.
+   🔴 **Each Agent Improver run reads the SIBLING instance's scorecard and hypothesis store too, before
+   it scores or opens any hypothesis — naming the two stores is not the same as wiring them together.**
+   Each run boots into its own store, so without this cross-read a hypothesis opened by one instance can
+   never be scored, closed, or respected by the other, and the ledger splits in half. Measured
+   2026-08-11: of ~15 open hypotheses, **exactly one (#28) appeared in both** — Claude held 5/10b/11/14/
+   15/16/18/19/21/27/28 and Codex held 28/29/30/31/32, so **#29–#32 were invisible to Claude**. That cost
+   two things the same day. **A duplicated heavy measurement:** Claude's ledger carried #19 as *"needs
+   attribution next run"* while the Codex run at **05:29Z had already attributed it** (one real
+   instruction-shaped cross-agent handoff, correctly rejected; every other dominant hit traced to loaded
+   definition, memory, telemetry-report or current-run echo) — and provenance is the miner's most
+   expensive section. **And an unsatisfiable constraint:** the `agent-improvement` skill's step 5 says to
+   continue only with work that cannot affect a pending hypothesis's tracked signature, yet Codex's
+   memory reads *"Do not change polling classification before those gates"* for its #29/#30 while
+   Claude's own **#10b tracks foreground polling** — the same signature. An instance cannot honour a gate
+   it has no path to read, so that rule was unenforceable across instances **by construction**. So: a
+   **sibling's pending hypothesis binds your signature-overlap decisions** exactly as your own does, and
+   a signature the sibling has already attributed in the current window is **not re-measured** — record
+   its verdict and move on. ⚠️ Both stores stay **private runtime state**: cross-*reading* them is
+   mandatory, cross-*publishing* them is not permitted, and nothing read this way enters a repository
+   artifact or public comment. The sibling's file remains **its** single source of truth — read it, never
+   write it. The
    **spend evidence/proposal/realisation ledger** — snapshots, proposals with their confidence, open
    maintainer asks, and the projected-versus-realised record — lives in the engineer's own runtime
    store: `/Users/homelab-mac-mini/.codex/automations/daily-ai-engineer/memory.md` for Codex and the


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The Agent Improver runs as two instances, and each one keeps its own private ledger of open
hypotheses. Both ledgers were named in the contract, but nothing ever said to read the *other* one — so
each run has been reasoning from half the picture. Measured today: of about fifteen open hypotheses,
exactly one appeared in both instances' ledgers.

That cost real work the same day. One instance was scheduled to spend its most expensive measurement
re-deriving a conclusion the other had already reached five hours earlier. Worse, the improvement
procedure tells a run to stay off any signature another hypothesis is still measuring — which an
instance simply cannot do for a hypothesis it has no way to see.

## What

Requires each Agent Improver run to read the sibling instance's scorecard and hypothesis store before
it scores or opens anything, to treat the sibling's pending hypotheses as binding on its own choices,
and not to re-measure something the sibling has already settled.

These remain private runtime stores: reading across is now mandatory, publishing across stays
forbidden, and each instance still writes only its own.

Contract text only — no runtime, permission, hook, or guard change.

Fixes #2771
