### PR TITLE
fix(agents): measure dropped ticks by dispatches, not skip records

### DIFF
--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -479,6 +479,23 @@ assert_prose 'liveness sample' \
   "cadence does not say what a per_task_limit record actually samples"
 assert_prose 'delayed into the next hour' \
   "cadence does not distinguish a delayed dispatch from a dropped one"
+# The two assertions above are satisfied by the historical EXPLANATION alone, so an edit that
+# dropped the correction while keeping the story would still pass them — which would leave the
+# discredited method as the operative instruction. Pin the DIRECTIVE and the corrected reading,
+# not only the account of why the old one was wrong.
+assert_prose 'comparing actual dispatches to scheduled slots' \
+  "cadence does not name the only method that yields a drop rate"
+assert_prose '133 of 164 slots' \
+  "cadence does not state the corrected, transcript-cross-validated dispatch count"
+# A zero skip count cannot establish the Improver's health: the second failure cause carries no
+# skip record at all, and one of its two instances IS an Improver dispatch. Reading that zero as
+# a clean bill is the same absence-as-evidence error, one lane over.
+assert_prose 'zero skip count is exactly why not' \
+  "cadence still infers Improver health from an absent skip record"
+# `constitution_flat` collapses newlines to single spaces, so the superseded sentence is matched
+# in its flattened form — it was wrapped across two lines in the source.
+refute_prose 'The Agent Improver is otherwise unaffected' \
+  "cadence again declares the Improver unaffected on the strength of a zero skip count"
 # The superseded absolute. Left in place it reads as the operative rule, because it is
 # stated as a flat invariant while the correction reads as a caveat about it.
 refute_prose 'next scheduled tick is always one hour later' \

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -468,6 +468,17 @@ assert_prose 'Codex dispatched 161/161' \
   "cadence does not state the Codex control that makes the shortfall a lane asymmetry"
 assert_prose 'never time anything off' \
   "cadence does not tell a run to stop planning against the next scheduled tick"
+# A `per_task_limit` record is a per-MINUTE liveness sample of "a run is currently open",
+# not a per-slot drop record — so counting those records, raw or hour-bucketed, counts a
+# slot that merely started LATE as one that never ran. Measured 2026-08-12 over 164 slots:
+# 37 of 66 refused hours dispatched anyway. Without this distinction every run re-derives
+# the rate from the skip store and gets a different answer; four measurements across both
+# instances spanned 32.9%-58.3% doing exactly that. Pin the METHOD, not only the number,
+# or the wrong method comes back the next time someone re-measures.
+assert_prose 'liveness sample' \
+  "cadence does not say what a per_task_limit record actually samples"
+assert_prose 'delayed into the next hour' \
+  "cadence does not distinguish a delayed dispatch from a dropped one"
 # The superseded absolute. Left in place it reads as the operative rule, because it is
 # stated as a flat invariant while the correction reads as a caveat about it.
 refute_prose 'next scheduled tick is always one hour later' \

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -3832,12 +3832,20 @@ if want drift; then
     ' "$store" 2>/dev/null
   }
 
-  # ── dropped dispatches ──────────────────────────────────────────────────────
+  # ── dispatch refusals ───────────────────────────────────────────────────────
   # A cron expansion counts SCHEDULED SLOTS. The Claude runtime declines any
   # dispatch that would overlap the previous run of the same task and records the
-  # refusal as `per_task_limit`, so a slot is not a run. Measured on the live
-  # store: 58 of 168 slots dropped over 2026-08-02→08-09 (34.5%), corroborating
-  # 52/142 (36.6%) and 108/161 (32.9%) from two earlier windows.
+  # refusal as `per_task_limit`, so a slot is not a run.
+  #
+  # What this metric reports is REFUSALS, which are an UPPER BOUND on drops — not
+  # drops. A refusal says the runtime declined at the due minute; the run can still
+  # start moments later, and measured 2026-08-12, **37 of 66 refused hours
+  # dispatched anyway**. Reading this count as a drop count is what produced five
+  # mutually-inconsistent rates (32.9%, 36.6%, 44.0%, 50.0%, 58.3%) across both
+  # instances — including the 58/168 (34.5%) this comment used to state as fact.
+  # A drop rate is derivable only by comparing ACTUAL DISPATCHES to scheduled slots
+  # (the transcript-cross-validated reading is 31 of 164, 18.9%), which this
+  # surface cannot see, so it is deliberately not published here.
   #
   # The store writes one record per POLL TICK — roughly every 60s for as long as
   # the task stays blocked — so raw records overstate badly: 1067 records for 58
@@ -4128,7 +4136,7 @@ if want drift; then
     # An empty floor means no record exists to prove the surface is live, so the
     # whole figure is UNKNOWN rather than zero.
     if [ -z "$CLAUDE_DROPPED" ] || [ -z "$SKIP_FLOOR" ]; then
-      echo "    claude engineer dropped dispatches: UNKNOWN (no readable skip record — an absent surface is not a zero)"
+      echo "    claude engineer dispatch refusals: UNKNOWN (no readable skip record — an absent surface is not a zero)"
     else
       # A rate is stated only when the store's records demonstrably cover the whole
       # window. Records that begin INSIDE it leave the earlier slots unaccounted,
@@ -4162,23 +4170,28 @@ if want drift; then
          && [ "$CLAUDE_DROPPED" -le "$RATE_TOTAL" ]; then
         RATE=$(awk -v d="$CLAUDE_DROPPED" -v t="$RATE_TOTAL" \
           'BEGIN { if (t > 0) printf "%.1f%% of %d slot(s) at the current cadence", 100 * d / t, t; else print "UNKNOWN" }')
-        echo "    claude engineer dropped dispatches: $CLAUDE_DROPPED slot(s) (per_task_limit), drop rate: $RATE"
+        echo "    claude engineer dispatch refusals: $CLAUDE_DROPPED slot(s) (per_task_limit), refusal rate: $RATE"
       elif [ -n "$RATE_TOTAL" ] && [ "$CLAUDE_ENG_SLOTS_DAY" -gt 0 ] \
            && [ "$CLAUDE_DROPPED" -gt "$RATE_TOTAL" ]; then
-        echo "    claude engineer dropped dispatches: $CLAUDE_DROPPED slot(s) (per_task_limit), drop rate: UNKNOWN (more drops than the window schedules — cadence changed within it)"
+        echo "    claude engineer dispatch refusals: $CLAUDE_DROPPED slot(s) (per_task_limit), refusal rate: UNKNOWN (more refusals than the window schedules — cadence changed within it)"
       elif [ "$ACTIVE_IN_WINDOW" -ne 1 ]; then
-        echo "    claude engineer dropped dispatches: $CLAUDE_DROPPED slot(s) (per_task_limit), drop rate: UNKNOWN (no dispatch or skip inside the window — scheduler not proven active)"
+        echo "    claude engineer dispatch refusals: $CLAUDE_DROPPED slot(s) (per_task_limit), refusal rate: UNKNOWN (no dispatch or skip inside the window — scheduler not proven active)"
       else
-        echo "    claude engineer dropped dispatches: $CLAUDE_DROPPED slot(s) (per_task_limit), drop rate: UNKNOWN (skip records do not span the window)"
+        echo "    claude engineer dispatch refusals: $CLAUDE_DROPPED slot(s) (per_task_limit), refusal rate: UNKNOWN (skip records do not span the window)"
       fi
+      # Every branch above prints a COUNT, so the qualifier belongs to all four rather than
+      # only the one that also states a rate — a reader who sees `3 slot(s)` beside
+      # `refusal rate: UNKNOWN` needs it just as much, and that is the shape the drift-section
+      # default actually emits.
+      echo "      ^ UPPER BOUND on dropped dispatches, not a drop count — a refused slot may still have dispatched (37 of 66 did, measured 2026-08-12). Derive drops by comparing actual dispatches to scheduled slots."
     fi
     # The Codex `automations` table records dispatches that HAPPENED; it carries no
     # skip surface, so a Codex drop is visible only as a gap. Reporting 0 here would
     # fabricate a clean lane out of a surface that cannot record the event.
-    echo "    codex engineer dropped dispatches: UNKNOWN (scheduler store records dispatches only, no skip surface)"
+    echo "    codex engineer dispatch refusals: UNKNOWN (scheduler store records dispatches only, no skip surface)"
   else
-    echo "    claude engineer dropped dispatches: UNKNOWN (claude engineer schedule unmeasured)"
-    echo "    codex engineer dropped dispatches: UNKNOWN (scheduler store records dispatches only, no skip surface)"
+    echo "    claude engineer dispatch refusals: UNKNOWN (claude engineer schedule unmeasured)"
+    echo "    codex engineer dispatch refusals: UNKNOWN (scheduler store records dispatches only, no skip surface)"
   fi
 
   echo

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -342,21 +342,34 @@ check "proves hourly engineer slots"       "$OUT" "local engineer slots schedule
 # the due-minute filter ran — the assertion passed against a wrong implementation
 # and the ablation proved nothing. With hour 12 present as noise only, dropping the
 # filter counts 4 and the test fails, which is what makes it a real check.
-nocheck "never counts poll-tick records as dropped dispatches" "$OUT" "dropped dispatches: 27"
-nocheck "never counts a skip recorded under another reason"     "$OUT" "dropped dispatches: 4 slot(s)"
-check   "counts dropped dispatches by due slot, not poll tick" "$OUT" \
-  "claude engineer dropped dispatches: 3 slot(s)"
+nocheck "never counts poll-tick records as dropped dispatches" "$OUT" "dispatch refusals: 27"
+nocheck "never counts a skip recorded under another reason"     "$OUT" "dispatch refusals: 4 slot(s)"
+check   "counts refusals by due slot, not poll tick" "$OUT" \
+  "claude engineer dispatch refusals: 3 slot(s)"
+# The count is an UPPER BOUND on drops, never a drop count: a refused slot can still
+# dispatch moments later, and 37 of 66 refused hours did (measured 2026-08-12). The
+# label and the disclosure are both pinned, because the failure mode here is not a
+# wrong number — it is a correct number published under the wrong name, which is what
+# produced five mutually-inconsistent "drop rates" from this one surface.
+check   "refusals are published as an upper bound, not a drop count" "$OUT" \
+  "UPPER BOUND on dropped dispatches"
+check   "the disclosure names the only method that yields a drop rate" "$OUT" \
+  "comparing actual dispatches to scheduled slots"
+nocheck "the discredited drop-count label cannot return" "$OUT" \
+  "dropped dispatches: 3 slot(s)"
+nocheck "no drop RATE is published from the refusal surface" "$OUT" \
+  "drop rate:"
 # Codex's store has no skip surface at all — `automations` records dispatches that
 # HAPPENED, so a Codex drop is visible only as a gap. Zero on a surface that cannot
 # record the event is not zero, and reporting 0 here would invent a clean lane.
 check "codex drop is UNKNOWN, never a fabricated zero" "$OUT" \
-  "codex engineer dropped dispatches: UNKNOWN"
-nocheck "codex drop never reports a zero"  "$OUT" "codex engineer dropped dispatches: 0"
+  "codex engineer dispatch refusals: UNKNOWN"
+nocheck "codex drop never reports a zero"  "$OUT" "codex engineer dispatch refusals: 0"
 
 # A rate needs the skip records to span the whole window. Here they start well
 # after a 3650-day window opens, so the denominator is unprovable and the rate
 # must fail closed rather than dividing by a window the store cannot cover.
-check "unspanned window refuses to state a rate" "$OUT" "drop rate: UNKNOWN"
+check "unspanned window refuses to state a rate" "$OUT" "refusal rate: UNKNOWN"
 
 # The minute alone identifies a dropped slot only while the cron covers every hour.
 # Under a finite hour list the runtime still records a poll tick at every hour's :50
@@ -371,9 +384,9 @@ jq '(.scheduledTasks[] | select(.id == "daily-ai-assistant") | .cronExpression) 
   "$FIX/claude-store/scheduled-tasks.json.bak" > "$FIX/claude-store/scheduled-tasks.json"
 OUT=$(run --section drift)
 check   "a finite hour list excludes unscheduled hours" "$OUT" \
-  "claude engineer dropped dispatches: 1 slot(s)"
+  "claude engineer dispatch refusals: 1 slot(s)"
 nocheck "an hour-list cron never counts every hour's due minute" "$OUT" \
-  "claude engineer dropped dispatches: 3 slot(s)"
+  "claude engineer dispatch refusals: 3 slot(s)"
 mv "$FIX/claude-store/scheduled-tasks.json.bak" "$FIX/claude-store/scheduled-tasks.json"
 
 # Coverage is not liveness, and the two must be tested separately.
@@ -385,10 +398,10 @@ mv "$FIX/claude-store/scheduled-tasks.json.bak" "$FIX/claude-store/scheduled-tas
 # error as a fabricated zero.
 OUT=$(run --section drift --since-days 1)
 check   "an inactive scheduler refuses to state a rate" "$OUT" \
-  "drop rate: UNKNOWN (no dispatch or skip inside the window"
-nocheck "an outage is never reported as a clean 0.0%" "$OUT" "drop rate: 0.0%"
+  "refusal rate: UNKNOWN (no dispatch or skip inside the window"
+nocheck "an outage is never reported as a clean 0.0%" "$OUT" "refusal rate: 0.0%"
 check   "window bounds the dropped-slot count" "$OUT" \
-  "claude engineer dropped dispatches: 0 slot(s)"
+  "claude engineer dispatch refusals: 0 slot(s)"
 
 # ACTIVE: same window, but `lastRunAt` now falls inside it, so the scheduler is
 # proven to have dispatched and the denominator describes slots something was
@@ -398,7 +411,7 @@ jq --arg now "$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')" \
   '(.scheduledTasks[] | select(.id == "daily-ai-assistant") | .lastRunAt) = $now' \
   "$FIX/claude-store/scheduled-tasks.json.bak" > "$FIX/claude-store/scheduled-tasks.json"
 OUT=$(run --section drift --since-days 1)
-check "a proven-active scheduler states a rate" "$OUT" "drop rate: 0.0%"
+check "a proven-active scheduler states a rate" "$OUT" "refusal rate: 0.0%"
 mv "$FIX/claude-store/scheduled-tasks.json.bak" "$FIX/claude-store/scheduled-tasks.json"
 
 # A store with NO skip surface must read UNKNOWN, never 0. The count alone cannot
@@ -410,9 +423,9 @@ jq 'del(.recordedSkips)' "$FIX/claude-store/scheduled-tasks.json.bak" \
   > "$FIX/claude-store/scheduled-tasks.json"
 OUT=$(run --section drift)
 check   "absent skip surface reads UNKNOWN" "$OUT" \
-  "claude engineer dropped dispatches: UNKNOWN"
+  "claude engineer dispatch refusals: UNKNOWN"
 nocheck "absent skip surface is never a zero" "$OUT" \
-  "claude engineer dropped dispatches: 0 slot(s)"
+  "claude engineer dispatch refusals: 0 slot(s)"
 mv "$FIX/claude-store/scheduled-tasks.json.bak" "$FIX/claude-store/scheduled-tasks.json"
 
 # Removing one pointer must fail closed rather than leaving the schedule surface
@@ -427,7 +440,7 @@ check "missing improver pointer is explicit" "$OUT" "UNKNOWN: codex improver sch
 # stored RRULE had lost BYSECOND=0, the aggregate gate went UNKNOWN, and the Claude
 # drop count — which depends on nothing Codex owns — disappeared with it.
 check "a codex pointer defect does not suppress the claude drop count" "$OUT" \
-  "claude engineer dropped dispatches: 3 slot(s)"
+  "claude engineer dispatch refusals: 3 slot(s)"
 mv "$FIX/codex/automations/agent-improver/automation.toml.missing" \
    "$FIX/codex/automations/agent-improver/automation.toml"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3059,9 +3059,14 @@ Corrected, and cross-validated against the transcripts rather than the skip stor
 dispatched; 31 did not (18.9%)** — 29 of those carrying a refusal (**17.7% genuinely dropped**) and
 **2 carrying no record at all**, so a second failure cause exists that the skip store cannot see (the
 Improver's own missing 2026-08-05 dispatch is one, and it has no `per_task_limit` record either). The
-effective Claude interval is therefore **~1.2 hours**, not 1.5. The Agent Improver is otherwise
-unaffected: the Claude store records **zero** `per_task_limit` skips for it, and the Codex scheduler
-refuses none.
+effective Claude interval is therefore **~1.2 hours**, not 1.5.
+⚠️ **The Improver is NOT proven unaffected — and its zero skip count is exactly why not.** The Claude
+store records **zero** `per_task_limit` skips for it, but the second failure cause above is invisible
+to that store, and the Improver's own missing 2026-08-05 dispatch is one of the two no-record cases.
+So zero skips establishes nothing about its health; reading it as a clean bill is the same
+absence-as-evidence error this whole correction is about. Measure the Improver the same way —
+scheduled slots against actual dispatches — before relying on its four daily starts. The Codex
+scheduler refuses none, which bounds *that* lane's refusal cause and says nothing about this one.
 ⚠️ **Re-derive this ONLY by comparing actual dispatches to scheduled slots** — never by counting skip
 records. Counting them is what produced five mutually-inconsistent readings (32.9%, 36.6%, 44.0%,
 50.0%, 58.3%) across both instances, each re-measured because the last one looked wrong.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3039,18 +3039,34 @@ case is safe by construction — same namespace, same deterministic branch name,
 is refused (see *Claim protocol* rule 4) — so it needs no handling beyond never force-pushing a claim
 branch.
 
-🔴 **Scheduled is not delivered — on the Claude lane about a third of ticks never happen.** Measured
-across one identical window (2026-08-02T03:50Z → 2026-08-08T19:50Z, **161 scheduled slots per lane**):
-**Codex dispatched 161/161**, because that scheduler starts a run even when the previous one is still
-open — one run whose record stayed open for 240 minutes did not block any of the four ticks behind it.
-**Claude dispatched 108/161**: its scheduler refuses any dispatch that would overlap the previous run
-of the same task and records it as `per_task_limit`, so **53 ticks — 32.9% — were dropped**, silently,
-producing no artifact anywhere. That is the second consecutive measurement of the same behaviour
-(36.6% over 2026-08-01→08-07), so it is the lane's normal state, not an incident, and the effective
-Claude interval is **~1.5 hours**. The Agent Improver is unaffected: the Claude store records **zero**
-dropped improver dispatches, and the Codex scheduler refuses none.
+🔴 **Scheduled is not delivered — on the Claude lane about one tick in five never happens.** The two
+machine-local schedulers differ. Measured across 2026-08-02T03:50Z → 2026-08-08T19:50Z (**161 scheduled
+slots per lane**), **Codex dispatched 161/161**, because that scheduler starts a run even when the
+previous one is still open — one run whose record stayed open for 240 minutes did not block any of the
+four ticks behind it. Claude's refuses any dispatch that would overlap the previous run of the same
+task and records it as `per_task_limit`. The reading over that same window was
+**Claude dispatched 108/161** — 53 ticks, 32.9% — with 36.6% over 2026-08-01→08-07. Those measurements
+are preserved as what they were; **both overstate the loss, and the cause is the METHOD, not the lane.**
+
+🔴 **A `per_task_limit` record is a per-minute liveness sample of "a run is currently open" — NOT a
+per-slot drop record.** Measured 2026-08-12: **1871 of 1922 inter-record gaps are 59–60 seconds**, so
+the scheduler re-records a skip every minute a run stays open and one long run writes dozens of them.
+Counting those records — raw, or bucketed by hour — therefore counts a slot that merely started
+**delayed into the next hour** as one that never ran at all. Over 164 slots
+(2026-08-05T12Z → 2026-08-12T07Z), **37 of the 66 refused hours dispatched anyway**.
+
+Corrected, and cross-validated against the transcripts rather than the skip store: **133 of 164 slots
+dispatched; 31 did not (18.9%)** — 29 of those carrying a refusal (**17.7% genuinely dropped**) and
+**2 carrying no record at all**, so a second failure cause exists that the skip store cannot see (the
+Improver's own missing 2026-08-05 dispatch is one, and it has no `per_task_limit` record either). The
+effective Claude interval is therefore **~1.2 hours**, not 1.5. The Agent Improver is otherwise
+unaffected: the Claude store records **zero** `per_task_limit` skips for it, and the Codex scheduler
+refuses none.
+⚠️ **Re-derive this ONLY by comparing actual dispatches to scheduled slots** — never by counting skip
+records. Counting them is what produced five mutually-inconsistent readings (32.9%, 36.6%, 44.0%,
+50.0%, 58.3%) across both instances, each re-measured because the last one looked wrong.
 **So never time anything off "the next tick."** A carry-forward, a claim-expiry judgement, or a "the
-next run will collect this" decision is wrong about a third of the time on Claude, and always in the
+next run will collect this" decision is wrong roughly one time in five on Claude, and always in the
 direction of waiting **longer** than planned — so prefer finishing inside the current run over handing
 work to a tick that may not come. The Agent Improver's four daily starts are additional work, not
 replacement slots. The scheduled interval is the gap **between runs, not a per-run time budget**; it


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The engineering contract records how often a scheduled run is silently skipped, and that number
steers real decisions — whether it is safe to hand work to "the next tick", and how long a claim
should be trusted. It was measured the wrong way.

The counter being used is a liveness sample written roughly once a minute while a run is open, not
one record per missed slot, so a single long run produces dozens of them. Counting them treats a slot
that merely started late as one that never ran. That method produced five mutually inconsistent
readings across both instances — each re-measured because the previous one looked wrong — which is
the real tell.

Counted properly, against actual dispatches and cross-checked against the run transcripts, the loss
is roughly **19%**, not the third or more previously recorded. The cross-check also surfaced a second
cause of missed runs that leaves no record at all, so the skip store could never have been complete.

### What this changes

Corrects the figure and pins the **method** behind a test, so the discredited way of counting cannot
quietly come back. Earlier readings are left standing as the measurements they were, with a note that
they overstate the loss because of how they were taken.