### PR TITLE
docs(agents): name the permitted way to put a worktree on a commit

### DIFF
--- a/.claude/scripts/git-safety-contract.test.sh
+++ b/.claude/scripts/git-safety-contract.test.sh
@@ -87,6 +87,9 @@ assert_section 'git -C <wt> checkout --no-overwrite-ignore --recurse-submodules 
 #     Fixture-verified: empty status, then a successful checkout that carried a foreign edit onto the
 #     target. \`worktree-cleanup.sh\` already makes this check, so the contract asking for less than
 #     its own tooling does would be an inconsistency as well as a hole.
+assert_section 'ls-files -v' \
+  "the Git safety section no longer requires the \`ls-files -v\` index-flag check — a file marked assume-unchanged or skip-worktree is invisible to \`status --porcelain\`, so the cleanliness pre-check passes while another writer's edit rides onto the target commit"
+
 # 2d. THE PER-SUBMODULE PRE-CHECK. \`--recurse-submodules\` mutates each populated submodule's working
 #     tree, which neither top-level check inspects, and \`--no-overwrite-ignore\` is NOT propagated to
 #     the recursive checkout. Fixture-verified: both top-level checks clean, and the prescribed
@@ -95,9 +98,6 @@ assert_section 'git -C <wt> checkout --no-overwrite-ignore --recurse-submodules 
 #     wider the pre-check must be, and it is easy to widen one without the other.
 assert_section 'submodule foreach' \
   "the Git safety section no longer requires the cleanliness checks to be run inside each populated submodule — \`--recurse-submodules\` writes to submodule working trees that the top-level \`status\`/\`ls-files\` checks never inspect, so the run would authorise a checkout that destroys another writer's work there"
-
-assert_section 'ls-files -v' \
-  "the Git safety section no longer requires the \`ls-files -v\` index-flag check — a file marked assume-unchanged or skip-worktree is invisible to \`status --porcelain\`, so the cleanliness pre-check passes while another writer's edit rides onto the target commit"
 
 # 2b. THE PR-HEAD ASSOCIATION. \`<sha>\` is deliberately the general placeholder — it is this
 #     contract's convention (27 backticked commands use it, against 1 for \`<headRefOid>\`), and the

--- a/.claude/scripts/git-safety-contract.test.sh
+++ b/.claude/scripts/git-safety-contract.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Guards the *Git safety* section's ban/alternative pair.
+#
+# Why this needs a guard at all. The runtime denies `git reset --hard` and the contract bans it, but
+# for a long time neither said how to do the thing runs legitimately need: put a freshly-created
+# maint worktree onto a PR's head commit. A prohibition with no named alternative does not stop the
+# behaviour — it relocates the instruction somewhere unreviewed. Here it landed in durable memory,
+# which came to prescribe `fetch` + `reset --hard FETCH_HEAD`, so every *compliant* run reached for a
+# command that could never execute. Measured across one day's session corpus: 3-4 denied calls over
+# three separate ticks, a standing share of the lane's permission-denial signature.
+#
+# The failure is worse than one wasted call. A denied COMPOUND call rolls the whole chain back, so
+# the `fetch` never runs either; the follow-up then fails on a missing `FETCH_HEAD` and reads like a
+# broken gitdir rather than a refusal, and the run diagnoses the wrong thing.
+#
+# BOTH HALVES ARE PINNED, and that is the point of this file rather than an accident of thoroughness.
+# Asserting only that the alternative is named would pass a future edit that "simplifies" the section
+# by keeping the alternative and dropping the prohibition — which converts a documentation fix into a
+# guardrail loosening, silently, with a green test. Asserting only the ban would let the alternative
+# be dropped again and re-open the vacuum this file exists to close. Neither assertion is redundant.
+#
+# Assertions are scoped to the Git safety section itself, not the whole file. A whole-file check is a
+# scope hole: the phrases below appear in the memory/loader prose elsewhere in this repository, so a
+# file-wide match would pass while the operative section said nothing.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+constitution="${repo_root}/AGENTS.md"
+
+fail() {
+  echo "git safety contract: FAIL — $*" >&2
+  exit 1
+}
+
+[ -r "${constitution}" ] || fail "cannot read ${constitution}"
+
+# Extract ONLY the Git safety section, then flatten it. Flattening matters because every sentence
+# below wraps across source lines, so a fragment spanning a line break would never match and the
+# test would be always-red regardless of the contract's content.
+section="$(
+  awk '
+    /^### Git safety$/                              { ins = 1; next }
+    ins && /^\*\*Worktree hygiene is SCHEDULED/     { ins = 0 }
+    ins                                              { print }
+  ' "${constitution}" | tr '\n' ' ' | tr -s '[:space:]' ' '
+)"
+
+[ -n "${section}" ] ||
+  fail "could not locate the '### Git safety' section — the extraction anchor moved, so every assertion below would be vacuous"
+
+# Guard the extraction itself. If the terminating anchor is renamed or removed, awk runs to
+# end-of-file and \`section\` becomes the whole rest of the contract — which silently restores the
+# scope hole described above while every assertion still passes.
+#
+# The bound separates two states that are orders of magnitude apart, and it is deliberately NOT set
+# just above the current size: the section is ~250 words, while a runaway extraction (end anchor
+# gone, awk running to EOF) measures in the tens of thousands. A snug bound would fail every
+# legitimate edit to this section while reporting a missing anchor — a false message that sends the
+# next reader hunting for a heading that is right there.
+section_words="$(printf '%s' "${section}" | wc -w | tr -d ' ')"
+[ "${section_words}" -lt 900 ] ||
+  fail "Git safety section extracted as ${section_words} words, which is runaway-extraction size — the 'Worktree hygiene is SCHEDULED' end anchor was probably renamed or removed, so these assertions would no longer be scoped to this section"
+
+assert_section() {
+  case "${section}" in
+    *"$1"*) ;;
+    *) fail "$2" ;;
+  esac
+}
+
+# 1. THE BAN SURVIVES. This is the half that keeps the file from becoming a loosening: without it,
+#    an edit that drops the prohibition and keeps only the alternative passes green.
+assert_section 'Never `git reset --hard`' \
+  "the Git safety section no longer bans \`git reset --hard\` — naming a safer alternative must never come at the cost of dropping the prohibition itself"
+
+# 2. THE ALTERNATIVE IS NAMED, with the flag that makes it safe. \`checkout\` alone is not the
+#    prescription: it is \`--detach\` onto an explicit commit that reproduces the banned form's
+#    outcome, and a bare branch checkout would not.
+assert_section 'git -C <wt> checkout --detach <sha>' \
+  "the Git safety section does not name \`git -C <wt> checkout --detach <sha>\` as the permitted way to put a worktree on a specific commit, so the ban again has no stated alternative and the instruction migrates to unreviewed memory"
+
+# 3. THE SEPARATE-CALLS REQUIREMENT. Chaining the fetch and the checkout is what turns a refusal into
+#    a misdiagnosis, so the prescription is incomplete without it — this is the measured second-order
+#    cost, not a style preference.
+assert_section 'SEPARATE calls' \
+  "the Git safety section does not require the fetch and the checkout to be issued as separate calls — a denied compound call rolls back the fetch too, and the follow-up then fails on a missing FETCH_HEAD in a way that reads like a broken gitdir rather than a refusal"
+
+# 4. THE SWAP IS RECORDED AS SAFE, WITH ITS REASON. The dirty-worktree abort is the whole argument
+#    that this needs no permission change; stated without it, a later reader cannot tell this apart
+#    from a workaround and may "resolve" it by widening the guard.
+assert_section 'aborts and preserves' \
+  "the Git safety section does not record that \`checkout --detach\` aborts and preserves uncommitted work on a dirty worktree — that property is what makes this a strictly safer swap rather than a workaround, and without it the next reader may try to widen the guard instead"
+
+echo "git safety contract: OK (${section_words} words scoped)"

--- a/.claude/scripts/git-safety-contract.test.sh
+++ b/.claude/scripts/git-safety-contract.test.sh
@@ -99,6 +99,23 @@ assert_section 'ls-files -v' \
 assert_section 'submodule foreach' \
   "the Git safety section no longer requires the cleanliness checks to be run inside each populated submodule — \`--recurse-submodules\` writes to submodule working trees that the top-level \`status\`/\`ls-files\` checks never inspect, so the run would authorise a checkout that destroys another writer's work there"
 
+# 2e. AND THE OPTION THAT MAKES 2d WORK. Pinning \`submodule foreach\` alone is not enough: deleting
+#     \`--ignored=matching\` leaves the foreach in place and this file green, while ordinary porcelain
+#     status stops reporting ignored paths — which is precisely the state that lets the recursive
+#     checkout destroy them, since \`--no-overwrite-ignore\` does not propagate into a submodule.
+#     Verified as a real gap before this assertion existed: stripping the option from the contract
+#     left the suite fully passing. This is the same both-halves reasoning as assertion 1 — pinning a
+#     mechanism without pinning what makes it effective is a guard that can be hollowed out in place.
+#
+#     MATCH IT IN COMMAND CONTEXT, not as a bare token. The section also NAMES the option in prose
+#     ("`--ignored=matching` is not optional here"), so a bare-token assertion is satisfied by that
+#     sentence alone and still passes when the option is deleted from the command itself — measured,
+#     not hypothesised: the first version of this assertion did exactly that and the strip ablation
+#     stayed green. Anchoring on `status --porcelain --ignored=matching` ties it to the invocation,
+#     and that string cannot collide with the top-level check, which deliberately omits the option.
+assert_section 'status --porcelain --ignored=matching' \
+  "the per-submodule pre-check no longer passes \`--ignored=matching\` — without it porcelain status omits ignored paths inside submodules, so the check reports clean and the recursive checkout silently destroys another writer's ignored work"
+
 # 2b. THE PR-HEAD ASSOCIATION. \`<sha>\` is deliberately the general placeholder — it is this
 #     contract's convention (27 backticked commands use it, against 1 for \`<headRefOid>\`), and the
 #     rule covers any commit, not only a PR head. But the motivating case IS the PR head, so the

--- a/.claude/scripts/git-safety-contract.test.sh
+++ b/.claude/scripts/git-safety-contract.test.sh
@@ -73,6 +73,7 @@ assert_section() {
 
 # 1. THE BAN SURVIVES. This is the half that keeps the file from becoming a loosening: without it,
 #    an edit that drops the prohibition and keeps only the alternative passes green.
+# shellcheck disable=SC2016 # Literal Markdown code span, not shell expansion.
 assert_section 'Never `git reset --hard`' \
   "the Git safety section no longer bans \`git reset --hard\` — naming a safer alternative must never come at the cost of dropping the prohibition itself"
 
@@ -87,15 +88,19 @@ assert_section 'git -C <wt> checkout --no-overwrite-ignore --detach <sha>' \
 #     Fixture-verified: empty status, then a successful checkout that carried a foreign edit onto the
 #     target. \`worktree-cleanup.sh\` already makes this check, so the contract asking for less than
 #     its own tooling does would be an inconsistency as well as a hole.
-assert_section 'git -C <wt> ls-files -v' \
-  "the Git safety section no longer requires the \`ls-files -v\` index-flag check — a file marked assume-unchanged or skip-worktree is invisible to \`status --porcelain\`, so the cleanliness pre-check passes while another writer's edit rides onto the target commit"
+# shellcheck disable=SC2016 # Literal Markdown code span, not shell expansion.
+assert_section 'Run `git -C <wt> status --porcelain` as its own call; require exit 0 and empty output' \
+  "the Git safety section no longer requires a successful, empty \`status --porcelain\` probe — a failed status command must not be accepted as a clean worktree"
+assert_section "Run \`(set -o pipefail; git -C <wt> ls-files -v | awk '\$1 ~ /^[a-z]\$/ || \$1 == \"S\"')\`; require the whole command to exit 0 and print nothing" \
+  "the Git safety section no longer binds the complete \`ls-files -v\` index-flag command to both a successful pipeline and empty output — a failed Git probe must not be accepted as a clean index"
 
 # 2d. THE SUBMODULE DETECTION RULE. `--detach` moves the superproject only, so on a gitlink-changing
 #     PR the run is NOT on the reviewed code — fixture-verified, with nothing but a bare " M <sub>" to
 #     show for it. In a monorepo largely made of submodule bumps that is the common case, and the
 #     failure is silent, so the contract must at minimum require DETECTING it before evaluation.
-assert_section 'submodule status' \
-  "the Git safety section no longer requires checking \`git -C <wt> submodule status\` after detaching — \`--detach\` moves only the superproject, so on a gitlink-changing PR the run evaluates the previous submodule content while believing it is on the reviewed commit"
+# shellcheck disable=SC2016 # Literal Markdown code span, not shell expansion.
+assert_section 'Run `git -C <wt> submodule status --recursive` and require it to exit 0 and every output line to begin with a space' \
+  "the Git safety section no longer requires a successful recursive submodule-status probe whose every line carries Git's clean leading-space marker — a stale, absent, nested, or unmerged submodule could be evaluated as reviewed code"
 
 # 2e. AND THE WARNING AGAINST THE OBVIOUS "FIX". `--recurse-submodules` is the natural thing to reach
 #     for once 2d is stated, and it is UNSAFE in this repo's mandated linked-worktree flow: measured,
@@ -103,7 +108,7 @@ assert_section 'submodule status' \
 #     gitlink absent locally, silently skips a submodule the target introduces, and does not propagate
 #     its ignored-file protection. Without this assertion a later editor closes 2d's gap by adding the
 #     flag — reintroducing every one of those, with a rule that looks more complete than before.
-assert_section '2833' \
+assert_section '[#2833](https://github.com/devantler-tech/monorepo/issues/2833)' \
   "the Git safety section no longer points at the follow-up issue for safe submodule detaching — without it the stated hazard reads as unsolved-and-unowned, and the next editor is likely to 'fix' it with \`--recurse-submodules\`, which is measurably unsafe in this repo's linked-worktree flow"
 
 # 2b. THE PR-HEAD ASSOCIATION. \`<sha>\` is deliberately the general placeholder — it is this
@@ -112,7 +117,7 @@ assert_section '2833' \
 #     value's identity must be stated or the prescription is unactionable exactly where it is most
 #     needed. Naming \`headRefOid\` also ties this to the commit *Merge policy* pins, which is what
 #     makes "the worktree you evaluated" and "the commit you merged" the same claim.
-assert_section '**`headRefOid`**' \
+assert_section "When that commit is a PR's head, \`<sha>\` is its **\`headRefOid\`**" \
   "the Git safety section no longer identifies a PR head's \`<sha>\` as its \`headRefOid\` — without it the prescription is unactionable in its motivating case, and the worktree you evaluate is no longer tied to the commit Merge policy pins"
 
 # 3. THE SEPARATE-CALLS REQUIREMENT. Chaining the fetch and the checkout is what turns a refusal into

--- a/.claude/scripts/git-safety-contract.test.sh
+++ b/.claude/scripts/git-safety-contract.test.sh
@@ -55,7 +55,7 @@ section="$(
 # scope hole described above while every assertion still passes.
 #
 # The bound separates two states that are far apart, and it is deliberately NOT set just above the
-# current size: the section measures several hundred words (1,095 at the time of writing), while a
+# current size: the section measures several hundred words (1,132 at the time of writing), while a
 # runaway extraction (end anchor gone, awk running to EOF) measured 9,968 — both figures observed
 # rather than estimated, which is what justifies the gap. A snug bound would fail every
 # legitimate edit to this section while reporting a missing anchor — a false message that sends the
@@ -79,42 +79,32 @@ assert_section 'Never `git reset --hard`' \
 # 2. THE ALTERNATIVE IS NAMED, with the flag that makes it safe. \`checkout\` alone is not the
 #    prescription: it is \`--detach\` onto an explicit commit that reproduces the banned form's
 #    outcome, and a bare branch checkout would not.
-assert_section 'git -C <wt> checkout --no-overwrite-ignore --recurse-submodules --detach <sha>' \
-  "the Git safety section does not name \`git -C <wt> checkout --no-overwrite-ignore --recurse-submodules --detach <sha>\` as the permitted way to put a worktree on a specific commit, so the ban again has no stated alternative and the instruction migrates to unreviewed memory"
+assert_section 'git -C <wt> checkout --no-overwrite-ignore --detach <sha>' \
+  "the Git safety section does not name \`git -C <wt> checkout --no-overwrite-ignore --detach <sha>\` as the permitted way to put a worktree on a specific commit, so the ban again has no stated alternative and the instruction migrates to unreviewed memory"
 
 # 2c. THE INDEX-HIDDEN-EDIT CHECK. \`status --porcelain\` omits any tracked file carrying
 #     \`assume-unchanged\` or \`skip-worktree\`, so an empty status is NOT proof the tree is clean.
 #     Fixture-verified: empty status, then a successful checkout that carried a foreign edit onto the
 #     target. \`worktree-cleanup.sh\` already makes this check, so the contract asking for less than
 #     its own tooling does would be an inconsistency as well as a hole.
-assert_section 'ls-files -v' \
+assert_section 'git -C <wt> ls-files -v' \
   "the Git safety section no longer requires the \`ls-files -v\` index-flag check — a file marked assume-unchanged or skip-worktree is invisible to \`status --porcelain\`, so the cleanliness pre-check passes while another writer's edit rides onto the target commit"
 
-# 2d. THE PER-SUBMODULE PRE-CHECK. \`--recurse-submodules\` mutates each populated submodule's working
-#     tree, which neither top-level check inspects, and \`--no-overwrite-ignore\` is NOT propagated to
-#     the recursive checkout. Fixture-verified: both top-level checks clean, and the prescribed
-#     command still destroyed a foreign ignored file inside a submodule. This assertion exists because
-#     the hazard was INTRODUCED by adding the recursion — the wider the command's blast radius, the
-#     wider the pre-check must be, and it is easy to widen one without the other.
-assert_section 'submodule foreach' \
-  "the Git safety section no longer requires the cleanliness checks to be run inside each populated submodule — \`--recurse-submodules\` writes to submodule working trees that the top-level \`status\`/\`ls-files\` checks never inspect, so the run would authorise a checkout that destroys another writer's work there"
+# 2d. THE SUBMODULE DETECTION RULE. `--detach` moves the superproject only, so on a gitlink-changing
+#     PR the run is NOT on the reviewed code — fixture-verified, with nothing but a bare " M <sub>" to
+#     show for it. In a monorepo largely made of submodule bumps that is the common case, and the
+#     failure is silent, so the contract must at minimum require DETECTING it before evaluation.
+assert_section 'submodule status' \
+  "the Git safety section no longer requires checking \`git -C <wt> submodule status\` after detaching — \`--detach\` moves only the superproject, so on a gitlink-changing PR the run evaluates the previous submodule content while believing it is on the reviewed commit"
 
-# 2e. AND THE OPTION THAT MAKES 2d WORK. Pinning \`submodule foreach\` alone is not enough: deleting
-#     \`--ignored=matching\` leaves the foreach in place and this file green, while ordinary porcelain
-#     status stops reporting ignored paths — which is precisely the state that lets the recursive
-#     checkout destroy them, since \`--no-overwrite-ignore\` does not propagate into a submodule.
-#     Verified as a real gap before this assertion existed: stripping the option from the contract
-#     left the suite fully passing. This is the same both-halves reasoning as assertion 1 — pinning a
-#     mechanism without pinning what makes it effective is a guard that can be hollowed out in place.
-#
-#     MATCH IT IN COMMAND CONTEXT, not as a bare token. The section also NAMES the option in prose
-#     ("`--ignored=matching` is not optional here"), so a bare-token assertion is satisfied by that
-#     sentence alone and still passes when the option is deleted from the command itself — measured,
-#     not hypothesised: the first version of this assertion did exactly that and the strip ablation
-#     stayed green. Anchoring on `status --porcelain --ignored=matching` ties it to the invocation,
-#     and that string cannot collide with the top-level check, which deliberately omits the option.
-assert_section 'status --porcelain --ignored=matching' \
-  "the per-submodule pre-check no longer passes \`--ignored=matching\` — without it porcelain status omits ignored paths inside submodules, so the check reports clean and the recursive checkout silently destroys another writer's ignored work"
+# 2e. AND THE WARNING AGAINST THE OBVIOUS "FIX". `--recurse-submodules` is the natural thing to reach
+#     for once 2d is stated, and it is UNSAFE in this repo's mandated linked-worktree flow: measured,
+#     it can write a `mod/.git` pointing at a nonexistent gitdir and exit 128, cannot fetch a target
+#     gitlink absent locally, silently skips a submodule the target introduces, and does not propagate
+#     its ignored-file protection. Without this assertion a later editor closes 2d's gap by adding the
+#     flag — reintroducing every one of those, with a rule that looks more complete than before.
+assert_section '2833' \
+  "the Git safety section no longer points at the follow-up issue for safe submodule detaching — without it the stated hazard reads as unsolved-and-unowned, and the next editor is likely to 'fix' it with \`--recurse-submodules\`, which is measurably unsafe in this repo's linked-worktree flow"
 
 # 2b. THE PR-HEAD ASSOCIATION. \`<sha>\` is deliberately the general placeholder — it is this
 #     contract's convention (27 backticked commands use it, against 1 for \`<headRefOid>\`), and the
@@ -122,7 +112,7 @@ assert_section 'status --porcelain --ignored=matching' \
 #     value's identity must be stated or the prescription is unactionable exactly where it is most
 #     needed. Naming \`headRefOid\` also ties this to the commit *Merge policy* pins, which is what
 #     makes "the worktree you evaluated" and "the commit you merged" the same claim.
-assert_section 'headRefOid' \
+assert_section '**`headRefOid`**' \
   "the Git safety section no longer identifies a PR head's \`<sha>\` as its \`headRefOid\` — without it the prescription is unactionable in its motivating case, and the worktree you evaluate is no longer tied to the commit Merge policy pins"
 
 # 3. THE SEPARATE-CALLS REQUIREMENT. Chaining the fetch and the checkout is what turns a refusal into
@@ -138,7 +128,7 @@ assert_section 'SEPARATE calls' \
 #    along and SUCCEEDS, landing on the target with another writer's uncommitted work in the tree and
 #    nothing in the output saying so. An earlier draft of this contract claimed the abort was
 #    unconditional — that claim was false and is exactly what this assertion prevents recurring.
-assert_section 'status --porcelain' \
+assert_section 'git -C <wt> status --porcelain' \
   "the Git safety section no longer requires the worktree to be verified clean before detaching — the abort is only a partial backstop (it fires only when the dirty path differs between HEAD and target), so without this precondition a run can silently detach over another instance's uncommitted work"
 
 # 4b. AND THE REASON THE BACKSTOP IS PARTIAL. Assertion 4 pins the rule; this pins the justification.

--- a/.claude/scripts/git-safety-contract.test.sh
+++ b/.claude/scripts/git-safety-contract.test.sh
@@ -54,9 +54,10 @@ section="$(
 # end-of-file and \`section\` becomes the whole rest of the contract — which silently restores the
 # scope hole described above while every assertion still passes.
 #
-# The bound separates two states that are orders of magnitude apart, and it is deliberately NOT set
-# just above the current size: the section is ~250 words, while a runaway extraction (end anchor
-# gone, awk running to EOF) measures in the tens of thousands. A snug bound would fail every
+# The bound separates two states that are far apart, and it is deliberately NOT set just above the
+# current size: the section measures a few hundred words (369 when this bound was set), while a
+# runaway extraction (end anchor gone, awk running to EOF) measured 9,968 — both figures observed
+# rather than estimated, which is what justifies the gap. A snug bound would fail every
 # legitimate edit to this section while reporting a missing anchor — a false message that sends the
 # next reader hunting for a heading that is right there.
 section_words="$(printf '%s' "${section}" | wc -w | tr -d ' ')"
@@ -80,6 +81,15 @@ assert_section 'Never `git reset --hard`' \
 #    outcome, and a bare branch checkout would not.
 assert_section 'git -C <wt> checkout --detach <sha>' \
   "the Git safety section does not name \`git -C <wt> checkout --detach <sha>\` as the permitted way to put a worktree on a specific commit, so the ban again has no stated alternative and the instruction migrates to unreviewed memory"
+
+# 2b. THE PR-HEAD ASSOCIATION. \`<sha>\` is deliberately the general placeholder — it is this
+#     contract's convention (27 backticked commands use it, against 1 for \`<headRefOid>\`), and the
+#     rule covers any commit, not only a PR head. But the motivating case IS the PR head, so the
+#     value's identity must be stated or the prescription is unactionable exactly where it is most
+#     needed. Naming \`headRefOid\` also ties this to the commit *Merge policy* pins, which is what
+#     makes "the worktree you evaluated" and "the commit you merged" the same claim.
+assert_section 'headRefOid' \
+  "the Git safety section no longer identifies a PR head's \`<sha>\` as its \`headRefOid\` — without it the prescription is unactionable in its motivating case, and the worktree you evaluate is no longer tied to the commit Merge policy pins"
 
 # 3. THE SEPARATE-CALLS REQUIREMENT. Chaining the fetch and the checkout is what turns a refusal into
 #    a misdiagnosis, so the prescription is incomplete without it — this is the measured second-order

--- a/.claude/scripts/git-safety-contract.test.sh
+++ b/.claude/scripts/git-safety-contract.test.sh
@@ -55,13 +55,13 @@ section="$(
 # scope hole described above while every assertion still passes.
 #
 # The bound separates two states that are far apart, and it is deliberately NOT set just above the
-# current size: the section measures a few hundred words (486 at the time of writing), while a
+# current size: the section measures several hundred words (748 at the time of writing), while a
 # runaway extraction (end anchor gone, awk running to EOF) measured 9,968 — both figures observed
 # rather than estimated, which is what justifies the gap. A snug bound would fail every
 # legitimate edit to this section while reporting a missing anchor — a false message that sends the
 # next reader hunting for a heading that is right there.
 section_words="$(printf '%s' "${section}" | wc -w | tr -d ' ')"
-[ "${section_words}" -lt 900 ] ||
+[ "${section_words}" -lt 1500 ] ||
   fail "Git safety section extracted as ${section_words} words, which is runaway-extraction size — the 'Worktree hygiene is SCHEDULED' end anchor was probably renamed or removed, so these assertions would no longer be scoped to this section"
 
 assert_section() {
@@ -79,8 +79,16 @@ assert_section 'Never `git reset --hard`' \
 # 2. THE ALTERNATIVE IS NAMED, with the flag that makes it safe. \`checkout\` alone is not the
 #    prescription: it is \`--detach\` onto an explicit commit that reproduces the banned form's
 #    outcome, and a bare branch checkout would not.
-assert_section 'git -C <wt> checkout --detach <sha>' \
-  "the Git safety section does not name \`git -C <wt> checkout --detach <sha>\` as the permitted way to put a worktree on a specific commit, so the ban again has no stated alternative and the instruction migrates to unreviewed memory"
+assert_section 'git -C <wt> checkout --no-overwrite-ignore --detach <sha>' \
+  "the Git safety section does not name \`git -C <wt> checkout --no-overwrite-ignore --detach <sha>\` as the permitted way to put a worktree on a specific commit, so the ban again has no stated alternative and the instruction migrates to unreviewed memory"
+
+# 2c. THE SUBMODULE STEP. \`--detach\` moves the superproject ONLY; a gitlink-changing PR therefore
+#     leaves submodules at their old commits, with nothing but a bare " M <sub>" to show for it.
+#     Fixture-verified. In a monorepo whose PRs are largely submodule bumps this is the common case,
+#     and the failure mode is evaluating different code from the headRefOid you believe you are on —
+#     so the follow-up step is part of the prescription, not an optional extra.
+assert_section 'submodule-init.sh' \
+  "the Git safety section no longer directs the run to update submodules after detaching — \`--detach\` moves only the superproject, so a gitlink-changing PR leaves the submodule stale and the run silently evaluates the wrong code"
 
 # 2b. THE PR-HEAD ASSOCIATION. \`<sha>\` is deliberately the general placeholder — it is this
 #     contract's convention (27 backticked commands use it, against 1 for \`<headRefOid>\`), and the

--- a/.claude/scripts/git-safety-contract.test.sh
+++ b/.claude/scripts/git-safety-contract.test.sh
@@ -39,30 +39,24 @@ fail() {
 # Extract ONLY the Git safety section, then flatten it. Flattening matters because every sentence
 # below wraps across source lines, so a fragment spanning a line break would never match and the
 # test would be always-red regardless of the contract's content.
-section="$(
+if ! section="$(
   awk '
     /^### Git safety$/                              { ins = 1; next }
-    ins && /^\*\*Worktree hygiene is SCHEDULED/     { ins = 0 }
+    ins && /^\*\*Worktree hygiene is SCHEDULED/     { found_end = 1; exit }
     ins                                              { print }
+    END                                              { if (!found_end) exit 42 }
   ' "${constitution}" | tr '\n' ' ' | tr -s '[:space:]' ' '
-)"
+)"; then
+  fail "could not find the 'Worktree hygiene is SCHEDULED' end anchor after '### Git safety' — refusing an unscoped whole-file assertion"
+fi
 
 [ -n "${section}" ] ||
   fail "could not locate the '### Git safety' section — the extraction anchor moved, so every assertion below would be vacuous"
 
-# Guard the extraction itself. If the terminating anchor is renamed or removed, awk runs to
-# end-of-file and \`section\` becomes the whole rest of the contract — which silently restores the
-# scope hole described above while every assertion still passes.
-#
-# The bound separates two states that are far apart, and it is deliberately NOT set just above the
-# current size: the section measures several hundred words (1,132 at the time of writing), while a
-# runaway extraction (end anchor gone, awk running to EOF) measured 9,968 — both figures observed
-# rather than estimated, which is what justifies the gap. A snug bound would fail every
-# legitimate edit to this section while reporting a missing anchor — a false message that sends the
-# next reader hunting for a heading that is right there.
+# Report the scoped size for diagnostics only. End-anchor detection above, not a content-size proxy,
+# is the guard against runaway extraction; legitimate additions therefore cannot trip a false
+# "missing anchor" failure.
 section_words="$(printf '%s' "${section}" | wc -w | tr -d ' ')"
-[ "${section_words}" -lt 1500 ] ||
-  fail "Git safety section extracted as ${section_words} words, which is runaway-extraction size — the 'Worktree hygiene is SCHEDULED' end anchor was probably renamed or removed, so these assertions would no longer be scoped to this section"
 
 assert_section() {
   case "${section}" in
@@ -73,23 +67,21 @@ assert_section() {
 
 # 1. THE BAN SURVIVES. This is the half that keeps the file from becoming a loosening: without it,
 #    an edit that drops the prohibition and keeps only the alternative passes green.
-# shellcheck disable=SC2016 # Literal Markdown code span, not shell expansion.
-assert_section 'Never `git reset --hard`' \
+assert_section "Never \`git reset --hard\`" \
   "the Git safety section no longer bans \`git reset --hard\` — naming a safer alternative must never come at the cost of dropping the prohibition itself"
 
 # 2. THE ALTERNATIVE IS NAMED, with the flag that makes it safe. \`checkout\` alone is not the
 #    prescription: it is \`--detach\` onto an explicit commit that reproduces the banned form's
 #    outcome, and a bare branch checkout would not.
-assert_section 'git -C <wt> checkout --no-overwrite-ignore --detach <sha>' \
-  "the Git safety section does not name \`git -C <wt> checkout --no-overwrite-ignore --detach <sha>\` as the permitted way to put a worktree on a specific commit, so the ban again has no stated alternative and the instruction migrates to unreviewed memory"
+assert_section 'git --no-replace-objects -C <wt> checkout --no-overwrite-ignore --detach <sha>' \
+  "the Git safety section does not name \`git --no-replace-objects -C <wt> checkout --no-overwrite-ignore --detach <sha>\` as the permitted way to put a worktree on a specific commit, so replacement refs can substitute a different tree for the reviewed commit"
 
 # 2c. THE INDEX-HIDDEN-EDIT CHECK. \`status --porcelain\` omits any tracked file carrying
 #     \`assume-unchanged\` or \`skip-worktree\`, so an empty status is NOT proof the tree is clean.
 #     Fixture-verified: empty status, then a successful checkout that carried a foreign edit onto the
 #     target. \`worktree-cleanup.sh\` already makes this check, so the contract asking for less than
 #     its own tooling does would be an inconsistency as well as a hole.
-# shellcheck disable=SC2016 # Literal Markdown code span, not shell expansion.
-assert_section 'Run `git -C <wt> status --porcelain` as its own call; require exit 0 and empty output' \
+assert_section "Run \`git -C <wt> status --porcelain\` as its own call; require exit 0 and empty output" \
   "the Git safety section no longer requires a successful, empty \`status --porcelain\` probe — a failed status command must not be accepted as a clean worktree"
 assert_section "Run \`(set -o pipefail; git -C <wt> ls-files -v | awk '\$1 ~ /^[a-z]\$/ || \$1 == \"S\"')\`; require the whole command to exit 0 and print nothing" \
   "the Git safety section no longer binds the complete \`ls-files -v\` index-flag command to both a successful pipeline and empty output — a failed Git probe must not be accepted as a clean index"
@@ -98,8 +90,7 @@ assert_section "Run \`(set -o pipefail; git -C <wt> ls-files -v | awk '\$1 ~ /^[
 #     PR the run is NOT on the reviewed code — fixture-verified, with nothing but a bare " M <sub>" to
 #     show for it. In a monorepo largely made of submodule bumps that is the common case, and the
 #     failure is silent, so the contract must at minimum require DETECTING it before evaluation.
-# shellcheck disable=SC2016 # Literal Markdown code span, not shell expansion.
-assert_section 'Run `git -C <wt> submodule status --recursive` and require it to exit 0 and every output line to begin with a space' \
+assert_section "Run \`git -C <wt> submodule status --recursive\` and require it to exit 0 and every output line to begin with a space" \
   "the Git safety section no longer requires a successful recursive submodule-status probe whose every line carries Git's clean leading-space marker — a stale, absent, nested, or unmerged submodule could be evaluated as reviewed code"
 
 # 2e. AND THE WARNING AGAINST THE OBVIOUS "FIX". `--recurse-submodules` is the natural thing to reach
@@ -108,6 +99,8 @@ assert_section 'Run `git -C <wt> submodule status --recursive` and require it to
 #     gitlink absent locally, silently skips a submodule the target introduces, and does not propagate
 #     its ignored-file protection. Without this assertion a later editor closes 2d's gap by adding the
 #     flag — reintroducing every one of those, with a rule that looks more complete than before.
+assert_section "Do NOT reach for \`--recurse-submodules\`" \
+  "the Git safety section no longer prohibits recursive checkout — the obvious workaround can corrupt linked-worktree submodule gitdirs, partially switch the tree, and overwrite ignored submodule work"
 assert_section '[#2833](https://github.com/devantler-tech/monorepo/issues/2833)' \
   "the Git safety section no longer points at the follow-up issue for safe submodule detaching — without it the stated hazard reads as unsolved-and-unowned, and the next editor is likely to 'fix' it with \`--recurse-submodules\`, which is measurably unsafe in this repo's linked-worktree flow"
 
@@ -141,5 +134,14 @@ assert_section 'git -C <wt> status --porcelain' \
 #     aborts, reasonably concludes it is redundant, and removes it.
 assert_section 'partial backstop' \
   "the Git safety section no longer explains that the abort is only a partial backstop — a reader who believes \`checkout --detach\` always refuses a dirty worktree will read the cleanliness precondition as redundant and drop it"
+
+# 5. POST-SWITCH RESIDUE. A target that removes an initialized submodule can leave its directory
+#    behind while `submodule status --recursive` emits nothing. Re-run tracked cleanliness and use a
+#    read-only `clean -ndx` dry-run so stale untracked or ignored repositories cannot be evaluated as
+#    part of a commit that removed them.
+assert_section "After detaching, repeat \`git -C <wt> status --porcelain\`" \
+  "the Git safety section no longer repeats the tracked-worktree cleanliness check after detaching — checkout can leave residue that did not exist at the pre-check"
+assert_section "Run \`git -C <wt> clean -ndx\` as its own read-only call; require exit 0 and empty output" \
+  "the Git safety section no longer rejects stale untracked or ignored residue after detaching — a removed initialized submodule can survive outside the reviewed tree while submodule status passes vacuously"
 
 echo "git safety contract: OK (${section_words} words scoped)"

--- a/.claude/scripts/git-safety-contract.test.sh
+++ b/.claude/scripts/git-safety-contract.test.sh
@@ -55,7 +55,7 @@ section="$(
 # scope hole described above while every assertion still passes.
 #
 # The bound separates two states that are far apart, and it is deliberately NOT set just above the
-# current size: the section measures a few hundred words (369 when this bound was set), while a
+# current size: the section measures a few hundred words (486 at the time of writing), while a
 # runaway extraction (end anchor gone, awk running to EOF) measured 9,968 — both figures observed
 # rather than estimated, which is what justifies the gap. A snug bound would fail every
 # legitimate edit to this section while reporting a missing anchor — a false message that sends the
@@ -97,10 +97,20 @@ assert_section 'headRefOid' \
 assert_section 'SEPARATE calls' \
   "the Git safety section does not require the fetch and the checkout to be issued as separate calls — a denied compound call rolls back the fetch too, and the follow-up then fails on a missing FETCH_HEAD in a way that reads like a broken gitdir rather than a refusal"
 
-# 4. THE SWAP IS RECORDED AS SAFE, WITH ITS REASON. The dirty-worktree abort is the whole argument
-#    that this needs no permission change; stated without it, a later reader cannot tell this apart
-#    from a workaround and may "resolve" it by widening the guard.
-assert_section 'aborts and preserves' \
-  "the Git safety section does not record that \`checkout --detach\` aborts and preserves uncommitted work on a dirty worktree — that property is what makes this a strictly safer swap rather than a workaround, and without it the next reader may try to widen the guard instead"
+# 4. THE CLEANLINESS PRECONDITION. This is the operative safety rule and the one most likely to be
+#    "simplified" away, because the abort LOOKS like it already covers the case. It does not.
+#    Measured on a two-commit fixture: `checkout --detach` aborts only when the dirty path DIFFERS
+#    between HEAD and the target; when the path is identical in both commits git carries the edit
+#    along and SUCCEEDS, landing on the target with another writer's uncommitted work in the tree and
+#    nothing in the output saying so. An earlier draft of this contract claimed the abort was
+#    unconditional — that claim was false and is exactly what this assertion prevents recurring.
+assert_section 'status --porcelain' \
+  "the Git safety section no longer requires the worktree to be verified clean before detaching — the abort is only a partial backstop (it fires only when the dirty path differs between HEAD and target), so without this precondition a run can silently detach over another instance's uncommitted work"
+
+# 4b. AND THE REASON THE BACKSTOP IS PARTIAL. Assertion 4 pins the rule; this pins the justification.
+#     Without it a later editor sees a cleanliness check guarding a command they believe always
+#     aborts, reasonably concludes it is redundant, and removes it.
+assert_section 'partial backstop' \
+  "the Git safety section no longer explains that the abort is only a partial backstop — a reader who believes \`checkout --detach\` always refuses a dirty worktree will read the cleanliness precondition as redundant and drop it"
 
 echo "git safety contract: OK (${section_words} words scoped)"

--- a/.claude/scripts/git-safety-contract.test.sh
+++ b/.claude/scripts/git-safety-contract.test.sh
@@ -55,7 +55,7 @@ section="$(
 # scope hole described above while every assertion still passes.
 #
 # The bound separates two states that are far apart, and it is deliberately NOT set just above the
-# current size: the section measures several hundred words (921 at the time of writing), while a
+# current size: the section measures several hundred words (1,095 at the time of writing), while a
 # runaway extraction (end anchor gone, awk running to EOF) measured 9,968 — both figures observed
 # rather than estimated, which is what justifies the gap. A snug bound would fail every
 # legitimate edit to this section while reporting a missing anchor — a false message that sends the
@@ -87,6 +87,15 @@ assert_section 'git -C <wt> checkout --no-overwrite-ignore --recurse-submodules 
 #     Fixture-verified: empty status, then a successful checkout that carried a foreign edit onto the
 #     target. \`worktree-cleanup.sh\` already makes this check, so the contract asking for less than
 #     its own tooling does would be an inconsistency as well as a hole.
+# 2d. THE PER-SUBMODULE PRE-CHECK. \`--recurse-submodules\` mutates each populated submodule's working
+#     tree, which neither top-level check inspects, and \`--no-overwrite-ignore\` is NOT propagated to
+#     the recursive checkout. Fixture-verified: both top-level checks clean, and the prescribed
+#     command still destroyed a foreign ignored file inside a submodule. This assertion exists because
+#     the hazard was INTRODUCED by adding the recursion — the wider the command's blast radius, the
+#     wider the pre-check must be, and it is easy to widen one without the other.
+assert_section 'submodule foreach' \
+  "the Git safety section no longer requires the cleanliness checks to be run inside each populated submodule — \`--recurse-submodules\` writes to submodule working trees that the top-level \`status\`/\`ls-files\` checks never inspect, so the run would authorise a checkout that destroys another writer's work there"
+
 assert_section 'ls-files -v' \
   "the Git safety section no longer requires the \`ls-files -v\` index-flag check — a file marked assume-unchanged or skip-worktree is invisible to \`status --porcelain\`, so the cleanliness pre-check passes while another writer's edit rides onto the target commit"
 

--- a/.claude/scripts/git-safety-contract.test.sh
+++ b/.claude/scripts/git-safety-contract.test.sh
@@ -55,7 +55,7 @@ section="$(
 # scope hole described above while every assertion still passes.
 #
 # The bound separates two states that are far apart, and it is deliberately NOT set just above the
-# current size: the section measures several hundred words (748 at the time of writing), while a
+# current size: the section measures several hundred words (921 at the time of writing), while a
 # runaway extraction (end anchor gone, awk running to EOF) measured 9,968 — both figures observed
 # rather than estimated, which is what justifies the gap. A snug bound would fail every
 # legitimate edit to this section while reporting a missing anchor — a false message that sends the
@@ -79,16 +79,16 @@ assert_section 'Never `git reset --hard`' \
 # 2. THE ALTERNATIVE IS NAMED, with the flag that makes it safe. \`checkout\` alone is not the
 #    prescription: it is \`--detach\` onto an explicit commit that reproduces the banned form's
 #    outcome, and a bare branch checkout would not.
-assert_section 'git -C <wt> checkout --no-overwrite-ignore --detach <sha>' \
-  "the Git safety section does not name \`git -C <wt> checkout --no-overwrite-ignore --detach <sha>\` as the permitted way to put a worktree on a specific commit, so the ban again has no stated alternative and the instruction migrates to unreviewed memory"
+assert_section 'git -C <wt> checkout --no-overwrite-ignore --recurse-submodules --detach <sha>' \
+  "the Git safety section does not name \`git -C <wt> checkout --no-overwrite-ignore --recurse-submodules --detach <sha>\` as the permitted way to put a worktree on a specific commit, so the ban again has no stated alternative and the instruction migrates to unreviewed memory"
 
-# 2c. THE SUBMODULE STEP. \`--detach\` moves the superproject ONLY; a gitlink-changing PR therefore
-#     leaves submodules at their old commits, with nothing but a bare " M <sub>" to show for it.
-#     Fixture-verified. In a monorepo whose PRs are largely submodule bumps this is the common case,
-#     and the failure mode is evaluating different code from the headRefOid you believe you are on —
-#     so the follow-up step is part of the prescription, not an optional extra.
-assert_section 'submodule-init.sh' \
-  "the Git safety section no longer directs the run to update submodules after detaching — \`--detach\` moves only the superproject, so a gitlink-changing PR leaves the submodule stale and the run silently evaluates the wrong code"
+# 2c. THE INDEX-HIDDEN-EDIT CHECK. \`status --porcelain\` omits any tracked file carrying
+#     \`assume-unchanged\` or \`skip-worktree\`, so an empty status is NOT proof the tree is clean.
+#     Fixture-verified: empty status, then a successful checkout that carried a foreign edit onto the
+#     target. \`worktree-cleanup.sh\` already makes this check, so the contract asking for less than
+#     its own tooling does would be an inconsistency as well as a hole.
+assert_section 'ls-files -v' \
+  "the Git safety section no longer requires the \`ls-files -v\` index-flag check — a file marked assume-unchanged or skip-worktree is invisible to \`status --porcelain\`, so the cleanliness pre-check passes while another writer's edit rides onto the target commit"
 
 # 2b. THE PR-HEAD ASSOCIATION. \`<sha>\` is deliberately the general placeholder — it is this
 #     contract's convention (27 backticked commands use it, against 1 for \`<headRefOid>\`), and the

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
       agent-role-delivery-contract: ${{ steps.filter.outputs.agent-role-delivery-contract }}
       work-priority-ladder: ${{ steps.filter.outputs.work-priority-ladder }}
       latency-discipline-contract: ${{ steps.filter.outputs.latency-discipline-contract }}
+      git-safety-contract: ${{ steps.filter.outputs.git-safety-contract }}
       merge-confirmation-read: ${{ steps.filter.outputs.merge-confirmation-read }}
       portfolio-surveyor: ${{ steps.filter.outputs.portfolio-surveyor }}
       product-value: ${{ steps.filter.outputs.product-value }}
@@ -192,6 +193,10 @@ jobs:
             latency-discipline-contract:
               - 'AGENTS.md'
               - '.claude/scripts/latency-discipline-contract.test.sh'
+              - '.github/workflows/ci.yaml'
+            git-safety-contract:
+              - 'AGENTS.md'
+              - '.claude/scripts/git-safety-contract.test.sh'
               - '.github/workflows/ci.yaml'
             self-review-contract:
               - 'AGENTS.md'
@@ -763,6 +768,21 @@ jobs:
       - name: Verify the latency discipline contract
         run: bash .claude/scripts/latency-discipline-contract.test.sh
 
+  test-git-safety-contract:
+    name: Test git safety contract
+    needs: changes
+    if: needs.changes.outputs.git-safety-contract == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify the git safety contract
+        run: bash .claude/scripts/git-safety-contract.test.sh
+
   test-self-review-contract:
     name: Test self-review contract
     needs: changes
@@ -894,6 +914,7 @@ jobs:
       - test-maintainer-preflight
       - test-memory-hygiene
       - test-latency-discipline-contract
+      - test-git-safety-contract
       - test-self-review-contract
       - test-review-provider-loop-contract
       - test-agent-role-delivery-contract
@@ -926,6 +947,7 @@ jobs:
             ${{ needs.test-maintainer-preflight.result }}
             ${{ needs.test-memory-hygiene.result }}
             ${{ needs.test-latency-discipline-contract.result }}
+            ${{ needs.test-git-safety-contract.result }}
             ${{ needs.test-self-review-contract.result }}
             ${{ needs.test-review-provider-loop-contract.result }}
             ${{ needs.test-agent-role-delivery-contract.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3057,8 +3057,10 @@ Never `git reset --hard`, `git stash`, force-push, or discard changes you did no
 `git add -A` / `git add .` — stage only files you edited. Never stage submodule-pointer bumps unless
 a task explicitly calls for it. Leave every checkout/worktree clean when done.
 
-**The permitted way to put a worktree on a specific commit is `git -C <wt> checkout --detach <sha>`,
-issued as its OWN call after the `fetch`.** When that commit is a PR's head, `<sha>` is its
+**The permitted way to put a worktree on a specific commit is
+`git -C <wt> checkout --no-overwrite-ignore --detach <sha>`, issued as its OWN call after the
+`fetch`** (the flag is not optional decoration — see the ignored-paths hazard below).
+When that commit is a PR's head, `<sha>` is its
 **`headRefOid`** — the same value *Merge policy* pins the merge to, so the worktree you evaluate and
 the commit you merge are provably the same one. A ban that never names the alternative is exactly the
 DevEx tax *Security hardening without a DevEx tax* forbids, and the vacuum gets filled by something
@@ -3079,6 +3081,23 @@ edit along and succeeds** — leaving you on the target commit with someone else
 tree, and nothing in the output saying so. So require `git -C <wt> status --porcelain` to be **empty**
 before detaching. If it is not, that is a live claim by another writer: do GitHub-API-only work per
 *Execution model* and never detach over it.
+🔴 **`--detach` moves the SUPERPROJECT ONLY, and in this monorepo that is the dangerous default.** It
+does not recurse into submodules, so detaching onto a PR that changes a gitlink leaves every submodule
+at its **old** commit — fixture-verified: HEAD lands on the target while the submodule still holds the
+previous content, and `status` shows nothing but a bare ` M <sub>`. You would then be evaluating
+**different code from the `headRefOid` you believe you are on**, and since a large share of PRs here
+are submodule bumps that is the common case rather than an edge one. So after detaching, bring each
+affected submodule to its pinned commit with
+[`submodule-init.sh`](.claude/scripts/submodule-init.sh) (fail-closed, and it repairs worktree
+isolation in the same step), then require `status --porcelain` to be empty **again** — a surviving
+` M <sub>` means that submodule is still stale.
+⚠️ **The pre-check cannot see IGNORED paths, and checkout overwrites them by default — which is why
+`--no-overwrite-ignore` is in the command above.** `git checkout` documents `--overwrite-ignore` as
+the default and `status --porcelain` never lists ignored files, so when the target commit starts
+tracking a path that is ignored at your current HEAD, an empty pre-check is followed by a **silent
+overwrite** of whatever was there (fixture-verified, including that the flag aborts instead). The
+window is narrow, but it is exactly the case the pre-check is blind to, so the default is the unsafe
+one and the flag is what makes the prescribed form safe by default.
 ⚠️ **It remains a strictly safer swap, never a loosening — the guard is untouched and needs no
 widening.** On a clean worktree it lands on exactly that commit, the same outcome the banned form
 would have produced, and wherever it *does* refuse it preserves what `reset --hard` would have

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3057,6 +3057,25 @@ Never `git reset --hard`, `git stash`, force-push, or discard changes you did no
 `git add -A` / `git add .` — stage only files you edited. Never stage submodule-pointer bumps unless
 a task explicitly calls for it. Leave every checkout/worktree clean when done.
 
+**The permitted way to put a worktree on a specific commit is `git -C <wt> checkout --detach <sha>`,
+issued as its OWN call after the `fetch`.** A ban that never names the alternative is exactly the
+DevEx tax *Security hardening without a DevEx tax* forbids, and the vacuum gets filled by something
+worse: durable memory came to prescribe `fetch` + `reset --hard FETCH_HEAD` for putting a fresh maint
+worktree onto a PR head — a command the runtime denies outright — so every compliant run reached for
+something that could never run (measured across one day's session corpus: 3–4 denied calls over three
+separate ticks). Memory is also **per-lane**, so correcting one lane's notes leaves the siblings
+reaching for the same denied form; that is why this belongs in the shared contract.
+🔴 **Issue the `fetch` and the `checkout` as SEPARATE calls — a denied COMPOUND call rolls back the
+whole chain**, so the `fetch` never runs either and the follow-up fails on a missing `FETCH_HEAD`.
+That reads like a broken gitdir rather than a refusal, which sends the run to diagnose the wrong
+thing — the denial costs a misdiagnosis on top of the wasted call.
+⚠️ **This is a strictly safer swap, never a loosening — the guard is untouched and needs no widening.**
+Verified on a real fixture, both arms: on a **clean** worktree `checkout --detach` lands on exactly
+that commit, the same outcome the banned form would have produced; on a **dirty** one it **aborts and
+preserves** the uncommitted content with HEAD unchanged, where `reset --hard` would have destroyed it.
+That refusal is precisely the property the ban exists to protect, so the replacement is *stricter* in
+the failure case rather than weaker.
+
 **Worktree hygiene is SCHEDULED, not per-run — never rely on a session to remove its own worktree.**
 The harness creates a per-session worktree at `<repo>/.claude/worktrees/<slug>`, and the owning
 session **structurally cannot remove it**: that directory is the session's own working directory, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3090,6 +3090,23 @@ edit straight onto the target commit. So also require
 or `S` marks exactly those bits). [`worktree-cleanup.sh`](.claude/scripts/worktree-cleanup.sh) already
 makes this check for the same reason — treat an empty `status` as authorization to detach only once
 this one is clear too.
+🔴 **Run BOTH of those checks inside every populated submodule too — the recursion mutates trees the
+top-level checks never inspect.** `--no-overwrite-ignore` is **not propagated** to the recursive
+submodule checkout, and neither `status --porcelain` nor `ls-files -v` at the top level looks inside a
+submodule's working tree. Fixture-verified: with both top-level checks reporting clean, the prescribed
+command **destroyed a foreign ignored file inside a populated submodule**. So also require
+
+```sh
+git -C <wt> submodule foreach --quiet --recursive \
+  'git status --porcelain --ignored=matching; git ls-files -v | awk "\$1 ~ /^[a-z]$/ || \$1 == \"S\""'
+```
+
+to print **nothing**. `--ignored=matching` is not optional here: the flag that protects ignored files
+at the top level cannot reach a submodule, so *detecting* them is the only defence left. Any output is
+another writer's work — do API-only work and never detach over it.
+🔑 **The general rule this instance teaches: a pre-check must cover every repository the command
+MUTATES.** Adding `--recurse-submodules` widened the mutation set; a check that stayed top-level then
+authorised writes it had never inspected.
 🔴 **`--detach` on its own moves the SUPERPROJECT ONLY, and in this monorepo that is the dangerous
 default — which is what `--recurse-submodules` above is for.** Without it, detaching onto a PR that
 changes a gitlink leaves every submodule at its **old** commit: fixture-verified, HEAD lands on the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3058,9 +3058,10 @@ Never `git reset --hard`, `git stash`, force-push, or discard changes you did no
 a task explicitly calls for it. Leave every checkout/worktree clean when done.
 
 **The permitted way to put a worktree on a specific commit is
-`git -C <wt> checkout --no-overwrite-ignore --recurse-submodules --detach <sha>`, issued as its OWN
-call after the `fetch`.** Neither flag is decoration: without them the command silently overwrites
-ignored files and leaves submodules stale — both hazards are below, and both were fixture-verified.
+`git -C <wt> checkout --no-overwrite-ignore --detach <sha>`, issued as its OWN call after the
+`fetch`.** The flag is not decoration — without it the command silently overwrites ignored files (see
+below, fixture-verified). This covers the **superproject**; submodules need more than a flag and are
+handled separately below.
 When that commit is a PR's head, `<sha>` is its
 **`headRefOid`** — the same value *Merge policy* pins the merge to, so the worktree you evaluate and
 the commit you merge are provably the same one. A ban that never names the alternative is exactly the
@@ -3090,36 +3091,34 @@ edit straight onto the target commit. So also require
 or `S` marks exactly those bits). [`worktree-cleanup.sh`](.claude/scripts/worktree-cleanup.sh) already
 makes this check for the same reason — treat an empty `status` as authorization to detach only once
 this one is clear too.
-🔴 **Run BOTH of those checks inside every populated submodule too — the recursion mutates trees the
-top-level checks never inspect.** `--no-overwrite-ignore` is **not propagated** to the recursive
-submodule checkout, and neither `status --porcelain` nor `ls-files -v` at the top level looks inside a
-submodule's working tree. Fixture-verified: with both top-level checks reporting clean, the prescribed
-command **destroyed a foreign ignored file inside a populated submodule**. So also require
-
-```sh
-git -C <wt> submodule foreach --quiet --recursive \
-  'git status --porcelain --ignored=matching; git ls-files -v | awk "\$1 ~ /^[a-z]$/ || \$1 == \"S\""'
-```
-
-to print **nothing**. `--ignored=matching` is not optional here: the flag that protects ignored files
-at the top level cannot reach a submodule, so *detecting* them is the only defence left. Any output is
-another writer's work — do API-only work and never detach over it.
-🔑 **The general rule this instance teaches: a pre-check must cover every repository the command
-MUTATES.** Adding `--recurse-submodules` widened the mutation set; a check that stayed top-level then
-authorised writes it had never inspected.
-🔴 **`--detach` on its own moves the SUPERPROJECT ONLY, and in this monorepo that is the dangerous
-default — which is what `--recurse-submodules` above is for.** Without it, detaching onto a PR that
-changes a gitlink leaves every submodule at its **old** commit: fixture-verified, HEAD lands on the
-target while the submodule still holds the previous content and `status` shows nothing but a bare
-` M <sub>`. You would then be evaluating **different code from the `headRefOid` you believe you are
-on** — and since a large share of PRs here are submodule bumps, that is the common case rather than an
-edge one. With the flag, the submodule lands on the pinned commit and the tree comes back clean.
-⚠️ **`submodule-init.sh` does NOT do this job and must not be prescribed for it.** Handed an
+🔴 **`--detach` moves the SUPERPROJECT ONLY, so after detaching you are NOT necessarily on the PR's
+code — DETECT that before evaluating anything.** Fixture-verified: on a PR that changes a gitlink, HEAD
+lands on the target while the submodule still holds its **previous** content, and `status` shows
+nothing but a bare ` M <sub>`. You would be reviewing **different code from the `headRefOid` you
+believe you are on**, and since a large share of PRs here are submodule bumps that is the common case
+rather than an edge one. So after detaching, treat a non-empty
+`git -C <wt> submodule status` marker — a leading `+` (gitlink mismatch) or `-` (not initialised) — as
+**you are not on the reviewed commit**, and do not evaluate it as though you were.
+🔴 **Do NOT reach for `--recurse-submodules` to fix that — it is unsafe in this repo's mandated
+throwaway-worktree flow, measured.** Where a submodule is initialised in the main checkout but empty in
+the linked worktree, both pre-checks above pass and the recursive checkout then writes a `mod/.git`
+pointing at a nonexistent gitdir and **exits 128** (`could not reset submodule index`), leaving that
+submodule unusable. It also cannot **fetch** a target gitlink absent from the local object database —
+the ordinary dependency-bump case — so it exits non-zero having already moved the superproject, leaving
+the tree half-switched; it silently **skips** a submodule the target commit introduces, exiting 0 with
+a clean status over a directory containing no code; and its `--no-overwrite-ignore` protection **does
+not propagate**, so foreign ignored work inside a populated submodule is destroyed while both
+top-level checks read clean.
+⚠️ **`submodule-init.sh` is not the answer either, and must not be prescribed as one.** Handed an
 **already-populated** submodule it deliberately repairs isolation *only* and refuses
 `git submodule update`, precisely so it cannot discard a local branch or ahead-of-pin work — so it
-would report success while the submodule stayed stale. Its job is populating an **uninitialised**
-submodule and repairing worktree isolation; moving a populated one onto the pinned gitlink is
-`--recurse-submodules`'s job. Keep the two uses distinct.
+reports success while the submodule stays stale. Its job is populating an **uninitialised** submodule
+and repairing worktree isolation, which is a different job from moving a populated one onto a pin.
+📌 **Landing a worktree on a PR head *including* its submodules therefore needs a real procedure —
+fetch, initialise additions, repair isolation, then probe — not a flag. That is
+[#2833](https://github.com/devantler-tech/monorepo/issues/2833).** Until it exists, detect the
+condition and stop; never paper over it with a flag that fails closed at exit 128 or, worse, fails
+open with a clean-looking status.
 ⚠️ **The pre-check cannot see IGNORED paths, and checkout overwrites them by default — which is why
 `--no-overwrite-ignore` is in the command above.** `git checkout` documents `--overwrite-ignore` as
 the default and `status --porcelain` never lists ignored files, so when the target commit starts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3058,10 +3058,12 @@ Never `git reset --hard`, `git stash`, force-push, or discard changes you did no
 a task explicitly calls for it. Leave every checkout/worktree clean when done.
 
 **The permitted way to put a worktree on a specific commit is
-`git -C <wt> checkout --no-overwrite-ignore --detach <sha>`, issued as its OWN call after the
-`fetch`.** The flag is not decoration — without it the command silently overwrites ignored files (see
-below, fixture-verified). This covers the **superproject**; submodules need more than a flag and are
-handled separately below.
+`git --no-replace-objects -C <wt> checkout --no-overwrite-ignore --detach <sha>`, issued as its OWN
+call after the `fetch`.** Both global protections are load-bearing: `--no-overwrite-ignore` stops the
+command from silently overwriting ignored files, while `--no-replace-objects` prevents a shared
+`refs/replace` entry from making the requested SHA materialize a different commit tree even though
+`HEAD` still prints the expected value (both fixture-verified). This covers the **superproject**;
+submodules need more than a flag and are handled separately below.
 When that commit is a PR's head, `<sha>` is its
 **`headRefOid`** — the same value *Merge policy* pins the merge to, so the worktree you evaluate and
 the commit you merge are provably the same one. A ban that never names the alternative is exactly the
@@ -3091,6 +3093,15 @@ edit straight onto the target commit. Run
 command to exit 0 and print nothing (a lowercase flag or `S` marks exactly those bits).
 [`worktree-cleanup.sh`](.claude/scripts/worktree-cleanup.sh) already makes this check for the same
 reason — treat an empty `status` as authorization to detach only once this one is clear too.
+🔴 **CHECK AGAIN AFTER DETACHING — the target can leave residue that did not exist in its tree.**
+After detaching, repeat `git -C <wt> status --porcelain`; require exit 0 and empty output. Run
+`git -C <wt> clean -ndx` as its own read-only call; require exit 0 and empty output. The latter is a
+dry run, never permission to clean: any line, including a skipped nested repository, means untracked
+or ignored material remains and evaluation stops. This specifically closes the removed-submodule
+case: non-recursive checkout can warn that it could not remove an initialized submodule directory,
+leave that old code behind, and then make `submodule status --recursive` pass vacuously because the
+target commit no longer declares the gitlink. Builds must not consume code absent from the reviewed
+tree.
 🔴 **`--detach` moves the SUPERPROJECT ONLY, so after detaching you are NOT necessarily on the PR's
 code — DETECT that before evaluating anything.** Fixture-verified: on a PR that changes a gitlink, HEAD
 lands on the target while the submodule still holds its **previous** content, and `status` shows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3080,25 +3080,27 @@ assuming it does is how you silently adopt another instance's uncommitted work.*
 two-commit fixture, both arms: it **aborts and preserves** only when the modified path **differs**
 between HEAD and the target; when the dirty path is **identical** in both commits, git **carries the
 edit along and succeeds** — leaving you on the target commit with someone else's work still in the
-tree, and nothing in the output saying so. So require `git -C <wt> status --porcelain` to be **empty**
-before detaching. If it is not, that is a live claim by another writer: do GitHub-API-only work per
-*Execution model* and never detach over it.
+tree, and nothing in the output saying so. Run `git -C <wt> status --porcelain` as its own call;
+require exit 0 and empty output before detaching. If it fails or prints anything, that is a live claim
+by another writer: do GitHub-API-only work per *Execution model* and never detach over it.
 ⚠️ **`status` alone is not sufficient, because the INDEX CAN HIDE a foreign edit.** A tracked file
 carrying `assume-unchanged` or `skip-worktree` is omitted from `status --porcelain` entirely —
 fixture-verified: an empty status, followed by a successful checkout that carried another writer's
-edit straight onto the target commit. So also require
-`git -C <wt> ls-files -v | awk '$1 ~ /^[a-z]$/ || $1 == "S"'` to print **nothing** (a lowercase flag
-or `S` marks exactly those bits). [`worktree-cleanup.sh`](.claude/scripts/worktree-cleanup.sh) already
-makes this check for the same reason — treat an empty `status` as authorization to detach only once
-this one is clear too.
+edit straight onto the target commit. Run
+`(set -o pipefail; git -C <wt> ls-files -v | awk '$1 ~ /^[a-z]$/ || $1 == "S"')`; require the whole
+command to exit 0 and print nothing (a lowercase flag or `S` marks exactly those bits).
+[`worktree-cleanup.sh`](.claude/scripts/worktree-cleanup.sh) already makes this check for the same
+reason — treat an empty `status` as authorization to detach only once this one is clear too.
 🔴 **`--detach` moves the SUPERPROJECT ONLY, so after detaching you are NOT necessarily on the PR's
 code — DETECT that before evaluating anything.** Fixture-verified: on a PR that changes a gitlink, HEAD
 lands on the target while the submodule still holds its **previous** content, and `status` shows
-nothing but a bare ` M <sub>`. You would be reviewing **different code from the `headRefOid` you
-believe you are on**, and since a large share of PRs here are submodule bumps that is the common case
-rather than an edge one. So after detaching, treat a non-empty
-`git -C <wt> submodule status` marker — a leading `+` (gitlink mismatch) or `-` (not initialised) — as
-**you are not on the reviewed commit**, and do not evaluate it as though you were.
+nothing but a leading space followed by `M <sub>`. You would be reviewing **different code from the
+`headRefOid` you believe you are on**, and since a large share of PRs here are submodule bumps that is
+the common case rather than an edge one. Run `git -C <wt> submodule status --recursive` and require it
+to exit 0 and every output line to begin with a space. Reject a leading `+` (gitlink mismatch), `-`
+(not initialised), or `U` (unmerged) before evaluating the reviewed commit. This marker check proves
+only that each populated submodule is on its recorded gitlink; it does not prove that files inside an
+initialised submodule are clean.
 🔴 **Do NOT reach for `--recurse-submodules` to fix that — it is unsafe in this repo's mandated
 throwaway-worktree flow, measured.** Where a submodule is initialised in the main checkout but empty in
 the linked worktree, both pre-checks above pass and the recursive checkout then writes a `mod/.git`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3058,7 +3058,9 @@ Never `git reset --hard`, `git stash`, force-push, or discard changes you did no
 a task explicitly calls for it. Leave every checkout/worktree clean when done.
 
 **The permitted way to put a worktree on a specific commit is `git -C <wt> checkout --detach <sha>`,
-issued as its OWN call after the `fetch`.** A ban that never names the alternative is exactly the
+issued as its OWN call after the `fetch`.** When that commit is a PR's head, `<sha>` is its
+**`headRefOid`** — the same value *Merge policy* pins the merge to, so the worktree you evaluate and
+the commit you merge are provably the same one. A ban that never names the alternative is exactly the
 DevEx tax *Security hardening without a DevEx tax* forbids, and the vacuum gets filled by something
 worse: durable memory came to prescribe `fetch` + `reset --hard FETCH_HEAD` for putting a fresh maint
 worktree onto a PR head — a command the runtime denies outright — so every compliant run reached for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3058,8 +3058,9 @@ Never `git reset --hard`, `git stash`, force-push, or discard changes you did no
 a task explicitly calls for it. Leave every checkout/worktree clean when done.
 
 **The permitted way to put a worktree on a specific commit is
-`git -C <wt> checkout --no-overwrite-ignore --detach <sha>`, issued as its OWN call after the
-`fetch`** (the flag is not optional decoration — see the ignored-paths hazard below).
+`git -C <wt> checkout --no-overwrite-ignore --recurse-submodules --detach <sha>`, issued as its OWN
+call after the `fetch`.** Neither flag is decoration: without them the command silently overwrites
+ignored files and leaves submodules stale — both hazards are below, and both were fixture-verified.
 When that commit is a PR's head, `<sha>` is its
 **`headRefOid`** — the same value *Merge policy* pins the merge to, so the worktree you evaluate and
 the commit you merge are provably the same one. A ban that never names the alternative is exactly the
@@ -3081,16 +3082,27 @@ edit along and succeeds** — leaving you on the target commit with someone else
 tree, and nothing in the output saying so. So require `git -C <wt> status --porcelain` to be **empty**
 before detaching. If it is not, that is a live claim by another writer: do GitHub-API-only work per
 *Execution model* and never detach over it.
-🔴 **`--detach` moves the SUPERPROJECT ONLY, and in this monorepo that is the dangerous default.** It
-does not recurse into submodules, so detaching onto a PR that changes a gitlink leaves every submodule
-at its **old** commit — fixture-verified: HEAD lands on the target while the submodule still holds the
-previous content, and `status` shows nothing but a bare ` M <sub>`. You would then be evaluating
-**different code from the `headRefOid` you believe you are on**, and since a large share of PRs here
-are submodule bumps that is the common case rather than an edge one. So after detaching, bring each
-affected submodule to its pinned commit with
-[`submodule-init.sh`](.claude/scripts/submodule-init.sh) (fail-closed, and it repairs worktree
-isolation in the same step), then require `status --porcelain` to be empty **again** — a surviving
-` M <sub>` means that submodule is still stale.
+⚠️ **`status` alone is not sufficient, because the INDEX CAN HIDE a foreign edit.** A tracked file
+carrying `assume-unchanged` or `skip-worktree` is omitted from `status --porcelain` entirely —
+fixture-verified: an empty status, followed by a successful checkout that carried another writer's
+edit straight onto the target commit. So also require
+`git -C <wt> ls-files -v | awk '$1 ~ /^[a-z]$/ || $1 == "S"'` to print **nothing** (a lowercase flag
+or `S` marks exactly those bits). [`worktree-cleanup.sh`](.claude/scripts/worktree-cleanup.sh) already
+makes this check for the same reason — treat an empty `status` as authorization to detach only once
+this one is clear too.
+🔴 **`--detach` on its own moves the SUPERPROJECT ONLY, and in this monorepo that is the dangerous
+default — which is what `--recurse-submodules` above is for.** Without it, detaching onto a PR that
+changes a gitlink leaves every submodule at its **old** commit: fixture-verified, HEAD lands on the
+target while the submodule still holds the previous content and `status` shows nothing but a bare
+` M <sub>`. You would then be evaluating **different code from the `headRefOid` you believe you are
+on** — and since a large share of PRs here are submodule bumps, that is the common case rather than an
+edge one. With the flag, the submodule lands on the pinned commit and the tree comes back clean.
+⚠️ **`submodule-init.sh` does NOT do this job and must not be prescribed for it.** Handed an
+**already-populated** submodule it deliberately repairs isolation *only* and refuses
+`git submodule update`, precisely so it cannot discard a local branch or ahead-of-pin work — so it
+would report success while the submodule stayed stale. Its job is populating an **uninitialised**
+submodule and repairing worktree isolation; moving a populated one onto the pinned gitlink is
+`--recurse-submodules`'s job. Keep the two uses distinct.
 ⚠️ **The pre-check cannot see IGNORED paths, and checkout overwrites them by default — which is why
 `--no-overwrite-ignore` is in the command above.** `git checkout` documents `--overwrite-ignore` as
 the default and `status --porcelain` never lists ignored files, so when the target commit starts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3071,12 +3071,19 @@ reaching for the same denied form; that is why this belongs in the shared contra
 whole chain**, so the `fetch` never runs either and the follow-up fails on a missing `FETCH_HEAD`.
 That reads like a broken gitdir rather than a refusal, which sends the run to diagnose the wrong
 thing — the denial costs a misdiagnosis on top of the wasted call.
-⚠️ **This is a strictly safer swap, never a loosening — the guard is untouched and needs no widening.**
-Verified on a real fixture, both arms: on a **clean** worktree `checkout --detach` lands on exactly
-that commit, the same outcome the banned form would have produced; on a **dirty** one it **aborts and
-preserves** the uncommitted content with HEAD unchanged, where `reset --hard` would have destroyed it.
-That refusal is precisely the property the ban exists to protect, so the replacement is *stricter* in
-the failure case rather than weaker.
+🔴 **CHECK THE WORKTREE IS CLEAN FIRST — `checkout --detach` does NOT reliably refuse a dirty one, and
+assuming it does is how you silently adopt another instance's uncommitted work.** Measured on a
+two-commit fixture, both arms: it **aborts and preserves** only when the modified path **differs**
+between HEAD and the target; when the dirty path is **identical** in both commits, git **carries the
+edit along and succeeds** — leaving you on the target commit with someone else's work still in the
+tree, and nothing in the output saying so. So require `git -C <wt> status --porcelain` to be **empty**
+before detaching. If it is not, that is a live claim by another writer: do GitHub-API-only work per
+*Execution model* and never detach over it.
+⚠️ **It remains a strictly safer swap, never a loosening — the guard is untouched and needs no
+widening.** On a clean worktree it lands on exactly that commit, the same outcome the banned form
+would have produced, and wherever it *does* refuse it preserves what `reset --hard` would have
+destroyed. It is never weaker than the banned form; the abort is simply a partial backstop rather than
+the check itself, which is why the cleanliness test above is the operative rule.
 
 **Worktree hygiene is SCHEDULED, not per-run — never rely on a session to remove its own worktree.**
 The harness creates a per-session worktree at `<repo>/.claude/worktrees/<slug>`, and the owning


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

*Git safety* bans `git reset --hard`, and the runtime denies it outright — but nothing said how to do the thing runs legitimately need: put a freshly-created worktree onto a PR head. A ban with no named alternative does not stop the behaviour, it relocates the instruction somewhere unreviewed. Here it landed in durable memory, which prescribed a form that can never execute, so every *compliant* run reached for a denied command. Measured across one day of sessions: 3–4 denied calls over three separate ticks.

It costs more than the wasted call. The denial rolls back the whole chained command, so the follow-up fails in a way that looks like a broken checkout rather than a refusal — and the run then diagnoses the wrong problem.

Memory is per-lane, so fixing one lane leaves the other two reaching for the same denied form. The rule has to live in the shared contract.

## What

Names the permitted alternative next to the ban, requires it as its own separate call, and records why it is strictly safer rather than a workaround — on a dirty worktree it refuses and preserves the work, which is the very property the ban exists to protect. **No guard is loosened and none is proposed; the permission layer is untouched.**

Adds a contract test pinning **both** halves — the ban and the alternative — so a later tidy-up cannot quietly drop the prohibition and still pass, and wires it into CI like the other contract guards.

Fixes #2828