### PR TITLE
fix(agents): scope clearance to actionable candidates

### DIFF
--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -118,9 +118,10 @@ public and private — no per-repo loop needed to enumerate):
    boundary intentionally leaves any such branch with repository automation and the human who edited it.
    Other API surfaces may render the same actors as `app/renovate` or `app/dependabot`; do not
    use search's unreliable `is_bot` field, a title, or a branch pattern as the classifier.
-   For **every remaining open PR — drafts and non-drafts, whoever authored it** — plus the
-   candidate-only `botantler-1[bot]` updater rows defined below, pull the
-   heavy fields one PR at a time. The orchestrator drives every one of these to a terminal state
+   Enumerate **every remaining open PR — drafts and non-drafts, whoever authored it** — plus the
+   candidate-only `botantler-1[bot]` updater rows defined below, then pull the heavy fields one PR at
+   a time for **at most eight actionable PRs per digest**. The orchestrator drives every one of these
+   to a terminal state
    (*You own EVERY pull request in the portfolio*), and it cannot review, promote, merge, close or
    park a PR whose pentad it never received: a cheap static row for an external or `Copilot` PR is
    **unactionable data**, so the deepening set is now defined by *what the run may act on*, not by
@@ -129,7 +130,8 @@ public and private — no per-repo loop needed to enumerate):
    `github-actions[bot]`, `coderabbitai[bot]`, `cursor[bot]` — **exact match, never a substring**;
    `Copilot`/`copilot-swe-agent[bot]` are NOT trusted) survives only to mark which branches may be
    run locally, and is reported per row rather than used as a filter.
-   ⚠️ **Deepening is budgeted, so spend it in the order the orchestrator will work.** This set is
+   ⚠️ **Deepening is both shard-bounded and budgeted, so spend it in the order the orchestrator will
+   work.** This set is
    much larger than the `devantler`-only one it replaces, and the heavy fields plus the GraphQL
    thread query are what exhaust the API pool mid-survey — measured 2026-08-09, when the pool ran
    out and **40 `platform` PRs went undeepened with no pentad at all**. Deepen in **`updatedAt`
@@ -138,6 +140,12 @@ public and private — no per-repo loop needed to enumerate):
    undeepened remainder as `NOT-DEEPENED (budget)` rows naming the count and the repos, never a
    silent cheap row that reads like a completed assessment:
    `gh pr view <n> --repo devantler-tech/<repo> --json number,state,isDraft,updatedAt,title,mergeStateStatus,reviewDecision,statusCheckRollup,mergedAt,headRefName,headRefOid,headRepositoryOwner,headRepository,author,body,files`
+   After eight successful candidate joins, stop deepening and emit the ordered remainder as
+   `NOT-DEEPENED (next-shard)` rows. A later failed or deferred join makes global health unknown, but
+   **deepened rows remain candidate-actionable** once their own exact head, pentad, control facts and
+   repository default-head health are complete. It never turns the remainder into a global mutation
+   lock. Because PRs outrank issues, **issue descent remains blocked** until every actionable PR is
+   classified as deepened, terminal, automation-owned, or parked on a named candidate-scoped blocker.
    🔴 **Every field this read returns SUPERSEDES the org-search value for the rest of the survey —
    including the three that are not about the head.** The search snapshot is minutes old by the time a
    PR is deepened, and a field can change without the head SHA changing, so "we refreshed the head"
@@ -1277,7 +1285,7 @@ Markdown; **omit products with no signal entirely** (don't echo empty lists):
 
 ```
 ## Survey digest — <UTC date>
-nothing_on_fire: <true|false|unknown>   # true only if NO CI red on main AND no actionable PR broken, whoever authored it; a GITHUB-MANAGED (NO-ACTION) line never makes this false — nor does its GITHUB-MANAGED-SCAN (NO-ACTION) specialisation — but a (REPEATED — ACTIONABLE) one does. 🔴 EMIT `unknown` WHENEVER ANY `NOT-DEEPENED (budget)` OR `DISCOVERY-TRUNCATED (prs, 300 cap)` ROW EXISTS (the issue-truncation row never affects this field): `true` asserts that no actionable PR is broken, which a survey that never assessed those PRs cannot know. `false` is equally wrong — it claims a fire nobody observed. `unknown` is the only honest value, and the orchestrator treats it as "re-survey the undeepened remainder before concluding the portfolio is healthy", never as a clean bill
+nothing_on_fire: <true|false|unknown>   # true only if NO CI red on main AND no actionable PR broken, whoever authored it; a GITHUB-MANAGED (NO-ACTION) line never makes this false — nor does its GITHUB-MANAGED-SCAN (NO-ACTION) specialisation — but a (REPEATED — ACTIONABLE) one does. 🔴 EMIT `unknown` WHENEVER ANY `NOT-DEEPENED (budget)`, `NOT-DEEPENED (next-shard)`, OR `DISCOVERY-TRUNCATED (prs, 300 cap)` ROW EXISTS (the issue-truncation row never affects this field): `true` asserts that no actionable PR is broken, which a survey that never assessed those PRs cannot know. `false` is equally wrong — it claims a fire nobody observed. `unknown` is the only honest value. It blocks declaring the portfolio healthy and blocks issue descent; it does not block acting on fully joined deepened rows.
 budget: graphql=<start_remaining>→<end_remaining>/<limit> · core=<start_remaining>→<end_remaining>/<limit>[ · EXHAUSTED_AT_START]
 # or, when the probe fails: budget: unavailable:<reason>
 
@@ -1302,6 +1310,7 @@ budget: graphql=<start_remaining>→<end_remaining>/<limit> · core=<start_remai
 - <repo>: untriaged → issues #a,#b · PRs #c   |   stale (>14d) → #d
 - <repo> #<n> "<title>" — <author>: EXTERNAL/Copilot — NEVER-RUN-LOCALLY (never run locally); reviewed statically, then driven to a terminal state like any other PR. Carries the same deepened pentad, `active=`, merge_group_result=<<conclusion>@<runId>@<runCreatedAt>|stale@<runId>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|none>, and classification as every other row, plus behaviour_observed=<check-name|static|none|unknown> (which CI check actually exercises the change; `static` = no exercisable runtime surface, evaluated statically instead; `none` = a check could exercise it but none does, and is the named blocker on its merge, per *You own EVERY pull request in the portfolio*). **`rd=` and `merge_group_result=` are NOT optional on this row just because its author is external** — an eviction is invisible in the head pentad (the queue's checks run on a synthetic ref) and a human CHANGES_REQUESTED is not one of the candidate-maintainer-comment surfaces, so omitting either loses a persistent block once the generic ~2h human-activity signal expires and the PR reads ready. This row takes the plain `<author>` form for `rd=`, with no `agent(…)`/`human(…)` qualifier: that qualifier exists only to tell a sibling instance's `devantler` review from the maintainer's, and an external author is neither
 - NOT-DEEPENED (budget) <repo> ×<n> [#a,#b,…]   # API pool exhausted before these PRs were deepened — they carry NO pentad and were NOT assessed; never report them as clean or actionable
+- NOT-DEEPENED (next-shard) <repo> ×<n> [#a,#b,…]   # deliberate remainder after the eight-candidate shard — carries NO pentad and keeps broad health unknown, while deepened rows remain candidate-actionable
 
 ### Advance
 - <repo>: roadmap-ready → #<n> "<title>" (<label>)

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -140,8 +140,9 @@ public and private — no per-repo loop needed to enumerate):
    undeepened remainder as `NOT-DEEPENED (budget)` rows naming the count and the repos, never a
    silent cheap row that reads like a completed assessment:
    `gh pr view <n> --repo devantler-tech/<repo> --json number,state,isDraft,updatedAt,title,mergeStateStatus,reviewDecision,statusCheckRollup,mergedAt,headRefName,headRefOid,headRepositoryOwner,headRepository,author,body,files`
-   After eight successful candidate joins, stop deepening and emit the ordered remainder as
-   `NOT-DEEPENED (next-shard)` rows. A later failed or deferred join makes global health unknown, but
+   After eight candidate deepening attempts, whether each join succeeded or failed, stop deepening
+   and emit the ordered remainder as `NOT-DEEPENED (next-shard)` rows. A later failed or deferred join
+   makes global health unknown, but
    **deepened rows remain candidate-actionable** once their own exact head, pentad, control facts and
    repository default-head health are complete. It never turns the remainder into a global mutation
    lock. Because PRs outrank issues, **issue descent remains blocked** until every actionable PR is

--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -140,8 +140,18 @@ public and private — no per-repo loop needed to enumerate):
    undeepened remainder as `NOT-DEEPENED (budget)` rows naming the count and the repos, never a
    silent cheap row that reads like a completed assessment:
    `gh pr view <n> --repo devantler-tech/<repo> --json number,state,isDraft,updatedAt,title,mergeStateStatus,reviewDecision,statusCheckRollup,mergedAt,headRefName,headRefOid,headRepositoryOwner,headRepository,author,body,files`
+   The orchestration prompt may supply the prior digest's `SHARD-CURSOR` plus an explicit classified
+   set from this run or the engineer's native-memory continuation record. Rebuild the cheap live queue
+   first, compare every supplied `repo#PR@head@updatedAt` tuple with live discovery, and **filter the explicitly supplied classified set before selecting the next eight** only while every tuple still
+   matches. A candidate that is absent from the open queue gets one bounded current-state read: a
+   **verified closed or merged is pruned from the supplied set**; an unreadable/missing result fails
+   closed and invalidates it. A changed-head or changed-`updatedAt` tuple is stale: **invalidate the supplied state and restart at the earliest changed candidate**, never skip it behind the cursor. With no
+   supplied state, begin at the first ordered candidate. State is a progress hint, not clearance:
+   only the candidate's freshly joined evidence can clear mutation.
+
    After eight candidate deepening attempts, whether each join succeeded or failed, stop deepening
-   and emit the ordered remainder as `NOT-DEEPENED (next-shard)` rows. A later failed or deferred join
+   and emit the ordered remainder as `NOT-DEEPENED (next-shard)` rows plus the resumable cursor shape
+   defined below. A later failed or deferred join
    makes global health unknown, but
    **deepened rows remain candidate-actionable** once their own exact head, pentad, control facts and
    repository default-head health are complete. It never turns the remainder into a global mutation
@@ -1286,7 +1296,7 @@ Markdown; **omit products with no signal entirely** (don't echo empty lists):
 
 ```
 ## Survey digest — <UTC date>
-nothing_on_fire: <true|false|unknown>   # true only if NO CI red on main AND no actionable PR broken, whoever authored it; a GITHUB-MANAGED (NO-ACTION) line never makes this false — nor does its GITHUB-MANAGED-SCAN (NO-ACTION) specialisation — but a (REPEATED — ACTIONABLE) one does. 🔴 EMIT `unknown` WHENEVER ANY `NOT-DEEPENED (budget)`, `NOT-DEEPENED (next-shard)`, OR `DISCOVERY-TRUNCATED (prs, 300 cap)` ROW EXISTS (the issue-truncation row never affects this field): `true` asserts that no actionable PR is broken, which a survey that never assessed those PRs cannot know. `false` is equally wrong — it claims a fire nobody observed. `unknown` is the only honest value. It blocks declaring the portfolio healthy and blocks issue descent; it does not block acting on fully joined deepened rows.
+nothing_on_fire: <true|false|unknown>   # true only if NO CI red on main AND no actionable PR broken, whoever authored it; a GITHUB-MANAGED (NO-ACTION) line never makes this false — nor does its GITHUB-MANAGED-SCAN (NO-ACTION) specialisation — but a (REPEATED — ACTIONABLE) one does. 🔴 EMIT `unknown` WHENEVER ANY `QUERY-UNKNOWN`, `NOT-DEEPENED (budget)`, `NOT-DEEPENED (next-shard)`, OR `DISCOVERY-TRUNCATED (prs, 300 cap)` ROW EXISTS (the issue-truncation row never affects this field): `true` asserts that no actionable PR is broken, which a survey that never assessed those PRs cannot know. `false` is equally wrong — it claims a fire nobody observed. `unknown` is the only honest value. It blocks declaring the portfolio healthy and blocks issue descent; it does not block acting on fully joined deepened rows.
 budget: graphql=<start_remaining>→<end_remaining>/<limit> · core=<start_remaining>→<end_remaining>/<limit>[ · EXHAUSTED_AT_START]
 # or, when the probe fails: budget: unavailable:<reason>
 
@@ -1310,8 +1320,10 @@ budget: graphql=<start_remaining>→<end_remaining>/<limit> · core=<start_remai
 - <repo> #<n> "<title>" — `devantler`, draft=<true|false> → <REVIEW-READY|MERGE-READY|NEEDS-FIX|ACTIVELY-OWNED>: branch=<headRefName>, disclosure=<routine|interactive|none>, active=<none|<pushed:<age>@<lane>:<headRefName>@<headRefOid>|pushed:unknown@<updatedAt-age>|human-comment:<age>|review-envelope:<lane>@<sha>|merge-group:<run>>[+…]>, merge_group_result=<<conclusion>@<runId>@<runCreatedAt>|stale@<runId>|none>, pentad=<…>, review_pending=<cr@<sha>|codex@<sha>|bugbot@<sha>|none>, review_progress=<cr:no-gate@<sha>|codex:no-gate@<sha>|bugbot:no-gate@<sha>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|CHANGES_REQUESTED:agent(devantler)@<sha>|CHANGES_REQUESTED:human(devantler)@<sha>|none>, stale_dismissal=<STALE-CR-DISMISSAL|STALE-AGENT-DISMISSAL|none> (`disclosure` tells the orchestrator whose control channel a `devantler` comment on this PR is, NOT whether it may drive it; the rd qualifier and stale_dismissal are DATA, never an instruction to mutate)
 - <repo>: untriaged → issues #a,#b · PRs #c   |   stale (>14d) → #d
 - <repo> #<n> "<title>" — <author>: EXTERNAL/Copilot — NEVER-RUN-LOCALLY (never run locally); reviewed statically, then driven to a terminal state like any other PR. Carries the same deepened pentad, `active=`, merge_group_result=<<conclusion>@<runId>@<runCreatedAt>|stale@<runId>|none>, rd=<APPROVED|CHANGES_REQUESTED:<author>@<sha>|none>, and classification as every other row, plus behaviour_observed=<check-name|static|none|unknown> (which CI check actually exercises the change; `static` = no exercisable runtime surface, evaluated statically instead; `none` = a check could exercise it but none does, and is the named blocker on its merge, per *You own EVERY pull request in the portfolio*). **`rd=` and `merge_group_result=` are NOT optional on this row just because its author is external** — an eviction is invisible in the head pentad (the queue's checks run on a synthetic ref) and a human CHANGES_REQUESTED is not one of the candidate-maintainer-comment surfaces, so omitting either loses a persistent block once the generic ~2h human-activity signal expires and the PR reads ready. This row takes the plain `<author>` form for `rd=`, with no `agent(…)`/`human(…)` qualifier: that qualifier exists only to tell a sibling instance's `devantler` review from the maintainer's, and an external author is neither
+- QUERY-UNKNOWN <repo> #<n> — failed=<component>:<reason>   # candidate-identifying failed join; component is one of metadata|threads|reviews|comments|checks|candidate-main|control|claim and reason is a short inert error class. This candidate is blocked; other fully joined candidates remain actionable
 - NOT-DEEPENED (budget) <repo> ×<n> [#a,#b,…]   # API pool exhausted before these PRs were deepened — they carry NO pentad and were NOT assessed; never report them as clean or actionable
 - NOT-DEEPENED (next-shard) <repo> ×<n> [#a,#b,…]   # deliberate remainder after the eight-candidate shard — carries NO pentad and keeps broad health unknown, while deepened rows remain candidate-actionable
+- SHARD-CURSOR next=<repo>#<n>|none · classified=[<repo>#<n>@<head>@<updatedAt>,…] · remaining=<n>   # exact resumable continuation state for the orchestrator; includes joined terminal or named-blocker candidates and candidate-scoped failed joins attempted in this shard, never an unjoined remainder
 
 ### Advance
 - <repo>: roadmap-ready → #<n> "<title>" (<label>)

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -502,6 +502,10 @@ assert_maintenance_prose 'never block an independently fully joined candidate' \
   "portfolio maintenance still permits unrelated query failures to freeze cleared work"
 assert_maintenance_prose 'issue descent remains blocked until the actionable-PR queue is completely classified' \
   "portfolio maintenance can descend into issues while higher-priority PR state is unknown"
+assert_maintenance_prose 'pass the prior digest' \
+  "portfolio maintenance does not pass continuation state when requesting the next survey shard"
+assert_maintenance_prose 'cursor is invalidated when any recorded candidate head changes' \
+  "portfolio maintenance can reuse stale shard state after a candidate head changes"
 # A `per_task_limit` record is a per-MINUTE liveness sample of "a run is currently open",
 # not a per-slot drop record — so counting those records, raw or hour-bucketed, counts a
 # slot that merely started LATE as one that never ran. Measured 2026-08-12 over 164 slots:

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -33,6 +33,7 @@ fail() {
 flatten() { tr '\n' ' ' < "$1" | tr -s '[:space:]' ' '; }
 constitution_flat="$(flatten "${constitution}")"
 engineer_flat="$(flatten "${engineer_agent}")"
+maintenance_overlay_flat="$(flatten "${maintenance_overlay}")"
 
 assert_prose() {
   case "${constitution_flat}" in
@@ -42,6 +43,12 @@ assert_prose() {
 }
 assert_engineer_prose() {
   case "${engineer_flat}" in
+    *"$1"*) ;;
+    *) fail "$2" ;;
+  esac
+}
+assert_maintenance_prose() {
+  case "${maintenance_overlay_flat}" in
     *"$1"*) ;;
     *) fail "$2" ;;
   esac
@@ -477,6 +484,24 @@ assert_prose 'same-lane task presence or post-start activity alone is never a gl
   "cadence still permits a scheduled role to no-op merely because another same-lane task is active"
 assert_prose 'a live conflicting claim, exact shared-artifact contention, or an unsafe runtime-local mutation' \
   "cadence does not preserve the artifact-scoped conditions that still require stand-down"
+
+# A complete portfolio census is health evidence, not a global mutation lease. Measured survey runs
+# repeatedly stopped after one of 80+ unrelated PR joins failed or hit a cap, even though earlier
+# candidates already had complete head, control, claim, CI, conflict, and review evidence. Clearance
+# must therefore be candidate-scoped: preserve UNKNOWN for the failed join and for broad health/issue
+# descent, while continuing through the ordered PR queue with fully joined independent candidates.
+assert_maintenance_prose 'Clearance is per candidate, never per portfolio' \
+  "portfolio maintenance still couples all mutation to a complete portfolio-wide join"
+assert_maintenance_prose 'cheap exhaustive enumeration' \
+  "portfolio maintenance does not separate cheap ordering from candidate deepening"
+assert_maintenance_prose "candidate repository's default-head health" \
+  "candidate clearance does not preserve repository-local default-head safety evidence"
+assert_maintenance_prose 'unrelated failed or capped joins remain `QUERY-UNKNOWN`' \
+  "portfolio maintenance does not preserve uncertainty for incomplete unrelated joins"
+assert_maintenance_prose 'never block an independently fully joined candidate' \
+  "portfolio maintenance still permits unrelated query failures to freeze cleared work"
+assert_maintenance_prose 'issue descent remains blocked until the actionable-PR queue is completely classified' \
+  "portfolio maintenance can descend into issues while higher-priority PR state is unknown"
 # A `per_task_limit` record is a per-MINUTE liveness sample of "a run is currently open",
 # not a per-slot drop record — so counting those records, raw or hour-bucketed, counts a
 # slot that merely started LATE as one that never ran. Measured 2026-08-12 over 164 slots:

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -468,6 +468,15 @@ assert_prose 'Codex dispatched 161/161' \
   "cadence does not state the Codex control that makes the shortfall a lane asymmetry"
 assert_prose 'never time anything off' \
   "cadence does not tell a run to stop planning against the next scheduled tick"
+
+# Same-lane schedules deliberately overlap and share one writer namespace. Mere task presence or
+# post-start activity is therefore not a global stop signal: the claim protocol must arbitrate the
+# exact artifact instead. Pin both arms so a future edit cannot restore starvation or erase the
+# scoped conflict fence while preserving progress.
+assert_prose 'same-lane task presence or post-start activity alone is never a global stand-down condition' \
+  "cadence still permits a scheduled role to no-op merely because another same-lane task is active"
+assert_prose 'a live conflicting claim, exact shared-artifact contention, or an unsafe runtime-local mutation' \
+  "cadence does not preserve the artifact-scoped conditions that still require stand-down"
 # A `per_task_limit` record is a per-MINUTE liveness sample of "a run is currently open",
 # not a per-slot drop record — so counting those records, raw or hour-bucketed, counts a
 # slot that merely started LATE as one that never ran. Measured 2026-08-12 over 164 slots:

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -500,6 +500,12 @@ assert_maintenance_prose 'unrelated failed or capped joins remain `QUERY-UNKNOWN
   "portfolio maintenance does not preserve uncertainty for incomplete unrelated joins"
 assert_maintenance_prose 'never block an independently fully joined candidate' \
   "portfolio maintenance still permits unrelated query failures to freeze cleared work"
+assert_maintenance_prose 'A candidate repository query failure blocks that candidate' \
+  "portfolio maintenance can act after the candidate repository query fails"
+assert_maintenance_prose 'An attempted in-shard join failure emits `QUERY-UNKNOWN <repo> #<n> — failed=<component>:<reason>`' \
+  "portfolio maintenance does not define the candidate-scoped producer row for failed joins"
+assert_maintenance_prose 'never-attempted candidates remain `NOT-DEEPENED`' \
+  "portfolio maintenance conflates failed attempted joins with candidates outside the shard"
 assert_maintenance_prose 'issue descent remains blocked until the actionable-PR queue is completely classified' \
   "portfolio maintenance can descend into issues while higher-priority PR state is unknown"
 assert_maintenance_prose 'pass the prior digest' \

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -1255,6 +1255,24 @@ grep -Fq 'invalidate the supplied state and restart at the earliest changed cand
 grep -Fq 'verified closed or merged is pruned from the supplied set' "${surveyor}" ||
   fail "surveyor treats a terminal candidate as cursor corruption and restarts completed shards"
 
+# Behavioural continuation fixture: an unchanged ten-candidate queue must select disjoint shards,
+# not merely carry words such as cursor or classified in the contract.
+stable_queue=(repo#1 repo#2 repo#3 repo#4 repo#5 repo#6 repo#7 repo#8 repo#9 repo#10)
+first_shard=("${stable_queue[@]:0:8}")
+classified=" ${first_shard[*]} "
+second_shard=()
+for candidate in "${stable_queue[@]}"; do
+  case "${classified}" in
+    *" ${candidate} "*) continue ;;
+  esac
+  second_shard+=("${candidate}")
+  [ "${#second_shard[@]}" -eq 8 ] && break
+done
+[ "${first_shard[*]}" = 'repo#1 repo#2 repo#3 repo#4 repo#5 repo#6 repo#7 repo#8' ] ||
+  fail "continuation fixture selected an unexpected first shard"
+[ "${second_shard[*]}" = 'repo#9 repo#10' ] ||
+  fail "continuation fixture repeated classified candidates instead of advancing"
+
 # monorepo#2482 — every agent instance reviews as `devantler`, so an `rd=` rule keyed on the login
 # alone reports a sibling instance's own superseded CHANGES_REQUESTED as a permanent human gate and
 # parks a finished PR. Measured live on monorepo#2432: a disclosed agent review blocked the PR for

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -2065,8 +2065,28 @@ case "${surveyor_flat}" in
   *) fail "the digest cannot express an unassessed portfolio" ;;
 esac
 case "${surveyor_flat}" in
-  *'EMIT `unknown` WHENEVER ANY `NOT-DEEPENED (budget)` OR `DISCOVERY-TRUNCATED (prs, 300 cap)` ROW EXISTS'*) ;;
+  *'EMIT `unknown` WHENEVER ANY `NOT-DEEPENED (budget)`, `NOT-DEEPENED (next-shard)`, OR `DISCOVERY-TRUNCATED (prs, 300 cap)` ROW EXISTS'*) ;;
   *) fail "the digest may still claim nothing_on_fire while PRs went unassessed or undiscovered" ;;
+esac
+# A survey that tries to deepen the whole portfolio before returning can spend the complete dispatch
+# on joins and deliver no candidate to the writer. Bound the expensive shard, preserve global UNKNOWN,
+# and make the already-deepened rows explicitly usable instead of treating the remainder as a global
+# mutation lock.
+case "${surveyor_flat}" in
+  *'at most eight actionable PRs per digest'*) ;;
+  *) fail "the surveyor still attempts an unbounded all-PR deepening pass before returning" ;;
+esac
+case "${surveyor_flat}" in
+  *'NOT-DEEPENED (next-shard)'*) ;;
+  *) fail "the digest cannot distinguish deliberate bounded deferral from API-budget exhaustion" ;;
+esac
+case "${surveyor_flat}" in
+  *'deepened rows remain candidate-actionable'*) ;;
+  *) fail "the surveyor still lets an incomplete later shard freeze fully joined candidates" ;;
+esac
+case "${surveyor_flat}" in
+  *'issue descent remains blocked'*) ;;
+  *) fail "the surveyor can descend into issues while the higher-priority PR queue is incomplete" ;;
 esac
 # Truncated discovery is unassessed coverage exactly as an undeepened PR is, so both must drive the
 # health field — but only the PR one. Pinning the issue row's EXCLUSION matters as much: issues are

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -2077,6 +2077,10 @@ case "${surveyor_flat}" in
   *) fail "the surveyor still attempts an unbounded all-PR deepening pass before returning" ;;
 esac
 case "${surveyor_flat}" in
+  *'After eight candidate deepening attempts, whether each join succeeded or failed'*) ;;
+  *) fail "failed joins can still evade the eight-candidate deepening bound" ;;
+esac
+case "${surveyor_flat}" in
   *'NOT-DEEPENED (next-shard)'*) ;;
   *) fail "the digest cannot distinguish deliberate bounded deferral from API-budget exhaustion" ;;
 esac

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -1242,6 +1242,19 @@ grep -Fq 'Do not gate this scan on assignees' "${surveyor}" ||
 grep -Fq 'none(cursor-lane)' "${surveyor}" ||
   fail "surveyor CLAIMED digest does not allow cursor-lane branch-only claims"
 
+# Candidate-scoped clearance must have a producer grammar, and bounded survey continuation must
+# advance past already classified or named-blocker rows without trusting stale head state.
+grep -Fq 'QUERY-UNKNOWN <repo> #<n> — failed=<component>:<reason>' "${surveyor}" ||
+  fail "surveyor cannot emit a candidate-identifying failed-join row"
+grep -Fq 'SHARD-CURSOR next=' "${surveyor}" ||
+  fail "surveyor does not emit resumable shard state"
+grep -Fq 'filter the explicitly supplied classified set before selecting the next eight' "${surveyor}" ||
+  fail "surveyor can restart at the same first shard indefinitely"
+grep -Fq 'invalidate the supplied state and restart at the earliest changed candidate' "${surveyor}" ||
+  fail "surveyor can skip a candidate after its recorded head changes"
+grep -Fq 'verified closed or merged is pruned from the supplied set' "${surveyor}" ||
+  fail "surveyor treats a terminal candidate as cursor corruption and restarts completed shards"
+
 # monorepo#2482 — every agent instance reviews as `devantler`, so an `rd=` rule keyed on the login
 # alone reports a sibling instance's own superseded CHANGES_REQUESTED as a permanent human gate and
 # parks a finished PR. Measured live on monorepo#2432: a disclosed agent review blocked the PR for
@@ -2065,7 +2078,7 @@ case "${surveyor_flat}" in
   *) fail "the digest cannot express an unassessed portfolio" ;;
 esac
 case "${surveyor_flat}" in
-  *'EMIT `unknown` WHENEVER ANY `NOT-DEEPENED (budget)`, `NOT-DEEPENED (next-shard)`, OR `DISCOVERY-TRUNCATED (prs, 300 cap)` ROW EXISTS'*) ;;
+  *'EMIT `unknown` WHENEVER ANY `QUERY-UNKNOWN`, `NOT-DEEPENED (budget)`, `NOT-DEEPENED (next-shard)`, OR `DISCOVERY-TRUNCATED (prs, 300 cap)` ROW EXISTS'*) ;;
   *) fail "the digest may still claim nothing_on_fire while PRs went unassessed or undiscovered" ;;
 esac
 # A survey that tries to deepen the whole portfolio before returning can spend the complete dispatch

--- a/.claude/scripts/work-priority-ladder.test.sh
+++ b/.claude/scripts/work-priority-ladder.test.sh
@@ -349,6 +349,12 @@ assert_prose 'never an execution of its branch' \
 # was assessed and found unremarkable, so the run reads a coverage gap as a clean bill of health.
 assert_prose 'NOT-DEEPENED (budget)' \
   "${surveyor_flat}" "the surveyor may drop PRs on budget exhaustion without declaring the gap"
+assert_prose 'SHARD-CURSOR next=' \
+  "${surveyor_flat}" "the surveyor does not return a continuation cursor for the next bounded shard"
+assert_prose 'filter the explicitly supplied classified set before selecting the next eight' \
+  "${surveyor_flat}" "the surveyor can repeatedly deepen the same parked PRs and starve later shards"
+assert_prose 'QUERY-UNKNOWN <repo> #<n> — failed=<component>:<reason>' \
+  "${surveyor_flat}" "the surveyor digest cannot identify the candidate and failed join component"
 
 # The ownership gate keyed on the orchestrator's creation record — which the surveyor cannot read,
 # and which NO maintainer-authored PR can ever satisfy, so it structurally parked exactly the PRs the

--- a/.claude/scripts/work-priority-ladder.test.sh
+++ b/.claude/scripts/work-priority-ladder.test.sh
@@ -328,11 +328,15 @@ assert_prose 'Author trust decides EXECUTION, never deepening' \
 # candidates and trusted bots, while its own pentad line two paragraphs later demanded that evidence
 # for every actionable PR whoever authored it. One file, two selectors, disagreeing — so a run
 # following the overlay literally reports a pentad it never fetched for exactly the PRs the
-# 2026-08-08 grant made it responsible for.
+# 2026-08-08 grant made it responsible for. Deepening is now sharded for bounded latency, so pin both
+# the inclusive queue and the deterministic shard instead of requiring one digest to join the whole
+# queue at once.
 assert_absent 'candidate/actionable trusted-bot PR' \
   "${skill_flat}" "the maintenance skill still deepens only devantler/trusted-bot PRs"
-assert_prose 'deepens every remaining open actionable PR' \
-  "${skill_flat}" "the maintenance skill no longer deepens every actionable PR regardless of author"
+assert_prose 'full hygiene pentad for EVERY open actionable PR whoever authored it' \
+  "${skill_flat}" "the maintenance skill no longer covers every actionable PR regardless of author"
+assert_prose 'deepens that queue in deterministic priority order, one bounded shard at a time' \
+  "${skill_flat}" "the maintenance skill no longer deepens the inclusive queue in bounded deterministic shards"
 # ...and here too the widening must RESCOPE execution trust, not delete it: deepening an external PR
 # reads the GitHub API, which is not running its branch. Without this the negative above could be
 # satisfied by dropping the distinction entirely.

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -131,10 +131,11 @@ after a side-by-side run proves parity against the checklist in
 Configure the plugin surveyor from this repo's `AGENTS.md` contract sections (*Portfolio map*,
 *Trust gate*, *Cadence*, *Memory*, *Maintainer channels*). The surveyor:
 - enumerates org-wide in two calls (`gh search prs/issues --owner devantler-tech --state open …`)
-  instead of looping `gh pr/issue list` per repo; exact `renovate[bot]`/`dependabot[bot]` search authors
-  are **automation-owned dependency PRs** and get only a compact `AUTOMATION-OWNED (NO-ACTION)` line,
-  with no pentad deepening or agent action; then it **deepens every remaining open actionable PR —
-  drafts and promoted, whoever authored it —** with a targeted
+  instead of looping `gh pr/issue list` per repo. This **cheap exhaustive enumeration** establishes
+  the complete actionable-PR queue and its contract priority before expensive joins begin. Exact
+  `renovate[bot]`/`dependabot[bot]` search authors are **automation-owned dependency PRs** and get only
+  a compact `AUTOMATION-OWNED (NO-ACTION)` line, with no pentad deepening or agent action. It then
+  deepens that queue in deterministic priority order, one bounded shard at a time, with a targeted
   `gh pr view <n> --json …mergeStateStatus,reviewDecision,statusCheckRollup,headRefOid`. **The only
   exclusion is the exact `renovate[bot]`/`dependabot[bot]` automation identity above**: since the
   orchestrator drives every other open PR to a terminal state, a selector limited to `devantler` and
@@ -146,8 +147,20 @@ Configure the plugin surveyor from this repo's `AGENTS.md` contract sections (*P
   and `disclosure` and emits **no ownership verdict**: that field tells the orchestrator whose control
   channel a `devantler` comment on the PR is, and is never a gate on whether it may drive the PR —
   which the data-only active-work signals decide;
-- checks **CI red on `main`** per repo with one bounded `gh run list --branch main --status failure
-  --limit 3` each;
+- applies this non-negotiable query boundary: **Clearance is per candidate, never per portfolio.** A
+  candidate is action-clear only when its own exact head, hygiene pentad, control/claim facts, and the
+  **candidate repository's default-head health** are complete. Any unrelated failed or capped joins
+  remain `QUERY-UNKNOWN` in the digest and keep broad portfolio health unknown, but they **never block
+  an independently fully joined candidate**. A failed candidate join blocks that candidate only; move
+  to the next item in the already-established queue and return every cleared row plus each scoped
+  unknown. When the orchestrator exhausts the returned cleared rows, deepen the next bounded shard
+  rather than restarting the census. Because PRs outrank issues, **issue descent remains blocked until
+  the actionable-PR queue is completely classified** as cleared, terminal, automation-owned, or
+  parked on a named candidate-scoped blocker;
+- checks the **candidate repository's current `main` health** together with each deepening shard, then
+  continues the remaining portfolio-wide default-head sweep as broad health evidence. A candidate
+  repository query failure blocks that candidate; a different repository's failure remains the
+  scoped `QUERY-UNKNOWN` described above and does not revoke already-complete candidate clearance;
 - enforces the **portfolio boundary**: it never enumerates PRs across other organisations or runs a
   broad author-based search, because scheduled discovery must not expose professional-work repos;
 - flags untriaged issues/PRs, stale actionable PRs (>14d), `roadmap`-ready issues, and products with

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -154,7 +154,13 @@ Configure the plugin surveyor from this repo's `AGENTS.md` contract sections (*P
   an independently fully joined candidate**. A failed candidate join blocks that candidate only; move
   to the next item in the already-established queue and return every cleared row plus each scoped
   unknown. When the orchestrator exhausts the returned cleared rows, deepen the next bounded shard
-  rather than restarting the census. Because PRs outrank issues, **issue descent remains blocked until
+  rather than restarting the census: **pass the prior digest's `SHARD-CURSOR` and explicit
+  `repo#PR@head@updatedAt` classified set into the next surveyor prompt**. Persist only the cursor and
+  unchanged named-blocker tuples in native memory across scheduled sessions; candidate-scoped query
+  failures are retried next session. The surveyor always rebuilds cheap discovery, and the **cursor is
+  invalidated when any recorded candidate head changes** (or its discovery `updatedAt` changes), so
+  stale progress can delay neither a new commit nor new control/review activity. Clear the cursor on
+  wrap (`next=none`) and start a fresh ordered pass. Because PRs outrank issues, **issue descent remains blocked until
   the actionable-PR queue is completely classified** as cleared, terminal, automation-owned, or
   parked on a named candidate-scoped blocker;
 - checks the **candidate repository's current `main` health** together with each deepening shard, then

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -153,7 +153,10 @@ Configure the plugin surveyor from this repo's `AGENTS.md` contract sections (*P
   remain `QUERY-UNKNOWN` in the digest and keep broad portfolio health unknown, but they **never block
   an independently fully joined candidate**. A failed candidate join blocks that candidate only; move
   to the next item in the already-established queue and return every cleared row plus each scoped
-  unknown. When the orchestrator exhausts the returned cleared rows, deepen the next bounded shard
+  unknown. **An attempted in-shard join failure emits `QUERY-UNKNOWN <repo> #<n> — failed=<component>:<reason>`;
+  never-attempted candidates remain `NOT-DEEPENED`** with the budget or next-shard reason. The scoped
+  row identifies the blocked candidate and failed component without converting repository-wide state
+  into a mutation verdict. When the orchestrator exhausts the returned cleared rows, deepen the next bounded shard
   rather than restarting the census: **pass the prior digest's `SHARD-CURSOR` and explicit
   `repo#PR@head@updatedAt` classified set into the next surveyor prompt**. Persist only the cursor and
   unchanged named-blocker tuples in native memory across scheduled sessions; candidate-scoped query

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3497,7 +3497,10 @@ writes its own namespace, so both pushes succeed and both believe they won. Scan
 Claude runs exceeding 60 minutes, your own lane's next dispatch often starts before you finish. That
 case is safe by construction — same namespace, same deterministic branch name, and a non-forced push
 is refused (see *Claim protocol* rule 4) — so it needs no handling beyond never force-pushing a claim
-branch.
+branch. Therefore, same-lane task presence or post-start activity alone is never a global stand-down
+condition: continue telemetry, selection, and unrelated delivery. Stand down only for a live
+conflicting claim, exact shared-artifact contention, or an unsafe runtime-local mutation that could
+break a sibling mid-flight; keep the fence scoped to that artifact or surface and continue elsewhere.
 
 🔴 **Scheduled is not delivered — on the Claude lane about one tick in five never happens.** The two
 machine-local schedulers differ. Measured across 2026-08-02T03:50Z → 2026-08-08T19:50Z (**161 scheduled


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- scope mutation clearance to the selected repository and exact work item instead of requiring a complete portfolio-wide survey
- require a live conflicting claim, exact shared-artifact contention, or unsafe runtime-local mutation before same-lane activity can force stand-down
- bound PR deepening to eight attempted candidates per digest, whether joins succeed or fail, and carry explicit `NOT-DEEPENED(next-shard)` evidence
- keep incomplete global coverage and issue descent unknown without discarding fully joined actionable candidates
- preserve projection-freshness and every fail-closed mutation gate
- add fail-closed contract coverage for same-lane, candidate-clearance, and failed-join bound regressions

## Verification

- `bash .claude/scripts/work-priority-ladder.test.sh`
- `bash .claude/scripts/agent-role-delivery-contract.test.sh`
- `bash .claude/scripts/portfolio-surveyor.test.sh`
- `bash .claude/scripts/git-safety-contract.test.sh`
- `shellcheck -S warning .claude/scripts/work-priority-ladder.test.sh .claude/scripts/agent-role-delivery-contract.test.sh .claude/scripts/portfolio-surveyor.test.sh .claude/scripts/git-safety-contract.test.sh`
- `git diff --check origin/main...HEAD`
