### PR TITLE
fix(agents): check the definition the runtime loaded against the one we pinned

### DIFF
--- a/.claude/scripts/plugin-definition-currency.sh
+++ b/.claude/scripts/plugin-definition-currency.sh
@@ -51,8 +51,8 @@ QUIET=0
 RECOVERY="
   To resolve: populate the pinned plugin submodule with .claude/scripts/submodule-init.sh
   libraries/agent-plugins, or make gh available so the pinned tree can be read from the forge.
-  UNKNOWN means UNCHECKED, not stale: report it and carry on with the reviewed definition at the
-  pinned gitlink — it must never silently halt a run."
+  UNKNOWN means UNCHECKED: never read it as current, report it, and carry on against the reviewed
+  definition at the pinned gitlink — it must never halt a run."
 
 die() { printf 'plugin-definition-currency: %s\n' "$*" >&2; exit 2; }
 # `shift 2` on a lone trailing flag returns 1, and under `set -e` that exits the script with 1 — the
@@ -128,19 +128,26 @@ tree=""
 sub="$REPO_ROOT/$SUBMODULE_PATH"
 if [ -e "$sub" ] && git -C "$sub" cat-file -e "$GITLINK^{commit}" 2>/dev/null; then
   tree="$(git -C "$sub" ls-tree -r "$GITLINK" -- "$prefix" 2>/dev/null \
-            | awk -F'\t' '{split($1, m, " "); if (m[2]=="blob") print m[3] "\t" $2}')" \
+            | awk -F'\t' '{split($1, m, " "); if (m[2]=="blob") print m[3] "\t" m[1] "\t" $2}')" \
     || die "could not read the pinned tree $GITLINK from $sub${RECOVERY}"
 else
   command -v gh >/dev/null 2>&1 || die "commit $GITLINK is not in the local object database and gh is unavailable${RECOVERY}"
+  command -v jq >/dev/null 2>&1 || die "jq is required to read the pinned tree from the forge"
   # Derived, never hard-coded: --submodule-path is a flag, so a fixed slug here would silently query
   # a different repository than the one whose gitlink was just read.
   url="$(git -C "$REPO_ROOT" config -f .gitmodules --get "submodule.$SUBMODULE_PATH.url" 2>/dev/null)" \
     || die "no .gitmodules url for '$SUBMODULE_PATH' — cannot resolve $GITLINK from the forge${RECOVERY}"
   slug="${url##*:}"; slug="${slug##*/github.com/}"; slug="${slug%.git}"
   case "$slug" in */*) ;; *) die "could not derive an owner/repo slug from '$url'" ;; esac
-  tree="$(gh api "repos/$slug/git/trees/$GITLINK?recursive=1" \
-            --jq '.tree[] | select(.type=="blob") | [.sha,.path] | @tsv' 2>/dev/null)" \
+  raw="$(gh api "repos/$slug/git/trees/$GITLINK?recursive=1" 2>/dev/null)" \
     || die "could not read the pinned tree $GITLINK from $slug${RECOVERY}"
+  # A truncated response is a PARTIAL tree. Comparing it as if complete is a fail-open: a pinned file
+  # the API omitted is also absent from `reviewed`, so an install missing it reports CURRENT.
+  case "$(printf '%s' "$raw" | jq -r '.truncated // false')" in
+    true) die "the forge returned a TRUNCATED tree for $GITLINK — cannot verify completeness${RECOVERY}" ;;
+  esac
+  tree="$(printf '%s' "$raw" | jq -r '.tree[] | select(.type=="blob") | [.sha,.mode,.path] | @tsv')" \
+    || die "could not parse the pinned tree $GITLINK from $slug"
 fi
 [ -n "$tree" ] || die "pinned revision $GITLINK yielded no tree entries"
 
@@ -149,11 +156,11 @@ fi
 reviewed="$(printf '%s
 ' "$tree" \
   | awk -F'	' -v p="$prefix" '
-      index($2,p)==1 {
-        rel = substr($2, length(p) + 1)
-        if (rel ~ /^agents\// || rel ~ /^skills\//) print $1 "	" rel
+      index($3,p)==1 {
+        rel = substr($3, length(p) + 1)
+        if (rel ~ /^agents\// || rel ~ /^skills\//) print $1 "	" $2 "	" rel
       }' \
-  | sort -k2,2)"
+  | sort -k3,3)"
 [ -n "$reviewed" ] || die "pinned revision $GITLINK contains no definition files under $prefix"
 
 # ── compare ────────────────────────────────────────────────────────────────────
@@ -163,7 +170,7 @@ say "pinned revision : $GITLINK"
 say "installed copy  : $INSTALLED"
 say ""
 
-while IFS=$'\t' read -r rev_sha rel; do
+while IFS=$'\t' read -r rev_sha rev_mode rel; do
   [ -n "$rel" ] || continue
   checked=$((checked + 1))
   if [ ! -f "$INSTALLED/$rel" ]; then
@@ -176,8 +183,19 @@ while IFS=$'\t' read -r rev_sha rel; do
   # was measured.
   own_sha="$(git hash-object --no-filters "$INSTALLED/$rel" 2>/dev/null)" \
     || die "cannot hash the installed definition $INSTALLED/$rel"
-  if [ "$own_sha" = "$rev_sha" ]; then
+  # Mode matters as much as content: a skill helper that loses its executable bit still hashes
+  # identically, so a content-only comparison reports `match` while a SKILL.md invoking it fails.
+  case "$rev_mode" in
+    100644) want_exec=no ;;
+    100755) want_exec=yes ;;
+    *) die "pinned $rel has unsupported mode $rev_mode — cannot verify it" ;;
+  esac
+  if [ -x "$INSTALLED/$rel" ]; then have_exec=yes; else have_exec=no; fi
+  if [ "$own_sha" = "$rev_sha" ] && [ "$want_exec" = "$have_exec" ]; then
     say "match    $rel"
+  elif [ "$own_sha" = "$rev_sha" ]; then
+    say "DRIFT    $rel  content matches but mode differs (reviewed executable=$want_exec, installed executable=$have_exec)"
+    drift=$((drift + 1))
   else
     say "DRIFT    $rel  installed=${own_sha:0:12} reviewed=${rev_sha:0:12}"
     drift=$((drift + 1))
@@ -205,7 +223,7 @@ done
 while IFS= read -r path; do
   [ -n "$path" ] || continue
   rel="${path#"$INSTALLED"/}"
-  if ! printf '%s\n' "$reviewed" | awk -F'\t' -v r="$rel" '$2==r{found=1} END{exit !found}'; then
+  if ! printf '%s\n' "$reviewed" | awk -F'\t' -v r="$rel" '$3==r{found=1} END{exit !found}'; then
     say "EXTRA    $rel  (installed but absent from the pinned revision)"
     drift=$((drift + 1))
   fi

--- a/.claude/scripts/plugin-definition-currency.sh
+++ b/.claude/scripts/plugin-definition-currency.sh
@@ -231,7 +231,7 @@ for d in agents skills; do
   [ -d "$INSTALLED/$d" ] || continue
   # One quoted invocation per directory: joining them into a string and splitting it would break any
   # installPath containing whitespace, turning a MATCHING install into UNKNOWN.
-  find "$INSTALLED/$d" -type f >> "$inst_list" \
+  find "$INSTALLED/$d" \( -type f -o -type l \) >> "$inst_list" \
     || die "could not enumerate the installed definitions under $INSTALLED/$d${RECOVERY}"
 done
 

--- a/.claude/scripts/plugin-definition-currency.sh
+++ b/.claude/scripts/plugin-definition-currency.sh
@@ -69,6 +69,19 @@ command -v git >/dev/null 2>&1 || die "git is required"
 
 say() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*"; }
 
+# The SHARED classifier. Both trees must be classified by the same rule: the reviewed side treating an
+# odd path as UNKNOWN while the installed side silently ignored it would leave the same fail-open this
+# check exists to close, just mirrored. Prints definition | unclassified | outside.
+classify() {
+  case "$1" in
+    agents/*) rest="${1#agents/}"
+      case "$rest" in */*) echo unclassified ;; *.agent.md) echo definition ;; *) echo unclassified ;; esac ;;
+    skills/*) rest="${1#skills/}"
+      case "$rest" in */*/*) echo unclassified ;; */SKILL.md) echo definition ;; *) echo unclassified ;; esac ;;
+    *) echo outside ;;
+  esac
+}
+
 # ── the PINNED revision ────────────────────────────────────────────────────────
 if [ -z "$REPO_ROOT" ]; then
   REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not inside a git repository"
@@ -193,14 +206,38 @@ done <<< "$reviewed"
 
 # A definition present in the install but absent from the pin is drift too: it is a role the runtime
 # can still dispatch and the reviewed revision no longer describes.
+#
+# Enumerated WITHOUT a filename filter and classified by the shared rule above, so an installed path
+# in an unexpected shape is reported rather than skipped. The listing goes through a temp file because
+# a process substitution's exit status is not observable — an unreadable subtree would otherwise look
+# like an empty one, hiding an extra definition and allowing CURRENT.
+inst_list="$(mktemp)"
+trap 'rm -f "$inst_list"' EXIT
+inst_dirs=""
+for d in agents skills; do
+  [ -d "$INSTALLED/$d" ] && inst_dirs="$inst_dirs $INSTALLED/$d"
+done
+if [ -n "$inst_dirs" ]; then
+  # shellcheck disable=SC2086  # deliberate word splitting: zero, one or two directories
+  find $inst_dirs -type f > "$inst_list" \
+    || die "could not enumerate the installed definitions under $INSTALLED"
+fi
+
 while IFS= read -r path; do
+  [ -n "$path" ] || continue
   rel="${path#"$INSTALLED"/}"
+  case "$(classify "$rel")" in
+    outside) continue ;;
+    unclassified)
+      say "UNKNOWN  $rel  (installed, inside the definition directories, but not a shape this check can compare)"
+      unclassified=$((unclassified + 1))
+      continue ;;
+  esac
   if ! printf '%s\n' "$reviewed" | awk -F'\t' -v r="$rel" '$2==r{found=1} END{exit !found}'; then
     say "EXTRA    $rel  (installed but absent from the pinned revision)"
     drift=$((drift + 1))
   fi
-done < <(find "$INSTALLED/agents" "$INSTALLED/skills" \
-           \( -name '*.agent.md' -o -name 'SKILL.md' \) -type f 2>/dev/null | sort)
+done < <(sort "$inst_list")
 
 say ""
 if [ "$unclassified" -gt 0 ]; then

--- a/.claude/scripts/plugin-definition-currency.sh
+++ b/.claude/scripts/plugin-definition-currency.sh
@@ -44,6 +44,7 @@ SUBMODULE_PATH="libraries/agent-plugins"
 PLUGIN_ID="agentic-engineering@devantler-plugins"
 PLUGIN_NAME="agentic-engineering"
 QUIET=0
+nl="\n"
 
 # Named beside every UNKNOWN that a fresh worktree can actually hit. A guard that blocks without
 # naming the resolving action is a friction tax the deployment's own hardening rule forbids — and it
@@ -156,11 +157,15 @@ fi
 reviewed="$(printf '%s
 ' "$tree" \
   | awk -F'	' -v p="$prefix" '
+      substr($3,1,1)=="\"" { print "QUOTED" ORS; next }
       index($3,p)==1 {
         rel = substr($3, length(p) + 1)
         if (rel ~ /^agents\// || rel ~ /^skills\//) print $1 "	" $2 "	" rel
       }' \
   | sort -k3,3)"
+case "$reviewed" in
+  QUOTED*|*"${nl}QUOTED"*) die "the pinned tree contains a path git had to quote (tab, newline or backslash) — cannot verify it${RECOVERY}" ;;
+esac
 [ -n "$reviewed" ] || die "pinned revision $GITLINK contains no definition files under $prefix"
 
 # ── compare ────────────────────────────────────────────────────────────────────
@@ -173,6 +178,14 @@ say ""
 while IFS=$'\t' read -r rev_sha rev_mode rel; do
   [ -n "$rel" ] || continue
   checked=$((checked + 1))
+  if [ -L "$INSTALLED/$rel" ]; then
+    # -f, `git hash-object` and -x all FOLLOW a symlink, so a definition replaced by a link to an
+    # identical file passed every test. The pinned tree has no symlinks (an unsupported mode already
+    # fails closed), so a link here is drift by construction.
+    say "DRIFT    $rel  installed as a SYMLINK where the pinned revision has a regular file"
+    drift=$((drift + 1))
+    continue
+  fi
   if [ ! -f "$INSTALLED/$rel" ]; then
     say "MISSING  $rel  (reviewed $rev_sha — the installed copy does not have this definition at all)"
     drift=$((drift + 1))
@@ -209,7 +222,9 @@ done <<< "$reviewed"
 # in an unexpected shape is reported rather than skipped. The listing goes through a temp file because
 # a process substitution's exit status is not observable — an unreadable subtree would otherwise look
 # like an empty one, hiding an extra definition and allowing CURRENT.
-inst_list="$(mktemp)"
+# Guarded: an unwritable or exhausted TMPDIR makes mktemp exit 1 under `set -e`, and 1 is the DRIFT
+# verdict — an infrastructure failure would have been read as a finding about the install.
+inst_list="$(mktemp)" || die "could not create a temporary file (is TMPDIR writable?)"
 trap 'rm -f "$inst_list"' EXIT
 : > "$inst_list"
 for d in agents skills; do

--- a/.claude/scripts/plugin-definition-currency.sh
+++ b/.claude/scripts/plugin-definition-currency.sh
@@ -6,7 +6,7 @@
 # the gitlink against upstream `main` — but the copy the agent and skill entrypoints are actually
 # served from is a runtime-managed install with no writer at all. Its staleness is therefore
 # unbounded: nothing advances it, and nothing notices. Measured 2026-08-14 on the Claude instance,
-# all five definition files differed from the pin and had not moved in 20 days, while both existing
+# 7 of 9 definition files differed from the pin and had not moved in 20 days, while both existing
 # controls read clean. See monorepo#2847.
 #
 # READ-ONLY. It never edits, and never needs write access to, the runtime's plugin install. Refresh
@@ -19,9 +19,17 @@
 # Usage: plugin-definition-currency.sh [--repo-root DIR] [--plugins-root DIR] [--gitlink SHA]
 #                                      [--installed DIR] [--submodule-path PATH] [--quiet]
 #
-# Exit 0  every installed definition file matches the pinned revision
+# Exit 0  every pinned definition file was CLASSIFIED and MATCHED
 #      1  DRIFT — at least one differs, is missing, or is unexpected
-#      2  UNKNOWN — could not determine (usage error, unresolvable install, unreachable revision)
+#      2  UNKNOWN — could not determine (usage error, unresolvable install, unreachable revision,
+#         or a path inside the definition directories this script cannot classify)
+#
+# Any OTHER non-zero status is an unexpected internal failure under `set -e` and also means UNKNOWN.
+# Only 0 and 1 are verdicts; a caller must not read anything else as "current". The lone exception
+# is `--help`, which exits 0 without checking anything.
+#
+# Exit 0 is deliberately narrow: every pinned path under the definition directories was recognised
+# AND matched, never "everything I happened to recognise matched".
 #
 # Exit 2 is deliberately NOT exit 0. "I could not check" and "it is current" are different answers,
 # and collapsing them is how a currency check becomes decoration.
@@ -38,23 +46,25 @@ PLUGIN_NAME="agentic-engineering"
 QUIET=0
 
 die() { printf 'plugin-definition-currency: %s\n' "$*" >&2; exit 2; }
+# `shift 2` on a lone trailing flag returns 1, and under `set -e` that exits the script with 1 — the
+# code that means DRIFT. A typo would otherwise produce a silent, evidence-free stale verdict.
+need() { [ "$1" -ge 2 ] || die "missing value for $2"; }
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --repo-root) REPO_ROOT="${2:-}"; shift 2 ;;
-    --plugins-root) PLUGINS_ROOT="${2:-}"; shift 2 ;;
-    --gitlink) GITLINK="${2:-}"; shift 2 ;;
-    --installed) INSTALLED="${2:-}"; shift 2 ;;
-    --submodule-path) SUBMODULE_PATH="${2:-}"; shift 2 ;;
-    --plugin-id) PLUGIN_ID="${2:-}"; shift 2 ;;
-    --plugin-name) PLUGIN_NAME="${2:-}"; shift 2 ;;
+    --repo-root) need $# "$1"; REPO_ROOT="$2"; shift 2 ;;
+    --plugins-root) need $# "$1"; PLUGINS_ROOT="$2"; shift 2 ;;
+    --gitlink) need $# "$1"; GITLINK="$2"; shift 2 ;;
+    --installed) need $# "$1"; INSTALLED="$2"; shift 2 ;;
+    --submodule-path) need $# "$1"; SUBMODULE_PATH="$2"; shift 2 ;;
+    --plugin-id) need $# "$1"; PLUGIN_ID="$2"; shift 2 ;;
+    --plugin-name) need $# "$1"; PLUGIN_NAME="$2"; shift 2 ;;
     --quiet) QUIET=1; shift ;;
-    -h|--help) sed -n '1,30p' "$0"; exit 0 ;;
+    -h|--help) sed -n '1,34p' "$0"; exit 0 ;;
     *) die "unknown argument: $1" ;;
   esac
 done
 
-command -v jq >/dev/null 2>&1 || die "jq is required"
 command -v git >/dev/null 2>&1 || die "git is required"
 
 say() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*"; }
@@ -67,7 +77,11 @@ fi
 
 if [ -z "$GITLINK" ]; then
   # `ls-tree` prints "160000 commit <sha>\t<path>" for a gitlink. Read the sha field.
-  GITLINK="$(git -C "$REPO_ROOT" ls-tree HEAD "$SUBMODULE_PATH" | awk '$2=="commit"{print $3}')"
+  # Guarded: an explicitly-passed --repo-root that is not a git repository would otherwise abort
+  # with git's own 128 rather than the documented UNKNOWN, and that is the path every caller uses.
+  gitlink_line="$(git -C "$REPO_ROOT" ls-tree HEAD "$SUBMODULE_PATH" 2>/dev/null)" \
+    || die "cannot read HEAD in $REPO_ROOT — is it a git repository?"
+  GITLINK="$(printf '%s\n' "$gitlink_line" | awk '$2=="commit"{print $3}')"
 fi
 [ -n "$GITLINK" ] || die "no gitlink for '$SUBMODULE_PATH' at HEAD — cannot establish the pinned revision"
 
@@ -75,10 +89,15 @@ fi
 # Resolved from the runtime's own record rather than guessed from a directory listing: the cache can
 # hold several versions at once and only this file says which one is served.
 if [ -z "$INSTALLED" ]; then
+  # jq is checked HERE, not at the top: it is needed only to read the registry, and every caller
+  # that passes --installed (the whole test suite) would otherwise fail for an unrelated reason.
+  command -v jq >/dev/null 2>&1 || die "jq is required to read the runtime plugin registry"
   registry="$PLUGINS_ROOT/installed_plugins.json"
   [ -r "$registry" ] || die "cannot read the runtime plugin registry: $registry"
   # No `mapfile`: the host runs bash 3.2, where it does not exist and the array would stay empty.
-  paths="$(jq -r --arg id "$PLUGIN_ID" '.plugins[$id][]?.installPath // empty' "$registry")"
+  # Guarded: malformed JSON, or entries of an unexpected shape, make jq exit 5.
+  paths="$(jq -r --arg id "$PLUGIN_ID" '.plugins[$id][]?.installPath // empty' "$registry" 2>/dev/null)" \
+    || die "could not parse the runtime plugin registry: $registry"
   [ -n "$paths" ] || die "plugin '$PLUGIN_ID' is not installed in $registry"
   count="$(printf '%s\n' "$paths" | wc -l | tr -d ' ')"
   [ "$count" -eq 1 ] || die "plugin '$PLUGIN_ID' has $count install paths; pass --installed to pick one"
@@ -89,19 +108,37 @@ fi
 # ── the pinned revision's definition tree ──────────────────────────────────────
 # Prefer the local submodule object database (offline, no API budget). Fall back to the forge only
 # when the pinned commit is not present locally, which is the normal state of a fresh worktree.
+#
+# Both branches normalise to "<sha>TAB<path>". The local branch splits the leading
+# "<mode> <type> <sha>" on spaces but the PATH on the tab only — reading the whole line with awk's
+# default whitespace splitting truncates any path containing a space, and a truncated path is then
+# dropped by the selector and invisible on BOTH sides of the comparison.
 prefix="plugins/$PLUGIN_NAME/"
 tree=""
 sub="$REPO_ROOT/$SUBMODULE_PATH"
 if [ -e "$sub" ] && git -C "$sub" cat-file -e "$GITLINK^{commit}" 2>/dev/null; then
-  tree="$(git -C "$sub" ls-tree -r "$GITLINK" -- "$prefix" | awk '$2=="blob"{print $3"\t"$4}')"
+  tree="$(git -C "$sub" ls-tree -r "$GITLINK" -- "$prefix" 2>/dev/null \
+            | awk -F'\t' '{split($1, m, " "); if (m[2]=="blob") print m[3] "\t" $2}')" \
+    || die "could not read the pinned tree $GITLINK from $sub"
 else
   command -v gh >/dev/null 2>&1 || die "commit $GITLINK is not in the local object database and gh is unavailable"
-  tree="$(gh api "repos/devantler-tech/agent-plugins/git/trees/$GITLINK?recursive=1" \
+  # Derived, never hard-coded: --submodule-path is a flag, so a fixed slug here would silently query
+  # a different repository than the one whose gitlink was just read.
+  url="$(git -C "$REPO_ROOT" config -f .gitmodules --get "submodule.$SUBMODULE_PATH.url" 2>/dev/null)" \
+    || die "no .gitmodules url for '$SUBMODULE_PATH' — cannot resolve $GITLINK from the forge"
+  slug="${url##*:}"; slug="${slug##*/github.com/}"; slug="${slug%.git}"
+  case "$slug" in */*) ;; *) die "could not derive an owner/repo slug from '$url'" ;; esac
+  tree="$(gh api "repos/$slug/git/trees/$GITLINK?recursive=1" \
             --jq '.tree[] | select(.type=="blob") | [.sha,.path] | @tsv' 2>/dev/null)" \
-    || die "could not read the pinned tree $GITLINK from the forge"
+    || die "could not read the pinned tree $GITLINK from $slug"
 fi
 [ -n "$tree" ] || die "pinned revision $GITLINK yielded no tree entries"
 
+# A path INSIDE agents/ or skills/ that matches neither shape is emitted as UNCLASSIFIED rather than
+# dropped. Dropping it is a FAIL-OPEN: the reviewed loop would never check it and the EXTRA sweep
+# only fires when it is present, so "pinned but unrecognised AND absent from the install" would
+# report CURRENT while a whole role definition was missing from the runtime.
+#
 # The DEFINITION surface only: the agent entrypoints and skill procedures a role actually executes.
 # README and the plugin manifest are excluded on purpose — a version bump that moves no definition is
 # not a behavioural drift, and firing on it would train the reader to ignore this check.
@@ -109,12 +146,13 @@ fi
 # not portable inside an awk /…/ literal — BSD awk aborts on it, which this script did until it was
 # run for real.
 reviewed="$(printf '%s\n' "$tree" \
-  | awk -v p="$prefix" '
+  | awk -F'\t' -v p="$prefix" '
       index($2,p)==1 {
         rel = substr($2, length(p) + 1)
         n = split(rel, c, "/")
         if (n == 2 && c[1] == "agents" && rel ~ /\.agent\.md$/) print $1 "\t" rel
         else if (n == 3 && c[1] == "skills" && c[3] == "SKILL.md") print $1 "\t" rel
+        else if (c[1] == "agents" || c[1] == "skills") print "UNCLASSIFIED\t" rel
       }' \
   | sort -k2,2)"
 [ -n "$reviewed" ] || die "pinned revision $GITLINK contains no definition files under $prefix"
@@ -122,19 +160,29 @@ reviewed="$(printf '%s\n' "$tree" \
 # ── compare ────────────────────────────────────────────────────────────────────
 drift=0
 checked=0
+unclassified=0
 say "pinned revision : $GITLINK"
 say "installed copy  : $INSTALLED"
 say ""
 
 while IFS=$'\t' read -r rev_sha rel; do
   [ -n "$rel" ] || continue
+  if [ "$rev_sha" = "UNCLASSIFIED" ]; then
+    say "UNKNOWN  $rel  (inside the definition directories but not a shape this check can compare)"
+    unclassified=$((unclassified + 1))
+    continue
+  fi
   checked=$((checked + 1))
   if [ ! -f "$INSTALLED/$rel" ]; then
     say "MISSING  $rel  (reviewed $rev_sha — the installed copy does not have this definition at all)"
     drift=$((drift + 1))
     continue
   fi
-  own_sha="$(git hash-object "$INSTALLED/$rel")"
+  # --no-filters: without it a clean filter (e.g. `* text eol=lf`) normalises the content first, so
+  # a CRLF copy and its LF twin hash identically and the "byte identity" promised above is not what
+  # was measured.
+  own_sha="$(git hash-object --no-filters "$INSTALLED/$rel" 2>/dev/null)" \
+    || die "cannot hash the installed definition $INSTALLED/$rel"
   if [ "$own_sha" = "$rev_sha" ]; then
     say "match    $rel"
   else
@@ -155,12 +203,19 @@ done < <(find "$INSTALLED/agents" "$INSTALLED/skills" \
            \( -name '*.agent.md' -o -name 'SKILL.md' \) -type f 2>/dev/null | sort)
 
 say ""
+if [ "$unclassified" -gt 0 ]; then
+  say "UNKNOWN — $unclassified path(s) in the definition directories could not be classified, so this"
+  say "check cannot vouch for the installed copy. Widen the selector, or verify those paths by hand."
+  exit 2
+fi
 if [ "$drift" -eq 0 ]; then
-  say "CURRENT — $checked definition file(s) match the pinned revision."
+  say "CURRENT — $checked pinned definition(s) match the installed copy."
   exit 0
 fi
 
-say "DRIFT — $drift of $checked definition file(s) differ from the pinned revision."
+# `drift` counts EXTRA files too, which are not among the `checked` pinned definitions — so phrasing
+# this as "N of M differ" can print a count larger than its own denominator.
+say "DRIFT — $drift finding(s) across $checked pinned definition(s)."
 say ""
 say "What to do, in this order:"
 say "  1. Do NOT proceed as if the loaded definition were current. Read the reviewed definition at"

--- a/.claude/scripts/plugin-definition-currency.sh
+++ b/.claude/scripts/plugin-definition-currency.sh
@@ -45,6 +45,15 @@ PLUGIN_ID="agentic-engineering@devantler-plugins"
 PLUGIN_NAME="agentic-engineering"
 QUIET=0
 
+# Named beside every UNKNOWN that a fresh worktree can actually hit. A guard that blocks without
+# naming the resolving action is a friction tax the deployment's own hardening rule forbids — and it
+# was named on the DRIFT path but not here, which is the path an unattended run reaches first.
+RECOVERY="
+  To resolve: populate the pinned plugin submodule with .claude/scripts/submodule-init.sh
+  libraries/agent-plugins, or make gh available so the pinned tree can be read from the forge.
+  UNKNOWN means UNCHECKED, not stale: report it and carry on with the reviewed definition at the
+  pinned gitlink — it must never silently halt a run."
+
 die() { printf 'plugin-definition-currency: %s\n' "$*" >&2; exit 2; }
 # `shift 2` on a lone trailing flag returns 1, and under `set -e` that exits the script with 1 — the
 # code that means DRIFT. A typo would otherwise produce a silent, evidence-free stale verdict.
@@ -69,18 +78,6 @@ command -v git >/dev/null 2>&1 || die "git is required"
 
 say() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*"; }
 
-# The SHARED classifier. Both trees must be classified by the same rule: the reviewed side treating an
-# odd path as UNKNOWN while the installed side silently ignored it would leave the same fail-open this
-# check exists to close, just mirrored. Prints definition | unclassified | outside.
-classify() {
-  case "$1" in
-    agents/*) rest="${1#agents/}"
-      case "$rest" in */*) echo unclassified ;; *.agent.md) echo definition ;; *) echo unclassified ;; esac ;;
-    skills/*) rest="${1#skills/}"
-      case "$rest" in */*/*) echo unclassified ;; */SKILL.md) echo definition ;; *) echo unclassified ;; esac ;;
-    *) echo outside ;;
-  esac
-}
 
 # ── the PINNED revision ────────────────────────────────────────────────────────
 if [ -z "$REPO_ROOT" ]; then
@@ -132,40 +129,29 @@ sub="$REPO_ROOT/$SUBMODULE_PATH"
 if [ -e "$sub" ] && git -C "$sub" cat-file -e "$GITLINK^{commit}" 2>/dev/null; then
   tree="$(git -C "$sub" ls-tree -r "$GITLINK" -- "$prefix" 2>/dev/null \
             | awk -F'\t' '{split($1, m, " "); if (m[2]=="blob") print m[3] "\t" $2}')" \
-    || die "could not read the pinned tree $GITLINK from $sub"
+    || die "could not read the pinned tree $GITLINK from $sub${RECOVERY}"
 else
-  command -v gh >/dev/null 2>&1 || die "commit $GITLINK is not in the local object database and gh is unavailable"
+  command -v gh >/dev/null 2>&1 || die "commit $GITLINK is not in the local object database and gh is unavailable${RECOVERY}"
   # Derived, never hard-coded: --submodule-path is a flag, so a fixed slug here would silently query
   # a different repository than the one whose gitlink was just read.
   url="$(git -C "$REPO_ROOT" config -f .gitmodules --get "submodule.$SUBMODULE_PATH.url" 2>/dev/null)" \
-    || die "no .gitmodules url for '$SUBMODULE_PATH' — cannot resolve $GITLINK from the forge"
+    || die "no .gitmodules url for '$SUBMODULE_PATH' — cannot resolve $GITLINK from the forge${RECOVERY}"
   slug="${url##*:}"; slug="${slug##*/github.com/}"; slug="${slug%.git}"
   case "$slug" in */*) ;; *) die "could not derive an owner/repo slug from '$url'" ;; esac
   tree="$(gh api "repos/$slug/git/trees/$GITLINK?recursive=1" \
             --jq '.tree[] | select(.type=="blob") | [.sha,.path] | @tsv' 2>/dev/null)" \
-    || die "could not read the pinned tree $GITLINK from $slug"
+    || die "could not read the pinned tree $GITLINK from $slug${RECOVERY}"
 fi
 [ -n "$tree" ] || die "pinned revision $GITLINK yielded no tree entries"
 
-# A path INSIDE agents/ or skills/ that matches neither shape is emitted as UNCLASSIFIED rather than
-# dropped. Dropping it is a FAIL-OPEN: the reviewed loop would never check it and the EXTRA sweep
-# only fires when it is present, so "pinned but unrecognised AND absent from the install" would
-# report CURRENT while a whole role definition was missing from the runtime.
-#
-# The DEFINITION surface only: the agent entrypoints and skill procedures a role actually executes.
-# README and the plugin manifest are excluded on purpose — a version bump that moves no definition is
-# not a behavioural drift, and firing on it would train the reader to ignore this check.
-# Selected by splitting on "/" rather than by a regex: a bracket expression containing a slash is
-# not portable inside an awk /…/ literal — BSD awk aborts on it, which this script did until it was
-# run for real.
-reviewed="$(printf '%s\n' "$tree" \
-  | awk -F'\t' -v p="$prefix" '
+# README, the manifest and resources/ stay outside the surface: they sit outside these two
+# directories, so a version bump that moves no definition still does not fire.
+reviewed="$(printf '%s
+' "$tree" \
+  | awk -F'	' -v p="$prefix" '
       index($2,p)==1 {
         rel = substr($2, length(p) + 1)
-        n = split(rel, c, "/")
-        if (n == 2 && c[1] == "agents" && rel ~ /\.agent\.md$/) print $1 "\t" rel
-        else if (n == 3 && c[1] == "skills" && c[3] == "SKILL.md") print $1 "\t" rel
-        else if (c[1] == "agents" || c[1] == "skills") print "UNCLASSIFIED\t" rel
+        if (rel ~ /^agents\// || rel ~ /^skills\//) print $1 "	" rel
       }' \
   | sort -k2,2)"
 [ -n "$reviewed" ] || die "pinned revision $GITLINK contains no definition files under $prefix"
@@ -173,18 +159,12 @@ reviewed="$(printf '%s\n' "$tree" \
 # ── compare ────────────────────────────────────────────────────────────────────
 drift=0
 checked=0
-unclassified=0
 say "pinned revision : $GITLINK"
 say "installed copy  : $INSTALLED"
 say ""
 
 while IFS=$'\t' read -r rev_sha rel; do
   [ -n "$rel" ] || continue
-  if [ "$rev_sha" = "UNCLASSIFIED" ]; then
-    say "UNKNOWN  $rel  (inside the definition directories but not a shape this check can compare)"
-    unclassified=$((unclassified + 1))
-    continue
-  fi
   checked=$((checked + 1))
   if [ ! -f "$INSTALLED/$rel" ]; then
     say "MISSING  $rel  (reviewed $rev_sha — the installed copy does not have this definition at all)"
@@ -213,26 +193,18 @@ done <<< "$reviewed"
 # like an empty one, hiding an extra definition and allowing CURRENT.
 inst_list="$(mktemp)"
 trap 'rm -f "$inst_list"' EXIT
-inst_dirs=""
+: > "$inst_list"
 for d in agents skills; do
-  [ -d "$INSTALLED/$d" ] && inst_dirs="$inst_dirs $INSTALLED/$d"
+  [ -d "$INSTALLED/$d" ] || continue
+  # One quoted invocation per directory: joining them into a string and splitting it would break any
+  # installPath containing whitespace, turning a MATCHING install into UNKNOWN.
+  find "$INSTALLED/$d" -type f >> "$inst_list" \
+    || die "could not enumerate the installed definitions under $INSTALLED/$d${RECOVERY}"
 done
-if [ -n "$inst_dirs" ]; then
-  # shellcheck disable=SC2086  # deliberate word splitting: zero, one or two directories
-  find $inst_dirs -type f > "$inst_list" \
-    || die "could not enumerate the installed definitions under $INSTALLED"
-fi
 
 while IFS= read -r path; do
   [ -n "$path" ] || continue
   rel="${path#"$INSTALLED"/}"
-  case "$(classify "$rel")" in
-    outside) continue ;;
-    unclassified)
-      say "UNKNOWN  $rel  (installed, inside the definition directories, but not a shape this check can compare)"
-      unclassified=$((unclassified + 1))
-      continue ;;
-  esac
   if ! printf '%s\n' "$reviewed" | awk -F'\t' -v r="$rel" '$2==r{found=1} END{exit !found}'; then
     say "EXTRA    $rel  (installed but absent from the pinned revision)"
     drift=$((drift + 1))
@@ -240,11 +212,6 @@ while IFS= read -r path; do
 done < <(sort "$inst_list")
 
 say ""
-if [ "$unclassified" -gt 0 ]; then
-  say "UNKNOWN — $unclassified path(s) in the definition directories could not be classified, so this"
-  say "check cannot vouch for the installed copy. Widen the selector, or verify those paths by hand."
-  exit 2
-fi
 if [ "$drift" -eq 0 ]; then
   say "CURRENT — $checked pinned definition(s) match the installed copy."
   exit 0

--- a/.claude/scripts/plugin-definition-currency.sh
+++ b/.claude/scripts/plugin-definition-currency.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# plugin-definition-currency.sh — is the definition the runtime LOADED the one the consumer PINNED?
+#
+# The deployment verifies that chain everywhere except its last link. `agent-role-delivery-contract`
+# hashes the desired state against the repository submodule at the gitlink, and monorepo#2736 tracks
+# the gitlink against upstream `main` — but the copy the agent and skill entrypoints are actually
+# served from is a runtime-managed install with no writer at all. Its staleness is therefore
+# unbounded: nothing advances it, and nothing notices. Measured 2026-08-14 on the Claude instance,
+# all five definition files differed from the pin and had not moved in 20 days, while both existing
+# controls read clean. See monorepo#2847.
+#
+# READ-ONLY. It never edits, and never needs write access to, the runtime's plugin install. Refresh
+# is a runtime control-plane action (the `/plugin` marketplace update), never a cache edit.
+#
+# Comparison is by GIT BLOB IDENTITY, not by version string: a version can be bumped without the
+# definitions moving, and — the case that actually bit — the definitions can be superseded while the
+# installed version string still looks plausible.
+#
+# Usage: plugin-definition-currency.sh [--repo-root DIR] [--plugins-root DIR] [--gitlink SHA]
+#                                      [--installed DIR] [--submodule-path PATH] [--quiet]
+#
+# Exit 0  every installed definition file matches the pinned revision
+#      1  DRIFT — at least one differs, is missing, or is unexpected
+#      2  UNKNOWN — could not determine (usage error, unresolvable install, unreachable revision)
+#
+# Exit 2 is deliberately NOT exit 0. "I could not check" and "it is current" are different answers,
+# and collapsing them is how a currency check becomes decoration.
+
+set -euo pipefail
+
+REPO_ROOT=""
+PLUGINS_ROOT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins"
+GITLINK=""
+INSTALLED=""
+SUBMODULE_PATH="libraries/agent-plugins"
+PLUGIN_ID="agentic-engineering@devantler-plugins"
+PLUGIN_NAME="agentic-engineering"
+QUIET=0
+
+die() { printf 'plugin-definition-currency: %s\n' "$*" >&2; exit 2; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-root) REPO_ROOT="${2:-}"; shift 2 ;;
+    --plugins-root) PLUGINS_ROOT="${2:-}"; shift 2 ;;
+    --gitlink) GITLINK="${2:-}"; shift 2 ;;
+    --installed) INSTALLED="${2:-}"; shift 2 ;;
+    --submodule-path) SUBMODULE_PATH="${2:-}"; shift 2 ;;
+    --plugin-id) PLUGIN_ID="${2:-}"; shift 2 ;;
+    --plugin-name) PLUGIN_NAME="${2:-}"; shift 2 ;;
+    --quiet) QUIET=1; shift ;;
+    -h|--help) sed -n '1,30p' "$0"; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || die "jq is required"
+command -v git >/dev/null 2>&1 || die "git is required"
+
+say() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*"; }
+
+# ── the PINNED revision ────────────────────────────────────────────────────────
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not inside a git repository"
+fi
+[ -d "$REPO_ROOT" ] || die "repo root does not exist: $REPO_ROOT"
+
+if [ -z "$GITLINK" ]; then
+  # `ls-tree` prints "160000 commit <sha>\t<path>" for a gitlink. Read the sha field.
+  GITLINK="$(git -C "$REPO_ROOT" ls-tree HEAD "$SUBMODULE_PATH" | awk '$2=="commit"{print $3}')"
+fi
+[ -n "$GITLINK" ] || die "no gitlink for '$SUBMODULE_PATH' at HEAD — cannot establish the pinned revision"
+
+# ── the INSTALLED copy ─────────────────────────────────────────────────────────
+# Resolved from the runtime's own record rather than guessed from a directory listing: the cache can
+# hold several versions at once and only this file says which one is served.
+if [ -z "$INSTALLED" ]; then
+  registry="$PLUGINS_ROOT/installed_plugins.json"
+  [ -r "$registry" ] || die "cannot read the runtime plugin registry: $registry"
+  # No `mapfile`: the host runs bash 3.2, where it does not exist and the array would stay empty.
+  paths="$(jq -r --arg id "$PLUGIN_ID" '.plugins[$id][]?.installPath // empty' "$registry")"
+  [ -n "$paths" ] || die "plugin '$PLUGIN_ID' is not installed in $registry"
+  count="$(printf '%s\n' "$paths" | wc -l | tr -d ' ')"
+  [ "$count" -eq 1 ] || die "plugin '$PLUGIN_ID' has $count install paths; pass --installed to pick one"
+  INSTALLED="$paths"
+fi
+[ -d "$INSTALLED" ] || die "installed plugin path does not exist: $INSTALLED"
+
+# ── the pinned revision's definition tree ──────────────────────────────────────
+# Prefer the local submodule object database (offline, no API budget). Fall back to the forge only
+# when the pinned commit is not present locally, which is the normal state of a fresh worktree.
+prefix="plugins/$PLUGIN_NAME/"
+tree=""
+sub="$REPO_ROOT/$SUBMODULE_PATH"
+if [ -e "$sub" ] && git -C "$sub" cat-file -e "$GITLINK^{commit}" 2>/dev/null; then
+  tree="$(git -C "$sub" ls-tree -r "$GITLINK" -- "$prefix" | awk '$2=="blob"{print $3"\t"$4}')"
+else
+  command -v gh >/dev/null 2>&1 || die "commit $GITLINK is not in the local object database and gh is unavailable"
+  tree="$(gh api "repos/devantler-tech/agent-plugins/git/trees/$GITLINK?recursive=1" \
+            --jq '.tree[] | select(.type=="blob") | [.sha,.path] | @tsv' 2>/dev/null)" \
+    || die "could not read the pinned tree $GITLINK from the forge"
+fi
+[ -n "$tree" ] || die "pinned revision $GITLINK yielded no tree entries"
+
+# The DEFINITION surface only: the agent entrypoints and skill procedures a role actually executes.
+# README and the plugin manifest are excluded on purpose — a version bump that moves no definition is
+# not a behavioural drift, and firing on it would train the reader to ignore this check.
+# Selected by splitting on "/" rather than by a regex: a bracket expression containing a slash is
+# not portable inside an awk /…/ literal — BSD awk aborts on it, which this script did until it was
+# run for real.
+reviewed="$(printf '%s\n' "$tree" \
+  | awk -v p="$prefix" '
+      index($2,p)==1 {
+        rel = substr($2, length(p) + 1)
+        n = split(rel, c, "/")
+        if (n == 2 && c[1] == "agents" && rel ~ /\.agent\.md$/) print $1 "\t" rel
+        else if (n == 3 && c[1] == "skills" && c[3] == "SKILL.md") print $1 "\t" rel
+      }' \
+  | sort -k2,2)"
+[ -n "$reviewed" ] || die "pinned revision $GITLINK contains no definition files under $prefix"
+
+# ── compare ────────────────────────────────────────────────────────────────────
+drift=0
+checked=0
+say "pinned revision : $GITLINK"
+say "installed copy  : $INSTALLED"
+say ""
+
+while IFS=$'\t' read -r rev_sha rel; do
+  [ -n "$rel" ] || continue
+  checked=$((checked + 1))
+  if [ ! -f "$INSTALLED/$rel" ]; then
+    say "MISSING  $rel  (reviewed $rev_sha — the installed copy does not have this definition at all)"
+    drift=$((drift + 1))
+    continue
+  fi
+  own_sha="$(git hash-object "$INSTALLED/$rel")"
+  if [ "$own_sha" = "$rev_sha" ]; then
+    say "match    $rel"
+  else
+    say "DRIFT    $rel  installed=${own_sha:0:12} reviewed=${rev_sha:0:12}"
+    drift=$((drift + 1))
+  fi
+done <<< "$reviewed"
+
+# A definition present in the install but absent from the pin is drift too: it is a role the runtime
+# can still dispatch and the reviewed revision no longer describes.
+while IFS= read -r path; do
+  rel="${path#"$INSTALLED"/}"
+  if ! printf '%s\n' "$reviewed" | awk -F'\t' -v r="$rel" '$2==r{found=1} END{exit !found}'; then
+    say "EXTRA    $rel  (installed but absent from the pinned revision)"
+    drift=$((drift + 1))
+  fi
+done < <(find "$INSTALLED/agents" "$INSTALLED/skills" \
+           \( -name '*.agent.md' -o -name 'SKILL.md' \) -type f 2>/dev/null | sort)
+
+say ""
+if [ "$drift" -eq 0 ]; then
+  say "CURRENT — $checked definition file(s) match the pinned revision."
+  exit 0
+fi
+
+say "DRIFT — $drift of $checked definition file(s) differ from the pinned revision."
+say ""
+say "What to do, in this order:"
+say "  1. Do NOT proceed as if the loaded definition were current. Read the reviewed definition at"
+say "     $GITLINK and follow that, then report the drift in the run report."
+say "  2. Refresh through the runtime's own control plane — the /plugin marketplace update flow."
+say "     Never edit the plugin cache: it is read-only evidence."
+say "  3. If the refresh needs an interactive session this run cannot open, surface it to the"
+say "     maintainer on a declared channel rather than leaving it unreported."
+exit 1

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -179,12 +179,12 @@ for case_name in depth space; do
   printf 'reviewed engineer definition\n' > "${op}/agents/agentic-engineer.agent.md"
   printf 'reviewed alpha procedure\n'      > "${op}/skills/alpha/SKILL.md"
   if [ "${case_name}" = depth ]; then
-    mkdir -p "${op}/skills/group/nested"
-    printf 'a definition at an unexpected depth\n' > "${op}/skills/group/nested/SKILL.md"
+    odd_path="skills/group/nested/SKILL.md"
   else
-    mkdir -p "${op}/skills/my skill"
-    printf 'a definition whose path contains a space\n' > "${op}/skills/my skill/SKILL.md"
+    odd_path="skills/my skill/SKILL.md"
   fi
+  mkdir -p "${op}/$(dirname "${odd_path}")"
+  printf 'a definition the old shape filter would have dropped\n' > "${op}/${odd_path}"
   git -C "${odd_repo}" init -q
   git -C "${odd_repo}" config user.email t@example.invalid
   git -C "${odd_repo}" config user.name t
@@ -203,26 +203,15 @@ for case_name in depth space; do
   out="$("${script}" --repo-root "${tmp}/odd-${case_name}" --gitlink "${odd_link}" \
                      --installed "${odd_install}" 2>&1)"; rc=$?
   set -e
-  # The load-bearing property both cases share: NEVER exit 0. What each becomes afterwards differs,
-  # and the difference is the point — the two fixes are not the same fix.
+  # The load-bearing property: NEVER exit 0. Comparing every file under agents/ and skills/ means
+  # both shapes are now ordinary definitions, so each is reported MISSING rather than needing a
+  # special unclassified state — strictly stronger than the drop this case was written against.
   [ "${rc}" -ne 0 ] || fail "FAIL OPEN (${case_name}): a pinned path absent from the install reported success: ${out}"
-  if [ "${case_name}" = depth ]; then
-    # Still unrecognisable by shape, so the honest answer is UNKNOWN rather than a verdict.
-    [ "${rc}" -eq 2 ] || fail "an unclassifiable pinned path must exit 2 (UNKNOWN), got ${rc}: ${out}"
-    case "${out}" in
-      *UNCLASSIFIED*|*"could not be classified"*) ok "a pinned path at an unexpected depth exits 2, never CURRENT" ;;
-      *) fail "exit 2 but the unclassified path was not reported: ${out}" ;;
-    esac
-  else
-    # Tab-aware parsing PROMOTES this one: the path is no longer truncated, so it classifies as an
-    # ordinary skill definition and is correctly reported MISSING. Asserting UNKNOWN here would pin
-    # the bug rather than the fix.
-    [ "${rc}" -eq 1 ] || fail "a pinned path containing a space must classify and exit 1, got ${rc}: ${out}"
-    case "${out}" in
-      *"MISSING  skills/my skill/SKILL.md"*) ok "a pinned path containing a space is parsed, not dropped" ;;
-      *) fail "exit 1 but the spaced path was not named — is it still being truncated? ${out}" ;;
-    esac
-  fi
+  [ "${rc}" -eq 1 ] || fail "an odd-shaped pinned path must be compared and exit 1, got ${rc}: ${out}"
+  case "${out}" in
+    *"MISSING  ${odd_path}"*) ok "an odd-shaped pinned path (${case_name}) is compared, not dropped" ;;
+    *) fail "exit 1 but the odd-shaped path was not named (${case_name}): ${out}" ;;
+  esac
 done
 
 # ── 7c. A missing option VALUE is UNKNOWN, not DRIFT ──────────────────────────
@@ -267,23 +256,72 @@ set +e; out="$("${script}" --repo-root "${tmp}/consumer" --gitlink "${gitlink}" 
 [ "${rc}" -eq 2 ] || fail "an absent registry must exit 2, got ${rc}: ${out}"
 ok "an absent registry exits 2"
 
-# ── 7e. The INSTALLED tree is classified by the SAME rule as the pinned tree ──
-# The mirror of 7b. If the reviewed side calls an odd path UNKNOWN while the installed side quietly
-# skips it, the fail-open is not closed — only moved. A filename-filtered scan of the install did
-# exactly that.
-for odd in "skills/alpha/nested/SKILL.md" "agents/sub/nested.agent.md"; do
+# ── 7e. The INSTALLED tree is compared by the SAME rule as the pinned tree ────
+# The mirror of 7b. A filename-filtered scan of the install skipped odd-shaped installed files, so
+# the fail-open was only moved, not closed. Comparing every file under agents/ and skills/ makes each
+# an ordinary EXTRA.
+for odd in "skills/alpha/references/notes.md" "agents/sub/nested.agent.md"; do
   inst="${tmp}/install-oddshape-$(printf '%s' "${odd}" | tr '/.' '__')"
   make_install "${inst}"
   mkdir -p "${inst}/$(dirname "${odd}")"
-  printf 'a role in a shape the check cannot compare\n' > "${inst}/${odd}"
+  printf 'a file the old shape filter would have skipped
+' > "${inst}/${odd}"
   set +e; out="$(run "${inst}")"; rc=$?; set -e
-  [ "${rc}" -ne 0 ] || fail "FAIL OPEN: an unclassifiable INSTALLED path (${odd}) reported success: ${out}"
-  [ "${rc}" -eq 2 ] || fail "an unclassifiable installed path must exit 2, got ${rc}: ${out}"
+  [ "${rc}" -ne 0 ] || fail "FAIL OPEN: an odd-shaped INSTALLED path (${odd}) reported success: ${out}"
   case "${out}" in
-    *"UNKNOWN  ${odd}"*) ok "an unclassifiable installed path (${odd}) exits 2, never CURRENT" ;;
-    *) fail "exit 2 but the installed path was not named (${odd}): ${out}" ;;
+    *"EXTRA    ${odd}"*) ok "an odd-shaped installed path (${odd}) is compared, not skipped" ;;
+    *) fail "the installed path was not reported (${odd}): ${out}" ;;
   esac
 done
+
+# ── 7f. A supporting file in a skill package is part of the surface ───────────
+# A SKILL.md can read or execute files beside it, so their drift is behaviourally relevant. Comparing
+# only depth-three SKILL.md would miss it AND would have pinned the check at permanent UNKNOWN the
+# first time upstream shipped a reference file.
+sup_repo="${tmp}/sup/libraries/agent-plugins"
+sp="${sup_repo}/plugins/agentic-engineering"
+mkdir -p "${sp}/agents" "${sp}/skills/alpha/references"
+printf 'reviewed engineer definition
+' > "${sp}/agents/agentic-engineer.agent.md"
+printf 'reviewed alpha procedure
+'      > "${sp}/skills/alpha/SKILL.md"
+printf 'reviewed reference material
+'   > "${sp}/skills/alpha/references/notes.md"
+git -C "${sup_repo}" init -q
+git -C "${sup_repo}" config user.email t@example.invalid
+git -C "${sup_repo}" config user.name t
+git -C "${sup_repo}" add -A
+git -C "${sup_repo}" commit -qm pin
+sup_link="$(git -C "${sup_repo}" rev-parse HEAD)"
+sup_inst="${tmp}/install-sup"
+mkdir -p "${sup_inst}"
+cp -R "${sp}/agents" "${sp}/skills" "${sup_inst}/"
+# Identical package must be CURRENT -- the permanent-UNKNOWN regression this guards against.
+if out="$("${script}" --repo-root "${tmp}/sup" --gitlink "${sup_link}" --installed "${sup_inst}" 2>&1)"; then
+  ok "a skill package with supporting files reports CURRENT when identical"
+else
+  fail "an identical multi-file skill package must exit 0, got $?: ${out}"
+fi
+# ...and a drifted supporting file must be caught.
+printf 'superseded reference material
+' > "${sup_inst}/skills/alpha/references/notes.md"
+set +e; out="$("${script}" --repo-root "${tmp}/sup" --gitlink "${sup_link}" --installed "${sup_inst}" 2>&1)"; rc=$?; set -e
+[ "${rc}" -eq 1 ] || fail "a drifted supporting file must exit 1, got ${rc}: ${out}"
+case "${out}" in
+  *"DRIFT    skills/alpha/references/notes.md"*) ok "a drifted supporting file inside a skill is caught" ;;
+  *) fail "exit 1 but the supporting file was not named: ${out}" ;;
+esac
+
+# ── 7g. An install path containing WHITESPACE still resolves ──────────────────
+# Enumerating the two directories through a joined, deliberately word-split string turned a MATCHING
+# install under such a path into UNKNOWN.
+ws="${tmp}/my install dir"
+make_install "${ws}"
+if out="$(run "${ws}")"; then
+  ok "an install path containing spaces reports CURRENT, not UNKNOWN"
+else
+  fail "an install path containing spaces must exit 0, got $?: ${out}"
+fi
 
 # ── 8. The remediation is NAMED in the failure output ─────────────────────────
 # The deployment's own "fail with the fix" rule: a guard that blocks without naming the resolving
@@ -330,8 +368,14 @@ case "${section}" in
   *) fail "the plugin contract section does not name the UNKNOWN (exit 2) verdict" ;;
 esac
 case "${section}" in
-  *"never as current"*) ok "the contract says UNKNOWN is not current" ;;
+  *"never read it as current"*) ok "the contract says UNKNOWN is not current" ;;
   *) fail "the plugin contract section does not say an UNKNOWN result must not be read as current" ;;
+esac
+# UNKNOWN must also not become a stop condition — a diagnostic that halts every plugin-sourced role
+# is the passive self-blocking this contract forbids elsewhere.
+case "${section}" in
+  *"never let it halt a run"*) ok "the contract says UNKNOWN must not halt a run" ;;
+  *) fail "the plugin contract section does not say an UNKNOWN must not halt a run" ;;
 esac
 # The needle is the FLOW, not the bare "/plugin" token: that token also appears in
 # `.claude/plugin-consumption/...` and in this check's own path, so a bare match is satisfied by

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -323,6 +323,67 @@ else
   fail "an install path containing spaces must exit 0, got $?: ${out}"
 fi
 
+# ── 7h. MODE is compared, not just content ───────────────────────────────────
+# A skill helper that loses its executable bit hashes identically, so a content-only comparison
+# reports `match` and the verdict is CURRENT — while a SKILL.md invoking that helper fails.
+mode_repo="${tmp}/mode/libraries/agent-plugins"
+mp="${mode_repo}/plugins/agentic-engineering"
+mkdir -p "${mp}/agents" "${mp}/skills/alpha"
+printf 'reviewed engineer definition\n' > "${mp}/agents/agentic-engineer.agent.md"
+printf 'reviewed alpha procedure\n'      > "${mp}/skills/alpha/SKILL.md"
+printf '#!/bin/sh\necho helper\n'        > "${mp}/skills/alpha/helper.sh"
+chmod +x "${mp}/skills/alpha/helper.sh"
+git -C "${mode_repo}" init -q
+git -C "${mode_repo}" config user.email t@example.invalid
+git -C "${mode_repo}" config user.name t
+git -C "${mode_repo}" add -A
+git -C "${mode_repo}" commit -qm pin
+mode_link="$(git -C "${mode_repo}" rev-parse HEAD)"
+mode_inst="${tmp}/install-mode"
+mkdir -p "${mode_inst}"
+cp -R "${mp}/agents" "${mp}/skills" "${mode_inst}/"
+# Identical, executable bit intact -> CURRENT. Without this the next assertion could pass trivially.
+if "${script}" --repo-root "${tmp}/mode" --gitlink "${mode_link}" --installed "${mode_inst}" >/dev/null 2>&1; then
+  ok "an executable helper with its mode intact reports CURRENT"
+else
+  fail "an identical install with an executable helper must exit 0"
+fi
+chmod -x "${mode_inst}/skills/alpha/helper.sh"
+set +e; out="$("${script}" --repo-root "${tmp}/mode" --gitlink "${mode_link}" --installed "${mode_inst}" 2>&1)"; rc=$?; set -e
+[ "${rc}" -eq 1 ] || fail "a lost executable bit must exit 1, got ${rc}: ${out}"
+case "${out}" in
+  *"mode differs"*) ok "a lost executable bit is caught even though the content hash matches" ;;
+  *) fail "exit 1 but the mode difference was not reported: ${out}" ;;
+esac
+
+# ── 7i. A TRUNCATED forge tree is UNKNOWN, never a comparison ─────────────────
+# GitHub marks an over-large recursive Trees response `truncated`. Comparing it as if complete is a
+# fail-open: a pinned file the API omitted is also absent from the reviewed set, so an install missing
+# that file reports CURRENT. Exercised with a gh shim so the case is hermetic.
+shim="${tmp}/shim"
+mkdir -p "${shim}"
+cat > "${shim}/gh" <<'SHIM'
+#!/bin/sh
+printf '{"truncated":true,"tree":[]}\n'
+SHIM
+chmod +x "${shim}/gh"
+mkdir -p "${tmp}/trunc"
+cat > "${tmp}/trunc/.gitmodules" <<'GM'
+[submodule "libraries/agent-plugins"]
+	path = libraries/agent-plugins
+	url = git@github.com:devantler-tech/agent-plugins.git
+GM
+# A gitlink absent from the local object database forces the forge branch.
+set +e
+out="$(PATH="${shim}:${PATH}" "${script}" --repo-root "${tmp}/trunc" --installed "${cur}" \
+        --gitlink 1111111111111111111111111111111111111111 2>&1)"; rc=$?
+set -e
+[ "${rc}" -eq 2 ] || fail "a truncated forge tree must exit 2 (UNKNOWN), got ${rc}: ${out}"
+case "${out}" in
+  *TRUNCATED*) ok "a truncated forge tree exits 2 rather than comparing a partial tree" ;;
+  *) fail "exit 2 but not because of truncation: ${out}" ;;
+esac
+
 # ── 8. The remediation is NAMED in the failure output ─────────────────────────
 # The deployment's own "fail with the fix" rule: a guard that blocks without naming the resolving
 # action is a friction tax, and it trains the reader to route around it. It must also keep saying

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -267,6 +267,24 @@ set +e; out="$("${script}" --repo-root "${tmp}/consumer" --gitlink "${gitlink}" 
 [ "${rc}" -eq 2 ] || fail "an absent registry must exit 2, got ${rc}: ${out}"
 ok "an absent registry exits 2"
 
+# ── 7e. The INSTALLED tree is classified by the SAME rule as the pinned tree ──
+# The mirror of 7b. If the reviewed side calls an odd path UNKNOWN while the installed side quietly
+# skips it, the fail-open is not closed — only moved. A filename-filtered scan of the install did
+# exactly that.
+for odd in "skills/alpha/nested/SKILL.md" "agents/sub/nested.agent.md"; do
+  inst="${tmp}/install-oddshape-$(printf '%s' "${odd}" | tr '/.' '__')"
+  make_install "${inst}"
+  mkdir -p "${inst}/$(dirname "${odd}")"
+  printf 'a role in a shape the check cannot compare\n' > "${inst}/${odd}"
+  set +e; out="$(run "${inst}")"; rc=$?; set -e
+  [ "${rc}" -ne 0 ] || fail "FAIL OPEN: an unclassifiable INSTALLED path (${odd}) reported success: ${out}"
+  [ "${rc}" -eq 2 ] || fail "an unclassifiable installed path must exit 2, got ${rc}: ${out}"
+  case "${out}" in
+    *"UNKNOWN  ${odd}"*) ok "an unclassifiable installed path (${odd}) exits 2, never CURRENT" ;;
+    *) fail "exit 2 but the installed path was not named (${odd}): ${out}" ;;
+  esac
+done
+
 # ── 8. The remediation is NAMED in the failure output ─────────────────────────
 # The deployment's own "fail with the fix" rule: a guard that blocks without naming the resolving
 # action is a friction tax, and it trains the reader to route around it. It must also keep saying
@@ -302,6 +320,33 @@ case "${section}" in
   *"read the reviewed definition at the pinned gitlink"*)
     ok "the contract names what to do on drift" ;;
   *) fail "the plugin contract section does not say to follow the reviewed definition on drift" ;;
+esac
+
+# Each remaining instruction is pinned on its own. Asserting only the check name and the fallback
+# would let a contract-only edit strip the exit semantics, the refresh path, or the cache prohibition
+# while this test stayed green — the same silent-loosening hole the both-halves rule exists to close.
+case "${section}" in
+  *UNKNOWN*) ok "the contract names the UNKNOWN verdict" ;;
+  *) fail "the plugin contract section does not name the UNKNOWN (exit 2) verdict" ;;
+esac
+case "${section}" in
+  *"never as current"*) ok "the contract says UNKNOWN is not current" ;;
+  *) fail "the plugin contract section does not say an UNKNOWN result must not be read as current" ;;
+esac
+# The needle is the FLOW, not the bare "/plugin" token: that token also appears in
+# `.claude/plugin-consumption/...` and in this check's own path, so a bare match is satisfied by
+# unrelated prose and the assertion never fires. Occurrence-counted before choosing.
+case "${section}" in
+  *"marketplace update flow"*) ok "the contract names the supported refresh flow" ;;
+  *) fail "the plugin contract section does not name the /plugin marketplace update refresh flow" ;;
+esac
+case "${section}" in
+  *"Never edit the plugin cache"*) ok "the contract forbids editing the plugin cache" ;;
+  *) fail "the plugin contract section does not forbid editing the plugin cache" ;;
+esac
+case "${section}" in
+  *"blob identity"*) ok "the contract pins comparison by blob identity, not a version string" ;;
+  *) fail "the plugin contract section does not require comparison by blob identity" ;;
 esac
 
 echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# Guards `plugin-definition-currency.sh` and the contract rule it enforces.
+#
+# The defect it exists for (monorepo#2847): the deployment verifies the whole definition chain except
+# its last link. One control tracks the gitlink against upstream, another hashes the desired state
+# against the repository submodule at that gitlink — but nothing compares either against the copy the
+# runtime actually loaded. That copy has no writer, so its staleness is unbounded rather than
+# self-healing. Measured 2026-08-14 on the Claude instance: 7 of 9 definition files differed from the
+# pin and had not moved in 20 days, while both existing controls read clean.
+#
+# The fixtures are hermetic — a local git repository stands in for the pinned plugin revision — so
+# this suite needs no network and no runtime install, and finishes well inside the tool's call
+# ceiling. That matters here: a validation script that cannot be run in one call does not get run.
+#
+# BOTH the behaviour and the contract prose are pinned. The script alone would let a later edit drop
+# the rule that tells a run to execute it, leaving a correct check nobody invokes; the prose alone
+# would let the check rot into something that cannot fire. Neither assertion covers the other.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="${repo_root}/.claude/scripts/plugin-definition-currency.sh"
+constitution="${repo_root}/AGENTS.md"
+
+pass_count=0
+fail() {
+  echo "plugin-definition-currency: FAIL — $*" >&2
+  exit 1
+}
+ok() {
+  pass_count=$((pass_count + 1))
+  echo "  ok — $*"
+}
+
+[ -x "${script}" ] || fail "${script} is missing or not executable"
+[ -r "${constitution}" ] || fail "cannot read ${constitution}"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+# ── the fixture "pinned revision" ─────────────────────────────────────────────
+# A real git repository, so the script exercises its local-object-database path exactly as it does
+# against the live submodule. Two agents and two skills, plus a README and a manifest that the
+# selector must ignore.
+pin_repo="${tmp}/consumer/libraries/agent-plugins"
+mkdir -p "${pin_repo}/plugins/agentic-engineering/agents" \
+         "${pin_repo}/plugins/agentic-engineering/skills/alpha" \
+         "${pin_repo}/plugins/agentic-engineering/skills/beta" \
+         "${pin_repo}/plugins/agentic-engineering/.claude-plugin"
+p="${pin_repo}/plugins/agentic-engineering"
+printf 'reviewed engineer definition\n' > "${p}/agents/agentic-engineer.agent.md"
+printf 'reviewed improver definition\n'  > "${p}/agents/agent-improver.agent.md"
+printf 'reviewed alpha procedure\n'      > "${p}/skills/alpha/SKILL.md"
+printf 'reviewed beta procedure\n'       > "${p}/skills/beta/SKILL.md"
+printf 'readme prose\n'                  > "${p}/README.md"
+printf '{"version":"9.9.9"}\n'           > "${p}/.claude-plugin/plugin.json"
+
+git -C "${pin_repo}" init -q
+git -C "${pin_repo}" config user.email t@example.invalid
+git -C "${pin_repo}" config user.name t
+git -C "${pin_repo}" add -A
+git -C "${pin_repo}" commit -qm pin
+gitlink="$(git -C "${pin_repo}" rev-parse HEAD)"
+
+run() { "${script}" --repo-root "${tmp}/consumer" --gitlink "${gitlink}" --installed "$1" 2>&1; }
+
+# A helper that builds an "installed" copy identical to the pin, which each case then perturbs in
+# exactly one way. Isolating one conjunct per fixture is what makes a firing attributable.
+make_install() {
+  local dest="$1"
+  mkdir -p "${dest}"
+  cp -R "${p}/agents" "${p}/skills" "${p}/README.md" "${dest}/"
+}
+
+# ── 1. NEGATIVE CONTROL — an identical install must NOT fire ──────────────────
+# Without this the suite proves nothing: a check that always reports drift would pass every other
+# case here while being useless in production.
+cur="${tmp}/install-current"
+make_install "${cur}"
+if out="$(run "${cur}")"; then
+  case "${out}" in
+    *CURRENT*) ok "an install matching the pin exits 0 and reports CURRENT" ;;
+    *) fail "matching install exited 0 but did not report CURRENT: ${out}" ;;
+  esac
+else
+  fail "matching install must exit 0, got $? — the check fires on a current install: ${out}"
+fi
+
+# ── 2. A CHANGED definition fires, and names the file ─────────────────────────
+chg="${tmp}/install-changed"
+make_install "${chg}"
+printf 'superseded improver definition\n' > "${chg}/agents/agent-improver.agent.md"
+set +e; out="$(run "${chg}")"; rc=$?; set -e
+[ "${rc}" -eq 1 ] || fail "a changed definition must exit 1, got ${rc}"
+case "${out}" in
+  *"DRIFT    agents/agent-improver.agent.md"*) ok "a changed definition exits 1 and names the file" ;;
+  *) fail "exit 1 but the changed file was not named: ${out}" ;;
+esac
+# The untouched files must still report as matching, or "names the file" is vacuous.
+case "${out}" in
+  *"match    agents/agentic-engineer.agent.md"*) ok "an untouched definition still reports match" ;;
+  *) fail "the untouched engineer definition was not reported as matching: ${out}" ;;
+esac
+
+# ── 3. A MISSING definition fires ─────────────────────────────────────────────
+# Distinct from case 2: an absent role is not a differing role, and a hash comparison that only
+# walks the installed side would silently skip it.
+mis="${tmp}/install-missing"
+make_install "${mis}"
+rm "${mis}/skills/beta/SKILL.md"
+set +e; out="$(run "${mis}")"; rc=$?; set -e
+[ "${rc}" -eq 1 ] || fail "a missing definition must exit 1, got ${rc}"
+case "${out}" in
+  *"MISSING  skills/beta/SKILL.md"*) ok "a definition absent from the install exits 1 as MISSING" ;;
+  *) fail "exit 1 but the missing file was not named: ${out}" ;;
+esac
+
+# ── 4. An EXTRA definition fires ──────────────────────────────────────────────
+# A role the runtime can still dispatch that the reviewed revision no longer describes. A check
+# driven only by the reviewed list cannot see this, which is why it is asserted separately.
+ext="${tmp}/install-extra"
+make_install "${ext}"
+mkdir -p "${ext}/skills/ghost"
+printf 'a role the pin does not describe\n' > "${ext}/skills/ghost/SKILL.md"
+set +e; out="$(run "${ext}")"; rc=$?; set -e
+[ "${rc}" -eq 1 ] || fail "an extra definition must exit 1, got ${rc}"
+case "${out}" in
+  *"EXTRA    skills/ghost/SKILL.md"*) ok "a definition absent from the pin exits 1 as EXTRA" ;;
+  *) fail "exit 1 but the extra file was not named: ${out}" ;;
+esac
+
+# ── 5. Non-definition files are EXCLUDED ──────────────────────────────────────
+# Firing on a README or a version bump that moves no definition would train the reader to ignore the
+# check, which is the same outcome as not having one.
+noi="${tmp}/install-noise"
+make_install "${noi}"
+printf 'entirely different readme\n' > "${noi}/README.md"
+mkdir -p "${noi}/.claude-plugin"
+printf '{"version":"0.0.1"}\n' > "${noi}/.claude-plugin/plugin.json"
+if out="$(run "${noi}")"; then
+  ok "a differing README and manifest do not fire — only definitions count"
+else
+  fail "the check fired on non-definition files: ${out}"
+fi
+
+# ── 6. FAIL CLOSED — an unresolvable install is UNKNOWN, never CURRENT ────────
+# The load-bearing exit code. "I could not check" reported as 0 is how a currency check becomes
+# decoration, and it is the failure mode a caller is least likely to notice.
+set +e; out="$("${script}" --repo-root "${tmp}/consumer" --gitlink "${gitlink}" \
+                           --installed "${tmp}/does-not-exist" 2>&1)"; rc=$?; set -e
+[ "${rc}" -eq 2 ] || fail "an unresolvable install must exit 2 (UNKNOWN), got ${rc}: ${out}"
+ok "an unresolvable install exits 2, not 0"
+
+# ── 7. FAIL CLOSED — an unreachable pinned revision is UNKNOWN ────────────────
+set +e; out="$("${script}" --repo-root "${tmp}/consumer" --installed "${cur}" \
+                           --gitlink 0000000000000000000000000000000000000000 2>&1)"; rc=$?; set -e
+[ "${rc}" -eq 2 ] || fail "an unreachable pinned revision must exit 2 (UNKNOWN), got ${rc}: ${out}"
+ok "an unreachable pinned revision exits 2, not 0"
+
+# ── 8. The remediation is NAMED in the failure output ─────────────────────────
+# The deployment's own "fail with the fix" rule: a guard that blocks without naming the resolving
+# action is a friction tax, and it trains the reader to route around it. It must also keep saying
+# that the cache is not the thing to edit, or the cheapest-looking fix is the forbidden one.
+out="$(run "${chg}" || true)"
+case "${out}" in
+  *"/plugin"*) ok "the failure output names the supported refresh path" ;;
+  *) fail "the failure output does not name how to refresh: ${out}" ;;
+esac
+case "${out}" in
+  *"Never edit the plugin cache"*) ok "the failure output still forbids editing the cache" ;;
+  *) fail "the failure output does not forbid the cache edit: ${out}" ;;
+esac
+
+# ── 9. The CONTRACT names the rule and its remediation ────────────────────────
+# Scoped to the plugin-contract section rather than the whole file: these phrases appear in this
+# script's own header and in the run report, so a file-wide match would pass while the operative
+# section said nothing. Flattened because every sentence wraps across source lines.
+section="$(
+  awk '
+    /^### Agentic engineering plugin contract$/ { ins = 1; next }
+    ins && /^### / { exit }
+    ins { print }
+  ' "${constitution}" | tr '\n' ' '
+)"
+[ -n "${section}" ] || fail "could not extract the plugin contract section from AGENTS.md"
+
+case "${section}" in
+  *"plugin-definition-currency.sh"*) ok "the contract names the check" ;;
+  *) fail "the plugin contract section does not name plugin-definition-currency.sh" ;;
+esac
+case "${section}" in
+  *"read the reviewed definition at the pinned gitlink"*)
+    ok "the contract names what to do on drift" ;;
+  *) fail "the plugin contract section does not say to follow the reviewed definition on drift" ;;
+esac
+
+echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -156,7 +156,116 @@ ok "an unresolvable install exits 2, not 0"
 set +e; out="$("${script}" --repo-root "${tmp}/consumer" --installed "${cur}" \
                            --gitlink 0000000000000000000000000000000000000000 2>&1)"; rc=$?; set -e
 [ "${rc}" -eq 2 ] || fail "an unreachable pinned revision must exit 2 (UNKNOWN), got ${rc}: ${out}"
-ok "an unreachable pinned revision exits 2, not 0"
+# The MESSAGE is asserted, not just the code. Exit 2 alone would still pass if the local-object
+# branch broke entirely and every case silently fell through to the forge — and it also pins that
+# this suite makes no network call: the fixture has no .gitmodules, so slug resolution dies first.
+case "${out}" in
+  *"no .gitmodules url"*) ok "an unreachable pinned revision exits 2 without reaching the network" ;;
+  *) fail "exit 2 but not by the expected network-free path — did it call out to the forge? ${out}" ;;
+esac
+
+# ── 7b. FAIL OPEN REGRESSION — an unrecognised pinned path is never silently dropped ──
+# The defect this guards: the selector recognises two shapes and had no else branch, so any other
+# path under agents/ or skills/ fell out of the reviewed list entirely. It was then invisible on BOTH
+# sides — the reviewed loop never checked it, and the EXTRA sweep only fires when it IS installed. So
+# "pinned but unrecognised AND absent from the install" reported CURRENT with a role definition
+# missing from the runtime. Two independent triggers, asserted separately because they have different
+# causes: an unexpected directory depth, and a space in the path (which awk's default field splitting
+# truncated out of existence).
+for case_name in depth space; do
+  odd_repo="${tmp}/odd-${case_name}/libraries/agent-plugins"
+  op="${odd_repo}/plugins/agentic-engineering"
+  mkdir -p "${op}/agents" "${op}/skills/alpha"
+  printf 'reviewed engineer definition\n' > "${op}/agents/agentic-engineer.agent.md"
+  printf 'reviewed alpha procedure\n'      > "${op}/skills/alpha/SKILL.md"
+  if [ "${case_name}" = depth ]; then
+    mkdir -p "${op}/skills/group/nested"
+    printf 'a definition at an unexpected depth\n' > "${op}/skills/group/nested/SKILL.md"
+  else
+    mkdir -p "${op}/skills/my skill"
+    printf 'a definition whose path contains a space\n' > "${op}/skills/my skill/SKILL.md"
+  fi
+  git -C "${odd_repo}" init -q
+  git -C "${odd_repo}" config user.email t@example.invalid
+  git -C "${odd_repo}" config user.name t
+  git -C "${odd_repo}" add -A
+  git -C "${odd_repo}" commit -qm pin
+  odd_link="$(git -C "${odd_repo}" rev-parse HEAD)"
+
+  # The install deliberately does NOT contain the odd path — that is the invisible-on-both-sides case.
+  odd_install="${tmp}/install-odd-${case_name}"
+  mkdir -p "${odd_install}"
+  cp -R "${op}/agents" "${odd_install}/"
+  mkdir -p "${odd_install}/skills/alpha"
+  cp "${op}/skills/alpha/SKILL.md" "${odd_install}/skills/alpha/SKILL.md"
+
+  set +e
+  out="$("${script}" --repo-root "${tmp}/odd-${case_name}" --gitlink "${odd_link}" \
+                     --installed "${odd_install}" 2>&1)"; rc=$?
+  set -e
+  # The load-bearing property both cases share: NEVER exit 0. What each becomes afterwards differs,
+  # and the difference is the point — the two fixes are not the same fix.
+  [ "${rc}" -ne 0 ] || fail "FAIL OPEN (${case_name}): a pinned path absent from the install reported success: ${out}"
+  if [ "${case_name}" = depth ]; then
+    # Still unrecognisable by shape, so the honest answer is UNKNOWN rather than a verdict.
+    [ "${rc}" -eq 2 ] || fail "an unclassifiable pinned path must exit 2 (UNKNOWN), got ${rc}: ${out}"
+    case "${out}" in
+      *UNCLASSIFIED*|*"could not be classified"*) ok "a pinned path at an unexpected depth exits 2, never CURRENT" ;;
+      *) fail "exit 2 but the unclassified path was not reported: ${out}" ;;
+    esac
+  else
+    # Tab-aware parsing PROMOTES this one: the path is no longer truncated, so it classifies as an
+    # ordinary skill definition and is correctly reported MISSING. Asserting UNKNOWN here would pin
+    # the bug rather than the fix.
+    [ "${rc}" -eq 1 ] || fail "a pinned path containing a space must classify and exit 1, got ${rc}: ${out}"
+    case "${out}" in
+      *"MISSING  skills/my skill/SKILL.md"*) ok "a pinned path containing a space is parsed, not dropped" ;;
+      *) fail "exit 1 but the spaced path was not named — is it still being truncated? ${out}" ;;
+    esac
+  fi
+done
+
+# ── 7c. A missing option VALUE is UNKNOWN, not DRIFT ──────────────────────────
+# `shift 2` on a lone trailing flag returns 1, and under `set -e` that exited the script with 1 — the
+# code that tells a caller the definition is stale. A typo would have produced a silent, output-free
+# drift verdict, which is the most misleading failure this script can have.
+for flag in --repo-root --gitlink --installed --plugins-root; do
+  set +e; out="$("${script}" "${flag}" 2>&1)"; rc=$?; set -e
+  [ "${rc}" -eq 2 ] || fail "a missing value for ${flag} must exit 2, got ${rc}: ${out}"
+done
+ok "a missing option value exits 2, never 1 (DRIFT)"
+
+# ── 7d. Registry resolution — the only path production actually uses ──────────
+# Every case above passes --installed, so without these the jq expression, the single-path check and
+# all three of their die paths ship untested.
+reg_root="${tmp}/plugins-root"
+mkdir -p "${reg_root}"
+printf '{"version":2,"plugins":{"agentic-engineering@devantler-plugins":[{"installPath":"%s"}]}}\n' \
+  "${cur}" > "${reg_root}/installed_plugins.json"
+if out="$("${script}" --repo-root "${tmp}/consumer" --gitlink "${gitlink}" --plugins-root "${reg_root}")"; then
+  case "${out}" in
+    *"${cur}"*) ok "a single registry entry resolves to its installPath" ;;
+    *) fail "resolved from the registry but did not use its installPath: ${out}" ;;
+  esac
+else
+  fail "a well-formed registry with a matching install must exit 0, got $?: ${out}"
+fi
+
+printf '{"version":2,"plugins":{"agentic-engineering@devantler-plugins":[{"installPath":"%s"},{"installPath":"%s"}]}}\n' \
+  "${cur}" "${cur}" > "${reg_root}/installed_plugins.json"
+set +e; out="$("${script}" --repo-root "${tmp}/consumer" --gitlink "${gitlink}" --plugins-root "${reg_root}" 2>&1)"; rc=$?; set -e
+[ "${rc}" -eq 2 ] || fail "an ambiguous registry (2 install paths) must exit 2, got ${rc}: ${out}"
+ok "an ambiguous registry exits 2 rather than picking one"
+
+printf 'not json at all\n' > "${reg_root}/installed_plugins.json"
+set +e; out="$("${script}" --repo-root "${tmp}/consumer" --gitlink "${gitlink}" --plugins-root "${reg_root}" 2>&1)"; rc=$?; set -e
+[ "${rc}" -eq 2 ] || fail "a malformed registry must exit 2, got ${rc}: ${out}"
+ok "a malformed registry exits 2, not a raw jq status"
+
+rm -f "${reg_root}/installed_plugins.json"
+set +e; out="$("${script}" --repo-root "${tmp}/consumer" --gitlink "${gitlink}" --plugins-root "${reg_root}" 2>&1)"; rc=$?; set -e
+[ "${rc}" -eq 2 ] || fail "an absent registry must exit 2, got ${rc}: ${out}"
+ok "an absent registry exits 2"
 
 # ── 8. The remediation is NAMED in the failure output ─────────────────────────
 # The deployment's own "fail with the fix" rule: a guard that blocks without naming the resolving

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -384,6 +384,30 @@ case "${out}" in
   *) fail "exit 2 but not because of truncation: ${out}" ;;
 esac
 
+# ── 7j. A SYMLINK is not a definition ────────────────────────────────────────
+# -f, `git hash-object` and -x all FOLLOW a symlink, so an installed definition replaced by a link to
+# an identical file passed every single test and reported CURRENT.
+sym="${tmp}/install-symlink"
+make_install "${sym}"
+printf 'reviewed improver definition\n' > "${tmp}/decoy.md"
+rm "${sym}/agents/agent-improver.agent.md"
+ln -s "${tmp}/decoy.md" "${sym}/agents/agent-improver.agent.md"
+set +e; out="$(run "${sym}")"; rc=$?; set -e
+[ "${rc}" -ne 0 ] || fail "FAIL OPEN: a definition replaced by a symlink to identical bytes reported success: ${out}"
+case "${out}" in
+  *"SYMLINK"*) ok "a definition installed as a symlink is drift, even with identical bytes" ;;
+  *) fail "exit ${rc} but the symlink was not reported: ${out}" ;;
+esac
+
+# ── 7k. DELIBERATELY NOT TESTED — the mktemp guard ───────────────────────────
+# `mktemp`'s failure path is guarded in the script (an unwritable TMPDIR would otherwise exit 1 under
+# `set -e`, and 1 is the DRIFT verdict, so an infrastructure failure would read as a finding about the
+# install). There is no assertion here because there is no portable way to force it: BSD/macOS mktemp
+# IGNORES an unusable TMPDIR and falls back to the system temp dir, so the obvious test passes on
+# every implementation regardless of the guard — verified by ablation, which did not fire.
+# A vacuous assertion is worse than none: it manufactures confidence in an untested path. Left absent
+# and explained rather than left green and meaningless.
+
 # ── 8. The remediation is NAMED in the failure output ─────────────────────────
 # The deployment's own "fail with the fix" rule: a guard that blocks without naming the resolving
 # action is a friction tax, and it trains the reader to route around it. It must also keep saying

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -399,7 +399,22 @@ case "${out}" in
   *) fail "exit ${rc} but the symlink was not reported: ${out}" ;;
 esac
 
-# ── 7k. DELIBERATELY NOT TESTED — the mktemp guard ───────────────────────────
+# ── 7k. An EXTRA SYMLINK is still an unreviewed definition ───────────────────
+# The pinned-path loop above catches a symlink only when it replaces a reviewed path. The installed
+# tree sweep must independently enumerate links, or a new link under agents/ or skills/ disappears
+# from both comparisons and the runtime can expose an unpinned definition while this reports CURRENT.
+extra_sym="${tmp}/install-extra-symlink"
+make_install "${extra_sym}"
+mkdir -p "${extra_sym}/skills/ghost"
+ln -s "${tmp}/decoy.md" "${extra_sym}/skills/ghost/SKILL.md"
+set +e; out="$(run "${extra_sym}")"; rc=$?; set -e
+[ "${rc}" -ne 0 ] || fail "FAIL OPEN: an extra definition symlink reported success: ${out}"
+case "${out}" in
+  *"EXTRA    skills/ghost/SKILL.md"*) ok "an extra definition symlink is caught by the installed-tree sweep" ;;
+  *) fail "exit ${rc} but the extra symlink was not reported: ${out}" ;;
+esac
+
+# ── 7l. DELIBERATELY NOT TESTED — the mktemp guard ───────────────────────────
 # `mktemp`'s failure path is guarded in the script (an unwritable TMPDIR would otherwise exit 1 under
 # `set -e`, and 1 is the DRIFT verdict, so an infrastructure failure would read as a finding about the
 # install). There is no assertion here because there is no portable way to force it: BSD/macOS mktemp

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
       work-priority-ladder: ${{ steps.filter.outputs.work-priority-ladder }}
       latency-discipline-contract: ${{ steps.filter.outputs.latency-discipline-contract }}
       git-safety-contract: ${{ steps.filter.outputs.git-safety-contract }}
+      plugin-definition-currency: ${{ steps.filter.outputs.plugin-definition-currency }}
       merge-confirmation-read: ${{ steps.filter.outputs.merge-confirmation-read }}
       portfolio-surveyor: ${{ steps.filter.outputs.portfolio-surveyor }}
       product-value: ${{ steps.filter.outputs.product-value }}
@@ -197,6 +198,11 @@ jobs:
             git-safety-contract:
               - 'AGENTS.md'
               - '.claude/scripts/git-safety-contract.test.sh'
+              - '.github/workflows/ci.yaml'
+            plugin-definition-currency:
+              - 'AGENTS.md'
+              - '.claude/scripts/plugin-definition-currency.sh'
+              - '.claude/scripts/plugin-definition-currency.test.sh'
               - '.github/workflows/ci.yaml'
             self-review-contract:
               - 'AGENTS.md'
@@ -783,6 +789,21 @@ jobs:
       - name: Verify the git safety contract
         run: bash .claude/scripts/git-safety-contract.test.sh
 
+  test-plugin-definition-currency:
+    name: Test plugin definition currency
+    needs: changes
+    if: needs.changes.outputs.plugin-definition-currency == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify the plugin definition currency check
+        run: bash .claude/scripts/plugin-definition-currency.test.sh
+
   test-self-review-contract:
     name: Test self-review contract
     needs: changes
@@ -915,6 +936,7 @@ jobs:
       - test-memory-hygiene
       - test-latency-discipline-contract
       - test-git-safety-contract
+      - test-plugin-definition-currency
       - test-self-review-contract
       - test-review-provider-loop-contract
       - test-agent-role-delivery-contract
@@ -948,6 +970,7 @@ jobs:
             ${{ needs.test-memory-hygiene.result }}
             ${{ needs.test-latency-discipline-contract.result }}
             ${{ needs.test-git-safety-contract.result }}
+            ${{ needs.test-plugin-definition-currency.result }}
             ${{ needs.test-self-review-contract.result }}
             ${{ needs.test-review-provider-loop-contract.result }}
             ${{ needs.test-agent-role-delivery-contract.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,10 +291,21 @@ every delegated survey ran a superseded definition while reporting a clean run
 ([#2847](https://github.com/devantler-tech/monorepo/issues/2847)).
 
 Run [`.claude/scripts/plugin-definition-currency.sh`](.claude/scripts/plugin-definition-currency.sh)
-before acting on a plugin-sourced role. It compares by **git blob identity, never a version string**
-— a version can be bumped without the definitions moving, and the definitions can be superseded
-while the installed version still looks plausible. It exits `0` current, `1` drift, and `2`
-**UNKNOWN**; treat `2` as unchecked, never as current.
+before acting on a plugin-sourced role. It compares every file under the plugin's `agents/` and
+`skills/` directories by **git blob identity, never a version string** — a version can be bumped
+without the definitions moving, and the definitions can be superseded while the installed version
+still looks plausible. It exits `0` current, `1` drift, and `2` **UNKNOWN**.
+
+⚠️ **`2` means UNCHECKED — never read it as current, and never let it halt a run.** Report it, continue against
+the reviewed definition at the pinned gitlink, and act on the recovery the script names. Treating an
+UNKNOWN as a stop condition would turn a diagnostic into the passive self-blocking this contract
+forbids everywhere else.
+
+🔴 **Scoped to the Claude machine-local runtime today.** Its default resolution reads that runtime's
+plugin registry, which is where the drift was measured. The Codex lane keeps its own cache and the
+Cursor lane has no local registry at all (it loads the reviewed role from the submodule), so neither
+is covered yet — see [#2850](https://github.com/devantler-tech/monorepo/issues/2850). Do not read a
+`CURRENT` from this check as a statement about a sibling instance.
 
 **On drift, do not proceed as if the loaded definition were current: read the reviewed definition at
 the pinned gitlink and follow that**, and report the drift. Refresh only through the runtime's own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,31 @@ that the generic plugin does not carry yet; remove it only after the side-by-sid
 [`.claude/plugin-consumption/agentic-engineering-surveyor-diff.md`](.claude/plugin-consumption/agentic-engineering-surveyor-diff.md)
 passes.
 
+🔴 **Verify that the definition the runtime LOADED is the one this consumer PINNED — the desired
+state's `refreshTiming: before-starting-each-run` is a declaration, not a mechanism.** Two controls
+already watch this chain and neither reaches its last link: [#2736](https://github.com/devantler-tech/monorepo/issues/2736)
+tracks the gitlink against upstream `main`, and `agent-role-delivery-contract.test.sh` hashes the
+desired state against the **repository submodule** at that gitlink. The copy the agent and skill
+entrypoints are actually served from is a runtime-managed install that **no writer advances**, so
+unlike the gitlink its staleness is unbounded rather than self-healing — and both controls read
+clean throughout. Measured on the Claude instance 2026-08-14: **7 of 9 definition files differed
+from the pin and had not moved in 20 days**, spanning all three roles, so every hourly dispatch and
+every delegated survey ran a superseded definition while reporting a clean run
+([#2847](https://github.com/devantler-tech/monorepo/issues/2847)).
+
+Run [`.claude/scripts/plugin-definition-currency.sh`](.claude/scripts/plugin-definition-currency.sh)
+before acting on a plugin-sourced role. It compares by **git blob identity, never a version string**
+— a version can be bumped without the definitions moving, and the definitions can be superseded
+while the installed version still looks plausible. It exits `0` current, `1` drift, and `2`
+**UNKNOWN**; treat `2` as unchecked, never as current.
+
+**On drift, do not proceed as if the loaded definition were current: read the reviewed definition at
+the pinned gitlink and follow that**, and report the drift. Refresh only through the runtime's own
+control plane — the `/plugin` marketplace update flow. **Never edit the plugin cache**; it is
+read-only evidence (see *Agent definition locations*). When the refresh needs an interactive session
+an unattended run cannot open, surface it on a declared *Maintainer channel* rather than leaving a
+silently superseded definition in place.
+
 ### Agent definition locations
 
 The Agent Improver may change only the surfaces named here. A path being readable does not make it a


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Every scheduler pointer tells an instance to load *"the latest reviewed"* agent definitions, and the
desired state declares they are refreshed before each run. Nothing checked that either was true. Two
controls already watch this chain — one tracks the pin against upstream, the other checks the pin
against what is in the repository — and neither reaches the copy the runtime actually loads. That
copy has no writer at all, so unlike the pin it never catches up on its own.

On this machine it had been 20 days behind: 7 of 9 definition files differed from what we pinned,
across all three agent roles, while both existing checks reported clean. That means hourly runs were
following superseded instructions and reporting a normal run — including instructions added hours
earlier in response to direct maintainer feedback.

### What

Adds a read-only check a run performs before acting on a plugin-sourced role, and states in the
contract what to do when it fires: follow the reviewed definition rather than the loaded one, report
the drift, and refresh through the supported flow. It never writes to the runtime, so it cannot fix
the staleness itself — it makes it visible instead of silent.

Fixes #2847
