### PR TITLE
fix(agent-improver): prevent evidence-clean no-op runs

### DIFF
--- a/.claude/plugin-consumption/agentic-engineering.desired-state.json
+++ b/.claude/plugin-consumption/agentic-engineering.desired-state.json
@@ -47,7 +47,8 @@
       },
       "agent-improver": {
         "enabledWhen": "Both optional consumer contract sections are present",
-        "mode": "separate-schedule-or-on-demand"
+        "mode": "separate-schedule-or-on-demand",
+        "definitionSha256": "bd7562cf141a0c965c1189e5a0fe37b10d444ac076211c405f385dd68019f882"
       }
     },
     "runtime": {

--- a/.claude/plugin-consumption/agentic-engineering.desired-state.json
+++ b/.claude/plugin-consumption/agentic-engineering.desired-state.json
@@ -48,7 +48,8 @@
       "agent-improver": {
         "enabledWhen": "Both optional consumer contract sections are present",
         "mode": "separate-schedule-or-on-demand",
-        "definitionSha256": "bd7562cf141a0c965c1189e5a0fe37b10d444ac076211c405f385dd68019f882"
+        "definitionSha256": "bd7562cf141a0c965c1189e5a0fe37b10d444ac076211c405f385dd68019f882",
+        "skillSha256": "193b59cb15826855dfd0ac1f3f99a180be7eca178f9e6d4f13c45f655e335736"
       }
     },
     "runtime": {

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -182,12 +182,15 @@ canonical_improver="${plugin_agents}/agent-improver.agent.md"
 consumer_entrypoint_sha="$(jq -r '.spec.source.entrypointSha256 // ""' "${desired_state}")"
 consumer_surveyor_sha="$(jq -r '.spec.roles["portfolio-surveyor"].definitionSha256 // ""' "${desired_state}")"
 consumer_improver_sha="$(jq -r '.spec.roles["agent-improver"].definitionSha256 // ""' "${desired_state}")"
+consumer_improver_skill_sha="$(jq -r '.spec.roles["agent-improver"].skillSha256 // ""' "${desired_state}")"
 [ "${consumer_entrypoint_sha}" = "$(sha256_file "${canonical_engineer}")" ] ||
   fail "consumer desired-state entrypointSha256 does not match the pinned agentic-engineer definition"
 [ "${consumer_surveyor_sha}" = "$(sha256_file "${canonical_surveyor}")" ] ||
   fail "consumer desired-state portfolio-surveyor definitionSha256 does not match the pinned definition"
 [ "${consumer_improver_sha}" = "$(sha256_file "${canonical_improver}")" ] ||
   fail "consumer desired-state agent-improver definitionSha256 does not match the pinned definition"
+[ "${consumer_improver_skill_sha}" = "$(sha256_file "${bundled_skill}")" ] ||
+  fail "consumer desired-state agent-improver skillSha256 does not match the pinned agent-improvement skill"
 
 canonical_engineer_flat="$(flatten "${canonical_engineer}")"
 assert_canonical_engineer_prose() {

--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -169,19 +169,25 @@ entrypoint="$(jq -r '.spec.source.entrypoint' "${desired_state}")"
   fail "desired state entrypoint '${entrypoint}' does not resolve to a bundled agent in ${plugin_agents}"
 canonical_engineer="${plugin_agents}/${entrypoint}.agent.md"
 canonical_surveyor="${plugin_agents}/portfolio-surveyor.agent.md"
+canonical_improver="${plugin_agents}/agent-improver.agent.md"
 [ -f "${canonical_surveyor}" ] ||
   fail "pinned plugin does not bundle portfolio-surveyor.agent.md"
+[ -f "${canonical_improver}" ] ||
+  fail "pinned plugin does not bundle agent-improver.agent.md"
 
-# The consumer copy used to omit both integrity fields while the pinned plugin resource already
-# carried them. That let the gitlink advance without proving that the machine-readable entrypoint
-# and delegated surveyor still named the reviewed bytes. Resolve both digests from the pinned files,
-# not from a floating default branch or a copied constant.
+# The consumer copy used to omit role integrity fields while the pinned plugin resource already
+# carried them. That let the gitlink advance without proving that the machine-readable entrypoint,
+# delegated surveyor, and Improver still named the reviewed bytes. Resolve all digests from the
+# pinned files, not from a floating default branch or a copied constant.
 consumer_entrypoint_sha="$(jq -r '.spec.source.entrypointSha256 // ""' "${desired_state}")"
 consumer_surveyor_sha="$(jq -r '.spec.roles["portfolio-surveyor"].definitionSha256 // ""' "${desired_state}")"
+consumer_improver_sha="$(jq -r '.spec.roles["agent-improver"].definitionSha256 // ""' "${desired_state}")"
 [ "${consumer_entrypoint_sha}" = "$(sha256_file "${canonical_engineer}")" ] ||
   fail "consumer desired-state entrypointSha256 does not match the pinned agentic-engineer definition"
 [ "${consumer_surveyor_sha}" = "$(sha256_file "${canonical_surveyor}")" ] ||
   fail "consumer desired-state portfolio-surveyor definitionSha256 does not match the pinned definition"
+[ "${consumer_improver_sha}" = "$(sha256_file "${canonical_improver}")" ] ||
+  fail "consumer desired-state agent-improver definitionSha256 does not match the pinned definition"
 
 canonical_engineer_flat="$(flatten "${canonical_engineer}")"
 assert_canonical_engineer_prose() {


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Outcome

Deploy the reviewed Agent Improver hardening that prevents eligible evidence-clean runs from silently no-oping. When telemetry and direct maintainer work yield no actionable improvement, the Improver must run a bounded state-of-the-art research pass and route exactly one Engineer, Improver, research, null, or QUERY-UNKNOWN disposition.

This also makes the Improver observe its own runs and fail closed if its pinned role definition drifts.

## Root cause and rollout

- Today’s sessions showed that conservative clearance and evidence gaps could consume a run without producing work or a durable future candidate.
- agent-skills v1.11.1 adds the bounded, leased, fenced, idempotent research fallback and clause-level regression coverage.
- agent-plugins 4.3.2 carries that reviewed skill plus the direct Agent Improver entrypoint and definition digest.
- This PR pins exact merged plugin commit `aae0f34e089194bfe4c55302c6a154636fe53c05` and validates the Improver digest from pinned bytes.

## Verification

- `bash .claude/scripts/agent-role-delivery-contract.test.sh`
- `shellcheck -S warning .claude/scripts/agent-role-delivery-contract.test.sh`
- `jq empty .claude/plugin-consumption/agentic-engineering.desired-state.json`
- `git diff --check`

Upstream: devantler-tech/agent-skills#91, #92 and devantler-tech/agent-plugins#132, #133, #134.