### PR TITLE
fix(agents): make the drift fallback executable instead of silently wrong

### DIFF
--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -595,4 +595,42 @@ case "${section}" in
   *) fail "the plugin contract section does not close the hidden-index hole in its cleanliness check" ;;
 esac
 
+# ── 12. The prose must pin the OUTCOME, not merely name the tool ──────────────
+# CodeRabbit on monorepo#2855: naming `STILL EMPTY`, `status --porcelain` and `ls-files -v` proves
+# only that the document mentions them — not that STILL EMPTY routes to the forge read, nor that the
+# status output is required to be EMPTY. A contract that names a command without its required outcome
+# is the same "named but not executable" gap section 10 exists to close, one level down.
+#
+# Patterns below are SINGLE-quoted: they contain `$(` and `${`, which inside a double-quoted case
+# pattern would be command-substituted / expanded, silently changing what is matched.
+case "${section}" in
+  *'pin=$(git rev-parse HEAD:libraries/agent-plugins)'*)
+    ok "the contract BINDS the resolved pin to a variable" ;;
+  *) fail "the plugin contract section does not bind the resolved pin to a variable" ;;
+esac
+# The bind is only worth anything if the forge request consumes it — a resolved-then-retyped revision
+# is exactly the wrong-revision read this section exists to stop.
+case "${section}" in
+  *'?ref=${pin}'*)
+    ok "the forge read consumes the pin that was just resolved" ;;
+  *) fail "the plugin contract section does not pass the resolved pin to the forge read" ;;
+esac
+# Ordering matters: the pin must be resolved BEFORE it is consumed, or the documented sequence cannot
+# be executed top-to-bottom as written.
+case "${section}" in
+  *'pin=$(git rev-parse HEAD:libraries/agent-plugins)'*'?ref=${pin}'*)
+    ok "the pin is resolved before the forge read consumes it" ;;
+  *) fail "the plugin contract section resolves the pin after the forge read that consumes it" ;;
+esac
+case "${section}" in
+  *"fall back to the forge read"*)
+    ok "STILL EMPTY routes to the forge read rather than ending the run" ;;
+  *) fail "the plugin contract section does not route a STILL EMPTY materialisation to the forge read" ;;
+esac
+case "${section}" in
+  *"must print nothing"*)
+    ok "the cleanliness check pins its required outcome, not just its command" ;;
+  *) fail "the plugin contract section does not require the cleanliness check to print nothing" ;;
+esac
+
 echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -644,4 +644,48 @@ case "${section}" in
   *) fail "the plugin contract section does not require the cleanliness check to print nothing" ;;
 esac
 
+# ── 13. The byte check must FAIL CLOSED, not merely exist ────────────────────
+# CodeRabbit on monorepo#2855 (🟠 Major, verified on fixtures): the byte-comparison loop is the one
+# assertion that survives a clean/smudge filter, so a hole in IT has no backstop. Three failure paths
+# made the naive form report success on a check that never ran, and the emptiest evidence produced
+# the strongest-looking result:
+#   (a) piping `ls-tree` into the loop takes the WHILE's status, so an enumeration failure runs the
+#       body zero times and prints nothing — identical output to a verified tree;
+#   (b) in an UNINITIALISED submodule every git call fails, so `want` and `got` are BOTH empty and
+#       `[ "$want" = "$got" ]` compares EQUAL — and an empty submodule is precisely the state this
+#       fallback is reached in;
+#   (c) `ls-tree` without `--no-replace-objects` enumerates a replaced tree while the lookups beside
+#       it do not, spanning two object namespaces inside one comparison.
+# Each assertion below pins the OUTCOME (a marker is emitted / a value is rejected), per section 12.
+case "${section}" in
+  *'--no-replace-objects ls-tree -r --name-only HEAD'*)
+    ok "the byte check enumerates in the same object namespace it compares in" ;;
+  *) fail "the byte check's ls-tree does not carry --no-replace-objects (two object namespaces)" ;;
+esac
+# Matched contiguously ON PURPOSE: the flag appears three times in this section, so a split pattern
+# would be satisfied by the pin line's occurrence even if ls-tree lost the flag entirely.
+case "${section}" in
+  *'BYTES-UNKNOWN <enumeration failed>'*)
+    ok "an enumeration failure is reported rather than read as no-differences" ;;
+  *) fail "the byte check does not report an enumeration failure (silent pass on a check that never ran)" ;;
+esac
+case "${section}" in
+  *'[ -n "$want" ] && [ -n "$got" ]'*)
+    ok "the byte check rejects empty hashes instead of comparing them equal" ;;
+  *) fail "the byte check does not reject empty hashes (two failed lookups would compare EQUAL)" ;;
+esac
+# The markers are worthless if the prose still says only a DIFFER means trouble.
+case "${section}" in
+  *"unproven is not proven"*)
+    ok "the contract counts BYTES-UNKNOWN as a failure, not as a pass" ;;
+  *) fail "the contract does not say an unverifiable byte check fails closed" ;;
+esac
+# Command substitution strips the trailing newline, so a bare `printf '%s'` makes `read` return false
+# on the final entry and drops the LAST file from the sweep unchecked — a silent partial verification.
+case "${section}" in
+  *"printf '%s\\n' \"\$files\""*)
+    ok "the byte check sweeps every file, including the last" ;;
+  *) fail "the byte check drops its last entry (printf without a trailing newline)" ;;
+esac
+
 echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -547,4 +547,52 @@ case "${section}" in
   *) fail "the plugin contract section does not name the recovery path after a revision mismatch" ;;
 esac
 
+# ── 11. The fallback must survive the cases that BREAK a working tree ─────────
+# Codex review of monorepo#2855 (3×P1, all verified against the scripts): the section 10 procedure
+# assumed a usable working tree, and each of its three assumptions fails in a case the fallback is
+# actually reached in.
+#
+# (a) The pin was sourced from "the pinned revision the check printed" — but every `die` in
+# plugin-definition-currency.sh exits BEFORE its reporting block (the pin prints at the `say` well
+# after the last `die`), so an UNKNOWN prints no pin at all. UNKNOWN is exactly when this fallback is
+# reached, so the instruction was unfollowable in its own trigger case. Matched as the complete
+# `HEAD:<path>` form: a bare "rev-parse" already appears above for the read-back.
+case "${section}" in
+  *"git rev-parse HEAD:libraries/agent-plugins"*)
+    ok "the contract resolves the pin independently of the check's output" ;;
+  *) fail "the plugin contract section does not name a pin source independent of the check" ;;
+esac
+# (b) A working-tree-free path must exist, because BOTH tree-based paths can fail: the submodule is
+# empty in a fresh worktree and `submodule-init.sh` can die STILL EMPTY there (its own comment
+# records `git submodule update --init` exiting 0 having populated nothing, observed from a linked
+# superproject). Without this, the prescribed recovery dead-ends and the run stops rather than
+# reading the reviewed definition. Matched on the repo-qualified contents path so the assertion
+# cannot be satisfied by an unrelated `gh api` elsewhere in the section.
+case "${section}" in
+  *"repos/devantler-tech/agent-plugins/contents"*)
+    ok "the contract names a read that needs no working tree" ;;
+  *) fail "the plugin contract section does not name a working-tree-free read of the reviewed definition" ;;
+esac
+case "${section}" in
+  *"STILL EMPTY"*)
+    ok "the contract says a STILL EMPTY materialisation is not the end of the run" ;;
+  *) fail "the plugin contract section does not tell a run what to do when materialisation populates nothing" ;;
+esac
+# (c) HEAD == pin does not establish CONTENT. Handed an already-populated submodule the helper
+# repairs isolation in place and refuses `git submodule update`, so a modified tracked definition
+# survives with HEAD still at the pin — the revision assertion passes over unreviewed instructions.
+# Bound to the same path as the revision read so the two cannot drift apart.
+case "${section}" in
+  *"git -C libraries/agent-plugins status --porcelain"*)
+    ok "the contract asserts the materialised tree is clean, not just its revision" ;;
+  *) fail "the plugin contract section does not require the materialised submodule tree to be clean" ;;
+esac
+# status alone is blind to assume-unchanged/skip-worktree, which is how a foreign edit hides from it
+# — the same hidden-index hole the Git-safety contract already closes for checkout.
+case "${section}" in
+  *"ls-files -v"*)
+    ok "the contract closes the hidden-index hole in that cleanliness check" ;;
+  *) fail "the plugin contract section does not close the hidden-index hole in its cleanliness check" ;;
+esac
+
 echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -557,8 +557,15 @@ esac
 # after the last `die`), so an UNKNOWN prints no pin at all. UNKNOWN is exactly when this fallback is
 # reached, so the instruction was unfollowable in its own trigger case. Matched as the complete
 # `HEAD:<path>` form: a bare "rev-parse" already appears above for the read-back.
+#
+# The match starts at `rev-parse`, NOT at `git`, because git-level flags sit between the two — the
+# section's pin line carries `--no-replace-objects` there, and a literal starting at `git` asserts
+# command SPELLING where the intent is that the pin comes from the gitlink rather than the check's
+# stdout. Hardening that command would then falsify this assertion, which is what it must not do.
+# `HEAD:<path>` is still what discriminates: the read-back above is `rev-parse HEAD` with no
+# colon-path, and the byte-comparison loop reads `rev-parse "HEAD:$f"`, so neither satisfies this.
 case "${section}" in
-  *"git rev-parse HEAD:libraries/agent-plugins"*)
+  *"rev-parse HEAD:libraries/agent-plugins"*)
     ok "the contract resolves the pin independently of the check's output" ;;
   *) fail "the plugin contract section does not name a pin source independent of the check" ;;
 esac
@@ -603,8 +610,12 @@ esac
 #
 # Patterns below are SINGLE-quoted: they contain `$(` and `${`, which inside a double-quoted case
 # pattern would be command-substituted / expanded, silently changing what is matched.
+#
+# Split around the git-level flag slot for the reason given at the pin-source assertion above: the
+# section's pin line carries `--no-replace-objects` between `git` and `rev-parse`, and each of the
+# two segments occurs exactly once in the section, so the split cannot be satisfied vacuously.
 case "${section}" in
-  *'pin=$(git rev-parse HEAD:libraries/agent-plugins)'*)
+  *'pin=$(git '*'rev-parse HEAD:libraries/agent-plugins)'*)
     ok "the contract BINDS the resolved pin to a variable" ;;
   *) fail "the plugin contract section does not bind the resolved pin to a variable" ;;
 esac
@@ -618,7 +629,7 @@ esac
 # Ordering matters: the pin must be resolved BEFORE it is consumed, or the documented sequence cannot
 # be executed top-to-bottom as written.
 case "${section}" in
-  *'pin=$(git rev-parse HEAD:libraries/agent-plugins)'*'?ref=${pin}'*)
+  *'pin=$(git '*'rev-parse HEAD:libraries/agent-plugins)'*'?ref=${pin}'*)
     ok "the pin is resolved before the forge read consumes it" ;;
   *) fail "the plugin contract section resolves the pin after the forge read that consumes it" ;;
 esac

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -502,16 +502,22 @@ esac
 # 43 deleted lines across all four definition files). The second is the fail-open: it returns a
 # plausible definition, so the run believes it complied while following an unreviewed revision.
 # Measured impact: of the 5 sessions that saw DRIFT that day, only 2 read any reviewed definition.
+# Matched as COMPLETE commands including their path argument. A bare "submodule-init.sh" would still
+# pass if an edit retargeted it at another submodule, and a bare "rev-parse HEAD" would pass if the
+# read-back were pointed somewhere other than the path just materialised — which is precisely the
+# wrong-revision read this section exists to stop.
 case "${section}" in
-  *"submodule-init.sh"*) ok "the contract names how to materialise the reviewed definition" ;;
-  *) fail "the plugin contract section does not name the command that materialises the reviewed definition" ;;
+  *".claude/scripts/submodule-init.sh libraries/agent-plugins"*)
+    ok "the contract names the exact materialisation command and its target" ;;
+  *) fail "the plugin contract section does not name the exact command that materialises the reviewed definition" ;;
 esac
 # The materialisation alone is still fail-open — it is the revision ASSERTION that converts a
 # wrong-revision read from a silent pass into a stop. Pinned separately so an edit cannot drop the
-# check while keeping the command.
+# check while keeping the command, and bound to the SAME path so the two cannot drift apart.
 case "${section}" in
-  *"rev-parse HEAD"*) ok "the contract requires reading back the materialised revision" ;;
-  *) fail "the plugin contract section does not require reading back the materialised revision" ;;
+  *"git -C libraries/agent-plugins rev-parse HEAD"*)
+    ok "the contract reads the revision back from the path it materialised" ;;
+  *) fail "the plugin contract section does not read the materialised revision back from that same path" ;;
 esac
 case "${section}" in
   *"must equal the pinned revision"*)
@@ -524,6 +530,21 @@ case "${section}" in
   *"shared checkout"*)
     ok "the contract warns that the populated shared checkout may be the wrong revision" ;;
   *) fail "the plugin contract section does not warn about the shared checkout's revision" ;;
+esac
+# Detecting the mismatch is only half of it: the run also has to be told what to DO. Re-running the
+# materialisation is the intuitive move and it cannot work — handed an already-populated submodule the
+# helper repairs isolation and refuses `git submodule update`, exiting `isolated ✓` on the stale
+# revision. Without this assertion the contract could name the comparison and leave the recovery to
+# guesswork, which lands straight back on the stale definition.
+case "${section}" in
+  *"a STOP, not a retry"*)
+    ok "the contract says a revision mismatch stops rather than retries" ;;
+  *) fail "the plugin contract section does not say a revision mismatch is a stop rather than a retry" ;;
+esac
+case "${section}" in
+  *"fresh isolated worktree"*)
+    ok "the contract names the recovery for a revision mismatch" ;;
+  *) fail "the plugin contract section does not name the recovery path after a revision mismatch" ;;
 esac
 
 echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -493,4 +493,37 @@ case "${section}" in
   *) fail "the plugin contract section does not require comparison by blob identity" ;;
 esac
 
+# ── 10. The fallback must be EXECUTABLE, not just named ───────────────────────
+# monorepo#2854: naming the reviewed definition as the fallback is not enough, because neither way a
+# run can reach it works unaided. The submodule holding it is empty in a fresh per-run worktree
+# (measured 2026-08-15: most live worktrees carried zero entries there), and where it IS populated —
+# the shared checkout — it sits at whatever revision it was last left on rather than this commit's
+# gitlink (measured the same day: bfde8656 against a pinned 564a6a0f, differing by 311 inserted and
+# 43 deleted lines across all four definition files). The second is the fail-open: it returns a
+# plausible definition, so the run believes it complied while following an unreviewed revision.
+# Measured impact: of the 5 sessions that saw DRIFT that day, only 2 read any reviewed definition.
+case "${section}" in
+  *"submodule-init.sh"*) ok "the contract names how to materialise the reviewed definition" ;;
+  *) fail "the plugin contract section does not name the command that materialises the reviewed definition" ;;
+esac
+# The materialisation alone is still fail-open — it is the revision ASSERTION that converts a
+# wrong-revision read from a silent pass into a stop. Pinned separately so an edit cannot drop the
+# check while keeping the command.
+case "${section}" in
+  *"rev-parse HEAD"*) ok "the contract requires reading back the materialised revision" ;;
+  *) fail "the plugin contract section does not require reading back the materialised revision" ;;
+esac
+case "${section}" in
+  *"must equal the pinned revision"*)
+    ok "the contract requires the materialised revision to equal the pin" ;;
+  *) fail "the plugin contract section does not require the materialised revision to equal the pin" ;;
+esac
+# The shared checkout is the specific trap, so it is named rather than left to inference: a run that
+# has not been told the populated copy can be the WRONG copy has no reason to suspect it.
+case "${section}" in
+  *"shared checkout"*)
+    ok "the contract warns that the populated shared checkout may be the wrong revision" ;;
+  *) fail "the plugin contract section does not warn about the shared checkout's revision" ;;
+esac
+
 echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,8 +308,31 @@ is covered yet — see [#2850](https://github.com/devantler-tech/monorepo/issues
 `CURRENT` from this check as a statement about a sibling instance.
 
 **On drift, do not proceed as if the loaded definition were current: read the reviewed definition at
-the pinned gitlink and follow that**, and report the drift. Refresh only through the runtime's own
-control plane — the `/plugin` marketplace update flow. **Never edit the plugin cache**; it is
+the pinned gitlink and follow that**, and report the drift.
+
+🔴 **"At the pinned gitlink" is a REVISION, not a directory — and both ways of reaching it fail
+unaided.** The reviewed copy lives in the `libraries/agent-plugins` submodule, which is **empty in a
+fresh per-run worktree**, so there is nothing to read; and where it is already populated — the
+**shared checkout** — it sits at whatever revision it was last left on, **not this commit's
+gitlink**. Measured 2026-08-15: the shared checkout stood at `bfde8656` against a pinned `564a6a0f`,
+a difference of **311 inserted and 43 deleted lines across all four definition files**, including the
+entire observation-plane and research-fallback material. The second case is the dangerous one,
+because it returns a plausible definition and the run believes it complied while following an
+unreviewed revision. Of the five sessions that saw `DRIFT` that day, **only two read any reviewed
+definition at all** ([#2854](https://github.com/devantler-tech/monorepo/issues/2854)).
+
+**Materialise it and then assert the revision, both from your own session worktree:**
+
+```sh
+.claude/scripts/submodule-init.sh libraries/agent-plugins   # checks out THIS commit's gitlink
+git -C libraries/agent-plugins rev-parse HEAD               # read the revision back
+```
+
+That read-back **must equal the pinned revision** the check printed. A mismatch means you are reading
+some other revision rather than the reviewed one — re-materialise instead of proceeding, and never
+read a definition out of an already-populated submodule without making this comparison.
+
+Refresh only through the runtime's own control plane — the `/plugin` marketplace update flow. **Never edit the plugin cache**; it is
 read-only evidence (see *Agent definition locations*). When the refresh needs an interactive session
 an unattended run cannot open, surface it on a declared *Maintainer channel* rather than leaving a
 silently superseded definition in place.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,24 +321,56 @@ because it returns a plausible definition and the run believes it complied while
 unreviewed revision. Of the five sessions that saw `DRIFT` that day, **only two read any reviewed
 definition at all** ([#2854](https://github.com/devantler-tech/monorepo/issues/2854)).
 
-**Materialise it in a fresh session worktree — where that submodule is still empty — then assert the
-revision:**
+🔴 **Resolve the pin yourself — do NOT depend on the check having printed it.** Every `die` in
+`plugin-definition-currency.sh` exits **before** its reporting block, so an **UNKNOWN prints no
+pinned revision at all** — and UNKNOWN is precisely when this fallback is reached. Read the gitlink
+straight out of this commit, which cannot fail for the reasons the check does:
+
+```sh
+git rev-parse HEAD:libraries/agent-plugins   # the pinned revision, independent of the check
+```
+
+**Prefer the forge read: it needs no working tree, so none of the traps below can reach it.** The
+revision is named in the request, so what comes back is the reviewed content by construction — this
+is the one path that works in a fresh worktree, a populated one, and a broken one alike:
+
+```sh
+gh api "repos/devantler-tech/agent-plugins/contents/<file>?ref=<pin>" \
+  -H "Accept: application/vnd.github.raw"
+```
+
+**Materialising it locally is the fallback, and it carries two assertions rather than one** — in a
+fresh session worktree, where that submodule is still empty:
 
 ```sh
 .claude/scripts/submodule-init.sh libraries/agent-plugins   # populates an EMPTY submodule at this commit's gitlink
 git -C libraries/agent-plugins rev-parse HEAD               # read the revision back
+git -C libraries/agent-plugins status --porcelain           # and prove the tree is CLEAN
 ```
 
-That read-back **must equal the pinned revision** the check printed.
+That read-back **must equal the pinned revision**, and the status must print nothing.
 
-🔴 **A mismatch is a STOP, not a retry — re-running that command cannot fix it.** Handed an
-**already-populated** submodule, `submodule-init.sh` repairs isolation only and deliberately refuses
-`git submodule update`, so it exits `isolated ✓` with the stale revision still checked out — the
-warning *Git safety* already carries, and exactly the shape being guarded against here. Moving a
-populated submodule onto a pin has **no procedure yet**
-([#2833](https://github.com/devantler-tech/monorepo/issues/2833)), so on a mismatch materialise in a
-fresh isolated worktree and repeat the comparison. Never read a definition out of an
-already-populated submodule until its `HEAD` equals the pinned revision.
+🔴 **The revision alone does NOT establish the content — assert the tree is clean too.** Handed an
+already-populated submodule, `submodule-init.sh` repairs isolation and deliberately refuses
+`git submodule update`, so a **modified tracked definition survives with `HEAD` still equal to the
+pin**: the revision assertion passes and the run follows unreviewed instructions anyway. Require an
+empty `status --porcelain`, and with it the hidden-index check *Git safety* prescribes
+(`git -C libraries/agent-plugins ls-files -v` showing no lowercase flag and no `S`), because
+`assume-unchanged` and `skip-worktree` hide a modification from `status` entirely.
+
+🔴 **A mismatch is a STOP, not a retry — re-running that command cannot fix it.** The same in-place
+repair means it exits `isolated ✓` with the stale revision still checked out — the warning *Git
+safety* already carries. Moving a populated submodule onto a pin has **no procedure yet**
+([#2833](https://github.com/devantler-tech/monorepo/issues/2833)), so on a mismatch use the forge
+read above, or materialise in a fresh isolated worktree and repeat the comparison. Never read a
+definition out of an already-populated submodule until its `HEAD` equals the pinned revision **and
+its tree is clean**.
+
+🔴 **`submodule-init.sh` can also stop having materialised NOTHING — which is not a dead end.** Run
+from a linked worktree, `git submodule update --init` can exit 0 while populating nothing, after
+which the helper deliberately dies `STILL EMPTY` rather than report a vacuous `isolated ✓`. That is
+the prescribed recovery worktree failing in exactly the case it was reached for, so do not let it end
+the run: fall back to the forge read, which needs no working tree.
 
 Refresh only through the runtime's own control plane — the `/plugin` marketplace update flow. **Never edit the plugin cache**; it is
 read-only evidence (see *Agent definition locations*). When the refresh needs an interactive session

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,16 +321,24 @@ because it returns a plausible definition and the run believes it complied while
 unreviewed revision. Of the five sessions that saw `DRIFT` that day, **only two read any reviewed
 definition at all** ([#2854](https://github.com/devantler-tech/monorepo/issues/2854)).
 
-**Materialise it and then assert the revision, both from your own session worktree:**
+**Materialise it in a fresh session worktree — where that submodule is still empty — then assert the
+revision:**
 
 ```sh
-.claude/scripts/submodule-init.sh libraries/agent-plugins   # checks out THIS commit's gitlink
+.claude/scripts/submodule-init.sh libraries/agent-plugins   # populates an EMPTY submodule at this commit's gitlink
 git -C libraries/agent-plugins rev-parse HEAD               # read the revision back
 ```
 
-That read-back **must equal the pinned revision** the check printed. A mismatch means you are reading
-some other revision rather than the reviewed one — re-materialise instead of proceeding, and never
-read a definition out of an already-populated submodule without making this comparison.
+That read-back **must equal the pinned revision** the check printed.
+
+🔴 **A mismatch is a STOP, not a retry — re-running that command cannot fix it.** Handed an
+**already-populated** submodule, `submodule-init.sh` repairs isolation only and deliberately refuses
+`git submodule update`, so it exits `isolated ✓` with the stale revision still checked out — the
+warning *Git safety* already carries, and exactly the shape being guarded against here. Moving a
+populated submodule onto a pin has **no procedure yet**
+([#2833](https://github.com/devantler-tech/monorepo/issues/2833)), so on a mismatch materialise in a
+fresh isolated worktree and repeat the comparison. Never read a definition out of an
+already-populated submodule without making it.
 
 Refresh only through the runtime's own control plane — the `/plugin` marketplace update flow. **Never edit the plugin cache**; it is
 read-only evidence (see *Agent definition locations*). When the refresh needs an interactive session

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,6 +406,7 @@ and treat a failed lookup as `BYTES-UNKNOWN` rather than as a match. `--no-repla
 the check silently spans two object namespaces. And keep `printf '%s\n'` — command substitution strips
 the trailing newline, and a bare `printf '%s'` makes `read` return false on the final entry, dropping
 the last file from the sweep unchecked.
+
 This is also why **the forge read above is preferred and not merely more convenient**: it names the
 revision in the request, so it is immune to replace refs, filters, and index bits alike — the local
 fallback needs all four assertions to reach the same confidence the forge read has by construction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,7 +338,7 @@ warning *Git safety* already carries, and exactly the shape being guarded agains
 populated submodule onto a pin has **no procedure yet**
 ([#2833](https://github.com/devantler-tech/monorepo/issues/2833)), so on a mismatch materialise in a
 fresh isolated worktree and repeat the comparison. Never read a definition out of an
-already-populated submodule without making it.
+already-populated submodule until its `HEAD` equals the pinned revision.
 
 Refresh only through the runtime's own control plane — the `/plugin` marketplace update flow. **Never edit the plugin cache**; it is
 read-only evidence (see *Agent definition locations*). When the refresh needs an interactive session

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,15 +327,17 @@ pinned revision at all** — and UNKNOWN is precisely when this fallback is reac
 straight out of this commit, which cannot fail for the reasons the check does:
 
 ```sh
-git rev-parse HEAD:libraries/agent-plugins   # the pinned revision, independent of the check
+pin=$(git rev-parse HEAD:libraries/agent-plugins)   # the pinned revision, independent of the check
 ```
 
 **Prefer the forge read: it needs no working tree, so none of the traps below can reach it.** The
 revision is named in the request, so what comes back is the reviewed content by construction — this
-is the one path that works in a fresh worktree, a populated one, and a broken one alike:
+is the one path that works in a fresh worktree, a populated one, and a broken one alike. Pass the
+`$pin` you just resolved, never a revision retyped from somewhere else — binding the two is what
+makes this executable rather than merely described:
 
 ```sh
-gh api "repos/devantler-tech/agent-plugins/contents/<file>?ref=<pin>" \
+gh api "repos/devantler-tech/agent-plugins/contents/<file>?ref=${pin}" \
   -H "Accept: application/vnd.github.raw"
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,15 +379,33 @@ Assert byte identity against the pinned blobs directly, which no filter can laun
 `--no-filters` bypasses the clean stage:
 
 ```sh
-git -C libraries/agent-plugins ls-tree -r --name-only HEAD -- plugins/agentic-engineering |
+files=$(git -C libraries/agent-plugins --no-replace-objects ls-tree -r --name-only HEAD -- plugins/agentic-engineering) || echo "BYTES-UNKNOWN <enumeration failed>"
+printf '%s\n' "$files" |
   while IFS= read -r f; do
-    want=$(git -C libraries/agent-plugins --no-replace-objects rev-parse "HEAD:$f")
-    got=$(git -C libraries/agent-plugins hash-object --no-filters -- "$f")
+    [ -n "$f" ] || continue
+    want=$(git -C libraries/agent-plugins --no-replace-objects rev-parse "HEAD:$f") \
+      || { echo "BYTES-UNKNOWN $f"; continue; }
+    got=$(git -C libraries/agent-plugins hash-object --no-filters -- "$f") \
+      || { echo "BYTES-UNKNOWN $f"; continue; }
+    { [ -n "$want" ] && [ -n "$got" ]; } || { echo "BYTES-UNKNOWN $f"; continue; }
     [ "$want" = "$got" ] || echo "BYTES-DIFFER $f"
   done
 ```
 
-Any output means the working tree is **not** the reviewed definition, whatever the other three said.
+Any output means the working tree is **not** the reviewed definition, whatever the other three said —
+and that includes `BYTES-UNKNOWN`, because unproven is not proven.
+
+🔴 **Every one of those guards closes a path where the naive form reports success on a check that
+never ran.** Piping `ls-tree` straight into the loop takes the **while's** exit status, so an
+enumeration failure runs the body zero times and prints nothing — indistinguishable from a verified
+tree. Worse, an **uninitialised submodule** makes *every* command fail: `rev-parse` and `hash-object`
+both return empty, and `[ "$want" = "$got" ]` then compares **equal**, so the emptiest possible
+evidence reads as the strongest. Capture the enumeration and check its status, reject an empty hash,
+and treat a failed lookup as `BYTES-UNKNOWN` rather than as a match. `--no-replace-objects` belongs on
+`ls-tree` too: without it the enumeration walks a replaced tree while the lookups beside it do not, so
+the check silently spans two object namespaces. And keep `printf '%s\n'` — command substitution strips
+the trailing newline, and a bare `printf '%s'` makes `read` return false on the final entry, dropping
+the last file from the sweep unchecked.
 This is also why **the forge read above is preferred and not merely more convenient**: it names the
 revision in the request, so it is immune to replace refs, filters, and index bits alike — the local
 fallback needs all four assertions to reach the same confidence the forge read has by construction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,8 +327,15 @@ pinned revision at all** — and UNKNOWN is precisely when this fallback is reac
 straight out of this commit, which cannot fail for the reasons the check does:
 
 ```sh
-pin=$(git rev-parse HEAD:libraries/agent-plugins)   # the pinned revision, independent of the check
+pin=$(git --no-replace-objects rev-parse HEAD:libraries/agent-plugins)   # the pinned revision
 ```
+
+⚠️ **`--no-replace-objects` is load-bearing here, exactly as it is in *Git safety*.** A `refs/replace`
+entry for `HEAD` makes `HEAD:libraries/agent-plugins` resolve **through the replacement commit** while
+`git rev-parse HEAD` still prints the expected commit — so the pin silently names an unreviewed
+revision, and the forge read below then fetches the wrong definitions **faithfully**, reporting them
+as reviewed. That is a fail-open on the one value everything downstream trusts, and the replace ref
+lives in the shared repository, so a single stale entry reaches every worktree.
 
 **Prefer the forge read: it needs no working tree, so none of the traps below can reach it.** The
 revision is named in the request, so what comes back is the reviewed content by construction — this
@@ -359,6 +366,31 @@ pin**: the revision assertion passes and the run follows unreviewed instructions
 empty `status --porcelain`, and with it the hidden-index check *Git safety* prescribes
 (`git -C libraries/agent-plugins ls-files -v` showing no lowercase flag and no `S`), because
 `assume-unchanged` and `skip-worktree` hide a modification from `status` entirely.
+
+🔴 **Even those three together do NOT prove the BYTES — a clean/smudge filter defeats all of them.**
+When `.gitattributes` (repository, global, or `$GIT_DIR/info/attributes`) assigns a filter to these
+paths, git compares the *cleaned* form: the file on disk can carry different instructions while
+`status --porcelain` prints nothing and `ls-files -v` reports an ordinary entry. Every assertion above
+passes and the run follows altered definitions. The three checks answer "is the tree unmodified
+**as git sees it**", which is a weaker claim than "are these the reviewed bytes" — and it is the
+weaker claim that is easy to mistake for proof.
+
+Assert byte identity against the pinned blobs directly, which no filter can launder because
+`--no-filters` bypasses the clean stage:
+
+```sh
+git -C libraries/agent-plugins ls-tree -r --name-only HEAD -- plugins/agentic-engineering |
+  while IFS= read -r f; do
+    want=$(git -C libraries/agent-plugins --no-replace-objects rev-parse "HEAD:$f")
+    got=$(git -C libraries/agent-plugins hash-object --no-filters -- "$f")
+    [ "$want" = "$got" ] || echo "BYTES-DIFFER $f"
+  done
+```
+
+Any output means the working tree is **not** the reviewed definition, whatever the other three said.
+This is also why **the forge read above is preferred and not merely more convenient**: it names the
+revision in the request, so it is immune to replace refs, filters, and index bits alike — the local
+fallback needs all four assertions to reach the same confidence the forge read has by construction.
 
 🔴 **A mismatch is a STOP, not a retry — re-running that command cannot fix it.** The same in-place
 repair means it exits `isolated ✓` with the stale revision still checked out — the warning *Git


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The definition-currency check shipped yesterday (#2848) tells a run what to do when the runtime loaded a superseded definition: read the reviewed one at the pinned gitlink instead. Measured today, **that fallback could not be followed as written, and its most natural reading failed silently** — so the check could report drift correctly and the run would still end up on the wrong definition.

Of the five sessions that saw `DRIFT` today, only two read any reviewed definition at all.

### What

Names the one command that materialises the reviewed definition, and requires reading the resulting revision back against the pin — so reaching for the wrong copy stops the run instead of passing unnoticed. The trap it closes is the populated shared checkout, which today sits 311 lines away from the pinned revision across all four definition files while looking perfectly normal.

Fixes #2854