### PR TITLE
fix(agents): name the control-byte spelling that loses a whole Bash call

### DIFF
--- a/.claude/scripts/control-character-command-contract.test.sh
+++ b/.claude/scripts/control-character-command-contract.test.sh
@@ -104,6 +104,6 @@ if ! command -v perl >/dev/null 2>&1; then
 fi
 raw_count="$(perl -ne '$n++ if /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/; END{print $n+0}' "${constitution}")"
 [ "${raw_count}" = "0" ] ||
-  fail "AGENTS.md contains ${raw_count} line(s) with a raw control byte — invisible in review, and any Bash command quoting them is rejected outright; write the byte as an escape (\$'\\x1f', or the jq \\u001f form)"
+  fail "AGENTS.md contains ${raw_count} line(s) with a raw control byte — invisible in review, and the non-whitespace C0 bytes among them are rejected outright by the Bash guard; write the byte as an escape (\$'\\x1f', or the jq \\u001f form)"
 
 echo "control-character command contract: OK — 7 assertions passed"

--- a/.claude/scripts/control-character-command-contract.test.sh
+++ b/.claude/scripts/control-character-command-contract.test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Guards the *Latency discipline* bullet that stops a `Bash` command being rejected outright for
+# carrying a raw control byte.
+#
+# Why this needs a guard. The runtime refuses such a call with `InputValidationError: command
+# contains control characters that would be hidden in the approval dialog`. Nothing is partially
+# applied — the call never runs — and the message names neither the offending byte nor its position,
+# so a lane rediscovers the limit by improvising a second spelling of the same command. Measured over
+# the 7 days to 2026-08-15: 18 occurrences across 14 distinct sessions, spread over 10+ branches in
+# both the routine and the maintainer-interactive lanes.
+#
+# The subtle part, and the reason a presence-only check is not enough: the OBVIOUS diagnosis is
+# wrong. Issue #2773 hypothesised "raw newlines and tabs ... inlining a multi-line jq program", and
+# a fix written to that hypothesis ("put the program in a file") addresses nothing, because a raw
+# newline and a raw tab are both ACCEPTED. The bytes that actually fire the guard are the
+# non-whitespace C0 delimiters chosen as collision-proof separators — measured census NUL x5,
+# SOH x5, US x4, SOH+STX x2. So assertion 2 pins the correction itself: while the contract can be
+# read as blaming newlines/tabs, the reader is sent to a fix that cannot work.
+#
+# Assertions are scoped to the bullet, not the whole file — asserting against the whole constitution
+# is a scope hole, since an unrelated section containing the phrase would satisfy the check while the
+# real sentence stayed wrong. Assertion 7 is deliberately the exception and is whole-file by design.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+constitution="${repo_root}/AGENTS.md"
+
+fail() {
+  echo "control-character command contract: FAIL — $*" >&2
+  exit 1
+}
+
+[ -r "${constitution}" ] || fail "cannot read ${constitution}"
+
+# Extract ONLY this bullet, then flatten it: the sentences wrap across source lines, so a fragment
+# spanning a line break would never match and the test would be always-red regardless of content.
+bullet="$(
+  awk '
+    /A raw control byte anywhere in a `Bash` command/ { inb = 1 }
+    inb && /^This changes only/                       { inb = 0 }
+    inb                                               { print }
+  ' "${constitution}" | tr '\n' ' ' | tr -s '[:space:]' ' '
+)"
+
+[ -n "${bullet}" ] ||
+  fail "could not locate the raw-control-byte bullet — the extraction anchor moved, so every assertion below would be vacuous"
+
+# Guard the extraction itself. If the terminating anchor disappears, awk runs to end-of-file and
+# `bullet` becomes the rest of the contract, silently restoring the scope hole while every assertion
+# still passes. The bound separates two states an order of magnitude apart (this bullet is ~330
+# words; a runaway extraction measures thousands), so it does not fail legitimate edits.
+bullet_words="$(printf '%s' "${bullet}" | wc -w | tr -d ' ')"
+[ "${bullet_words}" -lt 1200 ] ||
+  fail "bullet extracted as ${bullet_words} words, which is runaway-extraction size — the 'This changes only' end anchor was probably renamed or removed, so these assertions would no longer be scoped to this bullet"
+
+assert_bullet() {
+  case "${bullet}" in
+    *"$1"*) ;;
+    *) fail "$2" ;;
+  esac
+}
+
+# 1. The consequence is stated as total loss of the call, not a partial or retryable failure. An
+#    agent that believes the command half-ran will debug the pipeline instead of the spelling.
+assert_bullet 'loses the WHOLE call' \
+  "the bullet does not state that the entire Bash call is lost, so the failure reads as partial or retryable"
+
+# 2. THE CORRECTION. Without this the natural (and measured-false) 'newlines and tabs' reading
+#    survives, and the reader is sent to a fix that changes nothing.
+assert_bullet 'NOT "newlines and tabs"' \
+  "the bullet does not correct the measured-false 'newlines and tabs' diagnosis, so the reader is sent to a fix that cannot work"
+
+# 3. The accepted bytes are named explicitly. Assertion 2 says what the cause is not; this says what
+#    is safe, which is what stops the over-correction of banning multi-line commands outright.
+assert_bullet 'are both **accepted**' \
+  "the bullet does not state that a raw newline and a raw tab are accepted, inviting an over-correction that bans multi-line commands"
+
+# 4. The named alternative. A prohibition that does not say what to write instead is the DevEx tax
+#    this repo's own hardening rule forbids, and it is what relocates the real instruction into
+#    somewhere unreviewed.
+assert_bullet "\$'\\x1f'" \
+  "the bullet forbids the raw byte without naming the ANSI-C quoting alternative that emits the same byte"
+
+# 5. The jq form, which is a different spelling from the shell one and is the case that actually
+#    recurs in this deployment's TSV-shaped mining pipelines.
+assert_bullet 'jq string escape' \
+  "the bullet does not give the jq escape form, so a jq program is left with no stated alternative"
+
+# 6. The comment trap. The code can be correct while the annotation explaining it costs the call —
+#    reproduced live while this bullet was being written.
+assert_bullet 'comments included' \
+  "the bullet does not warn that the guard scans comments too, so a command whose code is fixed can still fail on its own annotation"
+
+# 7. WHOLE-FILE, and deliberately so. The contract must not itself contain a raw control byte: it is
+#    quoted, copied and grepped constantly, and a non-printing byte is invisible in review. This is
+#    not hypothetical — the first draft of this very bullet embedded a raw 0x1F inside the backticks
+#    meant to display the jq escape, so the rule forbidding raw control bytes was itself written with
+#    one. `perl` rather than `grep -P`: on this host `grep` is a ugrep wrapper function whose -P
+#    support is not reliably present, so a grep-based check can fail open.
+if ! command -v perl >/dev/null 2>&1; then
+  fail "perl is required for the raw-control-byte scan; without it assertion 7 would silently pass"
+fi
+raw_count="$(perl -ne '$n++ if /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/; END{print $n+0}' "${constitution}")"
+[ "${raw_count}" = "0" ] ||
+  fail "AGENTS.md contains ${raw_count} line(s) with a raw control byte — invisible in review, and any Bash command quoting them is rejected outright; write the byte as an escape (\$'\\x1f', or the jq \\u001f form)"
+
+echo "control-character command contract: OK — 7 assertions passed"

--- a/.claude/scripts/control-character-command-contract.test.sh
+++ b/.claude/scripts/control-character-command-contract.test.sh
@@ -15,12 +15,12 @@
 # a fix written to that hypothesis ("put the program in a file") addresses nothing, because a raw
 # newline and a raw tab are both ACCEPTED. The bytes that actually fire the guard are the
 # non-whitespace C0 delimiters chosen as collision-proof separators — measured census NUL x5,
-# SOH x5, US x4, SOH+STX x2. So assertion 2 pins the correction itself: while the contract can be
+# SOH x5, US x4, SOH+STX x2. So assertion 3 pins the correction itself: while the contract can be
 # read as blaming newlines/tabs, the reader is sent to a fix that cannot work.
 #
 # Assertions are scoped to the bullet, not the whole file — asserting against the whole constitution
 # is a scope hole, since an unrelated section containing the phrase would satisfy the check while the
-# real sentence stayed wrong. Assertion 7 is deliberately the exception and is whole-file by design.
+# real sentence stayed wrong. Assertion 8 is deliberately the exception and is whole-file by design.
 
 set -euo pipefail
 
@@ -38,9 +38,9 @@ fail() {
 # spanning a line break would never match and the test would be always-red regardless of content.
 bullet="$(
   awk '
-    /A raw control byte anywhere in a `Bash` command/ { inb = 1 }
-    inb && /^This changes only/                       { inb = 0 }
-    inb                                               { print }
+    /^- \*\*A raw / { inb = 1 }
+    inb && /^This changes only/ { inb = 0 }
+    inb                         { print }
   ' "${constitution}" | tr '\n' ' ' | tr -s '[:space:]' ' '
 )"
 
@@ -67,43 +67,50 @@ assert_bullet() {
 assert_bullet 'loses the WHOLE call' \
   "the bullet does not state that the entire Bash call is lost, so the failure reads as partial or retryable"
 
-# 2. THE CORRECTION. Without this the natural (and measured-false) 'newlines and tabs' reading
+# 2. The rejected class is named precisely in the HEADLINE claim. Without this the headline can say
+#    "raw control byte" while the paragraph below says newline and tab are accepted — and a newline
+#    and a tab ARE control bytes, so the bullet contradicts itself and reads as a ban on multi-line
+#    commands. The two halves must agree, so the classification is pinned where the rule is stated.
+assert_bullet 'raw non-whitespace C0 control byte' \
+  "the bullet does not identify raw non-whitespace C0 control bytes as the rejected class, so its headline contradicts its own newline/tab carve-out"
+
+# 3. THE CORRECTION. Without this the natural (and measured-false) 'newlines and tabs' reading
 #    survives, and the reader is sent to a fix that changes nothing.
 assert_bullet 'NOT "newlines and tabs"' \
   "the bullet does not correct the measured-false 'newlines and tabs' diagnosis, so the reader is sent to a fix that cannot work"
 
-# 3. The accepted bytes are named explicitly. Assertion 2 says what the cause is not; this says what
+# 4. The accepted bytes are named explicitly. Assertion 3 says what the cause is not; this says what
 #    is safe, which is what stops the over-correction of banning multi-line commands outright.
 assert_bullet 'are both **accepted**' \
   "the bullet does not state that a raw newline and a raw tab are accepted, inviting an over-correction that bans multi-line commands"
 
-# 4. The named alternative. A prohibition that does not say what to write instead is the DevEx tax
+# 5. The named alternative. A prohibition that does not say what to write instead is the DevEx tax
 #    this repo's own hardening rule forbids, and it is what relocates the real instruction into
 #    somewhere unreviewed.
 assert_bullet "\$'\\x1f'" \
   "the bullet forbids the raw byte without naming the ANSI-C quoting alternative that emits the same byte"
 
-# 5. The jq form, which is a different spelling from the shell one and is the case that actually
+# 6. The jq form, which is a different spelling from the shell one and is the case that actually
 #    recurs in this deployment's TSV-shaped mining pipelines.
 assert_bullet 'jq string escape' \
   "the bullet does not give the jq escape form, so a jq program is left with no stated alternative"
 
-# 6. The comment trap. The code can be correct while the annotation explaining it costs the call —
+# 7. The comment trap. The code can be correct while the annotation explaining it costs the call —
 #    reproduced live while this bullet was being written.
 assert_bullet 'comments included' \
   "the bullet does not warn that the guard scans comments too, so a command whose code is fixed can still fail on its own annotation"
 
-# 7. WHOLE-FILE, and deliberately so. The contract must not itself contain a raw control byte: it is
+# 8. WHOLE-FILE, and deliberately so. The contract must not itself contain a raw control byte: it is
 #    quoted, copied and grepped constantly, and a non-printing byte is invisible in review. This is
 #    not hypothetical — the first draft of this very bullet embedded a raw 0x1F inside the backticks
 #    meant to display the jq escape, so the rule forbidding raw control bytes was itself written with
 #    one. `perl` rather than `grep -P`: on this host `grep` is a ugrep wrapper function whose -P
 #    support is not reliably present, so a grep-based check can fail open.
 if ! command -v perl >/dev/null 2>&1; then
-  fail "perl is required for the raw-control-byte scan; without it assertion 7 would silently pass"
+  fail "perl is required for the raw-control-byte scan; without it assertion 8 would silently pass"
 fi
 raw_count="$(perl -ne '$n++ if /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/; END{print $n+0}' "${constitution}")"
 [ "${raw_count}" = "0" ] ||
   fail "AGENTS.md contains ${raw_count} line(s) with a raw control byte — invisible in review, and the non-whitespace C0 bytes among them are rejected outright by the Bash guard; write the byte as an escape (\$'\\x1f', or the jq \\u001f form)"
 
-echo "control-character command contract: OK — 7 assertions passed"
+echo "control-character command contract: OK — 8 assertions passed"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
       agent-role-delivery-contract: ${{ steps.filter.outputs.agent-role-delivery-contract }}
       work-priority-ladder: ${{ steps.filter.outputs.work-priority-ladder }}
       latency-discipline-contract: ${{ steps.filter.outputs.latency-discipline-contract }}
+      control-character-command-contract: ${{ steps.filter.outputs.control-character-command-contract }}
       git-safety-contract: ${{ steps.filter.outputs.git-safety-contract }}
       plugin-definition-currency: ${{ steps.filter.outputs.plugin-definition-currency }}
       merge-confirmation-read: ${{ steps.filter.outputs.merge-confirmation-read }}
@@ -194,6 +195,10 @@ jobs:
             latency-discipline-contract:
               - 'AGENTS.md'
               - '.claude/scripts/latency-discipline-contract.test.sh'
+              - '.github/workflows/ci.yaml'
+            control-character-command-contract:
+              - 'AGENTS.md'
+              - '.claude/scripts/control-character-command-contract.test.sh'
               - '.github/workflows/ci.yaml'
             git-safety-contract:
               - 'AGENTS.md'
@@ -774,6 +779,21 @@ jobs:
       - name: Verify the latency discipline contract
         run: bash .claude/scripts/latency-discipline-contract.test.sh
 
+  test-control-character-command-contract:
+    name: Test control character command contract
+    needs: changes
+    if: needs.changes.outputs.control-character-command-contract == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify the control character command contract
+        run: bash .claude/scripts/control-character-command-contract.test.sh
+
   test-git-safety-contract:
     name: Test git safety contract
     needs: changes
@@ -935,6 +955,7 @@ jobs:
       - test-maintainer-preflight
       - test-memory-hygiene
       - test-latency-discipline-contract
+      - test-control-character-command-contract
       - test-git-safety-contract
       - test-plugin-definition-currency
       - test-self-review-contract
@@ -969,6 +990,7 @@ jobs:
             ${{ needs.test-maintainer-preflight.result }}
             ${{ needs.test-memory-hygiene.result }}
             ${{ needs.test-latency-discipline-contract.result }}
+            ${{ needs.test-control-character-command-contract.result }}
             ${{ needs.test-git-safety-contract.result }}
             ${{ needs.test-plugin-definition-currency.result }}
             ${{ needs.test-self-review-contract.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3491,8 +3491,8 @@ window, unnoticed. The work was never the bottleneck; the **scheduling** was.
   IFS-split; only parameter expansion is exempt), so an unexpected result there is ordinary
   whitespace splitting, not this bug. Keep the two diagnoses apart — the parameter-expansion family
   is `set -- $var` and `cmd $args`.
-- **A raw control byte anywhere in a `Bash` command loses the WHOLE call — write the delimiter as an
-  escape instead.** The runtime refuses the call outright with
+- **A raw non-whitespace C0 control byte anywhere in a `Bash` command loses the WHOLE call — write the
+  delimiter as an escape instead.** The runtime refuses the call outright with
   `InputValidationError: command contains control characters that would be hidden in the approval
   dialog`, which is a **correct guard** — you cannot approve what you cannot see — so never touch it
   or any permission surface to work around this; fix the command. Measured over the 7 days to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3491,6 +3491,36 @@ window, unnoticed. The work was never the bottleneck; the **scheduling** was.
   IFS-split; only parameter expansion is exempt), so an unexpected result there is ordinary
   whitespace splitting, not this bug. Keep the two diagnoses apart — the parameter-expansion family
   is `set -- $var` and `cmd $args`.
+- **A raw control byte anywhere in a `Bash` command loses the WHOLE call — write the delimiter as an
+  escape instead.** The runtime refuses the call outright with
+  `InputValidationError: command contains control characters that would be hidden in the approval
+  dialog`, which is a **correct guard** — you cannot approve what you cannot see — so never touch it
+  or any permission surface to work around this; fix the command. Measured over the 7 days to
+  2026-08-15: **18 occurrences across 14 distinct sessions**, spread over 10+ branches in both the
+  routine and the maintainer-interactive lanes, making it the largest diagnosed avoidable reliability
+  cost. Nothing is partially applied — the call never runs, and the message names neither the
+  offending byte nor its position, which is why lanes rediscover it by improvising a second spelling
+  of the same command.
+  🔴 **It is NOT "newlines and tabs" — that natural reading is measured-false and sends you to a fix
+  that changes nothing.** A raw newline and a raw **tab** are both **accepted** (verified directly;
+  every multi-line command in this contract relies on it), so "put the multi-line program in a file"
+  addresses nothing. The bytes that actually fire it are the **non-whitespace C0 delimiters**, chosen
+  deliberately as collision-proof field/record separators for TSV-ish pipelines and then typed as raw
+  bytes: measured census **NUL ×5, SOH ×5, US ×4, SOH+STX ×2** — i.e. the habit is sound engineering
+  (a body containing tabs and newlines needs a separator that cannot collide) and only its *spelling*
+  is wrong.
+  **Write the separator so the source stays printable — verified to emit the identical byte:**
+  ```sh
+  printf 'a%sb' $'\x1f'                      # ANSI-C quoting -> the 0x1F byte
+  while IFS=$'\x1f' read -r a b; do …; done  # same split, printable source
+  printf 'p\0q\0' | xargs -0 -n1 …           # NUL: the \0 escape, never a raw byte
+  ```
+  For a `jq` program, the six printable characters `\u001f` are a jq string escape and emit the byte
+  at runtime, so the program text itself stays clean. The rule is only ever about **how the byte is
+  spelled in the command you send**, never about which byte the pipeline uses.
+  ⚠️ **The guard scans the ENTIRE command string, comments included** — reproduced live while writing
+  this rule: a trailing `# …` explaining the delimiter carried a raw byte and cost the call, with the
+  code itself already correct. So a command that looks fixed can still fail on its own annotation.
 
 This changes only *ordering and overlap* — never the quality bar. Validation, RED/GREEN proof,
 root-cause fixing, and every guardrail are unaffected; the point is to stop paying for them serially.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Agents keep losing whole `Bash` calls to a runtime refusal, and the contract has never said why. Over the 7 days to 2026-08-15 this hit **18 times across 14 distinct sessions**, on 10+ branches in both the routine and maintainer-interactive lanes — the largest diagnosed avoidable reliability cost we can currently measure. Nothing partially applies: the command simply never runs, and the error names neither the offending character nor where it is, so each lane rediscovers the limit by rewriting the same command a second way.

The obvious explanation is wrong, which is why it stayed open since #2773 was filed. That issue assumed raw newlines and tabs from inlined multi-line programs — but both are accepted, so its proposed fix (move the program into a file) would have changed nothing. The real cause is narrower and more sympathetic: agents pick a collision-proof separator for record-shaped pipelines and type it as a raw byte. The engineering instinct is right; only the spelling is wrong.

## What

States the constraint where commands are authored, and names the escape forms that emit the identical byte while keeping the command readable — so the technique survives and only the spelling changes. Adds a contract test wired into CI, including a whole-file check that the contract itself contains no raw control byte. That check is not hypothetical: the first draft of this rule embedded one inside the very backticks meant to display the escape.

The runtime guard is correct and is left alone; no permission surface is touched.

Fixes #2773