### PR TITLE
chore(agentic-engineering): update reviewed plugin

### DIFF
--- a/.claude/plugin-consumption/agentic-engineering.desired-state.json
+++ b/.claude/plugin-consumption/agentic-engineering.desired-state.json
@@ -49,7 +49,7 @@
         "enabledWhen": "Both optional consumer contract sections are present",
         "mode": "separate-schedule-or-on-demand",
         "definitionSha256": "bd7562cf141a0c965c1189e5a0fe37b10d444ac076211c405f385dd68019f882",
-        "skillSha256": "193b59cb15826855dfd0ac1f3f99a180be7eca178f9e6d4f13c45f655e335736"
+        "skillSha256": "dccf7463ecf0e11a12f03ae5e26dedbdc0b2c668616de548c68c269a69240cfa"
       }
     },
     "runtime": {


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The reviewed Agent Improver skill now distinguishes stale prescriptions from executor and guard defects. The consumer must pin the released plugin bytes and matching digest before a future run can load them.

## What

- advance libraries/agent-plugins from 564a6a0f to signed plugin 4.3.4 at 11b241cc
- update the consumer agent-improver skill digest to dccf7463ecf0e11a12f03ae5e26dedbdc0b2c668616de548c68c269a69240cfa

## Validation

- RED: delivery contract rejected the new gitlink with the old digest
- GREEN: agent-role-delivery-contract.test.sh
- plugin-definition-currency.test.sh: 56 assertions
- git diff --check

Part of devantler-tech/agent-skills#93.