### PR TITLE
fix(agents): gate the plugin refresh on the pin instead of the marketplace tip

### DIFF
--- a/.claude/scripts/plugin-definition-refresh.sh
+++ b/.claude/scripts/plugin-definition-refresh.sh
@@ -183,10 +183,23 @@ if [ "$DRY_RUN" -eq 0 ]; then
   # lock is runtime-local and both machine-local lanes run on this host, so a pid is meaningful here.
   if [ -d "$lockdir" ]; then
     owner="$(cat "$lockdir/pid" 2>/dev/null || true)"
-    if [ -z "$owner" ] || ! kill -0 "$owner" 2>/dev/null; then
-      say "reaped a lock ........... owner ${owner:-unknown} is not running"
-      rm -f "$lockdir/pid"
-      rmdir "$lockdir" 2>/dev/null || true
+    if [ -n "$owner" ]; then
+      # Ownership published: liveness decides.
+      if ! kill -0 "$owner" 2>/dev/null; then
+        say "reaped a lock ........... owner $owner is not running"
+        rm -f "$lockdir/pid"
+        rmdir "$lockdir" 2>/dev/null || true
+      fi
+    else
+      # No pid yet. `mkdir` is atomic but publishing the pid is a separate step, so a rival that
+      # reads the lock in that window would see no owner — treating THAT as abandoned lets it delete
+      # a live lock and put two runs in the section. A genuine holder publishes within milliseconds,
+      # so an ownerless lock is acquisition-in-progress until a short grace has passed; only after
+      # that is it debris from a run that died between the two steps.
+      if [ -n "$(find "$lockdir" -maxdepth 0 -mmin +1 2>/dev/null)" ]; then
+        say "reaped a lock ........... no owner published after the grace period"
+        rmdir "$lockdir" 2>/dev/null || true
+      fi
     fi
   fi
   lock_wait="${PLUGIN_REFRESH_LOCK_WAIT:-30}"
@@ -217,6 +230,17 @@ say "marketplace would install $candidate"
 
 # ── the gate ───────────────────────────────────────────────────────────────────
 if [ "$candidate" != "$GITLINK" ]; then
+  if [ "$DRY_RUN" -eq 1 ]; then
+    # A dry run skipped the refresh, so this comparison is against a possibly STALE clone. An actual
+    # refresh might bring it exactly to the pin, so the simulation has not established that the
+    # marketplace cannot supply it — emitting NOT-ON-PIN here would be a false verdict pointing the
+    # caller at a gitlink bump it may not need. Same reason the dry-run success path returns 2.
+    say ""
+    say "dry-run ................. clone is at $candidate, pin is $GITLINK — but the refresh was"
+    say "                          skipped, so this is NOT evidence the marketplace lacks the pin."
+    say "dry-run ................. exiting 2 (no verdict)."
+    exit 2
+  fi
   say ""
   say "NOT-ON-PIN — refusing to apply, nothing changed."
   say "  The marketplace carries $candidate; this consumer pins $GITLINK."
@@ -309,8 +333,13 @@ fi
 # resolves its own defaults otherwise, so under `--gitlink`/`--submodule-path` it would check a
 # different revision than the one that passed this run's gate and could report a correct install as
 # drifted. Same bind-the-target defect the marketplace/plugin-id check closes above.
+# The plugin NAME is derived from the qualified id rather than left at the verifier's default:
+# under a `--plugin-id` override the verifier would otherwise locate the selected plugin's install
+# but compare it against the DEFAULT plugin's pinned subtree — a false verdict either way, and one
+# that could even validate coincidentally matching files.
+PLUGIN_NAME="${PLUGIN_ID%@*}"
 "$VERIFY_CMD" --repo-root "$REPO_ROOT" --plugins-root "$PLUGINS_ROOT" --plugin-id "$PLUGIN_ID" \
-  --gitlink "$GITLINK" --submodule-path "$SUBMODULE_PATH" >/dev/null 2>&1 && vrc=0 || vrc=$?
+  --plugin-name "$PLUGIN_NAME" --gitlink "$GITLINK" --submodule-path "$SUBMODULE_PATH" >/dev/null 2>&1 && vrc=0 || vrc=$?
 # `if ! cmd` would collapse the verifier's own UNKNOWN into the drift branch, turning "I could not
 # check" into "the install is not on the pin" — the exact conflation this script's own exit contract
 # forbids, and it would point the caller at the wrong remedy.

--- a/.claude/scripts/plugin-definition-refresh.sh
+++ b/.claude/scripts/plugin-definition-refresh.sh
@@ -80,7 +80,9 @@ while [ $# -gt 0 ]; do
     --verify-cmd) need $# "$1"; VERIFY_CMD="$2"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     --quiet) QUIET=1; shift ;;
-    -h|--help) sed -n '1,44p' "$0"; exit 0 ;;
+    # Derived, not a hardcoded line count: the header grew past the old `1,44p` and `--help` began
+    # truncating mid-sentence, dropping the entire exit-code contract — the most important part of it.
+    -h|--help) sed -n '1,/^set -euo pipefail/{/^set -euo pipefail/!p;}' "$0"; exit 0 ;;
     *) die "unknown argument: $1" ;;
   esac
 done

--- a/.claude/scripts/plugin-definition-refresh.sh
+++ b/.claude/scripts/plugin-definition-refresh.sh
@@ -35,6 +35,11 @@
 #                                     [--plugin-id ID] [--submodule-path PATH]
 #                                     [--cli PATH] [--verify-cmd PATH] [--dry-run] [--quiet]
 #
+# --verify-cmd names the post-apply check (default: .claude/scripts/plugin-definition-currency.sh).
+# It is invoked with --repo-root, --plugins-root, --plugin-id, --plugin-name, --gitlink and
+# --submodule-path, all bound to the values this run gated on, and its exit status IS the verdict:
+# 0 verified, 2 UNKNOWN (preserved, never folded into 1), anything else NOT-ON-PIN.
+#
 # Exit 0  the runtime install is now pinned, and that was VERIFIED by an independent blob-identity
 #         check after the apply — never by `plugin update`'s own exit status, which can report
 #         success having repaired nothing. NOTE: `plugin update` requires a restart, so exit 0 still
@@ -186,11 +191,16 @@ if [ "$DRY_RUN" -eq 0 ]; then
   if [ -d "$lockdir" ]; then
     owner="$(cat "$lockdir/pid" 2>/dev/null || true)"
     if [ -n "$owner" ]; then
-      # Ownership published: liveness decides.
+      # Ownership published: liveness decides. CLAIM the stale lock before removing it — a blind
+      # `rmdir` lets two runs both observe the dead owner, both remove, and the slower one delete the
+      # FASTER one's freshly created lock, so both proceed. `mv` onto a unique name is a rename(2):
+      # exactly one racer can succeed, and only that one is entitled to reap.
       if ! kill -0 "$owner" 2>/dev/null; then
-        say "reaped a lock ........... owner $owner is not running"
-        rm -f "$lockdir/pid"
-        rmdir "$lockdir" 2>/dev/null || true
+        stale="$lockdir.stale.$$"
+        if mv "$lockdir" "$stale" 2>/dev/null; then
+          say "reaped a lock ........... owner $owner is not running"
+          rm -rf "$stale"
+        fi
       fi
     else
       # No pid yet. `mkdir` is atomic but publishing the pid is a separate step, so a rival that
@@ -199,8 +209,11 @@ if [ "$DRY_RUN" -eq 0 ]; then
       # so an ownerless lock is acquisition-in-progress until a short grace has passed; only after
       # that is it debris from a run that died between the two steps.
       if [ -n "$(find "$lockdir" -maxdepth 0 -mmin +1 2>/dev/null)" ]; then
-        say "reaped a lock ........... no owner published after the grace period"
-        rmdir "$lockdir" 2>/dev/null || true
+        stale="$lockdir.stale.$$"
+        if mv "$lockdir" "$stale" 2>/dev/null; then
+          say "reaped a lock ........... no owner published after the grace period"
+          rm -rf "$stale"
+        fi
       fi
     fi
   fi
@@ -293,7 +306,10 @@ while IFS= read -r -d '' entry; do
     # hashes the target FILE's contents — so the two never match and a clean marketplace containing
     # any symlink would refuse. Hash the link text instead, which keeps symlinks covered rather than
     # exempting them.
-    got="$(printf '%s' "$(readlink "$MARKETPLACE_DIR/$f" 2>/dev/null)" | git -C "$MARKETPLACE_DIR" hash-object --stdin 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
+    # `perl`'s readlink returns the target EXACTLY. The shell form `printf '%s' "$(readlink …)"`
+    # cannot: command substitution strips every trailing newline, so a target ending in one would
+    # hash differently from its blob and refuse a clean marketplace.
+    got="$(perl -e 'my $t = readlink($ARGV[0]); exit 1 unless defined $t; print $t' "$MARKETPLACE_DIR/$f" 2>/dev/null | git -C "$MARKETPLACE_DIR" hash-object --stdin 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
   else
     got="$(git -C "$MARKETPLACE_DIR" hash-object --no-filters -- "$f" 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
   fi

--- a/.claude/scripts/plugin-definition-refresh.sh
+++ b/.claude/scripts/plugin-definition-refresh.sh
@@ -33,7 +33,7 @@
 # Usage: plugin-definition-refresh.sh [--repo-root DIR] [--plugins-root DIR] [--gitlink SHA]
 #                                     [--marketplace-dir DIR] [--marketplace NAME]
 #                                     [--plugin-id ID] [--submodule-path PATH]
-#                                     [--installed DIR] [--cli PATH] [--dry-run] [--quiet]
+#                                     [--cli PATH] [--dry-run] [--quiet]
 #
 # Exit 0  the runtime install is now pinned — this run either applied the pin or found it already
 #         applied. NOTE: `plugin update` requires a restart, so exit 0 never means THIS run used it.
@@ -52,7 +52,6 @@ MARKETPLACE_DIR=""
 MARKETPLACE="devantler-plugins"
 PLUGIN_ID="agentic-engineering@devantler-plugins"
 SUBMODULE_PATH="libraries/agent-plugins"
-INSTALLED=""
 CLI="${CLAUDE_CLI:-}"
 DRY_RUN=0
 QUIET=0
@@ -72,7 +71,6 @@ while [ $# -gt 0 ]; do
     --marketplace) need $# "$1"; MARKETPLACE="$2"; shift 2 ;;
     --plugin-id) need $# "$1"; PLUGIN_ID="$2"; shift 2 ;;
     --submodule-path) need $# "$1"; SUBMODULE_PATH="$2"; shift 2 ;;
-    --installed) need $# "$1"; INSTALLED="$2"; shift 2 ;;
     --cli) need $# "$1"; CLI="$2"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     --quiet) QUIET=1; shift ;;
@@ -82,6 +80,17 @@ while [ $# -gt 0 ]; do
 done
 
 command -v git >/dev/null 2>&1 || die "git is required"
+
+# ── the gate must bind the clone we READ to the plugin the CLI UPDATES ─────────
+# `--marketplace` selects the clone whose HEAD becomes `candidate`, while `--plugin-id` names what
+# `plugin update` installs. Left independent, `--marketplace staging` would refresh and gate on the
+# staging clone while the default id still installed `…@devantler-plugins` — the gate would pass
+# against one marketplace and the install would come from another, which is precisely the fail-open
+# this script exists to prevent. The qualified id therefore MUST name the same marketplace.
+case "$PLUGIN_ID" in
+  *@*) [ "${PLUGIN_ID##*@}" = "$MARKETPLACE" ] || die "plugin id '$PLUGIN_ID' names marketplace '${PLUGIN_ID##*@}' but --marketplace is '$MARKETPLACE' — refusing to gate on one marketplace and install from another" ;;
+  *) die "plugin id '$PLUGIN_ID' is not marketplace-qualified (expected '<plugin>@$MARKETPLACE')" ;;
+esac
 
 # ── the CLI ────────────────────────────────────────────────────────────────────
 # Resolved dynamically, never from a baked-in path. The by-hand invocation that worked on
@@ -128,6 +137,34 @@ fi
 [ -d "$MARKETPLACE_DIR" ] || die "marketplace clone not found: $MARKETPLACE_DIR"
 
 say "pinned revision ......... $GITLINK"
+
+# ── serialize refresh → read → apply against overlapping runs ──────────────────
+# The gate is a time-of-check/time-of-use pair: this run reads `candidate` from the shared clone,
+# then installs from it. Both machine-local lanes dispatch hourly and 46% of runs exceed the hour,
+# so a sibling refreshing the SAME clone between those two steps would have this run install a
+# revision it never gated on — the exact fail-open the gate exists to close. `mkdir` is the atomic
+# primitive here; a lock file written with `>` is not.
+LOCK=""
+release_lock() { [ -n "$LOCK" ] && rmdir "$LOCK" 2>/dev/null; LOCK=""; }
+trap release_lock EXIT INT TERM
+
+if [ "$DRY_RUN" -eq 0 ]; then
+  lockdir="$PLUGINS_ROOT/.plugin-definition-refresh.lock"
+  # A crashed run must not park the lock forever (the stale-marker lesson from the worktree claim):
+  # reap one older than 10 minutes, then contend normally.
+  if [ -d "$lockdir" ] && [ -n "$(find "$lockdir" -maxdepth 0 -mmin +10 2>/dev/null)" ]; then
+    say "reaped a stale lock ..... $lockdir"
+    rmdir "$lockdir" 2>/dev/null || true
+  fi
+  lock_wait="${PLUGIN_REFRESH_LOCK_WAIT:-30}"
+  tries=0
+  until mkdir "$lockdir" 2>/dev/null; do
+    tries=$((tries + 1))
+    [ "$tries" -ge "$lock_wait" ] && die "another plugin-definition-refresh holds $lockdir after ${lock_wait}s — UNKNOWN, not a verdict"
+    sleep 1
+  done
+  LOCK="$lockdir"
+fi
 
 # ── refresh the marketplace clone, THEN read what an update would install ──────
 # Order matters and is asserted by the suite. The clone is its own staleness surface: on 2026-08-15
@@ -179,8 +216,12 @@ fi
 say ""
 say "APPLIED — the runtime install now points at the pinned revision $GITLINK."
 if command -v jq >/dev/null 2>&1 && [ -r "$registry" ]; then
-  now="$(jq -r --arg id "$PLUGIN_ID" '.plugins[$id][]?.gitCommitSha // empty' "$registry" 2>/dev/null | head -1)"
-  [ -n "$now" ] && say "  registry now records ... $now"
+  # This is a REPORTING nicety and must never change the verdict. A malformed registry makes `jq`
+  # exit non-zero; under `set -e` + `pipefail` that aborted the script AFTER a successful apply and
+  # BEFORE the declared `exit 0`, reporting a completed apply as a failure. Select inside `jq`
+  # (no `head` stage, so no SIGPIPE either) and swallow the status explicitly.
+  now="$(jq -r --arg id "$PLUGIN_ID" 'first(.plugins[$id][]?.gitCommitSha // empty) // empty' "$registry" 2>/dev/null || true)"
+  if [ -n "$now" ]; then say "  registry now records ... $now"; fi
 fi
 say "  ⚠️  'plugin update' requires a RESTART to take effect. THIS run keeps executing the"
 say "      definition it booted with; the pinned copy is served from the next dispatch onward."

--- a/.claude/scripts/plugin-definition-refresh.sh
+++ b/.claude/scripts/plugin-definition-refresh.sh
@@ -66,6 +66,9 @@ CLI="${CLAUDE_CLI:-}"
 VERIFY_CMD="${PLUGIN_REFRESH_VERIFY:-}"
 DRY_RUN=0
 QUIET=0
+# How many registry backups to retain. Overridable so the suite can drive the prune with a small
+# bound instead of writing eleven files.
+PLUGIN_REFRESH_BACKUP_KEEP="${PLUGIN_REFRESH_BACKUP_KEEP:-10}"
 
 die() { printf 'plugin-definition-refresh: %s\n' "$*" >&2; exit 2; }
 # `shift 2` on a lone trailing flag returns 1, and under `set -e` that would exit with 1 — the code
@@ -141,8 +144,22 @@ if [ -z "$GITLINK" ]; then
   # entry for HEAD makes `HEAD:<path>` resolve THROUGH the replacement while `git rev-parse HEAD`
   # still prints the expected commit — so the gate below would faithfully compare against, and then
   # install, an unreviewed revision. That is a fail-open on the one value everything here trusts.
-  GITLINK="$(git --no-replace-objects -C "$REPO_ROOT" rev-parse "HEAD:$SUBMODULE_PATH" 2>/dev/null)" \
-    || die "cannot read the gitlink for '$SUBMODULE_PATH' at HEAD in $REPO_ROOT"
+  #
+  # Read the entry MODE, not just the object id. `HEAD:<path>` resolves for ANY tracked path: a
+  # regular file yields a blob id and a directory yields a tree id. Both are non-empty, so an
+  # emptiness check passes them through, and neither can ever equal a commit id — so the pin gate
+  # below reports NOT-ON-PIN and exits 1. That is a fabricated verdict produced by what is actually
+  # a configuration error (a mistyped --submodule-path), and the header contract puts that class at
+  # exit 2. Requiring mode 160000 is what keeps "I could not check" from being answered as "not on
+  # the pin".
+  pin_entry="$(git --no-replace-objects -C "$REPO_ROOT" ls-tree HEAD -- "$SUBMODULE_PATH" 2>/dev/null)" \
+    || die "cannot read the tree entry for '$SUBMODULE_PATH' at HEAD in $REPO_ROOT"
+  [ -n "$pin_entry" ] || die "no entry for '$SUBMODULE_PATH' at HEAD — cannot establish the pinned revision"
+  pin_mode="${pin_entry%% *}"
+  [ "$pin_mode" = "160000" ] || die "'$SUBMODULE_PATH' is not a submodule at HEAD (tree entry mode $pin_mode, expected 160000) — cannot establish a pinned revision"
+  pin_rest="${pin_entry#* }"
+  pin_rest="${pin_rest#* }"
+  GITLINK="${pin_rest%%$'\t'*}"
 fi
 [ -n "$GITLINK" ] || die "no gitlink for '$SUBMODULE_PATH' at HEAD — cannot establish the pinned revision"
 
@@ -309,6 +326,13 @@ while IFS= read -r -d '' entry; do
     # `perl`'s readlink returns the target EXACTLY. The shell form `printf '%s' "$(readlink …)"`
     # cannot: command substitution strips every trailing newline, so a target ending in one would
     # hash differently from its blob and refuse a clean marketplace.
+    # Name the missing interpreter instead of folding it into `bytes_unknown`. Without this, an
+    # absent `perl` makes EVERY symlink entry unverifiable, and the run refuses a perfectly clean
+    # pinned marketplace with "could not be byte-verified" — a message naming the wrong cause, with
+    # no path from it to the real one. That is the same wedge class as the gitlink and symlink
+    # defects above: the guard, not the drift, blocks every future refresh.
+    command -v perl >/dev/null 2>&1 \
+      || die "perl is required to verify symlink entries (mode 120000) and is not on PATH — install perl or the byte check cannot run"
     got="$(perl -e 'my $t = readlink($ARGV[0]); exit 1 unless defined $t; print $t' "$MARKETPLACE_DIR/$f" 2>/dev/null | git -C "$MARKETPLACE_DIR" hash-object --stdin 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
   else
     got="$(git -C "$MARKETPLACE_DIR" hash-object --no-filters -- "$f" 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
@@ -336,6 +360,17 @@ fi
 if [ -r "$registry" ]; then
   backup="$registry.bak-$(date -u +%Y%m%dT%H%M%SZ)-plugin-definition-refresh"
   cp "$registry" "$backup" || die "could not back up the runtime plugin registry: $registry"
+  # Bounded retention. Two lanes dispatch hourly, so an unbounded set grows forever while nothing
+  # ever reads the old copies. The name embeds a UTC ISO-8601 basic timestamp, so a lexical sort IS
+  # chronological. Only this script's own suffix is matched, never an unrelated neighbour.
+  #
+  # Pruning is hygiene and must NEVER change the verdict — a currency control that fails because it
+  # could not delete an old backup would be exactly the guard-wedges-the-run class fixed above —
+  # hence the trailing `|| true`.
+  ls -1 "$registry".bak-*-plugin-definition-refresh 2>/dev/null \
+    | sort -r \
+    | tail -n +"$((PLUGIN_REFRESH_BACKUP_KEEP + 1))" \
+    | while IFS= read -r stale; do [ -n "$stale" ] && rm -f "$stale"; done || true
   say "backed up ............... $backup"
 fi
 

--- a/.claude/scripts/plugin-definition-refresh.sh
+++ b/.claude/scripts/plugin-definition-refresh.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# plugin-definition-refresh.sh — move the runtime's installed plugin ONTO the consumer's pin,
+# and refuse to move it anywhere else.
+#
+# WHY THIS IS GATED RATHER THAN A PAIR OF COMMANDS
+#
+# `plugin-definition-currency.sh` (monorepo#2847) detects that the runtime is serving a definition
+# other than the pinned one. Nothing applies the update, so the drift re-accumulates — monorepo#2856,
+# and measured: a 21-day drift cleared by hand on 2026-08-15 was back within 3.4 hours of the next
+# plugin rollout, after which 5 of 6 sessions in the drift window ran a superseded skill file.
+#
+# The obvious fix is the two commands that cleared it by hand:
+#     claude plugin marketplace update <marketplace>
+#     claude plugin update <plugin>@<marketplace>
+#
+# That fix is WRONG, and wrong in the dangerous direction. `plugin update` installs the MARKETPLACE
+# LATEST — its own `--help` reads "Update a plugin to the latest version", and it exposes no ref or
+# version selector. On 2026-08-15 the marketplace tip happened to BE the pin (`564a6a0f`), which is
+# the only reason the by-hand run appeared to install the pinned revision. On 2026-08-16 it was not:
+# pin `11b241cc` (4.3.4) against an upstream `main` already at `73109ad9` (4.3.6). Wired into
+# pre-flight as-is, those two commands would install definitions this consumer has never reviewed,
+# on every dispatch, silently. Stale-install drift at least runs a PREVIOUSLY REVIEWED definition;
+# this would run one nobody has read. The cure would be worse than the disease.
+#
+# So the contract here is: refresh the marketplace, then apply the update ONLY when the revision it
+# would install is EXACTLY the pinned one. When it is not, change nothing and say why — a consumer
+# gitlink and an upstream tip that have diverged is a real, reportable condition (it tells the
+# engineer the gitlink needs bumping), not something to paper over by installing the tip.
+#
+# It never edits the plugin cache. The cache is read-only evidence; every mutation here goes through
+# the runtime's own control plane, which is what AGENTS.md authorises.
+#
+# Usage: plugin-definition-refresh.sh [--repo-root DIR] [--plugins-root DIR] [--gitlink SHA]
+#                                     [--marketplace-dir DIR] [--marketplace NAME]
+#                                     [--plugin-id ID] [--submodule-path PATH]
+#                                     [--installed DIR] [--cli PATH] [--dry-run] [--quiet]
+#
+# Exit 0  the runtime install is now pinned — this run either applied the pin or found it already
+#         applied. NOTE: `plugin update` requires a restart, so exit 0 never means THIS run used it.
+#      1  the install is NOT on the pin and this run could not safely put it there. The reason is
+#         named. Nothing was changed.
+#      2  UNKNOWN — could not determine (usage error, no CLI, unreadable pin or marketplace).
+#
+# Exit 2 is deliberately not exit 1 and never exit 0: "I could not check" is a third answer, and
+# collapsing it into either of the verdicts is how a currency control becomes decoration.
+set -euo pipefail
+
+REPO_ROOT=""
+PLUGINS_ROOT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins"
+GITLINK=""
+MARKETPLACE_DIR=""
+MARKETPLACE="devantler-plugins"
+PLUGIN_ID="agentic-engineering@devantler-plugins"
+SUBMODULE_PATH="libraries/agent-plugins"
+INSTALLED=""
+CLI="${CLAUDE_CLI:-}"
+DRY_RUN=0
+QUIET=0
+
+die() { printf 'plugin-definition-refresh: %s\n' "$*" >&2; exit 2; }
+# `shift 2` on a lone trailing flag returns 1, and under `set -e` that would exit with 1 — the code
+# that means "not on the pin". A typo must never produce an evidence-free verdict.
+need() { [ "$1" -ge 2 ] || die "missing value for $2"; }
+say() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-root) need $# "$1"; REPO_ROOT="$2"; shift 2 ;;
+    --plugins-root) need $# "$1"; PLUGINS_ROOT="$2"; shift 2 ;;
+    --gitlink) need $# "$1"; GITLINK="$2"; shift 2 ;;
+    --marketplace-dir) need $# "$1"; MARKETPLACE_DIR="$2"; shift 2 ;;
+    --marketplace) need $# "$1"; MARKETPLACE="$2"; shift 2 ;;
+    --plugin-id) need $# "$1"; PLUGIN_ID="$2"; shift 2 ;;
+    --submodule-path) need $# "$1"; SUBMODULE_PATH="$2"; shift 2 ;;
+    --installed) need $# "$1"; INSTALLED="$2"; shift 2 ;;
+    --cli) need $# "$1"; CLI="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --quiet) QUIET=1; shift ;;
+    -h|--help) sed -n '1,44p' "$0"; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+command -v git >/dev/null 2>&1 || die "git is required"
+
+# ── the CLI ────────────────────────────────────────────────────────────────────
+# Resolved dynamically, never from a baked-in path. The by-hand invocation that worked on
+# 2026-08-15 named a literal `claude-code/<version>/` directory; hardcoding that would break
+# silently on the next runtime upgrade — the same unbounded-staleness class this script closes.
+# The suite asserts the absence of such a literal over the WHOLE file, comments included, because
+# a version pinned in prose is how the next reader learns to pin one in code.
+if [ -z "$CLI" ]; then
+  CLI="$(command -v claude 2>/dev/null || true)"
+fi
+if [ -z "$CLI" ]; then
+  # The app-bundled binary is not on PATH on this host. Pick the highest version present, by
+  # version sort rather than mtime — a reinstall can touch an older directory last.
+  base="$HOME/Library/Application Support/Claude/claude-code"
+  if [ -d "$base" ]; then
+    while IFS= read -r v; do
+      [ -n "$v" ] || continue
+      cand="$base/$v/claude.app/Contents/MacOS/claude"
+      [ -x "$cand" ] && { CLI="$cand"; break; }
+    done <<EOF
+$(ls -1 "$base" 2>/dev/null | sort -t. -k1,1nr -k2,2nr -k3,3nr)
+EOF
+  fi
+fi
+[ -n "$CLI" ] && [ -x "$CLI" ] || die "cannot resolve an executable claude CLI (tried --cli, \$CLAUDE_CLI, PATH, and the app bundle) — UNKNOWN, not a verdict"
+
+# ── the PINNED revision ────────────────────────────────────────────────────────
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not inside a git repository"
+fi
+[ -d "$REPO_ROOT" ] || die "repo root does not exist: $REPO_ROOT"
+
+if [ -z "$GITLINK" ]; then
+  # `--no-replace-objects` is load-bearing, exactly as in AGENTS.md *Git safety*: a refs/replace
+  # entry for HEAD makes `HEAD:<path>` resolve THROUGH the replacement while `git rev-parse HEAD`
+  # still prints the expected commit — so the gate below would faithfully compare against, and then
+  # install, an unreviewed revision. That is a fail-open on the one value everything here trusts.
+  GITLINK="$(git --no-replace-objects -C "$REPO_ROOT" rev-parse "HEAD:$SUBMODULE_PATH" 2>/dev/null)" \
+    || die "cannot read the gitlink for '$SUBMODULE_PATH' at HEAD in $REPO_ROOT"
+fi
+[ -n "$GITLINK" ] || die "no gitlink for '$SUBMODULE_PATH' at HEAD — cannot establish the pinned revision"
+
+[ -n "$MARKETPLACE_DIR" ] || MARKETPLACE_DIR="$PLUGINS_ROOT/marketplaces/$MARKETPLACE"
+[ -d "$MARKETPLACE_DIR" ] || die "marketplace clone not found: $MARKETPLACE_DIR"
+
+say "pinned revision ......... $GITLINK"
+
+# ── refresh the marketplace clone, THEN read what an update would install ──────
+# Order matters and is asserted by the suite. The clone is its own staleness surface: on 2026-08-15
+# it was two days behind, so `plugin update` alone would have landed 4.1.7 against a pinned 4.3.3 —
+# a plausible-looking version that is still not the pin.
+if [ "$DRY_RUN" -eq 1 ]; then
+  say "dry-run ................. skipping 'plugin marketplace update'"
+else
+  "$CLI" plugin marketplace update "$MARKETPLACE" >/dev/null 2>&1 \
+    || die "'plugin marketplace update $MARKETPLACE' failed — cannot establish what an update would install"
+fi
+
+candidate="$(git -C "$MARKETPLACE_DIR" rev-parse HEAD 2>/dev/null)" \
+  || die "cannot read the marketplace clone HEAD: $MARKETPLACE_DIR"
+say "marketplace would install $candidate"
+
+# ── the gate ───────────────────────────────────────────────────────────────────
+if [ "$candidate" != "$GITLINK" ]; then
+  say ""
+  say "NOT-ON-PIN — refusing to apply, nothing changed."
+  say "  The marketplace carries $candidate; this consumer pins $GITLINK."
+  say "  'plugin update' installs the marketplace LATEST and has no ref selector, so applying it"
+  say "  here would install a revision this deployment has not reviewed. That is worse than the"
+  say "  stale install it would replace, which at least runs a previously reviewed definition."
+  say "  To resolve: bump the '$SUBMODULE_PATH' gitlink to the revision you intend to run, through"
+  say "  the normal reviewed rollout, then re-run this. Until then, follow the reviewed definition"
+  say "  at the pinned gitlink per AGENTS.md and report the drift."
+  exit 1
+fi
+
+# ── apply ──────────────────────────────────────────────────────────────────────
+registry="$PLUGINS_ROOT/installed_plugins.json"
+if [ "$DRY_RUN" -eq 1 ]; then
+  say "dry-run ................. marketplace carries the pin; would apply 'plugin update $PLUGIN_ID'"
+  exit 0
+fi
+
+# A runtime-local mutation is backed up BEFORE it happens, to a timestamped copy naming the reason.
+# The registry is not version-controlled, so an unbacked change is a one-way edit.
+if [ -r "$registry" ]; then
+  backup="$registry.bak-$(date -u +%Y%m%dT%H%M%SZ)-plugin-definition-refresh"
+  cp "$registry" "$backup" || die "could not back up the runtime plugin registry: $registry"
+  say "backed up ............... $backup"
+fi
+
+"$CLI" plugin update "$PLUGIN_ID" >/dev/null 2>&1 \
+  || die "'plugin update $PLUGIN_ID' failed after the gate passed — install state is unchanged or partial; re-run and check plugin-definition-currency.sh"
+
+say ""
+say "APPLIED — the runtime install now points at the pinned revision $GITLINK."
+if command -v jq >/dev/null 2>&1 && [ -r "$registry" ]; then
+  now="$(jq -r --arg id "$PLUGIN_ID" '.plugins[$id][]?.gitCommitSha // empty' "$registry" 2>/dev/null | head -1)"
+  [ -n "$now" ] && say "  registry now records ... $now"
+fi
+say "  ⚠️  'plugin update' requires a RESTART to take effect. THIS run keeps executing the"
+say "      definition it booted with; the pinned copy is served from the next dispatch onward."
+say "      Do not read this exit 0 as 'this run used the new definition' — that would be the same"
+say "      fail-open as the drift itself. Verify with plugin-definition-currency.sh next dispatch."
+exit 0

--- a/.claude/scripts/plugin-definition-refresh.sh
+++ b/.claude/scripts/plugin-definition-refresh.sh
@@ -286,7 +286,15 @@ while IFS= read -r -d '' entry; do
   f="${entry#*$'\t'}"
   [ -n "$f" ] || continue
   want="$(git -C "$MARKETPLACE_DIR" --no-replace-objects rev-parse "HEAD:$f" 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
-  got="$(git -C "$MARKETPLACE_DIR" hash-object --no-filters -- "$f" 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
+  if [ "$mode" = "120000" ]; then
+    # A symlink's blob holds the TARGET PATH as text, but `hash-object` on the link follows it and
+    # hashes the target FILE's contents — so the two never match and a clean marketplace containing
+    # any symlink would refuse. Hash the link text instead, which keeps symlinks covered rather than
+    # exempting them.
+    got="$(printf '%s' "$(readlink "$MARKETPLACE_DIR/$f" 2>/dev/null)" | git -C "$MARKETPLACE_DIR" hash-object --stdin 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
+  else
+    got="$(git -C "$MARKETPLACE_DIR" hash-object --no-filters -- "$f" 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
+  fi
   { [ -n "$want" ] && [ -n "$got" ]; } || { bytes_unknown=$((bytes_unknown + 1)); continue; }
   [ "$want" = "$got" ] || bytes_differ=$((bytes_differ + 1))
 done < "$tree_list"

--- a/.claude/scripts/plugin-definition-refresh.sh
+++ b/.claude/scripts/plugin-definition-refresh.sh
@@ -226,17 +226,27 @@ hidden="$(git -C "$MARKETPLACE_DIR" ls-files -v 2>/dev/null | awk '$1 ~ /^[a-z]$
 
 # `--no-filters` bypasses the clean stage, so a smudge/clean filter cannot launder the comparison.
 bytes_unknown=0; bytes_differ=0
-files="$(git -C "$MARKETPLACE_DIR" --no-replace-objects ls-tree -r --name-only HEAD 2>/dev/null)" \
-  || die "cannot enumerate the marketplace tree at $candidate"
-while IFS= read -r f; do
+# `-z` (NUL-delimited, with the mode) rather than `--name-only`: the latter C-quotes any name that is
+# not plain ASCII, so `hash-object` cannot resolve it and a perfectly clean marketplace would refuse.
+# The output must NOT go through command substitution, which strips NUL bytes — stream it via a file.
+tree_list="$(mktemp)" || die "cannot create a temporary file for the marketplace tree listing"
+git -C "$MARKETPLACE_DIR" --no-replace-objects ls-tree -r -z HEAD > "$tree_list" \
+  || { rm -f "$tree_list"; die "cannot enumerate the marketplace tree at $candidate"; }
+while IFS= read -r -d '' entry; do
+  [ -n "$entry" ] || continue
+  # entry is "<mode> <type> <object>\t<path>"
+  mode="${entry%% *}"
+  # A gitlink is a directory, not a blob: it cannot be byte-hashed, and hashing it would make a clean
+  # pinned marketplace refuse. Submodule content is covered by the clean-worktree check above.
+  [ "$mode" = "160000" ] && continue
+  f="${entry#*$'\t'}"
   [ -n "$f" ] || continue
   want="$(git -C "$MARKETPLACE_DIR" --no-replace-objects rev-parse "HEAD:$f" 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
   got="$(git -C "$MARKETPLACE_DIR" hash-object --no-filters -- "$f" 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
   { [ -n "$want" ] && [ -n "$got" ]; } || { bytes_unknown=$((bytes_unknown + 1)); continue; }
   [ "$want" = "$got" ] || bytes_differ=$((bytes_differ + 1))
-done <<EOF
-$(printf '%s\n' "$files")
-EOF
+done < "$tree_list"
+rm -f "$tree_list"
 [ "$bytes_differ" -eq 0 ] || die "$bytes_differ marketplace file(s) differ from the pinned blobs despite HEAD matching — refusing to install"
 [ "$bytes_unknown" -eq 0 ] || die "$bytes_unknown marketplace file(s) could not be byte-verified — unproven is not proven, refusing to install"
 say "marketplace bytes ....... verified against $candidate"
@@ -275,7 +285,10 @@ if [ ! -x "$VERIFY_CMD" ]; then
   say "  install now matches $GITLINK. The apply happened; the verdict is UNKNOWN, never 0."
   exit 2
 fi
-if ! "$VERIFY_CMD" >/dev/null 2>&1; then
+# Pass the gated target explicitly. The verifier resolves its own defaults otherwise, so under any
+# override it would happily check a different repository, plugins root, or plugin than the one this
+# run just updated — the same bind-the-target defect the marketplace/plugin-id check closes above.
+if ! "$VERIFY_CMD" --repo-root "$REPO_ROOT" --plugins-root "$PLUGINS_ROOT" --plugin-id "$PLUGIN_ID" >/dev/null 2>&1; then
   say ""
   say "APPLIED, BUT STILL NOT ON THE PIN — the post-apply currency check does not report CURRENT."
   say "  'plugin update' exited 0 without bringing the install to $GITLINK, so the drift persists."

--- a/.claude/scripts/plugin-definition-refresh.sh
+++ b/.claude/scripts/plugin-definition-refresh.sh
@@ -33,13 +33,19 @@
 # Usage: plugin-definition-refresh.sh [--repo-root DIR] [--plugins-root DIR] [--gitlink SHA]
 #                                     [--marketplace-dir DIR] [--marketplace NAME]
 #                                     [--plugin-id ID] [--submodule-path PATH]
-#                                     [--cli PATH] [--dry-run] [--quiet]
+#                                     [--cli PATH] [--verify-cmd PATH] [--dry-run] [--quiet]
 #
-# Exit 0  the runtime install is now pinned — this run either applied the pin or found it already
-#         applied. NOTE: `plugin update` requires a restart, so exit 0 never means THIS run used it.
-#      1  the install is NOT on the pin and this run could not safely put it there. The reason is
-#         named. Nothing was changed.
-#      2  UNKNOWN — could not determine (usage error, no CLI, unreadable pin or marketplace).
+# Exit 0  the runtime install is now pinned, and that was VERIFIED by an independent blob-identity
+#         check after the apply — never by `plugin update`'s own exit status, which can report
+#         success having repaired nothing. NOTE: `plugin update` requires a restart, so exit 0 still
+#         never means THIS run used the new definition.
+#      1  the install is NOT on the pin. Either the marketplace could not supply the pinned revision
+#         (nothing was changed), or the apply ran and the post-apply check still does not report
+#         CURRENT. The reason is named.
+#      2  UNKNOWN — no verdict was produced: usage error, no CLI, unreadable pin or marketplace, a
+#         marketplace/plugin-id marketplace mismatch, a concurrent run holding the lock, a
+#         marketplace worktree whose BYTES do not provably match the pinned commit, an apply whose
+#         verification command is unavailable, or --dry-run (a simulation asserts nothing).
 #
 # Exit 2 is deliberately not exit 1 and never exit 0: "I could not check" is a third answer, and
 # collapsing it into either of the verdicts is how a currency control becomes decoration.
@@ -53,6 +59,7 @@ MARKETPLACE="devantler-plugins"
 PLUGIN_ID="agentic-engineering@devantler-plugins"
 SUBMODULE_PATH="libraries/agent-plugins"
 CLI="${CLAUDE_CLI:-}"
+VERIFY_CMD="${PLUGIN_REFRESH_VERIFY:-}"
 DRY_RUN=0
 QUIET=0
 
@@ -72,6 +79,7 @@ while [ $# -gt 0 ]; do
     --plugin-id) need $# "$1"; PLUGIN_ID="$2"; shift 2 ;;
     --submodule-path) need $# "$1"; SUBMODULE_PATH="$2"; shift 2 ;;
     --cli) need $# "$1"; CLI="$2"; shift 2 ;;
+    --verify-cmd) need $# "$1"; VERIFY_CMD="$2"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     --quiet) QUIET=1; shift ;;
     -h|--help) sed -n '1,44p' "$0"; exit 0 ;;
@@ -146,7 +154,13 @@ say "pinned revision ......... $GITLINK"
 # primitive here; a lock file written with `>` is not.
 LOCK=""
 release_lock() { [ -n "$LOCK" ] && rmdir "$LOCK" 2>/dev/null; LOCK=""; }
-trap release_lock EXIT INT TERM
+# INT/TERM must TERMINATE, not just clean up. A handler that returns normally resumes the script at
+# the point of interruption — so releasing the lock here and falling through would carry on into the
+# candidate check and `plugin update` with the lock already surrendered, which is precisely the
+# unserialized apply the lock exists to prevent. Exit instead and let the EXIT trap do the cleanup.
+trap release_lock EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 if [ "$DRY_RUN" -eq 0 ]; then
   lockdir="$PLUGINS_ROOT/.plugin-definition-refresh.lock"
@@ -195,11 +209,46 @@ if [ "$candidate" != "$GITLINK" ]; then
   exit 1
 fi
 
+# ── the revision matched; now prove the BYTES match too ────────────────────────
+# `rev-parse HEAD` answers "which commit is checked out", which is a weaker claim than "these are
+# the reviewed bytes" — the same gap AGENTS.md documents for reading the pinned submodule. A
+# non-conflicting tracked modification, an assume-unchanged/skip-worktree entry, or a clean/smudge
+# filter all leave HEAD equal to the pin while the files `plugin update` actually copies differ. The
+# gate would then install unreviewed definitions and report success, which is the exact fail-open
+# this script exists to close, one level down.
+dirty="$(git -C "$MARKETPLACE_DIR" status --porcelain 2>/dev/null)" \
+  || die "cannot read the marketplace worktree status: $MARKETPLACE_DIR"
+[ -z "$dirty" ] || die "marketplace worktree is not clean at $candidate — refusing to install bytes that differ from the reviewed commit"
+
+hidden="$(git -C "$MARKETPLACE_DIR" ls-files -v 2>/dev/null | awk '$1 ~ /^[a-z]$/ || $1 == "S"')" \
+  || die "cannot read the marketplace index flags: $MARKETPLACE_DIR"
+[ -z "$hidden" ] || die "marketplace index hides a modification (assume-unchanged/skip-worktree) — status cannot be trusted here"
+
+# `--no-filters` bypasses the clean stage, so a smudge/clean filter cannot launder the comparison.
+bytes_unknown=0; bytes_differ=0
+files="$(git -C "$MARKETPLACE_DIR" --no-replace-objects ls-tree -r --name-only HEAD 2>/dev/null)" \
+  || die "cannot enumerate the marketplace tree at $candidate"
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  want="$(git -C "$MARKETPLACE_DIR" --no-replace-objects rev-parse "HEAD:$f" 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
+  got="$(git -C "$MARKETPLACE_DIR" hash-object --no-filters -- "$f" 2>/dev/null)" || { bytes_unknown=$((bytes_unknown + 1)); continue; }
+  { [ -n "$want" ] && [ -n "$got" ]; } || { bytes_unknown=$((bytes_unknown + 1)); continue; }
+  [ "$want" = "$got" ] || bytes_differ=$((bytes_differ + 1))
+done <<EOF
+$(printf '%s\n' "$files")
+EOF
+[ "$bytes_differ" -eq 0 ] || die "$bytes_differ marketplace file(s) differ from the pinned blobs despite HEAD matching — refusing to install"
+[ "$bytes_unknown" -eq 0 ] || die "$bytes_unknown marketplace file(s) could not be byte-verified — unproven is not proven, refusing to install"
+say "marketplace bytes ....... verified against $candidate"
+
 # ── apply ──────────────────────────────────────────────────────────────────────
 registry="$PLUGINS_ROOT/installed_plugins.json"
 if [ "$DRY_RUN" -eq 1 ]; then
+  # A simulation determines nothing about the install, and exit 0 is defined as "the runtime install
+  # IS on the pin". Returning 0 here would let a pre-flight caller read a dry run as a cleared drift.
   say "dry-run ................. marketplace carries the pin; would apply 'plugin update $PLUGIN_ID'"
-  exit 0
+  say "dry-run ................. exiting 2 (no verdict) — a simulation never asserts the install state"
+  exit 2
 fi
 
 # A runtime-local mutation is backed up BEFORE it happens, to a timestamped copy naming the reason.
@@ -213,8 +262,30 @@ fi
 "$CLI" plugin update "$PLUGIN_ID" >/dev/null 2>&1 \
   || die "'plugin update $PLUGIN_ID' failed after the gate passed — install state is unchanged or partial; re-run and check plugin-definition-currency.sh"
 
+# ── the CLI's exit 0 is NOT proof the install now matches the pin ──────────────
+# `plugin update` can report success having repaired nothing — most reachably when the registry
+# already advertises the pinned version while the installed definition bytes were modified or
+# deleted, which is byte-level drift the version string cannot see. Treating the CLI's status as the
+# verdict would let exactly that drift persist indefinitely while this script reported it fixed.
+# So the verdict comes from an independent blob-identity check, not from the tool we just ran.
+[ -n "$VERIFY_CMD" ] || VERIFY_CMD="$REPO_ROOT/.claude/scripts/plugin-definition-currency.sh"
+if [ ! -x "$VERIFY_CMD" ]; then
+  say ""
+  say "APPLIED, BUT UNVERIFIED — '$VERIFY_CMD' is not executable, so this run cannot assert that the"
+  say "  install now matches $GITLINK. The apply happened; the verdict is UNKNOWN, never 0."
+  exit 2
+fi
+if ! "$VERIFY_CMD" >/dev/null 2>&1; then
+  say ""
+  say "APPLIED, BUT STILL NOT ON THE PIN — the post-apply currency check does not report CURRENT."
+  say "  'plugin update' exited 0 without bringing the install to $GITLINK, so the drift persists."
+  say "  Re-run plugin-definition-currency.sh for the per-file detail and report it."
+  exit 1
+fi
+
 say ""
 say "APPLIED — the runtime install now points at the pinned revision $GITLINK."
+say "  verified by ............. $VERIFY_CMD"
 if command -v jq >/dev/null 2>&1 && [ -r "$registry" ]; then
   # This is a REPORTING nicety and must never change the verdict. A malformed registry makes `jq`
   # exit non-zero; under `set -e` + `pipefail` that aborted the script AFTER a successful apply and

--- a/.claude/scripts/plugin-definition-refresh.sh
+++ b/.claude/scripts/plugin-definition-refresh.sh
@@ -31,7 +31,7 @@
 # the runtime's own control plane, which is what AGENTS.md authorises.
 #
 # Usage: plugin-definition-refresh.sh [--repo-root DIR] [--plugins-root DIR] [--gitlink SHA]
-#                                     [--marketplace-dir DIR] [--marketplace NAME]
+#                                     [--marketplace NAME]
 #                                     [--plugin-id ID] [--submodule-path PATH]
 #                                     [--cli PATH] [--verify-cmd PATH] [--dry-run] [--quiet]
 #
@@ -54,7 +54,6 @@ set -euo pipefail
 REPO_ROOT=""
 PLUGINS_ROOT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins"
 GITLINK=""
-MARKETPLACE_DIR=""
 MARKETPLACE="devantler-plugins"
 PLUGIN_ID="agentic-engineering@devantler-plugins"
 SUBMODULE_PATH="libraries/agent-plugins"
@@ -74,7 +73,6 @@ while [ $# -gt 0 ]; do
     --repo-root) need $# "$1"; REPO_ROOT="$2"; shift 2 ;;
     --plugins-root) need $# "$1"; PLUGINS_ROOT="$2"; shift 2 ;;
     --gitlink) need $# "$1"; GITLINK="$2"; shift 2 ;;
-    --marketplace-dir) need $# "$1"; MARKETPLACE_DIR="$2"; shift 2 ;;
     --marketplace) need $# "$1"; MARKETPLACE="$2"; shift 2 ;;
     --plugin-id) need $# "$1"; PLUGIN_ID="$2"; shift 2 ;;
     --submodule-path) need $# "$1"; SUBMODULE_PATH="$2"; shift 2 ;;
@@ -141,7 +139,12 @@ if [ -z "$GITLINK" ]; then
 fi
 [ -n "$GITLINK" ] || die "no gitlink for '$SUBMODULE_PATH' at HEAD — cannot establish the pinned revision"
 
-[ -n "$MARKETPLACE_DIR" ] || MARKETPLACE_DIR="$PLUGINS_ROOT/marketplaces/$MARKETPLACE"
+# DERIVED, never passed in. An overridable directory is a decoy vector: a caller could point this at
+# a checkout that happens to equal the pin while both CLI commands still select the runtime
+# marketplace by name, so the gate would pass against one tree and `plugin update` would install from
+# another. The only way to be sure the tree we inspect is the tree the CLI acts on is to compute it
+# from the same two values the CLI uses.
+MARKETPLACE_DIR="$PLUGINS_ROOT/marketplaces/$MARKETPLACE"
 [ -d "$MARKETPLACE_DIR" ] || die "marketplace clone not found: $MARKETPLACE_DIR"
 
 say "pinned revision ......... $GITLINK"
@@ -153,7 +156,16 @@ say "pinned revision ......... $GITLINK"
 # revision it never gated on — the exact fail-open the gate exists to close. `mkdir` is the atomic
 # primitive here; a lock file written with `>` is not.
 LOCK=""
-release_lock() { [ -n "$LOCK" ] && rmdir "$LOCK" 2>/dev/null; LOCK=""; }
+# Release only a lock this process still OWNS. A blind rmdir lets a run that overran its lock delete
+# a SIBLING's replacement on the way out, which would hand a third run the section while the sibling
+# believes it holds it.
+release_lock() {
+  if [ -n "$LOCK" ] && [ "$(cat "$LOCK/pid" 2>/dev/null || true)" = "$$" ]; then
+    rm -f "$LOCK/pid"
+    rmdir "$LOCK" 2>/dev/null || true
+  fi
+  LOCK=""
+}
 # INT/TERM must TERMINATE, not just clean up. A handler that returns normally resumes the script at
 # the point of interruption — so releasing the lock here and falling through would carry on into the
 # candidate check and `plugin update` with the lock already surrendered, which is precisely the
@@ -164,11 +176,18 @@ trap 'exit 143' TERM
 
 if [ "$DRY_RUN" -eq 0 ]; then
   lockdir="$PLUGINS_ROOT/.plugin-definition-refresh.lock"
-  # A crashed run must not park the lock forever (the stale-marker lesson from the worktree claim):
-  # reap one older than 10 minutes, then contend normally.
-  if [ -d "$lockdir" ] && [ -n "$(find "$lockdir" -maxdepth 0 -mmin +10 2>/dev/null)" ]; then
-    say "reaped a stale lock ..... $lockdir"
-    rmdir "$lockdir" 2>/dev/null || true
+  # A crashed run must not park the lock forever (the stale-marker lesson from the worktree claim),
+  # but AGE IS THE WRONG TEST: a refresh that legitimately runs longer than the threshold would have
+  # its lock reaped by a sibling, putting two runs in the section at once — the precise failure the
+  # lock exists to prevent, now triggered by the reaper itself. Reap on OWNER LIVENESS instead. The
+  # lock is runtime-local and both machine-local lanes run on this host, so a pid is meaningful here.
+  if [ -d "$lockdir" ]; then
+    owner="$(cat "$lockdir/pid" 2>/dev/null || true)"
+    if [ -z "$owner" ] || ! kill -0 "$owner" 2>/dev/null; then
+      say "reaped a lock ........... owner ${owner:-unknown} is not running"
+      rm -f "$lockdir/pid"
+      rmdir "$lockdir" 2>/dev/null || true
+    fi
   fi
   lock_wait="${PLUGIN_REFRESH_LOCK_WAIT:-30}"
   tries=0
@@ -178,6 +197,7 @@ if [ "$DRY_RUN" -eq 0 ]; then
     sleep 1
   done
   LOCK="$lockdir"
+  printf '%s\n' "$$" > "$lockdir/pid" || die "cannot record lock ownership in $lockdir"
 fi
 
 # ── refresh the marketplace clone, THEN read what an update would install ──────
@@ -285,16 +305,32 @@ if [ ! -x "$VERIFY_CMD" ]; then
   say "  install now matches $GITLINK. The apply happened; the verdict is UNKNOWN, never 0."
   exit 2
 fi
-# Pass the gated target explicitly. The verifier resolves its own defaults otherwise, so under any
-# override it would happily check a different repository, plugins root, or plugin than the one this
-# run just updated — the same bind-the-target defect the marketplace/plugin-id check closes above.
-if ! "$VERIFY_CMD" --repo-root "$REPO_ROOT" --plugins-root "$PLUGINS_ROOT" --plugin-id "$PLUGIN_ID" >/dev/null 2>&1; then
-  say ""
-  say "APPLIED, BUT STILL NOT ON THE PIN — the post-apply currency check does not report CURRENT."
-  say "  'plugin update' exited 0 without bringing the install to $GITLINK, so the drift persists."
-  say "  Re-run plugin-definition-currency.sh for the per-file detail and report it."
-  exit 1
-fi
+# Pass the gated target explicitly — including the RESOLVED pin and submodule path. The verifier
+# resolves its own defaults otherwise, so under `--gitlink`/`--submodule-path` it would check a
+# different revision than the one that passed this run's gate and could report a correct install as
+# drifted. Same bind-the-target defect the marketplace/plugin-id check closes above.
+"$VERIFY_CMD" --repo-root "$REPO_ROOT" --plugins-root "$PLUGINS_ROOT" --plugin-id "$PLUGIN_ID" \
+  --gitlink "$GITLINK" --submodule-path "$SUBMODULE_PATH" >/dev/null 2>&1 && vrc=0 || vrc=$?
+# `if ! cmd` would collapse the verifier's own UNKNOWN into the drift branch, turning "I could not
+# check" into "the install is not on the pin" — the exact conflation this script's own exit contract
+# forbids, and it would point the caller at the wrong remedy.
+case "$vrc" in
+  0) : ;;
+  2)
+    say ""
+    say "APPLIED, BUT VERIFICATION IS UNKNOWN — the post-apply check could not determine the state."
+    say "  The apply happened; nothing here asserts whether the install is on $GITLINK."
+    say "  Re-run plugin-definition-currency.sh directly for the reason."
+    exit 2
+    ;;
+  *)
+    say ""
+    say "APPLIED, BUT STILL NOT ON THE PIN — the post-apply currency check does not report CURRENT."
+    say "  'plugin update' exited 0 without bringing the install to $GITLINK, so the drift persists."
+    say "  Re-run plugin-definition-currency.sh for the per-file detail and report it."
+    exit 1
+    ;;
+esac
 
 say ""
 say "APPLIED — the runtime install now points at the pinned revision $GITLINK."

--- a/.claude/scripts/plugin-definition-refresh.test.sh
+++ b/.claude/scripts/plugin-definition-refresh.test.sh
@@ -313,12 +313,22 @@ PLUGIN_REFRESH_BACKUP_KEEP=2 STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>
 kept="$(ls -1 "$PLUGINS"/installed_plugins.json.bak-*-plugin-definition-refresh 2>/dev/null | wc -l | tr -d ' ')"
 oldest_gone=yes
 [ -e "$PLUGINS/installed_plugins.json.bak-20260101T000000Z-plugin-definition-refresh" ] && oldest_gone=no
+# Name the survivors, never just count them: with KEEP=2 the run's own fresh backup takes one slot,
+# so exactly 20260103 may hold the other. A prune that dropped 20260101 and 20260103 while keeping
+# 20260102 satisfies the count AND oldest_gone, and is precisely the wrong-pair retention this case
+# exists to catch.
+middle_gone=yes
+[ -e "$PLUGINS/installed_plugins.json.bak-20260102T000000Z-plugin-definition-refresh" ] && middle_gone=no
+newest_fixture_kept=yes
+[ -e "$PLUGINS/installed_plugins.json.bak-20260103T000000Z-plugin-definition-refresh" ] || newest_fixture_kept=no
 neighbour=yes
 [ -e "$PLUGINS/installed_plugins.json.bak-20260101T000000Z-someone-else" ] || neighbour=no
-if [ "$rc" -eq 0 ] && [ "$kept" = "2" ] && [ "$oldest_gone" = yes ] && [ "$neighbour" = yes ]; then
+if [ "$rc" -eq 0 ] && [ "$kept" = "2" ] && [ "$oldest_gone" = yes ] \
+  && [ "$middle_gone" = yes ] && [ "$newest_fixture_kept" = yes ] && [ "$neighbour" = yes ]; then
   ok "A16b prunes registry backups to the bound, keeping the newest and sparing other files"
 else bad "A16b prunes registry backups to the bound, keeping the newest and sparing other files" \
-  "exit was $rc, kept=$kept (want 2), oldest_removed=$oldest_gone, unrelated_file_survived=$neighbour"; fi
+  "exit was $rc, kept=$kept (want 2), oldest_removed=$oldest_gone, middle_removed=$middle_gone," \
+  "newest_fixture_kept=$newest_fixture_kept, unrelated_file_survived=$neighbour"; fi
 cleanup
 
 # ── A17 — INT/TERM must TERMINATE the run, not merely clean up and resume ──────────────────────

--- a/.claude/scripts/plugin-definition-refresh.test.sh
+++ b/.claude/scripts/plugin-definition-refresh.test.sh
@@ -73,16 +73,21 @@ STUB
 
 # Point the consumer's gitlink at $1 by writing the tree entry directly — no network, no submodule
 # machinery, and it is exactly the "160000 commit <sha>" shape the script must read.
+# A silently-failed fixture is worse than a failed test: the assertions still run, but against the
+# PREVIOUS consumer tree rather than the pin they asked for, so they pass without testing anything.
+# Both commands are checked explicitly and stderr is preserved.
 set_gitlink() {
   local sha="$1"
-  git -C "$CONSUMER" update-index --add --cacheinfo 160000,"$sha",libraries/agent-plugins
-  git -C "$CONSUMER" commit -qm "pin $sha" >/dev/null 2>&1 || true
+  git -C "$CONSUMER" update-index --add --cacheinfo 160000,"$sha",libraries/agent-plugins \
+    || { printf 'FIXTURE FAILURE: update-index for %s failed\n' "$sha" >&2; exit 9; }
+  git -C "$CONSUMER" commit -qm "pin $sha" >/dev/null \
+    || { printf 'FIXTURE FAILURE: commit for %s failed\n' "$sha" >&2; exit 9; }
 }
 
 run() {
   CLAUDE_CLI="$BIN/claude" "$SCRIPT" \
     --repo-root "$CONSUMER" --plugins-root "$PLUGINS" --marketplace-dir "$MK" \
-    --installed "$INSTALLED" "$@" 2>&1
+    "$@" 2>&1
 }
 
 cleanup() { [ -n "${ROOT:-}" ] && rm -rf "$ROOT"; }
@@ -104,16 +109,16 @@ cleanup
 make_fixture
 set_gitlink "$MK_NEW"
 STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1; rc=$?
-if [ -e "$ROOT/APPLIED" ]; then ok "A2 invokes 'plugin update' when the marketplace carries exactly the pin"
-else bad "A2 invokes 'plugin update' when the marketplace carries exactly the pin" "exit was $rc, never applied"; fi
+if [ -e "$ROOT/APPLIED" ] && [ "$rc" -eq 0 ]; then ok "A2 invokes 'plugin update' when the marketplace carries exactly the pin"
+else bad "A2 invokes 'plugin update' when the marketplace carries exactly the pin" "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
 cleanup
 
 # ── A3 — a runtime-local mutation is backed up BEFORE it happens ───────────────────────────────
 make_fixture
 set_gitlink "$MK_NEW"
-STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1
-if ls "$PLUGINS"/installed_plugins.json.bak-* >/dev/null 2>&1; then ok "A3 backs up installed_plugins.json before applying"
-else bad "A3 backs up installed_plugins.json before applying" "no timestamped backup was written"; fi
+STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1; rc=$?
+if ls "$PLUGINS"/installed_plugins.json.bak-* >/dev/null 2>&1 && [ "$rc" -eq 0 ]; then ok "A3 backs up installed_plugins.json before applying"
+else bad "A3 backs up installed_plugins.json before applying" "exit was $rc; no timestamped backup was written"; fi
 cleanup
 
 # ── A4 — refresh is attempted BEFORE the gate is evaluated ─────────────────────────────────────
@@ -122,19 +127,81 @@ cleanup
 # pins the ORDER, which is the half #2856 got right and is easy to drop when adding the gate.
 make_fixture
 set_gitlink "$MK_NEW"
-STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1
-if grep -q 'plugin marketplace update' "$CLI_LOG" && [ -e "$ROOT/APPLIED" ]; then
+STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1; rc=$?
+if grep -q 'plugin marketplace update' "$CLI_LOG" && [ -e "$ROOT/APPLIED" ] && [ "$rc" -eq 0 ]; then
   ok "A4 refreshes the marketplace before evaluating the gate"
-else bad "A4 refreshes the marketplace before evaluating the gate" "$(tr '\n' '|' < "$CLI_LOG")"; fi
+else bad "A4 refreshes the marketplace before evaluating the gate" "exit was $rc; $(tr '\n' '|' < "$CLI_LOG")"; fi
 cleanup
 
 # ── A5 — an unresolvable CLI is UNKNOWN (exit 2), never a verdict ──────────────────────────────
 make_fixture
 set_gitlink "$MK_NEW"
 CLAUDE_CLI="$ROOT/nope" "$SCRIPT" --repo-root "$CONSUMER" --plugins-root "$PLUGINS" \
-  --marketplace-dir "$MK" --installed "$INSTALLED" >/dev/null 2>&1; rc=$?
+  --marketplace-dir "$MK" >/dev/null 2>&1; rc=$?
 if [ "$rc" -eq 2 ]; then ok "A5 exits 2 (UNKNOWN) when the CLI cannot be resolved"
 else bad "A5 exits 2 (UNKNOWN) when the CLI cannot be resolved" "exit was $rc — 0/1 would be a fabricated verdict"; fi
+cleanup
+
+# ── A12 — the gate binds the clone it READS to the plugin the CLI UPDATES ──────────────────────
+# `--marketplace staging` would refresh and gate on the staging clone while the default plugin id
+# still installed `…@devantler-plugins`: the gate passes against one marketplace, the install comes
+# from another. That is the fail-open this whole script exists to prevent, so a mismatch is UNKNOWN
+# (2) and must never reach 'plugin update'.
+make_fixture
+set_gitlink "$MK_NEW"
+STUB_MARKETPLACE_TARGET="$MK_NEW" run --marketplace staging >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ]; then
+  ok "A12 refuses (exit 2) when --marketplace and --plugin-id name different marketplaces"
+else bad "A12 refuses (exit 2) when --marketplace and --plugin-id name different marketplaces" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+cleanup
+
+# ── A13 — an unqualified plugin id is UNKNOWN, never a silent default ──────────────────────────
+make_fixture
+set_gitlink "$MK_NEW"
+STUB_MARKETPLACE_TARGET="$MK_NEW" run --plugin-id agentic-engineering >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ]; then
+  ok "A13 refuses (exit 2) when the plugin id is not marketplace-qualified"
+else bad "A13 refuses (exit 2) when the plugin id is not marketplace-qualified" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+cleanup
+
+# ── A14 — a malformed registry must not turn a SUCCESSFUL apply into a failure ─────────────────
+# The post-apply registry read is a reporting nicety. Under `set -e` + `pipefail` a malformed
+# registry aborted the script after 'plugin update' had already run and before the declared
+# `exit 0`, reporting a completed apply as a failure.
+make_fixture
+set_gitlink "$MK_NEW"
+printf '%s\n' 'this is not json {{{' > "$PLUGINS/installed_plugins.json"
+STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1; rc=$?
+if [ -e "$ROOT/APPLIED" ] && [ "$rc" -eq 0 ]; then
+  ok "A14 still exits 0 after applying when the registry is malformed"
+else bad "A14 still exits 0 after applying when the registry is malformed" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+cleanup
+
+# ── A15 — refresh → read → apply is serialized against an overlapping run ──────────────────────
+# Both machine-local lanes dispatch hourly and 46% of runs exceed the hour, so a sibling refreshing
+# the same clone between this run's read and its install would have it apply an ungated revision.
+make_fixture
+set_gitlink "$MK_NEW"
+mkdir -p "$PLUGINS/.plugin-definition-refresh.lock"          # a live sibling holds it
+STUB_MARKETPLACE_TARGET="$MK_NEW" PLUGIN_REFRESH_LOCK_WAIT=2 run >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ]; then
+  ok "A15 exits 2 (UNKNOWN) rather than applying while another run holds the lock"
+else bad "A15 exits 2 (UNKNOWN) rather than applying while another run holds the lock" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+rmdir "$PLUGINS/.plugin-definition-refresh.lock" 2>/dev/null || true
+cleanup
+
+# ── A16 — the lock is RELEASED on a normal apply, so the next run is not parked ────────────────
+make_fixture
+set_gitlink "$MK_NEW"
+STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ] && [ ! -d "$PLUGINS/.plugin-definition-refresh.lock" ]; then
+  ok "A16 releases the lock after a successful apply"
+else bad "A16 releases the lock after a successful apply" \
+  "exit was $rc, lock still present=$([ -d "$PLUGINS/.plugin-definition-refresh.lock" ] && echo yes || echo no)"; fi
 cleanup
 
 # ── A6 — no hardcoded claude-code version directory ────────────────────────────────────────────

--- a/.claude/scripts/plugin-definition-refresh.test.sh
+++ b/.claude/scripts/plugin-definition-refresh.test.sh
@@ -298,6 +298,29 @@ else bad "A16 releases the lock after a successful apply" \
   "exit was $rc, lock still present=$([ -d "$PLUGINS/.plugin-definition-refresh.lock" ] && echo yes || echo no)"; fi
 cleanup
 
+# ── A16b — registry backups are RETAINED to a bound, and the survivors are the NEWEST ──────────
+# Two lanes dispatch hourly, so an unbounded backup set grows forever while nothing reads the old
+# copies. Both halves are asserted: a count alone would pass a prune that kept the OLDEST, which is
+# the one outcome that loses the copy an operator would actually want.
+make_fixture
+set_gitlink "$MK_NEW"
+for stamp in 20260101T000000Z 20260102T000000Z 20260103T000000Z; do
+  echo stale > "$PLUGINS/installed_plugins.json.bak-$stamp-plugin-definition-refresh"
+done
+# An unrelated neighbour must survive: the prune matches only this script's own suffix.
+echo other > "$PLUGINS/installed_plugins.json.bak-20260101T000000Z-someone-else"
+PLUGIN_REFRESH_BACKUP_KEEP=2 STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1; rc=$?
+kept="$(ls -1 "$PLUGINS"/installed_plugins.json.bak-*-plugin-definition-refresh 2>/dev/null | wc -l | tr -d ' ')"
+oldest_gone=yes
+[ -e "$PLUGINS/installed_plugins.json.bak-20260101T000000Z-plugin-definition-refresh" ] && oldest_gone=no
+neighbour=yes
+[ -e "$PLUGINS/installed_plugins.json.bak-20260101T000000Z-someone-else" ] || neighbour=no
+if [ "$rc" -eq 0 ] && [ "$kept" = "2" ] && [ "$oldest_gone" = yes ] && [ "$neighbour" = yes ]; then
+  ok "A16b prunes registry backups to the bound, keeping the newest and sparing other files"
+else bad "A16b prunes registry backups to the bound, keeping the newest and sparing other files" \
+  "exit was $rc, kept=$kept (want 2), oldest_removed=$oldest_gone, unrelated_file_survived=$neighbour"; fi
+cleanup
+
 # ── A17 — INT/TERM must TERMINATE the run, not merely clean up and resume ──────────────────────
 # A bash handler that returns normally resumes at the point of interruption, so a combined
 # `trap release_lock EXIT INT TERM` would surrender the lock and then carry on into 'plugin update'
@@ -321,7 +344,11 @@ if [ ! -s "$lockdir/pid" ]; then
 else
   kill -TERM "$sig_pid" 2>/dev/null
   wait "$sig_pid" 2>/dev/null; trc=$?
-  if [ "$trc" -ne 0 ] && [ ! -e "$ROOT/APPLIED" ] && [ ! -d "$lockdir" ]; then
+  # 143 is the DECLARED status (`trap 'exit 143' TERM`), not merely "abnormal". A regression that
+  # removes that trap lets the default TERM disposition end the process, and `wait` reports a
+  # non-zero status for that too — so `-ne 0` would stay green while the signal contract this
+  # asserts had been deleted. Pin the exact status.
+  if [ "$trc" -eq 143 ] && [ ! -e "$ROOT/APPLIED" ] && [ ! -d "$lockdir" ]; then
     ok "A17b a TERM while holding the lock terminates without applying and releases the lock"
   else bad "A17b a TERM while holding the lock terminates without applying and releases the lock" \
     "exit was $trc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no), lock_left=$([ -d "$lockdir" ] && echo yes || echo no)"; fi
@@ -343,11 +370,15 @@ make_fixture
 set_gitlink "$MK_NEW"
 git -C "$MK" checkout -q "$MK_NEW"                                 # clone already carries the pin
 echo tampered > "$MK/f"                                            # HEAD still == pin, bytes differ
-STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1; rc=$?
-if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ]; then
+out="$(STUB_MARKETPLACE_TARGET="$MK_NEW" run 2>&1)"; rc=$?
+# Assert the REASON, as A5/A12/A13/A15/A15c/A18b/A19b already do. Exit 2 covers eight conditions in
+# the script and almost none of them apply the update, so `rc -eq 2` plus "no APPLIED" discriminates
+# weakly: a regression that exits 2 anywhere earlier keeps this green while the dirty-worktree guard
+# under test never runs.
+if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ] && printf '%s' "$out" | grep -q 'is not clean at'; then
   ok "A18 refuses (exit 2) when the marketplace worktree is dirty at the pinned commit"
 else bad "A18 refuses (exit 2) when the marketplace worktree is dirty at the pinned commit" \
-  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no), out=$(printf '%s' "$out" | tr '\n' '|')"; fi
 cleanup
 
 # ── A18b — a clean FILTER defeats status and the index; only the byte check catches it ─────────
@@ -381,10 +412,14 @@ cleanup
 # bugs in the guard itself, which is worse than the drift it protects against.
 make_fixture
 SUB="$ROOT/sub"; mkdir -p "$SUB"
-git -C "$SUB" init -q -b main; git -C "$SUB" config user.email t@t; git -C "$SUB" config user.name t
-echo s > "$SUB/s"; git -C "$SUB" add s; git -C "$SUB" commit -qm sub
+# Routed through `g` (defined by make_fixture, which has already run, so it is in scope): an
+# unchecked setup command reports its failure as a downstream symptom — `gitlinks=0` in the
+# precondition — rather than naming the command that actually failed. stderr is kept for the same
+# reason.
+g git -C "$SUB" init -q -b main; g git -C "$SUB" config user.email t@t; g git -C "$SUB" config user.name t
+echo s > "$SUB/s"; g git -C "$SUB" add s; g git -C "$SUB" commit -qm sub
 SUB_SHA="$(git -C "$SUB" rev-parse HEAD)"
-git -C "$MK" checkout -q "$MK_NEW"
+g git -C "$MK" checkout -q "$MK_NEW"
 # ANSI-C quoting, NOT double quotes: bash does not expand \xNN inside "…", so `"na\xc3\xafve"` is
 # the literal 12-character ASCII name `na\xc3\xafve`. That name is still C-quoted by git (it contains
 # backslashes), so the case passed while testing something other than what it claimed. $'…' emits the
@@ -398,25 +433,32 @@ git -C "$MK" add -- "$NONASCII" \
 ln -s f "$MK/alias"
 git -C "$MK" add -- alias \
   || { printf 'FIXTURE FAILURE: could not add the symlink\n' >&2; exit 9; }
+# A target ending in a NEWLINE is the case the script's `perl` branch exists for, and `ln -s f` does
+# not reach it: command substitution strips trailing newlines, so `printf '%s' "$(readlink …)"`
+# hashes `f` for both links and stays green. Only a target whose bytes end in \n makes the shell
+# form differ from the blob — without this link, reverting that branch to the shell form would not
+# fail any assertion here.
+ln -s $'f\n' "$MK/alias-nl"
+g git -C "$MK" add -- alias-nl
 # NOT `git add -A`: that stages the DELETION of the gitlink (its directory is absent at this point),
 # which silently produced a tree with zero gitlinks — a fixture that tested nothing. Caught by
 # ablating the gitlink skip and watching this assertion stay green.
-git -C "$MK" update-index --add --cacheinfo 160000,"$SUB_SHA",vendored
-git -C "$MK" commit -qm "gitlink + non-ascii" >/dev/null 2>&1
+g git -C "$MK" update-index --add --cacheinfo 160000,"$SUB_SHA",vendored
+g git -C "$MK" commit -qm "gitlink + non-ascii"
 MK_SUB="$(git -C "$MK" rev-parse HEAD)"
 # Materialise the submodule so the worktree is genuinely CLEAN; otherwise the dirty-status guard
 # fires first and this case never reaches the byte loop it is meant to exercise.
-git -c protocol.file.allow=always -C "$MK" clone -q "$SUB" vendored 2>/dev/null
-git -C "$MK/vendored" checkout -q "$SUB_SHA" 2>/dev/null
+g git -c protocol.file.allow=always -C "$MK" clone -q "$SUB" vendored
+g git -C "$MK/vendored" checkout -q "$SUB_SHA"
 set_gitlink "$MK_SUB"
 gl_count="$(git -C "$MK" ls-tree -r HEAD | awk '$1=="160000"' | wc -l | tr -d ' ')"
 sl_count="$(git -C "$MK" ls-tree -r HEAD | awk '$1=="120000"' | wc -l | tr -d ' ')"
 # Prove the name really is C-quoted by `--name-only`; that quoting is what the -z streaming exists
 # to avoid, so if it is absent this case is not exercising the path it claims to.
 quoted="$(git -C "$MK" ls-tree -r --name-only HEAD | grep -c '^"' | tr -d ' ')"
-if [ "$gl_count" != "1" ] || [ "$sl_count" != "1" ] || [ "$quoted" -lt 1 ] \
+if [ "$gl_count" != "1" ] || [ "$sl_count" != "2" ] || [ "$quoted" -lt 1 ] \
   || [ -n "$(git -C "$MK" status --porcelain)" ]; then
-  bad "A18c fixture precondition: one gitlink, one symlink, a C-quoted name and a clean worktree" \
+  bad "A18c fixture precondition: one gitlink, two symlinks (one newline-terminated), a C-quoted name and a clean worktree" \
     "gitlinks=$gl_count symlinks=$sl_count quoted-names=$quoted status=[$(git -C "$MK" status --porcelain)]"
 else
   out="$(STUB_MARKETPLACE_TARGET="$MK_SUB" run 2>&1)"; rc=$?

--- a/.claude/scripts/plugin-definition-refresh.test.sh
+++ b/.claude/scripts/plugin-definition-refresh.test.sh
@@ -58,8 +58,9 @@ JSON
 
   # Stub post-apply verifier. The real one is plugin-definition-currency.sh; the point of the seam
   # is that the verdict comes from an INDEPENDENT check rather than from `plugin update`'s status.
+  VERIFY_LOG="$ROOT/verify.log"; : > "$VERIFY_LOG"
   VERIFY="$BIN/verify-ok"
-  printf '#!/usr/bin/env bash\nexit 0\n' > "$VERIFY"; chmod +x "$VERIFY"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s"\nexit 0\n' "$VERIFY_LOG" > "$VERIFY"; chmod +x "$VERIFY"
   VERIFY_BAD="$BIN/verify-drift"
   printf '#!/usr/bin/env bash\nexit 1\n' > "$VERIFY_BAD"; chmod +x "$VERIFY_BAD"
 
@@ -156,21 +157,23 @@ cleanup
 # (2) and must never reach 'plugin update'.
 make_fixture
 set_gitlink "$MK_NEW"
-STUB_MARKETPLACE_TARGET="$MK_NEW" run --marketplace staging >/dev/null 2>&1; rc=$?
-if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ]; then
-  ok "A12 refuses (exit 2) when --marketplace and --plugin-id name different marketplaces"
-else bad "A12 refuses (exit 2) when --marketplace and --plugin-id name different marketplaces" \
-  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+out="$(STUB_MARKETPLACE_TARGET="$MK_NEW" run --marketplace staging 2>&1)"; rc=$?
+# Assert the REASON, not merely the code: exit 2 covers eight distinct conditions, so a regression
+# that exits 2 earlier for an unrelated reason would keep this green while the guard never ran.
+if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ] && printf '%s' "$out" | grep -q 'refusing to gate on one marketplace and install from another'; then
+  ok "A12 refuses (exit 2, named reason) when --marketplace and --plugin-id name different marketplaces"
+else bad "A12 refuses (exit 2, named reason) when --marketplace and --plugin-id name different marketplaces" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no), out=$(printf '%s' "$out" | tr '\n' '|')"; fi
 cleanup
 
 # ── A13 — an unqualified plugin id is UNKNOWN, never a silent default ──────────────────────────
 make_fixture
 set_gitlink "$MK_NEW"
-STUB_MARKETPLACE_TARGET="$MK_NEW" run --plugin-id agentic-engineering >/dev/null 2>&1; rc=$?
-if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ]; then
-  ok "A13 refuses (exit 2) when the plugin id is not marketplace-qualified"
-else bad "A13 refuses (exit 2) when the plugin id is not marketplace-qualified" \
-  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+out="$(STUB_MARKETPLACE_TARGET="$MK_NEW" run --plugin-id agentic-engineering 2>&1)"; rc=$?
+if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ] && printf '%s' "$out" | grep -q 'is not marketplace-qualified'; then
+  ok "A13 refuses (exit 2, named reason) when the plugin id is not marketplace-qualified"
+else bad "A13 refuses (exit 2, named reason) when the plugin id is not marketplace-qualified" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no), out=$(printf '%s' "$out" | tr '\n' '|')"; fi
 cleanup
 
 # ── A14 — a malformed registry must not turn a SUCCESSFUL apply into a failure ─────────────────
@@ -237,21 +240,80 @@ else bad "A18 refuses (exit 2) when the marketplace worktree is dirty at the pin
   "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
 cleanup
 
-# ── A18b — the byte-identity comparison exists and fails CLOSED ────────────────────────────────
-# HONEST LIMITATION, stated rather than papered over: this assertion is STRUCTURAL, not behavioural.
-# The dirty-status and hidden-index guards above subsume every fixture that could reach the byte
-# loop at runtime — verified by ablation, which is how the gap was found: neutralising the byte
-# comparison left A18 green. The loop is kept as defense-in-depth because it mirrors the
-# four-assertion pattern AGENTS.md already prescribes for reading the pinned submodule, and because
-# `--no-filters` is the only one of the three that a clean/smudge filter cannot launder. What is
-# pinned here is its presence and its fail-closed direction: an unverifiable file must refuse, since
-# unproven is not proven.
-if grep -q 'hash-object --no-filters' "$SCRIPT" \
-  && grep -q 'bytes_unknown" -eq 0 \] || die' "$SCRIPT" \
-  && grep -q 'bytes_differ" -eq 0 \] || die' "$SCRIPT"; then
-  ok "A18b byte-identity check is present and fails closed on an unverifiable file"
-else bad "A18b byte-identity check is present and fails closed on an unverifiable file" \
-  "$(grep -n 'bytes_unknown\|bytes_differ\|no-filters' "$SCRIPT" | tr '\n' '|')"; fi
+# ── A18b — a clean FILTER defeats status and the index; only the byte check catches it ─────────
+# The equal-length detail is what makes this reachable, and it took a measurement to find: with
+# differing lengths `status` still reports the file modified on its stat check, so the dirty-status
+# guard fires first and the byte loop is never reached. With the filtered and raw forms the SAME
+# length, status is clean, no index flags are set, and `hash-object --no-filters` is the only thing
+# that can tell the worktree bytes from the pinned blob. This is the case the byte check exists for.
+make_fixture
+set_gitlink "$MK_NEW"
+git -C "$MK" checkout -q "$MK_NEW"
+git -C "$MK" config filter.fake.clean 'tr A-Z a-z'
+printf 'f filter=fake\n' > "$MK/.git/info/attributes"
+printf 'NEW\n' > "$MK/f"                       # cleans to "new\n" (the pinned blob); same length
+git -C "$MK" diff >/dev/null 2>&1              # settle the stat cache so status is genuinely clean
+if [ -n "$(git -C "$MK" status --porcelain)" ]; then
+  bad "A18b fixture precondition: status must be clean for this case to reach the byte check" \
+    "status=[$(git -C "$MK" status --porcelain)]"
+else
+  out="$(STUB_MARKETPLACE_TARGET="$MK_NEW" run 2>&1)"; rc=$?
+  if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ] && printf '%s' "$out" | grep -q 'differ from the pinned blobs'; then
+    ok "A18b refuses (exit 2) when a clean filter hides differing bytes from status and the index"
+  else bad "A18b refuses (exit 2) when a clean filter hides differing bytes from status and the index" \
+    "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no), out=$(printf '%s' "$out" | tr '\n' '|')"; fi
+fi
+cleanup
+
+# ── A18c — a gitlink must NOT make a clean pinned marketplace refuse ───────────────────────────
+# `ls-tree --name-only` also C-quotes non-ASCII names, and a gitlink is a directory that cannot be
+# byte-hashed: either would turn a perfectly clean marketplace into exit 2. Both are availability
+# bugs in the guard itself, which is worse than the drift it protects against.
+make_fixture
+SUB="$ROOT/sub"; mkdir -p "$SUB"
+git -C "$SUB" init -q -b main; git -C "$SUB" config user.email t@t; git -C "$SUB" config user.name t
+echo s > "$SUB/s"; git -C "$SUB" add s; git -C "$SUB" commit -qm sub
+SUB_SHA="$(git -C "$SUB" rev-parse HEAD)"
+git -C "$MK" checkout -q "$MK_NEW"
+printf 'na\xc3\xafve\n' > "$MK/na\xc3\xafve"
+git -C "$MK" add "$MK/na\xc3\xafve" >/dev/null 2>&1
+# NOT `git add -A`: that stages the DELETION of the gitlink (its directory is absent at this point),
+# which silently produced a tree with zero gitlinks — a fixture that tested nothing. Caught by
+# ablating the gitlink skip and watching this assertion stay green.
+git -C "$MK" update-index --add --cacheinfo 160000,"$SUB_SHA",vendored
+git -C "$MK" commit -qm "gitlink + non-ascii" >/dev/null 2>&1
+MK_SUB="$(git -C "$MK" rev-parse HEAD)"
+# Materialise the submodule so the worktree is genuinely CLEAN; otherwise the dirty-status guard
+# fires first and this case never reaches the byte loop it is meant to exercise.
+git -c protocol.file.allow=always -C "$MK" clone -q "$SUB" vendored 2>/dev/null
+git -C "$MK/vendored" checkout -q "$SUB_SHA" 2>/dev/null
+set_gitlink "$MK_SUB"
+if [ "$(git -C "$MK" ls-tree -r HEAD | awk '$1=="160000"' | wc -l | tr -d ' ')" != "1" ] \
+  || [ -n "$(git -C "$MK" status --porcelain)" ]; then
+  bad "A18c fixture precondition: exactly one gitlink and a clean worktree" \
+    "gitlinks=$(git -C "$MK" ls-tree -r HEAD | awk '$1=="160000"' | wc -l | tr -d ' ') status=[$(git -C "$MK" status --porcelain)]"
+else
+  out="$(STUB_MARKETPLACE_TARGET="$MK_SUB" run 2>&1)"; rc=$?
+  if [ "$rc" -eq 0 ] && [ -e "$ROOT/APPLIED" ]; then
+    ok "A18c a gitlink and a non-ASCII name do not make a clean marketplace refuse"
+  else bad "A18c a gitlink and a non-ASCII name do not make a clean marketplace refuse" \
+    "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no), out=$(printf '%s' "$out" | tr '\n' '|')"; fi
+fi
+cleanup
+
+# ── A18d — the post-apply verifier is told WHICH target to check ───────────────────────────────
+# Without the explicit arguments the verifier resolves its own defaults, so under any override it
+# would check a different repo/plugins-root/plugin than the one this run just updated.
+make_fixture
+set_gitlink "$MK_NEW"
+STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1
+if grep -q -- "--repo-root $CONSUMER" "$VERIFY_LOG" \
+  && grep -q -- "--plugins-root $PLUGINS" "$VERIFY_LOG" \
+  && grep -q -- "--plugin-id agentic-engineering@devantler-plugins" "$VERIFY_LOG"; then
+  ok "A18d passes the gated repo, plugins root and plugin id to the verifier"
+else bad "A18d passes the gated repo, plugins root and plugin id to the verifier" \
+  "verifier args were: [$(tr '\n' '|' < "$VERIFY_LOG")]"; fi
+cleanup
 
 # ── A19 — --dry-run asserts nothing about the install, so it is never a 0 verdict ──────────────
 # --dry-run deliberately skips the marketplace refresh, so the clone must ALREADY carry the pin to
@@ -286,9 +348,12 @@ set_gitlink "$MK_NEW"
 STUB_MARKETPLACE_TARGET="$MK_NEW" CLAUDE_CLI="$BIN/claude" "$SCRIPT" \
   --repo-root "$CONSUMER" --plugins-root "$PLUGINS" --marketplace-dir "$MK" \
   --verify-cmd "$ROOT/no-such-verifier" >/dev/null 2>&1; rc=$?
-if [ "$rc" -eq 2 ]; then
-  ok "A21 exits 2 (UNKNOWN) when the post-apply verifier is unavailable"
-else bad "A21 exits 2 (UNKNOWN) when the post-apply verifier is unavailable" "exit was $rc"; fi
+# The contract for this path is "the apply HAPPENED, only the verdict is unknown" — so asserting the
+# code alone would also pass if the script refused before ever applying, a different outcome.
+if [ "$rc" -eq 2 ] && [ -e "$ROOT/APPLIED" ]; then
+  ok "A21 exits 2 (UNKNOWN) after applying when the post-apply verifier is unavailable"
+else bad "A21 exits 2 (UNKNOWN) after applying when the post-apply verifier is unavailable" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
 cleanup
 
 # ── A6 — no hardcoded claude-code version directory ────────────────────────────────────────────

--- a/.claude/scripts/plugin-definition-refresh.test.sh
+++ b/.claude/scripts/plugin-definition-refresh.test.sh
@@ -32,8 +32,13 @@ bad()  { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; [ $# -ge 2 ] && printf '  
 # stub CLI that records every invocation and moves the clone on `marketplace update`.
 make_fixture() {
   ROOT="$(mktemp -d)"
-  MK="$ROOT/marketplace"; CONSUMER="$ROOT/consumer"; BIN="$ROOT/bin"
+  CONSUMER="$ROOT/consumer"; BIN="$ROOT/bin"
   PLUGINS="$ROOT/plugins"; INSTALLED="$ROOT/installed"
+  # The marketplace clone sits at the REAL derived location. The script no longer accepts a
+  # `--marketplace-dir` override, because an overridable directory is a decoy vector: a caller could
+  # point it at a checkout equal to the pin while both CLI commands still selected the runtime
+  # marketplace by name. The fixture therefore uses the same path the script computes.
+  MK="$PLUGINS/marketplaces/devantler-plugins"
   mkdir -p "$MK" "$CONSUMER" "$BIN" "$PLUGINS" "$INSTALLED"
 
   git -C "$MK" init -q -b main
@@ -94,7 +99,7 @@ set_gitlink() {
 
 run() {
   CLAUDE_CLI="$BIN/claude" "$SCRIPT" \
-    --repo-root "$CONSUMER" --plugins-root "$PLUGINS" --marketplace-dir "$MK" \
+    --repo-root "$CONSUMER" --plugins-root "$PLUGINS" \
     --verify-cmd "$VERIFY" "$@" 2>&1
 }
 
@@ -145,7 +150,7 @@ cleanup
 make_fixture
 set_gitlink "$MK_NEW"
 CLAUDE_CLI="$ROOT/nope" "$SCRIPT" --repo-root "$CONSUMER" --plugins-root "$PLUGINS" \
-  --marketplace-dir "$MK" >/dev/null 2>&1; rc=$?
+  >/dev/null 2>&1; rc=$?
 if [ "$rc" -eq 2 ]; then ok "A5 exits 2 (UNKNOWN) when the CLI cannot be resolved"
 else bad "A5 exits 2 (UNKNOWN) when the CLI cannot be resolved" "exit was $rc — 0/1 would be a fabricated verdict"; fi
 cleanup
@@ -195,13 +200,35 @@ cleanup
 # the same clone between this run's read and its install would have it apply an ungated revision.
 make_fixture
 set_gitlink "$MK_NEW"
-mkdir -p "$PLUGINS/.plugin-definition-refresh.lock"          # a live sibling holds it
+mkdir -p "$PLUGINS/.plugin-definition-refresh.lock"
+# The owner must be a LIVE pid, or the liveness reaper correctly treats the lock as abandoned and
+# takes it — which is what this fixture did on its first version, failing for the right reason.
+printf '%s\n' "$$" > "$PLUGINS/.plugin-definition-refresh.lock/pid"
 STUB_MARKETPLACE_TARGET="$MK_NEW" PLUGIN_REFRESH_LOCK_WAIT=2 run >/dev/null 2>&1; rc=$?
 if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ]; then
-  ok "A15 exits 2 (UNKNOWN) rather than applying while another run holds the lock"
-else bad "A15 exits 2 (UNKNOWN) rather than applying while another run holds the lock" \
+  ok "A15 exits 2 (UNKNOWN) rather than applying while a LIVE run holds the lock"
+else bad "A15 exits 2 (UNKNOWN) rather than applying while a LIVE run holds the lock" \
   "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+rm -f "$PLUGINS/.plugin-definition-refresh.lock/pid"
 rmdir "$PLUGINS/.plugin-definition-refresh.lock" 2>/dev/null || true
+cleanup
+
+# ── A15b — a lock whose owner is GONE is reaped; age is deliberately not the test ───────────────
+# Reaping on age would let a sibling steal the lock from a refresh that legitimately ran long,
+# putting two runs in the section at once — the failure the lock exists to prevent, caused by the
+# reaper. Liveness is the correct test, and a crashed run must still not park the lock forever.
+make_fixture
+set_gitlink "$MK_NEW"
+mkdir -p "$PLUGINS/.plugin-definition-refresh.lock"
+# A pid that is certainly not running: claim one, then let it exit.
+dead_pid="$( (exec sh -c 'echo $$') )"
+while kill -0 "$dead_pid" 2>/dev/null; do dead_pid=$((dead_pid + 1)); done
+printf '%s\n' "$dead_pid" > "$PLUGINS/.plugin-definition-refresh.lock/pid"
+STUB_MARKETPLACE_TARGET="$MK_NEW" PLUGIN_REFRESH_LOCK_WAIT=2 run >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ] && [ -e "$ROOT/APPLIED" ]; then
+  ok "A15b reaps a lock whose owner process is gone, rather than parking forever"
+else bad "A15b reaps a lock whose owner process is gone, rather than parking forever" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
 cleanup
 
 # ── A16 — the lock is RELEASED on a normal apply, so the next run is not parked ────────────────
@@ -309,10 +336,29 @@ set_gitlink "$MK_NEW"
 STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1
 if grep -q -- "--repo-root $CONSUMER" "$VERIFY_LOG" \
   && grep -q -- "--plugins-root $PLUGINS" "$VERIFY_LOG" \
-  && grep -q -- "--plugin-id agentic-engineering@devantler-plugins" "$VERIFY_LOG"; then
-  ok "A18d passes the gated repo, plugins root and plugin id to the verifier"
-else bad "A18d passes the gated repo, plugins root and plugin id to the verifier" \
+  && grep -q -- "--plugin-id agentic-engineering@devantler-plugins" "$VERIFY_LOG" \
+  && grep -q -- "--gitlink $MK_NEW" "$VERIFY_LOG" \
+  && grep -q -- "--submodule-path libraries/agent-plugins" "$VERIFY_LOG"; then
+  ok "A18d passes the gated repo, plugins root, plugin id, PIN and submodule path to the verifier"
+else bad "A18d passes the gated repo, plugins root, plugin id, PIN and submodule path to the verifier" \
   "verifier args were: [$(tr '\n' '|' < "$VERIFY_LOG")]"; fi
+cleanup
+
+# ── A18e — the verifier's own UNKNOWN must survive, not become a drift verdict ──────────────────
+# `if ! cmd` collapses every non-zero status into one branch, so a verifier that exits 2 because it
+# could not read its evidence would be reported as "the install is not on the pin" — turning "I
+# could not check" into a false verdict and pointing the caller at the wrong remedy. That is the
+# exact conflation this script's own exit contract forbids.
+make_fixture
+set_gitlink "$MK_NEW"
+VERIFY_UNK="$BIN/verify-unknown"
+printf '#!/usr/bin/env bash\nexit 2\n' > "$VERIFY_UNK"; chmod +x "$VERIFY_UNK"
+out="$(STUB_MARKETPLACE_TARGET="$MK_NEW" CLAUDE_CLI="$BIN/claude" "$SCRIPT" \
+  --repo-root "$CONSUMER" --plugins-root "$PLUGINS" --verify-cmd "$VERIFY_UNK" 2>&1)"; rc=$?
+if [ "$rc" -eq 2 ] && [ -e "$ROOT/APPLIED" ] && printf '%s' "$out" | grep -q 'VERIFICATION IS UNKNOWN'; then
+  ok "A18e preserves the verifier's UNKNOWN (exit 2) instead of reporting a false drift"
+else bad "A18e preserves the verifier's UNKNOWN (exit 2) instead of reporting a false drift" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no), out=$(printf '%s' "$out" | tr '\n' '|')"; fi
 cleanup
 
 # ── A19 — --dry-run asserts nothing about the install, so it is never a 0 verdict ──────────────
@@ -334,7 +380,7 @@ cleanup
 make_fixture
 set_gitlink "$MK_NEW"
 STUB_MARKETPLACE_TARGET="$MK_NEW" CLAUDE_CLI="$BIN/claude" "$SCRIPT" \
-  --repo-root "$CONSUMER" --plugins-root "$PLUGINS" --marketplace-dir "$MK" \
+  --repo-root "$CONSUMER" --plugins-root "$PLUGINS" \
   --verify-cmd "$VERIFY_BAD" >/dev/null 2>&1; rc=$?
 if [ "$rc" -eq 1 ] && [ -e "$ROOT/APPLIED" ]; then
   ok "A20 exits 1 when the post-apply check still does not report CURRENT"
@@ -346,7 +392,7 @@ cleanup
 make_fixture
 set_gitlink "$MK_NEW"
 STUB_MARKETPLACE_TARGET="$MK_NEW" CLAUDE_CLI="$BIN/claude" "$SCRIPT" \
-  --repo-root "$CONSUMER" --plugins-root "$PLUGINS" --marketplace-dir "$MK" \
+  --repo-root "$CONSUMER" --plugins-root "$PLUGINS" \
   --verify-cmd "$ROOT/no-such-verifier" >/dev/null 2>&1; rc=$?
 # The contract for this path is "the apply HAPPENED, only the verdict is unknown" — so asserting the
 # code alone would also pass if the script refused before ever applying, a different outcome.

--- a/.claude/scripts/plugin-definition-refresh.test.sh
+++ b/.claude/scripts/plugin-definition-refresh.test.sh
@@ -204,11 +204,11 @@ mkdir -p "$PLUGINS/.plugin-definition-refresh.lock"
 # The owner must be a LIVE pid, or the liveness reaper correctly treats the lock as abandoned and
 # takes it — which is what this fixture did on its first version, failing for the right reason.
 printf '%s\n' "$$" > "$PLUGINS/.plugin-definition-refresh.lock/pid"
-STUB_MARKETPLACE_TARGET="$MK_NEW" PLUGIN_REFRESH_LOCK_WAIT=2 run >/dev/null 2>&1; rc=$?
-if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ]; then
-  ok "A15 exits 2 (UNKNOWN) rather than applying while a LIVE run holds the lock"
-else bad "A15 exits 2 (UNKNOWN) rather than applying while a LIVE run holds the lock" \
-  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+out="$(STUB_MARKETPLACE_TARGET="$MK_NEW" PLUGIN_REFRESH_LOCK_WAIT=2 run 2>&1)"; rc=$?
+if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ] && printf '%s' "$out" | grep -q 'holds .* after'; then
+  ok "A15 exits 2 (UNKNOWN, named reason) rather than applying while a LIVE run holds the lock"
+else bad "A15 exits 2 (UNKNOWN, named reason) rather than applying while a LIVE run holds the lock" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no), out=$(printf '%s' "$out" | tr '\n' '|')"; fi
 rm -f "$PLUGINS/.plugin-definition-refresh.lock/pid"
 rmdir "$PLUGINS/.plugin-definition-refresh.lock" 2>/dev/null || true
 cleanup
@@ -220,11 +220,13 @@ cleanup
 make_fixture
 set_gitlink "$MK_NEW"
 mkdir -p "$PLUGINS/.plugin-definition-refresh.lock"          # fresh, no pid published yet
-STUB_MARKETPLACE_TARGET="$MK_NEW" PLUGIN_REFRESH_LOCK_WAIT=2 run >/dev/null 2>&1; rc=$?
-if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ]; then
+out="$(STUB_MARKETPLACE_TARGET="$MK_NEW" PLUGIN_REFRESH_LOCK_WAIT=2 run 2>&1)"; rc=$?
+# The reason matters here too: exit 2 covers eight conditions, so a regression that exits 2 before
+# the lock code runs would keep this green while the guard under test never executed.
+if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ] && printf '%s' "$out" | grep -q 'holds .* after'; then
   ok "A15c does not steal a freshly-created lock that has not published its owner yet"
 else bad "A15c does not steal a freshly-created lock that has not published its owner yet" \
-  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no), out=$(printf '%s' "$out" | tr '\n' '|')"; fi
 rmdir "$PLUGINS/.plugin-definition-refresh.lock" 2>/dev/null || true
 cleanup
 
@@ -330,8 +332,19 @@ git -C "$SUB" init -q -b main; git -C "$SUB" config user.email t@t; git -C "$SUB
 echo s > "$SUB/s"; git -C "$SUB" add s; git -C "$SUB" commit -qm sub
 SUB_SHA="$(git -C "$SUB" rev-parse HEAD)"
 git -C "$MK" checkout -q "$MK_NEW"
-printf 'na\xc3\xafve\n' > "$MK/na\xc3\xafve"
-git -C "$MK" add "$MK/na\xc3\xafve" >/dev/null 2>&1
+# ANSI-C quoting, NOT double quotes: bash does not expand \xNN inside "…", so `"na\xc3\xafve"` is
+# the literal 12-character ASCII name `na\xc3\xafve`. That name is still C-quoted by git (it contains
+# backslashes), so the case passed while testing something other than what it claimed. $'…' emits the
+# actual UTF-8 bytes.
+NONASCII=$'na\xc3\xafve'
+printf 'x\n' > "$MK/$NONASCII"
+git -C "$MK" add -- "$NONASCII" \
+  || { printf 'FIXTURE FAILURE: could not add the non-ASCII name\n' >&2; exit 9; }
+# A symlink's blob is its TARGET TEXT while `hash-object` on the link hashes the target's contents,
+# so an unhandled symlink also makes a clean marketplace refuse.
+ln -s f "$MK/alias"
+git -C "$MK" add -- alias \
+  || { printf 'FIXTURE FAILURE: could not add the symlink\n' >&2; exit 9; }
 # NOT `git add -A`: that stages the DELETION of the gitlink (its directory is absent at this point),
 # which silently produced a tree with zero gitlinks — a fixture that tested nothing. Caught by
 # ablating the gitlink skip and watching this assertion stay green.
@@ -343,15 +356,20 @@ MK_SUB="$(git -C "$MK" rev-parse HEAD)"
 git -c protocol.file.allow=always -C "$MK" clone -q "$SUB" vendored 2>/dev/null
 git -C "$MK/vendored" checkout -q "$SUB_SHA" 2>/dev/null
 set_gitlink "$MK_SUB"
-if [ "$(git -C "$MK" ls-tree -r HEAD | awk '$1=="160000"' | wc -l | tr -d ' ')" != "1" ] \
+gl_count="$(git -C "$MK" ls-tree -r HEAD | awk '$1=="160000"' | wc -l | tr -d ' ')"
+sl_count="$(git -C "$MK" ls-tree -r HEAD | awk '$1=="120000"' | wc -l | tr -d ' ')"
+# Prove the name really is C-quoted by `--name-only`; that quoting is what the -z streaming exists
+# to avoid, so if it is absent this case is not exercising the path it claims to.
+quoted="$(git -C "$MK" ls-tree -r --name-only HEAD | grep -c '^"' | tr -d ' ')"
+if [ "$gl_count" != "1" ] || [ "$sl_count" != "1" ] || [ "$quoted" -lt 1 ] \
   || [ -n "$(git -C "$MK" status --porcelain)" ]; then
-  bad "A18c fixture precondition: exactly one gitlink and a clean worktree" \
-    "gitlinks=$(git -C "$MK" ls-tree -r HEAD | awk '$1=="160000"' | wc -l | tr -d ' ') status=[$(git -C "$MK" status --porcelain)]"
+  bad "A18c fixture precondition: one gitlink, one symlink, a C-quoted name and a clean worktree" \
+    "gitlinks=$gl_count symlinks=$sl_count quoted-names=$quoted status=[$(git -C "$MK" status --porcelain)]"
 else
   out="$(STUB_MARKETPLACE_TARGET="$MK_SUB" run 2>&1)"; rc=$?
   if [ "$rc" -eq 0 ] && [ -e "$ROOT/APPLIED" ]; then
-    ok "A18c a gitlink and a non-ASCII name do not make a clean marketplace refuse"
-  else bad "A18c a gitlink and a non-ASCII name do not make a clean marketplace refuse" \
+    ok "A18c a gitlink, a symlink and a non-ASCII name do not make a clean marketplace refuse"
+  else bad "A18c a gitlink, a symlink and a non-ASCII name do not make a clean marketplace refuse" \
     "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no), out=$(printf '%s' "$out" | tr '\n' '|')"; fi
 fi
 cleanup

--- a/.claude/scripts/plugin-definition-refresh.test.sh
+++ b/.claude/scripts/plugin-definition-refresh.test.sh
@@ -41,19 +41,27 @@ make_fixture() {
   MK="$PLUGINS/marketplaces/devantler-plugins"
   mkdir -p "$MK" "$CONSUMER" "$BIN" "$PLUGINS" "$INSTALLED"
 
-  git -C "$MK" init -q -b main
-  git -C "$MK" config user.email t@t; git -C "$MK" config user.name t
-  echo old > "$MK/f"; git -C "$MK" add f; git -C "$MK" commit -qm one
-  MK_OLD="$(git -C "$MK" rev-parse HEAD)"
-  echo new > "$MK/f"; git -C "$MK" add f; git -C "$MK" commit -qm two
-  MK_NEW="$(git -C "$MK" rev-parse HEAD)"
-  git -C "$MK" checkout -q "$MK_OLD"        # clone starts STALE, as the real one was
+  # Every setup command is checked. An unguarded fixture does not fail the suite — it leaves the
+  # assertions running against a tree that was never built, which is how three cases in this file
+  # came to pass while testing nothing.
+  g() { "$@" || { printf 'FIXTURE FAILURE: %s\n' "$*" >&2; exit 9; }; }
+
+  g git -C "$MK" init -q -b main
+  g git -C "$MK" config user.email t@t; g git -C "$MK" config user.name t
+  echo old > "$MK/f" || { printf 'FIXTURE FAILURE: write f\n' >&2; exit 9; }
+  g git -C "$MK" add f; g git -C "$MK" commit -qm one
+  MK_OLD="$(git -C "$MK" rev-parse HEAD)" || { printf 'FIXTURE FAILURE: rev-parse OLD\n' >&2; exit 9; }
+  echo new > "$MK/f" || { printf 'FIXTURE FAILURE: rewrite f\n' >&2; exit 9; }
+  g git -C "$MK" add f; g git -C "$MK" commit -qm two
+  MK_NEW="$(git -C "$MK" rev-parse HEAD)" || { printf 'FIXTURE FAILURE: rev-parse NEW\n' >&2; exit 9; }
+  g git -C "$MK" checkout -q "$MK_OLD"      # clone starts STALE, as the real one was
 
   # consumer repo carrying a gitlink to the marketplace at a chosen revision
-  git -C "$CONSUMER" init -q -b main
-  git -C "$CONSUMER" config user.email t@t; git -C "$CONSUMER" config user.name t
+  g git -C "$CONSUMER" init -q -b main
+  g git -C "$CONSUMER" config user.email t@t; g git -C "$CONSUMER" config user.name t
   git -C "$CONSUMER" config protocol.file.allow always 2>/dev/null || true
-  echo x > "$CONSUMER/x"; git -C "$CONSUMER" add x; git -C "$CONSUMER" commit -qm base
+  echo x > "$CONSUMER/x" || { printf 'FIXTURE FAILURE: write x\n' >&2; exit 9; }
+  g git -C "$CONSUMER" add x; g git -C "$CONSUMER" commit -qm base
 
   # runtime registry pointing at an install dir
   cat > "$PLUGINS/installed_plugins.json" <<JSON
@@ -75,6 +83,8 @@ JSON
 printf '%s\n' "\$*" >> "$CLI_LOG"
 if [ "\${1:-}" = plugin ] && [ "\${2:-}" = marketplace ] && [ "\${3:-}" = update ]; then
   git -C "$MK" checkout -q "\${STUB_MARKETPLACE_TARGET:-$MK_OLD}"
+  # Optional window so a test can signal the script while it holds the lock.
+  [ -n "\${STUB_REFRESH_SLEEP:-}" ] && sleep "\$STUB_REFRESH_SLEEP"
 fi
 if [ "\${1:-}" = plugin ] && [ "\${2:-}" = update ]; then
   touch "$ROOT/APPLIED"
@@ -149,11 +159,26 @@ cleanup
 # ── A5 — an unresolvable CLI is UNKNOWN (exit 2), never a verdict ──────────────────────────────
 make_fixture
 set_gitlink "$MK_NEW"
-CLAUDE_CLI="$ROOT/nope" "$SCRIPT" --repo-root "$CONSUMER" --plugins-root "$PLUGINS" \
-  >/dev/null 2>&1; rc=$?
-if [ "$rc" -eq 2 ]; then ok "A5 exits 2 (UNKNOWN) when the CLI cannot be resolved"
-else bad "A5 exits 2 (UNKNOWN) when the CLI cannot be resolved" "exit was $rc — 0/1 would be a fabricated verdict"; fi
+out="$(CLAUDE_CLI="$ROOT/nope" "$SCRIPT" --repo-root "$CONSUMER" --plugins-root "$PLUGINS" 2>&1)"; rc=$?
+# The reason, not just the code: exit 2 covers eight conditions here, so a regression that exits 2
+# earlier for an unrelated reason would keep this green while the CLI resolution never ran.
+if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -q 'cannot resolve an executable claude CLI'; then
+  ok "A5 exits 2 (UNKNOWN, named reason) when the CLI cannot be resolved"
+else bad "A5 exits 2 (UNKNOWN, named reason) when the CLI cannot be resolved" \
+  "exit was $rc — 0/1 would be a fabricated verdict; out=$(printf '%s' "$out" | tr '\n' '|')"; fi
 cleanup
+
+# ── A22 — --help prints the WHOLE header, including the exit-code contract ─────────────────────
+# It was truncating at a hardcoded line count as the header grew, dropping the exit-2 explanation —
+# the part the contract most turns on. Behavioural, not a grep of the source.
+help_out="$("$SCRIPT" --help 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] \
+  && printf '%s' "$help_out" | grep -q 'Exit 2 is deliberately not exit 1' \
+  && printf '%s' "$help_out" | grep -q 'Usage: plugin-definition-refresh.sh' \
+  && ! printf '%s' "$help_out" | grep -q '^set -euo pipefail'; then
+  ok "A22 --help prints the full header including the exit-code contract, and stops before the code"
+else bad "A22 --help prints the full header including the exit-code contract, and stops before the code" \
+  "exit was $rc; lines=$(printf '%s' "$help_out" | wc -l | tr -d ' ')"; fi
 
 # ── A12 — the gate binds the clone it READS to the plugin the CLI UPDATES ──────────────────────
 # `--marketplace staging` would refresh and gate on the staging clone while the default plugin id
@@ -250,9 +275,11 @@ cleanup
 make_fixture
 set_gitlink "$MK_NEW"
 mkdir -p "$PLUGINS/.plugin-definition-refresh.lock"
-# A pid that is certainly not running: claim one, then let it exit.
-dead_pid="$( (exec sh -c 'echo $$') )"
-while kill -0 "$dead_pid" 2>/dev/null; do dead_pid=$((dead_pid + 1)); done
+# A pid that WAS OURS and has since exited. Scanning for a pid that `kill -0` rejects does not
+# prove absence: that also fails with EPERM for a LIVE process owned by another user.
+sh -c 'exit 0' &
+dead_pid=$!
+wait "$dead_pid" 2>/dev/null
 printf '%s\n' "$dead_pid" > "$PLUGINS/.plugin-definition-refresh.lock/pid"
 STUB_MARKETPLACE_TARGET="$MK_NEW" PLUGIN_REFRESH_LOCK_WAIT=2 run >/dev/null 2>&1; rc=$?
 if [ "$rc" -eq 0 ] && [ -e "$ROOT/APPLIED" ]; then
@@ -275,6 +302,32 @@ cleanup
 # A bash handler that returns normally resumes at the point of interruption, so a combined
 # `trap release_lock EXIT INT TERM` would surrender the lock and then carry on into 'plugin update'
 # — an unserialized apply, which is the very thing the lock exists to prevent.
+# ── A17b — BEHAVIOURAL: a TERM while holding the lock must terminate, not resume ───────────────
+# A17 below asserts the trap lines; this asserts what they are for. The script is signalled while it
+# holds the lock inside the refresh, and must (a) not go on to apply, and (b) leave no lock behind.
+# A handler that merely released and returned would resume into 'plugin update' — an unserialized
+# apply with the lock already surrendered.
+make_fixture
+set_gitlink "$MK_NEW"
+STUB_MARKETPLACE_TARGET="$MK_NEW" STUB_REFRESH_SLEEP=5 CLAUDE_CLI="$BIN/claude" "$SCRIPT" \
+  --repo-root "$CONSUMER" --plugins-root "$PLUGINS" --verify-cmd "$VERIFY" >/dev/null 2>&1 &
+sig_pid=$!
+lockdir="$PLUGINS/.plugin-definition-refresh.lock"
+for _ in $(seq 1 40); do [ -s "$lockdir/pid" ] && break; sleep 0.25; done
+if [ ! -s "$lockdir/pid" ]; then
+  bad "A17b fixture precondition: the script must be holding the lock before it is signalled" \
+    "no lock published within 10s"
+  kill "$sig_pid" 2>/dev/null || true; wait "$sig_pid" 2>/dev/null
+else
+  kill -TERM "$sig_pid" 2>/dev/null
+  wait "$sig_pid" 2>/dev/null; trc=$?
+  if [ "$trc" -ne 0 ] && [ ! -e "$ROOT/APPLIED" ] && [ ! -d "$lockdir" ]; then
+    ok "A17b a TERM while holding the lock terminates without applying and releases the lock"
+  else bad "A17b a TERM while holding the lock terminates without applying and releases the lock" \
+    "exit was $trc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no), lock_left=$([ -d "$lockdir" ] && echo yes || echo no)"; fi
+fi
+cleanup
+
 if grep -Eq '^trap release_lock EXIT$' "$SCRIPT" \
   && grep -Eq "^trap 'exit 130' INT$" "$SCRIPT" \
   && grep -Eq "^trap 'exit 143' TERM$" "$SCRIPT" \

--- a/.claude/scripts/plugin-definition-refresh.test.sh
+++ b/.claude/scripts/plugin-definition-refresh.test.sh
@@ -56,6 +56,13 @@ make_fixture() {
   {"scope":"user","installPath":"$INSTALLED","version":"0.0.0","gitCommitSha":"$MK_OLD"}]}}
 JSON
 
+  # Stub post-apply verifier. The real one is plugin-definition-currency.sh; the point of the seam
+  # is that the verdict comes from an INDEPENDENT check rather than from `plugin update`'s status.
+  VERIFY="$BIN/verify-ok"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$VERIFY"; chmod +x "$VERIFY"
+  VERIFY_BAD="$BIN/verify-drift"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$VERIFY_BAD"; chmod +x "$VERIFY_BAD"
+
   CLI_LOG="$ROOT/cli.log"; : > "$CLI_LOG"
   cat > "$BIN/claude" <<STUB
 #!/usr/bin/env bash
@@ -87,7 +94,7 @@ set_gitlink() {
 run() {
   CLAUDE_CLI="$BIN/claude" "$SCRIPT" \
     --repo-root "$CONSUMER" --plugins-root "$PLUGINS" --marketplace-dir "$MK" \
-    "$@" 2>&1
+    --verify-cmd "$VERIFY" "$@" 2>&1
 }
 
 cleanup() { [ -n "${ROOT:-}" ] && rm -rf "$ROOT"; }
@@ -202,6 +209,86 @@ if [ "$rc" -eq 0 ] && [ ! -d "$PLUGINS/.plugin-definition-refresh.lock" ]; then
   ok "A16 releases the lock after a successful apply"
 else bad "A16 releases the lock after a successful apply" \
   "exit was $rc, lock still present=$([ -d "$PLUGINS/.plugin-definition-refresh.lock" ] && echo yes || echo no)"; fi
+cleanup
+
+# ── A17 — INT/TERM must TERMINATE the run, not merely clean up and resume ──────────────────────
+# A bash handler that returns normally resumes at the point of interruption, so a combined
+# `trap release_lock EXIT INT TERM` would surrender the lock and then carry on into 'plugin update'
+# — an unserialized apply, which is the very thing the lock exists to prevent.
+if grep -Eq '^trap release_lock EXIT$' "$SCRIPT" \
+  && grep -Eq "^trap 'exit 130' INT$" "$SCRIPT" \
+  && grep -Eq "^trap 'exit 143' TERM$" "$SCRIPT" \
+  && ! grep -Eq '^trap release_lock EXIT INT TERM$' "$SCRIPT"; then
+  ok "A17 INT/TERM exit instead of resuming after releasing the lock"
+else bad "A17 INT/TERM exit instead of resuming after releasing the lock" \
+  "$(grep -n '^trap ' "$SCRIPT" | tr '\n' '|')"; fi
+
+# ── A18 — HEAD == pin does NOT establish the BYTES; a dirty marketplace must not be installed ──
+# A non-conflicting tracked modification leaves `rev-parse HEAD` equal to the pin while the files
+# 'plugin update' copies differ from the reviewed commit.
+make_fixture
+set_gitlink "$MK_NEW"
+git -C "$MK" checkout -q "$MK_NEW"                                 # clone already carries the pin
+echo tampered > "$MK/f"                                            # HEAD still == pin, bytes differ
+STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ]; then
+  ok "A18 refuses (exit 2) when the marketplace worktree is dirty at the pinned commit"
+else bad "A18 refuses (exit 2) when the marketplace worktree is dirty at the pinned commit" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+cleanup
+
+# ── A18b — the byte-identity comparison exists and fails CLOSED ────────────────────────────────
+# HONEST LIMITATION, stated rather than papered over: this assertion is STRUCTURAL, not behavioural.
+# The dirty-status and hidden-index guards above subsume every fixture that could reach the byte
+# loop at runtime — verified by ablation, which is how the gap was found: neutralising the byte
+# comparison left A18 green. The loop is kept as defense-in-depth because it mirrors the
+# four-assertion pattern AGENTS.md already prescribes for reading the pinned submodule, and because
+# `--no-filters` is the only one of the three that a clean/smudge filter cannot launder. What is
+# pinned here is its presence and its fail-closed direction: an unverifiable file must refuse, since
+# unproven is not proven.
+if grep -q 'hash-object --no-filters' "$SCRIPT" \
+  && grep -q 'bytes_unknown" -eq 0 \] || die' "$SCRIPT" \
+  && grep -q 'bytes_differ" -eq 0 \] || die' "$SCRIPT"; then
+  ok "A18b byte-identity check is present and fails closed on an unverifiable file"
+else bad "A18b byte-identity check is present and fails closed on an unverifiable file" \
+  "$(grep -n 'bytes_unknown\|bytes_differ\|no-filters' "$SCRIPT" | tr '\n' '|')"; fi
+
+# ── A19 — --dry-run asserts nothing about the install, so it is never a 0 verdict ──────────────
+# --dry-run deliberately skips the marketplace refresh, so the clone must ALREADY carry the pin to
+# reach the would-apply branch at all; otherwise the gate correctly refuses first with exit 1.
+make_fixture
+set_gitlink "$MK_NEW"
+git -C "$MK" checkout -q "$MK_NEW"
+STUB_MARKETPLACE_TARGET="$MK_NEW" run --dry-run >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ]; then
+  ok "A19 --dry-run exits 2 (no verdict) and never applies"
+else bad "A19 --dry-run exits 2 (no verdict) and never applies" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+cleanup
+
+# ── A20 — the CLI's exit 0 is not the verdict; an independent check decides ────────────────────
+# 'plugin update' can exit 0 having repaired nothing (byte-level drift under an already-current
+# version string). The post-apply check, not the tool's status, decides.
+make_fixture
+set_gitlink "$MK_NEW"
+STUB_MARKETPLACE_TARGET="$MK_NEW" CLAUDE_CLI="$BIN/claude" "$SCRIPT" \
+  --repo-root "$CONSUMER" --plugins-root "$PLUGINS" --marketplace-dir "$MK" \
+  --verify-cmd "$VERIFY_BAD" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 1 ] && [ -e "$ROOT/APPLIED" ]; then
+  ok "A20 exits 1 when the post-apply check still does not report CURRENT"
+else bad "A20 exits 1 when the post-apply check still does not report CURRENT" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+cleanup
+
+# ── A21 — an unavailable verifier is UNKNOWN, never a success verdict ──────────────────────────
+make_fixture
+set_gitlink "$MK_NEW"
+STUB_MARKETPLACE_TARGET="$MK_NEW" CLAUDE_CLI="$BIN/claude" "$SCRIPT" \
+  --repo-root "$CONSUMER" --plugins-root "$PLUGINS" --marketplace-dir "$MK" \
+  --verify-cmd "$ROOT/no-such-verifier" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ]; then
+  ok "A21 exits 2 (UNKNOWN) when the post-apply verifier is unavailable"
+else bad "A21 exits 2 (UNKNOWN) when the post-apply verifier is unavailable" "exit was $rc"; fi
 cleanup
 
 # ── A6 — no hardcoded claude-code version directory ────────────────────────────────────────────

--- a/.claude/scripts/plugin-definition-refresh.test.sh
+++ b/.claude/scripts/plugin-definition-refresh.test.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# plugin-definition-refresh.test.sh — contract test for plugin-definition-refresh.sh
+#
+# The defect under test (measured 2026-08-16, monorepo#2856):
+#   `claude plugin update <plugin>` installs the MARKETPLACE LATEST, not the consumer's PINNED
+#   revision — its own `--help` says "Update a plugin to the latest version" and it exposes no
+#   ref/version selector. On 2026-08-15 the two coincided (clone HEAD == pin `564a6a0f`), which is
+#   the only reason the by-hand refresh appeared to install the pin. On 2026-08-16 they did NOT:
+#   pin `11b241cc` (4.3.4) against an upstream `main` already at `73109ad9` (4.3.6). A pre-flight
+#   wired to the two commands as #2856 describes them would therefore install definitions this
+#   consumer has never reviewed — a strictly worse failure than the stale-install drift it fixes,
+#   because drift at least runs a PREVIOUSLY REVIEWED definition.
+#
+# So the contract is a GATED refresh: refresh the marketplace, then apply the plugin update ONLY
+# when the revision it would install is exactly the pinned one. Otherwise refuse and report.
+#
+# Read-only against the real host: every assertion runs against fixtures in a temp dir with a
+# stubbed CLI. The suite never touches the runtime's plugin install.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/plugin-definition-refresh.sh"
+
+pass=0; fail=0
+ok()   { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; [ $# -ge 2 ] && printf '       %s\n' "$2"; }
+
+[ -x "$SCRIPT" ] || { printf 'plugin-definition-refresh.sh is missing or not executable: %s\n' "$SCRIPT" >&2; exit 1; }
+
+# ── fixture ────────────────────────────────────────────────────────────────────
+# A marketplace clone with two commits, a consumer repo whose gitlink names one of them, and a
+# stub CLI that records every invocation and moves the clone on `marketplace update`.
+make_fixture() {
+  ROOT="$(mktemp -d)"
+  MK="$ROOT/marketplace"; CONSUMER="$ROOT/consumer"; BIN="$ROOT/bin"
+  PLUGINS="$ROOT/plugins"; INSTALLED="$ROOT/installed"
+  mkdir -p "$MK" "$CONSUMER" "$BIN" "$PLUGINS" "$INSTALLED"
+
+  git -C "$MK" init -q -b main
+  git -C "$MK" config user.email t@t; git -C "$MK" config user.name t
+  echo old > "$MK/f"; git -C "$MK" add f; git -C "$MK" commit -qm one
+  MK_OLD="$(git -C "$MK" rev-parse HEAD)"
+  echo new > "$MK/f"; git -C "$MK" add f; git -C "$MK" commit -qm two
+  MK_NEW="$(git -C "$MK" rev-parse HEAD)"
+  git -C "$MK" checkout -q "$MK_OLD"        # clone starts STALE, as the real one was
+
+  # consumer repo carrying a gitlink to the marketplace at a chosen revision
+  git -C "$CONSUMER" init -q -b main
+  git -C "$CONSUMER" config user.email t@t; git -C "$CONSUMER" config user.name t
+  git -C "$CONSUMER" config protocol.file.allow always 2>/dev/null || true
+  echo x > "$CONSUMER/x"; git -C "$CONSUMER" add x; git -C "$CONSUMER" commit -qm base
+
+  # runtime registry pointing at an install dir
+  cat > "$PLUGINS/installed_plugins.json" <<JSON
+{"version":2,"plugins":{"agentic-engineering@devantler-plugins":[
+  {"scope":"user","installPath":"$INSTALLED","version":"0.0.0","gitCommitSha":"$MK_OLD"}]}}
+JSON
+
+  CLI_LOG="$ROOT/cli.log"; : > "$CLI_LOG"
+  cat > "$BIN/claude" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$CLI_LOG"
+if [ "\${1:-}" = plugin ] && [ "\${2:-}" = marketplace ] && [ "\${3:-}" = update ]; then
+  git -C "$MK" checkout -q "\${STUB_MARKETPLACE_TARGET:-$MK_OLD}"
+fi
+if [ "\${1:-}" = plugin ] && [ "\${2:-}" = update ]; then
+  touch "$ROOT/APPLIED"
+fi
+exit 0
+STUB
+  chmod +x "$BIN/claude"
+}
+
+# Point the consumer's gitlink at $1 by writing the tree entry directly — no network, no submodule
+# machinery, and it is exactly the "160000 commit <sha>" shape the script must read.
+set_gitlink() {
+  local sha="$1"
+  git -C "$CONSUMER" update-index --add --cacheinfo 160000,"$sha",libraries/agent-plugins
+  git -C "$CONSUMER" commit -qm "pin $sha" >/dev/null 2>&1 || true
+}
+
+run() {
+  CLAUDE_CLI="$BIN/claude" "$SCRIPT" \
+    --repo-root "$CONSUMER" --plugins-root "$PLUGINS" --marketplace-dir "$MK" \
+    --installed "$INSTALLED" "$@" 2>&1
+}
+
+cleanup() { [ -n "${ROOT:-}" ] && rm -rf "$ROOT"; }
+trap cleanup EXIT
+
+printf '\nplugin-definition-refresh contract\n'
+
+# ── A1 — the measured defect: marketplace latest != pin ⇒ REFUSE, and never apply ─────────────
+make_fixture
+set_gitlink "$MK_OLD"                      # pin = OLD; marketplace will refresh to NEW
+STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 1 ]; then ok "A1 refuses (exit 1) when the refreshed marketplace does not carry the pin"
+else bad "A1 refuses (exit 1) when the refreshed marketplace does not carry the pin" "exit was $rc"; fi
+if [ ! -e "$ROOT/APPLIED" ]; then ok "A1b does NOT invoke 'plugin update' when the pin is unavailable"
+else bad "A1b does NOT invoke 'plugin update' when the pin is unavailable" "it applied an unreviewed revision"; fi
+cleanup
+
+# ── A2 — the safe case: marketplace latest == pin ⇒ apply ──────────────────────────────────────
+make_fixture
+set_gitlink "$MK_NEW"
+STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1; rc=$?
+if [ -e "$ROOT/APPLIED" ]; then ok "A2 invokes 'plugin update' when the marketplace carries exactly the pin"
+else bad "A2 invokes 'plugin update' when the marketplace carries exactly the pin" "exit was $rc, never applied"; fi
+cleanup
+
+# ── A3 — a runtime-local mutation is backed up BEFORE it happens ───────────────────────────────
+make_fixture
+set_gitlink "$MK_NEW"
+STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1
+if ls "$PLUGINS"/installed_plugins.json.bak-* >/dev/null 2>&1; then ok "A3 backs up installed_plugins.json before applying"
+else bad "A3 backs up installed_plugins.json before applying" "no timestamped backup was written"; fi
+cleanup
+
+# ── A4 — refresh is attempted BEFORE the gate is evaluated ─────────────────────────────────────
+# Clone starts at OLD and the pin is NEW. Only a script that refreshes FIRST can ever apply here;
+# one that read the clone HEAD up front would see OLD != NEW and refuse. This is the assertion that
+# pins the ORDER, which is the half #2856 got right and is easy to drop when adding the gate.
+make_fixture
+set_gitlink "$MK_NEW"
+STUB_MARKETPLACE_TARGET="$MK_NEW" run >/dev/null 2>&1
+if grep -q 'plugin marketplace update' "$CLI_LOG" && [ -e "$ROOT/APPLIED" ]; then
+  ok "A4 refreshes the marketplace before evaluating the gate"
+else bad "A4 refreshes the marketplace before evaluating the gate" "$(tr '\n' '|' < "$CLI_LOG")"; fi
+cleanup
+
+# ── A5 — an unresolvable CLI is UNKNOWN (exit 2), never a verdict ──────────────────────────────
+make_fixture
+set_gitlink "$MK_NEW"
+CLAUDE_CLI="$ROOT/nope" "$SCRIPT" --repo-root "$CONSUMER" --plugins-root "$PLUGINS" \
+  --marketplace-dir "$MK" --installed "$INSTALLED" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ]; then ok "A5 exits 2 (UNKNOWN) when the CLI cannot be resolved"
+else bad "A5 exits 2 (UNKNOWN) when the CLI cannot be resolved" "exit was $rc — 0/1 would be a fabricated verdict"; fi
+cleanup
+
+# ── A6 — no hardcoded claude-code version directory ────────────────────────────────────────────
+# The by-hand invocation that worked on 2026-08-15 hardcoded `claude-code/2.1.229/`. Baking that in
+# breaks silently on the next runtime upgrade, which is the same unbounded-staleness class this
+# script exists to close.
+if ! grep -Eq 'claude-code/[0-9]+\.[0-9]+\.[0-9]+' "$SCRIPT"; then
+  ok "A6 does not hardcode a claude-code version directory"
+else bad "A6 does not hardcode a claude-code version directory" "$(grep -Eon 'claude-code/[0-9]+\.[0-9]+\.[0-9]+' "$SCRIPT" | head -1)"; fi
+
+# ── A7 — the pin is resolved with --no-replace-objects ─────────────────────────────────────────
+# AGENTS.md *Git safety*: a refs/replace entry makes HEAD:<path> resolve through a replacement
+# commit while `git rev-parse HEAD` still prints the expected value, so the pin silently names an
+# unreviewed revision — a fail-open on the one value everything downstream trusts.
+#
+# Matched on the INVOCATION line — both `--no-replace-objects` and `rev-parse` on one line — not
+# anywhere in the file. Ablation caught the loose form passing vacuously: stripping the flag from
+# the command still left the phrase in the comment explaining it, so the assertion could never fail
+# while the rationale was documented. An assertion a comment can satisfy tests the prose.
+if grep -Eq -- '--no-replace-objects[^\n]*rev-parse|rev-parse[^\n]*--no-replace-objects' "$SCRIPT"; then
+  ok "A7 resolves the pinned revision with --no-replace-objects"
+else bad "A7 resolves the pinned revision with --no-replace-objects" "the gate can be pointed at an unreviewed revision"; fi
+
+# ── A8 — the restart semantics are stated on the applying path ─────────────────────────────────
+# `plugin update` says "restart required to apply". The applying run keeps executing the OLD
+# definition, so an exit 0 that reads as "this run used the new definition" is the same fail-open
+# as the drift itself (#2856 acceptance criterion 2).
+make_fixture
+set_gitlink "$MK_NEW"
+#
+# Keyed on the CLI's own word, `restart`. The first draft also accepted "next dispatch" and "this
+# run"; ablation showed that set survived deleting the restart sentence outright, because those
+# phrases recur throughout the surrounding prose. A needle that common asserts the topic, not the
+# statement.
+out="$(STUB_MARKETPLACE_TARGET="$MK_NEW" run 2>&1)"
+if printf '%s' "$out" | grep -qi 'restart'; then
+  ok "A8 states that the applying run still executes the previous definition"
+else bad "A8 states that the applying run still executes the previous definition" "$(printf '%s' "$out" | tail -3 | tr '\n' '|')"; fi
+cleanup
+
+# ── A9–A11 — the CONTRACT carries the rule, not just this script ───────────────────────────────
+# A script nobody is told to run is decoration, and the marketplace-latest hazard is the one fact
+# that makes the gate look like needless friction if it is not written down. Scoped to the plugin
+# contract section, matching the currency suite: these phrases also appear in this file and in the
+# script header, so a file-wide match would pass while the operative section said nothing.
+CONSTITUTION="$(cd "$HERE/../.." && pwd)/AGENTS.md"
+if [ -r "$CONSTITUTION" ]; then
+  section="$(awk '
+      /^### Agentic engineering plugin contract$/ { ins = 1; next }
+      ins && /^### / { exit }
+      ins { print }
+    ' "$CONSTITUTION" | tr '\n' ' ')"
+  [ -n "$section" ] || bad "A9-A11 could not extract the plugin contract section from AGENTS.md"
+
+  case "$section" in
+    *"plugin-definition-refresh.sh"*) ok "A9 the contract names the gated refresh script" ;;
+    *) bad "A9 the contract names the gated refresh script" "pre-flight has no prescribed way to apply the pin" ;;
+  esac
+  # The hazard, not merely the gate: without it the refusal reads as over-caution and the next
+  # reader "fixes" it by dropping the gate — which is precisely the fail-open.
+  case "$section" in
+    *"installs the MARKETPLACE LATEST"*) ok "A10 the contract states that plugin update installs the marketplace latest" ;;
+    *) bad "A10 the contract states that plugin update installs the marketplace latest" "the reason for the gate is unrecorded" ;;
+  esac
+  case "$section" in
+    *"requires a restart"*) ok "A11 the contract states the restart semantics of an apply" ;;
+    *) bad "A11 the contract states the restart semantics of an apply" "an apply-time exit 0 could be read as 'this run is current'" ;;
+  esac
+else
+  bad "A9-A11 AGENTS.md is unreadable at $CONSTITUTION"
+fi
+
+printf '\n  %d passed, %d failed\n\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/scripts/plugin-definition-refresh.test.sh
+++ b/.claude/scripts/plugin-definition-refresh.test.sh
@@ -213,6 +213,34 @@ rm -f "$PLUGINS/.plugin-definition-refresh.lock/pid"
 rmdir "$PLUGINS/.plugin-definition-refresh.lock" 2>/dev/null || true
 cleanup
 
+# ── A15c — a briefly OWNERLESS lock is acquisition-in-progress, not debris ─────────────────────
+# `mkdir` is atomic but publishing the pid is a separate step. A rival that reads the lock inside
+# that window sees no owner; treating THAT as abandoned lets it delete a live lock and put two runs
+# in the section — the failure the lock exists to prevent, reintroduced by the reaper.
+make_fixture
+set_gitlink "$MK_NEW"
+mkdir -p "$PLUGINS/.plugin-definition-refresh.lock"          # fresh, no pid published yet
+STUB_MARKETPLACE_TARGET="$MK_NEW" PLUGIN_REFRESH_LOCK_WAIT=2 run >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ]; then
+  ok "A15c does not steal a freshly-created lock that has not published its owner yet"
+else bad "A15c does not steal a freshly-created lock that has not published its owner yet" \
+  "exit was $rc, applied=$([ -e "$ROOT/APPLIED" ] && echo yes || echo no)"; fi
+rmdir "$PLUGINS/.plugin-definition-refresh.lock" 2>/dev/null || true
+cleanup
+
+# ── A19b — a dry run cannot produce a NOT-ON-PIN verdict either ────────────────────────────────
+# --dry-run skips the refresh, so a stale clone is compared against the pin. An actual refresh may
+# bring it exactly to that pin, so this proves nothing about whether the marketplace can supply it;
+# emitting exit 1 here would point the caller at a gitlink bump it may not need.
+make_fixture
+set_gitlink "$MK_NEW"                        # clone is still at OLD; refresh is skipped in dry-run
+out="$(STUB_MARKETPLACE_TARGET="$MK_NEW" run --dry-run 2>&1)"; rc=$?
+if [ "$rc" -eq 2 ] && [ ! -e "$ROOT/APPLIED" ] && printf '%s' "$out" | grep -q 'NOT evidence the marketplace lacks the pin'; then
+  ok "A19b --dry-run against a stale clone exits 2, never a false NOT-ON-PIN"
+else bad "A19b --dry-run against a stale clone exits 2, never a false NOT-ON-PIN" \
+  "exit was $rc, out=$(printf '%s' "$out" | tr '\n' '|')"; fi
+cleanup
+
 # ── A15b — a lock whose owner is GONE is reaped; age is deliberately not the test ───────────────
 # Reaping on age would let a sibling steal the lock from a refresh that legitimately ran long,
 # putting two runs in the section at once — the failure the lock exists to prevent, caused by the
@@ -338,6 +366,7 @@ if grep -q -- "--repo-root $CONSUMER" "$VERIFY_LOG" \
   && grep -q -- "--plugins-root $PLUGINS" "$VERIFY_LOG" \
   && grep -q -- "--plugin-id agentic-engineering@devantler-plugins" "$VERIFY_LOG" \
   && grep -q -- "--gitlink $MK_NEW" "$VERIFY_LOG" \
+  && grep -q -- "--plugin-name agentic-engineering" "$VERIFY_LOG" \
   && grep -q -- "--submodule-path libraries/agent-plugins" "$VERIFY_LOG"; then
   ok "A18d passes the gated repo, plugins root, plugin id, PIN and submodule path to the verifier"
 else bad "A18d passes the gated repo, plugins root, plugin id, PIN and submodule path to the verifier" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
       control-character-command-contract: ${{ steps.filter.outputs.control-character-command-contract }}
       git-safety-contract: ${{ steps.filter.outputs.git-safety-contract }}
       plugin-definition-currency: ${{ steps.filter.outputs.plugin-definition-currency }}
+      plugin-definition-refresh: ${{ steps.filter.outputs.plugin-definition-refresh }}
       merge-confirmation-read: ${{ steps.filter.outputs.merge-confirmation-read }}
       portfolio-surveyor: ${{ steps.filter.outputs.portfolio-surveyor }}
       product-value: ${{ steps.filter.outputs.product-value }}
@@ -216,6 +217,11 @@ jobs:
               - 'AGENTS.md'
               - '.claude/scripts/plugin-definition-currency.sh'
               - '.claude/scripts/plugin-definition-currency.test.sh'
+              - '.github/workflows/ci.yaml'
+            plugin-definition-refresh:
+              - 'AGENTS.md'
+              - '.claude/scripts/plugin-definition-refresh.sh'
+              - '.claude/scripts/plugin-definition-refresh.test.sh'
               - '.github/workflows/ci.yaml'
             self-review-contract:
               - 'AGENTS.md'
@@ -859,6 +865,21 @@ jobs:
       - name: Verify the plugin definition currency check
         run: bash .claude/scripts/plugin-definition-currency.test.sh
 
+  test-plugin-definition-refresh:
+    name: Test plugin definition refresh
+    needs: changes
+    if: needs.changes.outputs.plugin-definition-refresh == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify the gated plugin definition refresh
+        run: bash .claude/scripts/plugin-definition-refresh.test.sh
+
   test-self-review-contract:
     name: Test self-review contract
     needs: changes
@@ -994,6 +1015,7 @@ jobs:
       - test-control-character-command-contract
       - test-git-safety-contract
       - test-plugin-definition-currency
+      - test-plugin-definition-refresh
       - test-self-review-contract
       - test-review-provider-loop-contract
       - test-agent-role-delivery-contract
@@ -1030,6 +1052,7 @@ jobs:
             ${{ needs.test-control-character-command-contract.result }}
             ${{ needs.test-git-safety-contract.result }}
             ${{ needs.test-plugin-definition-currency.result }}
+            ${{ needs.test-plugin-definition-refresh.result }}
             ${{ needs.test-self-review-contract.result }}
             ${{ needs.test-review-provider-loop-contract.result }}
             ${{ needs.test-agent-role-delivery-contract.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -222,6 +222,9 @@ jobs:
               - 'AGENTS.md'
               - '.claude/scripts/plugin-definition-refresh.sh'
               - '.claude/scripts/plugin-definition-refresh.test.sh'
+              # The refresh script's DEFAULT post-apply verifier. Its exit codes are the verdict, so
+              # a change there changes this script's behaviour without touching either file above.
+              - '.claude/scripts/plugin-definition-currency.sh'
               - '.github/workflows/ci.yaml'
             self-review-contract:
               - 'AGENTS.md'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,8 +438,16 @@ supply that revision, or the apply ran and the post-apply check still does not r
 different marketplace than the clone being gated, a concurrent run holding the lock, a marketplace
 worktree whose bytes do not provably match the pinned commit, an unavailable verifier, or
 `--dry-run`, since a simulation asserts nothing about the install. Run it on a `DRIFT`; a `1` or `2`
-is reported, never a run-stopper, and you continue against the reviewed definition at the pinned
-gitlink exactly as above.
+is reported, never a run-stopper, and you continue by **reading** the reviewed definition at the
+pinned gitlink and following it, exactly as above.
+
+⚠️ **Running the refresh never makes the pin active for THIS run — do not report it as if it had.**
+On a `1` or `2` the installed definition is unchanged by construction, so the runtime is still
+serving whatever it served before; and even a `0` only records that the install is now on the pin,
+because `plugin update` requires a restart. In every case the definition this run executes is the
+one it booted with. That is exactly why the fallback is to read the reviewed definition at the pin
+rather than to trust the install: the currency check's next verdict, in a later run, is what
+establishes that the pinned definition is live.
 
 🔴 **`plugin update` installs the MARKETPLACE LATEST — it is NOT a way to install the pin, and
 wiring the bare commands into pre-flight would be a fail-open worse than the drift.** Its own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,10 +425,35 @@ which the helper deliberately dies `STILL EMPTY` rather than report a vacuous `i
 the prescribed recovery worktree failing in exactly the case it was reached for, so do not let it end
 the run: fall back to the forge read, which needs no working tree.
 
-Refresh only through the runtime's own control plane — the `/plugin` marketplace update flow. **Never edit the plugin cache**; it is
-read-only evidence (see *Agent definition locations*). When the refresh needs an interactive session
-an unattended run cannot open, surface it on a declared *Maintainer channel* rather than leaving a
-silently superseded definition in place.
+Refresh only through the runtime's own control plane — the `/plugin` marketplace update flow
+interactively, or, in an unattended run, that same control plane driven by
+[`.claude/scripts/plugin-definition-refresh.sh`](.claude/scripts/plugin-definition-refresh.sh)
+through the app-bundled binary. **Never edit the plugin cache**; it is read-only evidence (see
+*Agent definition locations*). The script exits `0` once the install is on the pin, `1` when it is
+not and could not safely be put there, and `2` UNKNOWN. Run it on a `DRIFT`; a `1` or `2` is
+reported, never a run-stopper, and you continue against the reviewed definition at the pinned
+gitlink exactly as above.
+
+🔴 **`plugin update` installs the MARKETPLACE LATEST — it is NOT a way to install the pin, and
+wiring the bare commands into pre-flight would be a fail-open worse than the drift.** Its own
+`--help` reads *"Update a plugin to the latest version"*, and it takes no ref or version selector.
+The two coincide only when the consumer's gitlink happens to equal the upstream tip, which is
+exactly what made the 2026-08-15 by-hand refresh look like it installed the pinned revision — the
+marketplace tip *was* `564a6a0f`. Measured the next day: pin `11b241cc` (4.3.4) against an upstream
+`main` already at `73109ad9` (4.3.6), so the bare commands would have installed a revision nobody
+here has reviewed. **Stale-install drift at least runs a previously reviewed definition; this would
+run one that was never read.** That is why the script gates on marketplace-HEAD **==** pin and
+refuses otherwise rather than taking the tip.
+
+⚠️ **A refusal is a real finding about the ROLLOUT, not a failure of the check.** It means the
+gitlink and upstream have diverged, so the fix is to bump `libraries/agent-plugins` to the revision
+you intend to run through the normal reviewed rollout — never to install the tip to make the
+message go away. ⚠️ And `plugin update` **requires a restart**, so a `0` never means *this* run used
+the new definition; the pinned copy is served from the next dispatch, and only a later run's
+currency check confirms it. Reading the apply-time `0` as "this run is current" is the same
+fail-open as the drift itself. When the script cannot resolve its CLI, or a refusal persists across
+rollouts, surface it on a declared *Maintainer channel* rather than leaving a silently superseded
+definition in place.
 
 ### Agent definition locations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,11 +428,13 @@ the run: fall back to the forge read, which needs no working tree.
 Refresh only through the runtime's own control plane — the `/plugin` marketplace update flow
 interactively, or, in an unattended run, that same control plane driven by
 [`.claude/scripts/plugin-definition-refresh.sh`](.claude/scripts/plugin-definition-refresh.sh)
-through the app-bundled binary. **Never edit the plugin cache**; it is read-only evidence (see
+through the resolved Claude CLI (`--cli`, `$CLAUDE_CLI`, `PATH`, then the app bundle). **Never edit
+the plugin cache**; it is read-only evidence (see
 *Agent definition locations*). The script exits `0` once the install is on the pin, `1` when it is
-not and could not safely be put there, and `2` UNKNOWN. Run it on a `DRIFT`; a `1` or `2` is
-reported, never a run-stopper, and you continue against the reviewed definition at the pinned
-gitlink exactly as above.
+not and could not safely be put there, and `2` UNKNOWN — which now also covers a plugin id naming a
+different marketplace than the clone being gated, and a concurrent run holding the lock. Run it on a
+`DRIFT`; a `1` or `2` is reported, never a run-stopper, and you continue against the reviewed
+definition at the pinned gitlink exactly as above.
 
 🔴 **`plugin update` installs the MARKETPLACE LATEST — it is NOT a way to install the pin, and
 wiring the bare commands into pre-flight would be a fail-open worse than the drift.** Its own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,11 +430,16 @@ interactively, or, in an unattended run, that same control plane driven by
 [`.claude/scripts/plugin-definition-refresh.sh`](.claude/scripts/plugin-definition-refresh.sh)
 through the resolved Claude CLI (`--cli`, `$CLAUDE_CLI`, `PATH`, then the app bundle). **Never edit
 the plugin cache**; it is read-only evidence (see
-*Agent definition locations*). The script exits `0` once the install is on the pin, `1` when it is
-not and could not safely be put there, and `2` UNKNOWN — which now also covers a plugin id naming a
-different marketplace than the clone being gated, and a concurrent run holding the lock. Run it on a
-`DRIFT`; a `1` or `2` is reported, never a run-stopper, and you continue against the reviewed
-definition at the pinned gitlink exactly as above.
+*Agent definition locations*). It exits `0` only once the install is on the pin **and an independent
+blob-identity check confirms it** — never on `plugin update`'s own exit status, which can report
+success having repaired nothing. `1` means the install is not on the pin (the marketplace could not
+supply that revision, or the apply ran and the post-apply check still does not report `CURRENT`).
+`2` is UNKNOWN — no verdict produced: no CLI, an unreadable pin or marketplace, a plugin id naming a
+different marketplace than the clone being gated, a concurrent run holding the lock, a marketplace
+worktree whose bytes do not provably match the pinned commit, an unavailable verifier, or
+`--dry-run`, since a simulation asserts nothing about the install. Run it on a `DRIFT`; a `1` or `2`
+is reported, never a run-stopper, and you continue against the reviewed definition at the pinned
+gitlink exactly as above.
 
 🔴 **`plugin update` installs the MARKETPLACE LATEST — it is NOT a way to install the pin, and
 wiring the bare commands into pre-flight would be a fail-open worse than the drift.** Its own


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Every scheduled Claude dispatch loads its agent definitions from a runtime-managed plugin install that **nothing ever advances**. A 21-day drift was cleared by hand yesterday; it came back **within 3.4 hours** of the next rollout, and 5 of 6 sessions in today's drift window ran a superseded definition while reporting clean runs.

The obvious fix is the two commands that cleared it by hand. That fix is wrong, and wrong in the expensive direction: `plugin update` installs whatever the marketplace currently has, not what this repo pins, and it has no way to ask for a specific revision. Yesterday those two happened to be the same thing — which is the only reason the manual refresh looked like it worked. Today they are not, so the naive version would have installed a plugin revision nobody here has reviewed. Running a stale-but-reviewed definition is bad; running an unreviewed one automatically, every hour, is worse.

## What

Adds a refresh step that only ever moves the install **onto the pinned revision**, and that treats "the tool said it worked" as insufficient: it proves the marketplace really holds the reviewed bytes before applying, and confirms the install actually matches the pin afterwards with an independent check. Anything it cannot prove is reported as unknown rather than success. When the marketplace cannot supply the pinned revision it changes nothing and reports the divergence — which is itself the useful signal, because it means the pin needs bumping through the normal reviewed rollout.

Verified against the live host today: it refused, correctly, and touched nothing. Two review rounds (CodeRabbit, then Codex) raised 11 findings between them, including two fail-opens in the gate itself and a bug in its own locking; all are fixed or refuted on the threads.

The contract now points pre-flight at it, and records why the gate exists so a later reader does not "simplify" it away.

Fixes #2856
