### PR TITLE
docs(dependabot): correct the git-registry opt-in rationale

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,12 +13,13 @@ updates:
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"
-    # Opt in to the org-level "Git Source" private registry (https://github.com, a
-    # classic PAT) so Dependabot can reach our PRIVATE submodules — wedding-app and
-    # ascoachingogvaner (org-private). Without access the whole "submodules in /."
-    # job fails with git_dependencies_not_reachable. The credential lives in the
-    # org's Dependabot private-registries UI (not a repo secret); .gitmodules keeps
-    # its SSH URLs, so local `git submodule` operations are unaffected.
+    # Opt in to the org-level "Git Source" registry (https://github.com, a classic
+    # PAT) so Dependabot can reach every submodule this repo tracks — including the
+    # ones outside devantler-tech, since github/personal/* point at the maintainer's
+    # own account. Without access the whole "submodules in /." job fails with
+    # git_dependencies_not_reachable. The credential lives in the org's Dependabot
+    # private-registries UI (not a repo secret); .gitmodules keeps its SSH URLs, so
+    # local `git submodule` operations are unaffected.
     registries: "*"
     schedule:
       interval: "daily"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Our Dependabot config explains why it needs the org-level registry credential by saying two of our apps are private repositories. Both are public today, and so is every other submodule this repo tracks. That matters right now because #2779 is an open investigation into why the submodule updates stopped running — and anyone reading this file to debug it starts from a premise that is no longer true.

### What

Replaces the stale justification with what the credential actually has to reach: every submodule tracked here, including the two that point at the maintainer's personal account rather than the organisation. Comment only — no change to what Dependabot does.

Part of #2779
