### PR TITLE
fix(agents): size a Bash call against the 2-minute default

### DIFF
--- a/.claude/scripts/bash-call-timeout-budget-contract.test.sh
+++ b/.claude/scripts/bash-call-timeout-budget-contract.test.sh
@@ -36,25 +36,51 @@ fail() {
 
 # Extract ONLY this bullet, then flatten it: the sentences wrap across source lines, so a fragment
 # spanning a line break would never match and the test would be always-red regardless of content.
-# The end anchor is the section's closing paragraph, which follows this bullet.
-bullet="$(
-  awk '
+# The end anchor is the section's closing paragraph, which follows this bullet. The extraction emits
+# a sentinel line when it sees that anchor, so a missing anchor is detected DIRECTLY rather than
+# inferred from the size of what got captured.
+sentinel='@@END-ANCHOR-SEEN@@'
+extracted="$(
+  awk -v s="${sentinel}" '
     /^- \*\*SIZE A `Bash` CALL BEFORE YOU MAKE IT/ { inb = 1 }
-    inb && /^This changes only /                   { inb = 0 }
+    inb && /^This changes only /                   { inb = 0; print s }
     inb                                            { print }
-  ' "${constitution}" | tr '\n' ' ' | tr -s '[:space:]' ' '
+  ' "${constitution}"
 )"
 
-[ -n "${bullet}" ] ||
-  fail "could not locate the size-the-call bullet — the extraction anchor moved, so every assertion below would be vacuous"
+end_anchor_seen=0
+case "${extracted}" in
+  *"${sentinel}"*) end_anchor_seen=1 ;;
+esac
 
-# Guard the extraction itself. If the terminating anchor disappears, awk runs to end-of-file and
-# `bullet` becomes the rest of the contract, silently restoring the scope hole while every assertion
-# still passes. The bound separates two states an order of magnitude apart (this bullet is ~300
-# words; a runaway extraction measures thousands), so it does not fail legitimate edits.
+# `sed` rather than `grep -v`: grep exits 1 when it emits no lines, and under `set -e` + `pipefail`
+# that aborts the script mid-assignment — so a MISSING START ANCHOR would kill the test silently
+# instead of reaching the "could not locate" failure below. Verified by ablation on 2026-08-17.
+bullet="$(printf '%s\n' "${extracted}" | sed "/^${sentinel}\$/d" | tr '\n' ' ' | tr -s '[:space:]' ' ')"
+
+# Test the RAW extraction, not the flattened bullet. Flattening turns an empty capture into a single
+# space, which is non-empty — so a `-n "${bullet}"` test passes on a missing START anchor and the
+# failure surfaces later as a misleading "end anchor was never reached". Verified by ablation.
+[ -n "${extracted}" ] ||
+  fail "could not locate the size-the-call bullet — the start anchor moved, so every assertion below would be vacuous"
+
+# Guard the extraction itself, DIRECTLY. If the terminating anchor disappears, awk runs to
+# end-of-file and `bullet` becomes the rest of the contract, silently restoring the scope hole while
+# every assertion still passes.
+#
+# A word-count bound alone does NOT close this. It only fires because a lot of file happens to follow
+# this bullet today: measured 2026-08-17, deleting the anchor captures 7,544 words, so the bound
+# catches it — but the bound is a proxy for "something else came after", and it silently stops working
+# the moment this bullet becomes the last content in the file. Requiring the anchor to have been SEEN
+# holds in that case too, which the size bound cannot.
+[ "${end_anchor_seen}" -eq 1 ] ||
+  fail "the closing-paragraph end anchor was never reached, so the extraction ran to end-of-file and these assertions are no longer scoped to this bullet"
+
+# Kept as a second, independent signal: it catches an anchor that still EXISTS but has moved far below
+# the bullet, which the seen-check above would happily accept.
 bullet_words="$(printf '%s' "${bullet}" | wc -w | tr -d ' ')"
 [ "${bullet_words}" -lt 1000 ] ||
-  fail "bullet extracted as ${bullet_words} words, which is runaway-extraction size — the closing-paragraph end anchor was probably reworded or removed, so these assertions would no longer be scoped to this bullet"
+  fail "bullet extracted as ${bullet_words} words, which is runaway-extraction size — the closing-paragraph end anchor probably moved below unrelated content, so these assertions would no longer be scoped to this bullet"
 
 assert_bullet() {
   case "${bullet}" in
@@ -87,9 +113,18 @@ assert_bullet '85%' \
   "the bullet does not record that the sessions which lost a call already used these parameters elsewhere, so it reads as teaching a parameter rather than fixing when it is chosen"
 
 # 5. The classes that actually recur here, so the rule is actionable on sight instead of requiring a
-#    judgement call about whether this particular command is slow.
+#    judgement call about whether this particular command is slow. EVERY class is asserted separately,
+#    not just one: pinning a single class leaves the other three deletable with the test still green,
+#    and the list is the part a reader acts on — verified 2026-08-17 by removing the test-suite and
+#    corpus-scan classes, which a one-class assertion passed.
+assert_bullet 'contract-test-suite runs' \
+  "the bullet no longer names contract-test-suite runs, the largest measured over-budget class"
 assert_bullet 'portfolio sweeps' \
-  "the bullet does not name the measured classes that exceed the default, leaving the reader to guess which calls to bound"
+  "the bullet no longer names gh portfolio sweeps as an over-budget class"
+assert_bullet 'corpus scans over the session transcripts' \
+  "the bullet no longer names corpus scans over the session transcripts as an over-budget class"
+assert_bullet '`ksail` validations' \
+  "the bullet no longer names ksail validations as an over-budget class"
 
 # 6. THE PRESCRIPTION, and the wrong reflex it displaces. Raising the timeout keeps the foreground
 #    block and still returns nothing past the ceiling; backgrounding costs no wall-clock because the
@@ -109,4 +144,4 @@ assert_bullet 'announces its completion' \
 assert_bullet 'do not then poll what you backgrounded' \
   "the bullet prescribes backgrounding without ruling out polling its output, inviting the sleep-and-read busy-wait the section already forbids"
 
-echo "bash-call-timeout-budget contract: OK — 8 assertions passed"
+echo "bash-call-timeout-budget contract: OK — 11 assertions passed"

--- a/.claude/scripts/bash-call-timeout-budget-contract.test.sh
+++ b/.claude/scripts/bash-call-timeout-budget-contract.test.sh
@@ -3,11 +3,12 @@
 # Guards the *Latency discipline* bullet that stops a `Bash` call being killed by the tool's
 # two-minute default timeout.
 #
-# Why this needs a guard. Measured over the 7 days to 2026-08-17 across 300 Claude sessions and
-# 26,979 `Bash` calls: 112 foreground calls were killed by the timeout and 90 of them (80%) ran at
-# the untouched default, costing ~180 minutes of blocked wall-clock that produced nothing. 66 of the
-# 300 sessions (22%) lost at least one call that way, at most 5 in any one session — so this is
-# broad behaviour rather than one looping run.
+# Why this needs a guard. Measured over the 7 days to 2026-08-17T10:03Z on a single denominator —
+# every `Bash` call whose own record falls in that window, measuring session excluded: 26,967 calls
+# across 299 sessions. 112 were killed by the timeout and 90 of them (80%) ran at the untouched
+# default, costing ~180 minutes of blocked wall-clock that produced nothing. 66 of those 299 sessions
+# (22%) lost at least one call that way, at most 5 in any one session — so this is broad behaviour
+# rather than one looping run.
 #
 # The subtle part, and the reason a presence-only check is not enough: 56 of those 66 sessions (85%)
 # used `timeout` or `run_in_background` elsewhere in the SAME session. The capability was never

--- a/.claude/scripts/bash-call-timeout-budget-contract.test.sh
+++ b/.claude/scripts/bash-call-timeout-budget-contract.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Guards the *Latency discipline* bullet that stops a `Bash` call being killed by the tool's
+# two-minute default timeout.
+#
+# Why this needs a guard. Measured over the 7 days to 2026-08-17 across 300 Claude sessions and
+# 26,979 `Bash` calls: 112 foreground calls were killed by the timeout and 90 of them (80%) ran at
+# the untouched default, costing ~180 minutes of blocked wall-clock that produced nothing. 66 of the
+# 300 sessions (22%) lost at least one call that way, at most 5 in any one session — so this is
+# broad behaviour rather than one looping run.
+#
+# The subtle part, and the reason a presence-only check is not enough: 56 of those 66 sessions (85%)
+# used `timeout` or `run_in_background` elsewhere in the SAME session. The capability was never
+# missing; it was applied only after the first failure had already been paid for. A bullet that
+# merely names the parameters therefore fixes nothing — it has to pin (a) that the budget is spent
+# up front on the call you are about to make, and (b) that backgrounding, not a bigger timeout, is
+# the default answer. Bumping the timeout keeps the foreground block and still returns nothing when
+# the work exceeds the ten-minute ceiling, which several of the measured classes do.
+#
+# Assertions are scoped to the bullet, not the whole file — asserting against the whole constitution
+# is a scope hole, since an unrelated section containing the phrase would satisfy the check while the
+# real sentence stayed wrong.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+constitution="${repo_root}/AGENTS.md"
+
+fail() {
+  echo "bash-call-timeout-budget contract: FAIL — $*" >&2
+  exit 1
+}
+
+[ -r "${constitution}" ] || fail "cannot read ${constitution}"
+
+# Extract ONLY this bullet, then flatten it: the sentences wrap across source lines, so a fragment
+# spanning a line break would never match and the test would be always-red regardless of content.
+# The end anchor is the section's closing paragraph, which follows this bullet.
+bullet="$(
+  awk '
+    /^- \*\*SIZE A `Bash` CALL BEFORE YOU MAKE IT/ { inb = 1 }
+    inb && /^This changes only /                   { inb = 0 }
+    inb                                            { print }
+  ' "${constitution}" | tr '\n' ' ' | tr -s '[:space:]' ' '
+)"
+
+[ -n "${bullet}" ] ||
+  fail "could not locate the size-the-call bullet — the extraction anchor moved, so every assertion below would be vacuous"
+
+# Guard the extraction itself. If the terminating anchor disappears, awk runs to end-of-file and
+# `bullet` becomes the rest of the contract, silently restoring the scope hole while every assertion
+# still passes. The bound separates two states an order of magnitude apart (this bullet is ~300
+# words; a runaway extraction measures thousands), so it does not fail legitimate edits.
+bullet_words="$(printf '%s' "${bullet}" | wc -w | tr -d ' ')"
+[ "${bullet_words}" -lt 1000 ] ||
+  fail "bullet extracted as ${bullet_words} words, which is runaway-extraction size — the closing-paragraph end anchor was probably reworded or removed, so these assertions would no longer be scoped to this bullet"
+
+assert_bullet() {
+  case "${bullet}" in
+    *"$1"*) ;;
+    *) fail "$2" ;;
+  esac
+}
+
+# 1. The number itself. Without it the reader has no budget to size against and cannot tell whether
+#    the call they are about to make is near the limit.
+assert_bullet 'default budget is TWO MINUTES' \
+  "the bullet does not state the two-minute default, leaving the reader with no budget to size against"
+
+# 2. The ceiling, in the units the parameter actually takes. A reader who knows only the default will
+#    reach for a bigger number without knowing where the number stops being available.
+assert_bullet '600000' \
+  "the bullet does not name the ten-minute ceiling in milliseconds, so a reader raising the timeout cannot tell where the parameter stops helping"
+
+# 3. The consequence is stated as total loss. An agent that believes the command half-ran will debug
+#    the pipeline instead of the budget — the same misreading that keeps the neighbouring
+#    classifier-denial signature alive.
+assert_bullet 'loses the WHOLE call' \
+  "the bullet does not state that the entire call is lost, so a timeout reads as partial progress rather than discarded work"
+
+# 4. THE TIMING CLAIM, and the assertion most likely to be cut as redundant by someone who reads the
+#    bullet as "use the timeout parameter". It is not redundant: it is the measured finding that
+#    distinguishes this defect from a missing-capability one. 85% of the sessions that paid already
+#    used these parameters elsewhere, so a rule that only names them changes nothing.
+assert_bullet '85%' \
+  "the bullet does not record that the sessions which lost a call already used these parameters elsewhere, so it reads as teaching a parameter rather than fixing when it is chosen"
+
+# 5. The classes that actually recur here, so the rule is actionable on sight instead of requiring a
+#    judgement call about whether this particular command is slow.
+assert_bullet 'portfolio sweeps' \
+  "the bullet does not name the measured classes that exceed the default, leaving the reader to guess which calls to bound"
+
+# 6. THE PRESCRIPTION, and the wrong reflex it displaces. Raising the timeout keeps the foreground
+#    block and still returns nothing past the ceiling; backgrounding costs no wall-clock because the
+#    runtime announces completion. Without this the reader complies by bumping the number and
+#    converts a two-minute loss into a ten-minute one.
+assert_bullet 'run_in_background: true' \
+  "the bullet does not prescribe backgrounding as the default answer, so the reader complies by raising the timeout and keeps the foreground block"
+
+# 7. The reason backgrounding is not merely a bigger budget. This is what ties the rule to the rest of
+#    the section: the announcement is why a backgrounded call needs no waiting at all.
+assert_bullet 'announces its completion' \
+  "the bullet does not say the runtime announces a backgrounded call's completion, so backgrounding looks like a way to lose the result rather than a way to avoid waiting for it"
+
+# 8. Closes the obvious wrong turn out of assertion 6: an agent told to background a long call is one
+#    step from sleeping on its output file, which is the busy-wait this same section forbids and a
+#    signature this corpus has repeatedly produced.
+assert_bullet 'do not then poll what you backgrounded' \
+  "the bullet prescribes backgrounding without ruling out polling its output, inviting the sleep-and-read busy-wait the section already forbids"
+
+echo "bash-call-timeout-budget contract: OK — 8 assertions passed"

--- a/.claude/scripts/control-character-command-contract.test.sh
+++ b/.claude/scripts/control-character-command-contract.test.sh
@@ -36,9 +36,17 @@ fail() {
 
 # Extract ONLY this bullet, then flatten it: the sentences wrap across source lines, so a fragment
 # spanning a line break would never match and the test would be always-red regardless of content.
+#
+# The end anchor is the NEXT BULLET, not the section's closing paragraph. It has to be: the
+# size-the-call bullet that follows also contains the phrase `loses the WHOLE call`, so a
+# paragraph-anchored extraction spans both and assertion 1 becomes satisfiable by the neighbour.
+# Verified by ablation on 2026-08-17 — with that phrase removed from THIS bullet and left intact in
+# the next one, the paragraph-anchored version still reported all 8 assertions passing. The closing
+# paragraph is kept as a second stop so the extraction still terminates if that bullet is renamed.
 bullet="$(
   awk '
-    /^- \*\*A raw / { inb = 1 }
+    /^- \*\*A raw /             { inb = 1 }
+    inb && /^- \*\*SIZE A /     { inb = 0 }
     inb && /^This changes only/ { inb = 0 }
     inb                         { print }
   ' "${constitution}" | tr '\n' ' ' | tr -s '[:space:]' ' '

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
       latency-discipline-contract: ${{ steps.filter.outputs.latency-discipline-contract }}
       control-character-command-contract: ${{ steps.filter.outputs.control-character-command-contract }}
       one-verb-per-bash-call-contract: ${{ steps.filter.outputs.one-verb-per-bash-call-contract }}
+      bash-call-timeout-budget-contract: ${{ steps.filter.outputs.bash-call-timeout-budget-contract }}
       git-safety-contract: ${{ steps.filter.outputs.git-safety-contract }}
       plugin-definition-currency: ${{ steps.filter.outputs.plugin-definition-currency }}
       plugin-definition-refresh: ${{ steps.filter.outputs.plugin-definition-refresh }}
@@ -233,6 +234,10 @@ jobs:
             one-verb-per-bash-call-contract:
               - 'AGENTS.md'
               - '.claude/scripts/one-verb-per-bash-call-contract.test.sh'
+              - '.github/workflows/ci.yaml'
+            bash-call-timeout-budget-contract:
+              - 'AGENTS.md'
+              - '.claude/scripts/bash-call-timeout-budget-contract.test.sh'
               - '.github/workflows/ci.yaml'
             git-safety-contract:
               - 'AGENTS.md'
@@ -916,6 +921,21 @@ jobs:
       - name: Verify the one verb per bash call contract
         run: bash .claude/scripts/one-verb-per-bash-call-contract.test.sh
 
+  test-bash-call-timeout-budget-contract:
+    name: Test bash call timeout budget contract
+    needs: changes
+    if: needs.changes.outputs.bash-call-timeout-budget-contract == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify the bash call timeout budget contract
+        run: bash .claude/scripts/bash-call-timeout-budget-contract.test.sh
+
   test-git-safety-contract:
     name: Test git safety contract
     needs: changes
@@ -1097,6 +1117,7 @@ jobs:
       - test-latency-discipline-contract
       - test-control-character-command-contract
       - test-one-verb-per-bash-call-contract
+      - test-bash-call-timeout-budget-contract
       - test-git-safety-contract
       - test-plugin-definition-currency
       - test-plugin-definition-refresh
@@ -1137,6 +1158,7 @@ jobs:
             ${{ needs.test-latency-discipline-contract.result }}
             ${{ needs.test-control-character-command-contract.result }}
             ${{ needs.test-one-verb-per-bash-call-contract.result }}
+            ${{ needs.test-bash-call-timeout-budget-contract.result }}
             ${{ needs.test-git-safety-contract.result }}
             ${{ needs.test-plugin-definition-currency.result }}
             ${{ needs.test-plugin-definition-refresh.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3716,6 +3716,34 @@ window, unnoticed. The work was never the bottleneck; the **scheduling** was.
   ⚠️ **The guard scans the ENTIRE command string, comments included** — reproduced live while writing
   this rule: a trailing `# …` explaining the delimiter carried a raw byte and cost the call, with the
   code itself already correct. So a command that looks fixed can still fail on its own annotation.
+- **SIZE A `Bash` CALL BEFORE YOU MAKE IT — the default budget is TWO MINUTES, and overrunning it
+  loses the WHOLE call.** `timeout` is in milliseconds, defaults to `120000`, and caps at `600000`
+  (ten minutes). A killed call returns **nothing**: no partial output, no partial effect, and no
+  indication of how far it got — so the measurement it was making is discarded along with the wait,
+  and the retry pays the wall-clock again.
+  🔴 **This is a BUDGETING failure, not a slow-command problem — the budget is usually never
+  considered at all.** Measured over the 7 days to 2026-08-17 across 300 Claude sessions and 26,979
+  `Bash` calls: **112 foreground calls were killed by the timeout, and 90 of them (80%) ran at the
+  untouched two-minute default**, costing ~180 minutes of blocked wall-clock that produced nothing.
+  **66 of 300 sessions (22%) lost at least one call this way**, at most 5 in any one session — broad
+  behaviour, not one looping run.
+  ⚠️ **The capability is already known; only its TIMING is wrong.** **56 of those 66 sessions (85%)
+  used `timeout` or `run_in_background` elsewhere in the same session** — just never before the first
+  failure. So the fix is not to learn a parameter, it is to choose one *up front*, on the call you
+  are about to make.
+  **These classes reliably exceed the default — background or bound them without waiting to find
+  out.** Of the 76 calls killed at exactly two minutes: **32 contract-test-suite runs, 25 `gh`
+  portfolio sweeps, 8 corpus scans over the session transcripts, 6 `ksail` validations.** Every one
+  is a mandated run-loop operation, so this is the ordinary path rather than an unusual one.
+  🔴 **Raising `timeout` is the WRONG default reflex — prefer `run_in_background: true`.** The
+  ceiling is ten minutes and several of these classes exceed it outright, so a bump converts a
+  two-minute loss into a ten-minute one and still returns nothing; a bumped call also blocks the
+  foreground for its whole budget, which is the waste the rest of this section exists to stop. A
+  backgrounded call has neither problem: the runtime **announces its completion**, so it costs no
+  wall-clock and needs no waiting. Raise `timeout` only when the work is genuinely bounded, you need
+  the result before the next call can be written, and it comfortably fits inside the ceiling.
+  ⚠️ **And do not then poll what you backgrounded** — the announcement is the notification, so a
+  `sleep`-and-read loop over its output file is the busy-wait this section already forbids.
 
 This changes only *ordering and overlap* — never the quality bar. Validation, RED/GREEN proof,
 root-cause fixing, and every guardrail are unaffected; the point is to stop paying for them serially.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3718,9 +3718,17 @@ window, unnoticed. The work was never the bottleneck; the **scheduling** was.
   code itself already correct. So a command that looks fixed can still fail on its own annotation.
 - **SIZE A `Bash` CALL BEFORE YOU MAKE IT — the default budget is TWO MINUTES, and overrunning it
   loses the WHOLE call.** `timeout` is in milliseconds, defaults to `120000`, and caps at `600000`
-  (ten minutes). A killed call returns **nothing**: no partial output, no partial effect, and no
-  indication of how far it got — so the measurement it was making is discarded along with the wait,
-  and the retry pays the wall-clock again.
+  (ten minutes). A killed call returns **nothing** — no partial output and no indication of how far
+  it got — so the measurement it was making is discarded along with the wait, and the retry pays the
+  wall-clock again.
+  🔴 **Its SIDE EFFECTS are not rolled back, and assuming otherwise is the one way this bullet can
+  cause harm rather than cost time.** The kill removes the *result*, never the *effects*: a call
+  killed at the boundary has already run for its whole budget, so a `git push` may have landed on the
+  remote, a `gh pr merge` may have merged, a comment may have posted, a file may be written. The
+  reader's next move is the retry this bullet describes — so **re-read state before retrying any call
+  that writes, pushes, merges, or posts**, exactly as *Git safety* requires a push be verified by git
+  output **and** a re-read. Retrying a non-idempotent call on the assumption that the first attempt
+  was a no-op is how a double-merge or a clobbering second push happens.
   🔴 **This is a BUDGETING failure, not a slow-command problem — the budget is usually never
   considered at all.** Measured over the 7 days to 2026-08-17T10:03Z, over every `Bash` call in the
   Claude corpus whose own record falls in that window, with the measuring session excluded: **26,967

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3722,19 +3722,22 @@ window, unnoticed. The work was never the bottleneck; the **scheduling** was.
   indication of how far it got — so the measurement it was making is discarded along with the wait,
   and the retry pays the wall-clock again.
   🔴 **This is a BUDGETING failure, not a slow-command problem — the budget is usually never
-  considered at all.** Measured over the 7 days to 2026-08-17 across 300 Claude sessions and 26,979
-  `Bash` calls: **112 foreground calls were killed by the timeout, and 90 of them (80%) ran at the
-  untouched two-minute default**, costing ~180 minutes of blocked wall-clock that produced nothing.
-  **66 of 300 sessions (22%) lost at least one call this way**, at most 5 in any one session — broad
-  behaviour, not one looping run.
+  considered at all.** Measured over the 7 days to 2026-08-17T10:03Z, over every `Bash` call in the
+  Claude corpus whose own record falls in that window, with the measuring session excluded: **26,967
+  calls across 299 sessions**. Of those, **112 were killed by the timeout, and 90 of them (80%) ran
+  at the untouched two-minute default** — costing ~180 minutes of blocked wall-clock that produced
+  nothing. **66 of the 299 sessions (22%) lost at least one call this way**, at most 5 in any one
+  session, so this is broad behaviour rather than one looping run. For scale on the same denominator:
+  `timeout` is set on 1,536 calls (5.7%) and `run_in_background` on 662 (2.5%).
   ⚠️ **The capability is already known; only its TIMING is wrong.** **56 of those 66 sessions (85%)
   used `timeout` or `run_in_background` elsewhere in the same session** — just never before the first
   failure. So the fix is not to learn a parameter, it is to choose one *up front*, on the call you
   are about to make.
   **These classes reliably exceed the default — background or bound them without waiting to find
-  out.** Of the 76 calls killed at exactly two minutes: **32 contract-test-suite runs, 25 `gh`
-  portfolio sweeps, 8 corpus scans over the session transcripts, 6 `ksail` validations.** Every one
-  is a mandated run-loop operation, so this is the ordinary path rather than an unusual one.
+  out.** Classifying those same 90 calls: **29 contract-test-suite runs, 20 `gh` portfolio sweeps,
+  13 corpus scans over the session transcripts, 7 `ksail` validations**, and 21 that fit no single
+  class. Every named one is a mandated run-loop operation, so this is the ordinary path rather than
+  an unusual one.
   🔴 **Raising `timeout` is the WRONG default reflex — prefer `run_in_background: true`.** The
   ceiling is ten minutes and several of these classes exceed it outright, so a bump converts a
   two-minute loss into a ten-minute one and still returns nothing; a bumped call also blocks the


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

A shell call that runs longer than two minutes is killed and returns nothing at all. The contract
never said so — it covered waiting on *remote* systems in detail but never mentioned the budget for
the agent's own commands — so runs kept discovering the limit by paying for it.

Over the last 7 days that cost **22% of sessions at least one lost call** and about **180 minutes of
blocked time that produced nothing**. Four fifths of those losses happened at the untouched default,
and 85% of the sessions that paid were already using the right settings elsewhere in the same
session — so this was never a missing capability, only a decision made too late.

### Changes

Adds a rule that has the reader size a call before making it, and prescribes running long work in
the background rather than simply asking for more time — the ceiling is ten minutes, several of the
routine operations here exceed it, and a longer wait still blocks and still returns nothing. Pinned
by a contract test in CI, as the neighbouring rules are.

Also tightens an adjacent test's scope: the new rule reuses a phrase the older test asserts on, which
would have let that older check pass while the sentence it guards was gone.

Fixes #2870
