### PR TITLE
fix(agents): detect a Codex lane that dispatches but produces nothing

### DIFF
--- a/.claude/scripts/codex-lane-liveness.sh
+++ b/.claude/scripts/codex-lane-liveness.sh
@@ -252,7 +252,11 @@ EOF
 "
     any_dead=1
   else
-    report="${report}  OK  ${id} — ${stubs}/${n} newest settled runs are stubs, longest $(( maxdur_ms / 1000 ))s
+    # Reported in MILLISECONDS, matching the comparison. Dividing back to whole seconds here would
+    # make a run just over the threshold print as exactly STUB_SECONDS beside a `stub<=${STUB_SECONDS}s`
+    # header — a correct OK verdict that reads as a contradiction, in a diagnostic whose only job is to
+    # be believed.
+    report="${report}  OK  ${id} — ${stubs}/${n} newest settled runs are stubs, longest ${maxdur_ms}ms
 "
   fi
 done <<EOF

--- a/.claude/scripts/codex-lane-liveness.sh
+++ b/.claude/scripts/codex-lane-liveness.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# codex-lane-liveness.sh — did the Codex lane's dispatched runs actually RUN?
+#
+# *Agent definition locations* resolves Codex cadence and its dispatch marker from an automation's
+# `rrule` and `last_run_at`. Neither observes the turn. When every dispatched run dies seconds after
+# starting, the scheduler still dispatches on time, so `last_run_at` advances and `next_run_at` stays
+# correct — and the prescribed check reports a healthy lane while that lane produces nothing at all.
+#
+# Measured 2026-08-17 on the local scheduler store: 32 consecutive dead dispatches over ~29h across
+# BOTH Codex automations (3 `agent-improver`, 29 `daily-ai-engineer`), entirely undetected. The prior
+# fortnight's healthy `agent-improver` runs ran 768-24,428s and each wrote an inbox item, against
+# 4-second stubs that wrote none. See monorepo#2885.
+#
+# Two pre-existing signals independently fail to catch this, which is why a third is needed:
+#   - `notification_policy = "failed_runs_only"` never fires: the scheduler records these runs
+#     PENDING_REVIEW, the SAME status healthy runs carry. Status cannot discriminate.
+#   - `last_run_at` records that a dispatch STARTED, never that it ran.
+#
+# READ-ONLY, and deliberately NARROW in what it reads. It selects run timings and a computed
+# inbox-presence FLAG only — never `last_error`, `inbox_summary`, `thread_title`, or any archived
+# message. The cause of a stall is frequently private runtime state (billing, credentials, account
+# posture); this check is about the deployment being BLIND, so it must stay generic across causes and
+# must not be able to carry such state into a repository artifact or a run report.
+#
+# Usage: codex-lane-liveness.sh [--store PATH] [--automation ID] [--grace-seconds N]
+#                              [--stub-seconds N] [--consecutive N] [--now-ms MS] [--quiet]
+#
+# Exit 0  every ACTIVE automation checked has a healthy run among its newest settled runs
+#      1  NOT PRODUCING — some automation's newest settled runs are ALL stubs
+#      2  UNKNOWN — could not determine (no sqlite3, unreadable/absent store, unexpected schema,
+#         an unusable automation id, or too little settled history to judge)
+#
+# Any OTHER non-zero status is an unexpected internal failure under `set -e` and also means UNKNOWN.
+# Only 0 and 1 are verdicts. Exit 2 is deliberately NOT exit 0: "I could not check" and "the lane is
+# alive" are different answers, and collapsing them is how a liveness check becomes decoration —
+# which is precisely the failure this script exists to correct.
+#
+# Exit 1 requires BOTH discriminators on EVERY run in the window. Duration alone fires on a
+# legitimately fast run; inbox-presence alone fires on a run that wrote nothing for a benign reason.
+# Requiring both, on consecutive runs, is what keeps a real verdict rare enough to act on.
+
+set -euo pipefail
+
+STORE="${CODEX_HOME:-$HOME/.codex}/sqlite/codex-dev.db"
+AUTOMATION=""
+GRACE_SECONDS=300
+STUB_SECONDS=60
+CONSECUTIVE=2
+NOW_MS=""
+QUIET=0
+
+RECOVERY="
+  To resolve: confirm the lane's runs are reaching the model at all. A stub run is a dispatch whose
+  turn ended immediately, so look at the runtime's own run record rather than the scheduler's — the
+  scheduler's view is healthy by construction here. Re-run this check once a run has settled."
+
+usage() {
+  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+die_unknown() {
+  printf 'codex-lane-liveness: UNKNOWN — %s\n' "$1" >&2
+  printf '%s\n' "$RECOVERY" >&2
+  exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --help|-h) usage; exit 0 ;;
+    --store) [ "$#" -ge 2 ] || die_unknown "--store needs a value"; STORE="$2"; shift 2 ;;
+    --automation) [ "$#" -ge 2 ] || die_unknown "--automation needs a value"; AUTOMATION="$2"; shift 2 ;;
+    --grace-seconds) [ "$#" -ge 2 ] || die_unknown "--grace-seconds needs a value"; GRACE_SECONDS="$2"; shift 2 ;;
+    --stub-seconds) [ "$#" -ge 2 ] || die_unknown "--stub-seconds needs a value"; STUB_SECONDS="$2"; shift 2 ;;
+    --consecutive) [ "$#" -ge 2 ] || die_unknown "--consecutive needs a value"; CONSECUTIVE="$2"; shift 2 ;;
+    --now-ms) [ "$#" -ge 2 ] || die_unknown "--now-ms needs a value"; NOW_MS="$2"; shift 2 ;;
+    --quiet) QUIET=1; shift ;;
+    *) die_unknown "unrecognised argument: $1" ;;
+  esac
+done
+
+# Every numeric knob is validated before use. An unvalidated value would otherwise reach arithmetic
+# and either abort under `set -e` (reported as an internal failure) or, worse, silently widen the
+# stub window until the check cannot fire.
+for pair in "GRACE_SECONDS:$GRACE_SECONDS" "STUB_SECONDS:$STUB_SECONDS" "CONSECUTIVE:$CONSECUTIVE"; do
+  name=${pair%%:*}; val=${pair#*:}
+  case "$val" in
+    ''|*[!0-9]*) die_unknown "$name must be a non-negative integer, got: $val" ;;
+  esac
+done
+[ "$CONSECUTIVE" -ge 1 ] || die_unknown "--consecutive must be at least 1"
+
+if [ -n "$NOW_MS" ]; then
+  case "$NOW_MS" in
+    ''|*[!0-9]*) die_unknown "--now-ms must be a non-negative integer, got: $NOW_MS" ;;
+  esac
+else
+  NOW_MS=$(( $(date +%s) * 1000 ))
+fi
+
+command -v sqlite3 >/dev/null 2>&1 || die_unknown "sqlite3 is not available"
+[ -f "$STORE" ] || die_unknown "scheduler store not found: $STORE"
+[ -r "$STORE" ] || die_unknown "scheduler store is not readable: $STORE"
+
+# Open read-only. The sibling lane may be mid-dispatch, and *Obligations* forbids a change that could
+# break a sibling in flight; a read-only URI cannot create the -wal/-shm files a plain open would.
+sq() {
+  sqlite3 "file:${STORE}?mode=ro" "$@" 2>/dev/null || return 1
+}
+
+sq 'SELECT 1;' >/dev/null || die_unknown "scheduler store could not be opened read-only: $STORE"
+
+# Schema is asserted, never assumed. A renamed column would otherwise make every comparison below
+# return empty, and an empty result set reads exactly like "no stubs found" — a silent pass in the
+# one case the check exists for.
+for spec in "automations:id" "automations:status" "automation_runs:automation_id" \
+            "automation_runs:created_at" "automation_runs:updated_at" "automation_runs:inbox_title"; do
+  tbl=${spec%%:*}; col=${spec#*:}
+  have=$(sq "SELECT COUNT(*) FROM pragma_table_info('${tbl}') WHERE name='${col}';") \
+    || die_unknown "could not read schema for ${tbl}"
+  [ "${have:-0}" = "1" ] || die_unknown "unexpected schema: ${tbl}.${col} is missing"
+done
+
+if [ -n "$AUTOMATION" ]; then
+  case "$AUTOMATION" in
+    *[!A-Za-z0-9._-]*) die_unknown "unusable automation id: $AUTOMATION" ;;
+  esac
+  ids=$AUTOMATION
+else
+  ids=$(sq "SELECT id FROM automations WHERE status='ACTIVE' ORDER BY id;") \
+    || die_unknown "could not enumerate automations"
+fi
+
+[ -n "$ids" ] || die_unknown "no ACTIVE automations found in $STORE"
+
+settled_before=$(( NOW_MS - GRACE_SECONDS * 1000 ))
+# Tracked as two independent flags rather than one severity counter. A counter invites the ordering
+# bug this had on its first run: a later unjudgeable lane overwrote an already-detected dead lane,
+# downgrading a real verdict to UNKNOWN purely because of the order automations were enumerated in.
+any_dead=0
+any_unknown=0
+report=""
+
+while IFS= read -r id; do
+  [ -n "$id" ] || continue
+  # The id came out of a local store rather than from this script, so it is validated before being
+  # interpolated into SQL — the same discipline the contract applies to any value it did not construct.
+  case "$id" in
+    *[!A-Za-z0-9._-]*)
+      report="${report}  UNKNOWN  ${id} — unusable automation id, skipped
+"
+      any_unknown=1
+      continue ;;
+  esac
+
+  # Only SETTLED runs are classified. An in-flight run is short BECAUSE it is still running — most
+  # acutely when the checking run inspects its own row — so classifying it would make the guard fire
+  # on a healthy lane every time it ran. This is the trap that would have made the check useless.
+  rows=$(sq "SELECT ((updated_at - created_at) / 1000) AS dur,
+                    CASE WHEN inbox_title IS NULL OR trim(inbox_title) = '' THEN 1 ELSE 0 END AS no_inbox
+             FROM automation_runs
+             WHERE automation_id = '${id}' AND updated_at <= ${settled_before}
+             ORDER BY created_at DESC
+             LIMIT ${CONSECUTIVE};") || die_unknown "could not read runs for ${id}"
+
+  n=0
+  stubs=0
+  maxdur=-1
+  while IFS='|' read -r dur no_inbox; do
+    [ -n "$dur" ] || continue
+    n=$(( n + 1 ))
+    # A negative or absent duration is not evidence of anything; treat it as non-stub so a clock
+    # anomaly can never manufacture a verdict.
+    case "$dur" in ''|*[!0-9-]*) dur=-1 ;; esac
+    # An `[ ... ] && x=y` here would return non-zero whenever the test is false and abort the loop
+    # under `set -e`, so the assignment is written as a full conditional.
+    if [ "$dur" -gt "$maxdur" ]; then maxdur=$dur; fi
+    if [ "$dur" -ge 0 ] && [ "$dur" -le "$STUB_SECONDS" ] && [ "$no_inbox" = "1" ]; then
+      stubs=$(( stubs + 1 ))
+    fi
+  done <<EOF
+$rows
+EOF
+
+  if [ "$n" -lt "$CONSECUTIVE" ]; then
+    report="${report}  UNKNOWN  ${id} — only ${n} settled run(s), need ${CONSECUTIVE} to judge
+"
+    any_unknown=1
+  elif [ "$stubs" -eq "$n" ]; then
+    report="${report}  NOT-PRODUCING  ${id} — newest ${n} settled runs all ended within ${STUB_SECONDS}s with no inbox item
+"
+    any_dead=1
+  else
+    report="${report}  OK  ${id} — ${stubs}/${n} newest settled runs are stubs, longest ${maxdur}s
+"
+  fi
+done <<EOF
+$ids
+EOF
+
+if [ "$QUIET" -eq 0 ]; then
+  printf 'codex-lane-liveness: store=%s grace=%ss stub<=%ss window=%s runs\n' \
+    "$STORE" "$GRACE_SECONDS" "$STUB_SECONDS" "$CONSECUTIVE"
+  printf '%s' "$report"
+fi
+
+# A detected dead lane OUTRANKS an unjudgeable one: exit 1 is actionable now, and letting an UNKNOWN
+# elsewhere mask it would hide the very condition this check exists to surface.
+if [ "$any_dead" -eq 1 ]; then
+  printf 'codex-lane-liveness: NOT PRODUCING — a dispatched lane is not doing work.\n' >&2
+  printf '%s\n' "$RECOVERY" >&2
+  exit 1
+fi
+if [ "$any_unknown" -eq 1 ]; then
+  printf 'codex-lane-liveness: UNKNOWN — at least one lane could not be judged.\n' >&2
+  exit 2
+fi
+exit 0

--- a/.claude/scripts/codex-lane-liveness.sh
+++ b/.claude/scripts/codex-lane-liveness.sh
@@ -48,6 +48,10 @@ trap 'ec=$?; [ "$ec" -eq 0 ] || exit 2' ERR
 
 STORE="${CODEX_HOME:-$HOME/.codex}/sqlite/codex-dev.db"
 AUTOMATION=""
+# Tracked separately from the value, because `--automation ""` is a REQUEST for one automation that
+# happens to be empty, not an absent flag. Testing the value alone would silently widen that request
+# to every ACTIVE automation — the opposite of what the caller asked for.
+AUTOMATION_SET=0
 GRACE_SECONDS=300
 STUB_SECONDS=60
 CONSECUTIVE=2
@@ -73,7 +77,7 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --help|-h) usage; exit 0 ;;
     --store) [ "$#" -ge 2 ] || die_unknown "--store needs a value"; STORE="$2"; shift 2 ;;
-    --automation) [ "$#" -ge 2 ] || die_unknown "--automation needs a value"; AUTOMATION="$2"; shift 2 ;;
+    --automation) [ "$#" -ge 2 ] || die_unknown "--automation needs a value"; AUTOMATION="$2"; AUTOMATION_SET=1; shift 2 ;;
     --grace-seconds) [ "$#" -ge 2 ] || die_unknown "--grace-seconds needs a value"; GRACE_SECONDS="$2"; shift 2 ;;
     --stub-seconds) [ "$#" -ge 2 ] || die_unknown "--stub-seconds needs a value"; STUB_SECONDS="$2"; shift 2 ;;
     --consecutive) [ "$#" -ge 2 ] || die_unknown "--consecutive needs a value"; CONSECUTIVE="$2"; shift 2 ;;
@@ -142,10 +146,18 @@ for spec in "automations:id" "automations:status" "automation_runs:automation_id
   [ "${have:-0}" = "1" ] || die_unknown "unexpected schema: ${tbl}.${col} is missing"
 done
 
-if [ -n "$AUTOMATION" ]; then
+if [ "$AUTOMATION_SET" -eq 1 ]; then
+  [ -n "$AUTOMATION" ] || die_unknown "--automation must not be empty"
   case "$AUTOMATION" in
     *[!A-Za-z0-9._-]*) die_unknown "unusable automation id: $AUTOMATION" ;;
   esac
+  # A named automation is held to the SAME ACTIVE filter the unfiltered branch applies. An inactive
+  # automation does not dispatch, so its newest settled runs are old by definition and would classify
+  # as a dead lane — reporting NOT-PRODUCING for something that is not supposed to be producing. That
+  # is a false positive on the one verdict this check exists to make, so it fails closed to UNKNOWN.
+  active=$(sq "SELECT COUNT(*) FROM automations WHERE id = '${AUTOMATION}' AND status = 'ACTIVE';") \
+    || die_unknown "could not look up automation ${AUTOMATION}"
+  [ "${active:-0}" = "1" ] || die_unknown "automation ${AUTOMATION} is not an ACTIVE automation in $STORE"
   ids=$AUTOMATION
 else
   ids=$(sq "SELECT id FROM automations WHERE status='ACTIVE' ORDER BY id;") \
@@ -186,7 +198,11 @@ while IFS= read -r id; do
   # Only SETTLED runs are classified. An in-flight run is short BECAUSE it is still running — most
   # acutely when the checking run inspects its own row — so classifying it would make the guard fire
   # on a healthy lane every time it ran. This is the trap that would have made the check useless.
-  rows=$(sq "SELECT ((updated_at - created_at) / 1000) AS dur,
+  # The duration is selected in RAW MILLISECONDS and compared in milliseconds. Dividing by 1000 here
+  # truncates, so a run lasting `STUB_SECONDS * 1000 + 999` ms would report as exactly STUB_SECONDS
+  # and be counted a stub — a run that is genuinely over the threshold classified as under it, which
+  # is the direction that produces a false NOT-PRODUCING on a healthy lane.
+  rows=$(sq "SELECT (updated_at - created_at) AS dur_ms,
                     CASE WHEN inbox_title IS NULL OR trim(inbox_title) = '' THEN 1 ELSE 0 END AS no_inbox
              FROM automation_runs
              WHERE automation_id = '${id}' AND updated_at <= ${settled_before}
@@ -195,26 +211,28 @@ while IFS= read -r id; do
 
   n=0
   stubs=0
-  maxdur=-1
+  maxdur_ms=-1
   malformed=0
-  while IFS='|' read -r dur no_inbox; do
-    [ -n "$dur" ] || continue
+  stub_ms=$(( STUB_SECONDS * 1000 ))
+  while IFS='|' read -r dur_ms no_inbox; do
+    [ -n "$dur_ms" ] || continue
     n=$(( n + 1 ))
     # BOTH fields are validated. An unparsable value must never fall through to the healthy verdict:
     # `no_inbox` in particular is compared against the literal 1, so without this check every
     # unexpected value (empty, NULL, a header token, a shifted column) would read as "produced an
     # inbox item" and therefore as NOT a stub — making the default for "I could not parse this" the
-    # answer that exits 0. Strip at most one leading '-' so forms like `--5` or `1-2` are rejected
-    # rather than reaching `[ ]` and erroring into a false non-stub.
-    case "${dur#-}" in ''|*[!0-9]*) dur=-1 ;; esac
+    # answer that exits 0. A NEGATIVE duration (updated_at before created_at) is corrupt timing data,
+    # not a long run, so it is malformed too: accepting it would have made it a non-stub and fed the
+    # healthy verdict, which is the same fall-through this validation exists to prevent.
+    case "$dur_ms" in ''|*[!0-9]*) malformed=1; break ;; esac
     case "$no_inbox" in
       0|1) : ;;
       *) malformed=1; break ;;
     esac
     # An `[ ... ] && x=y` here would return non-zero whenever the test is false and abort the loop
     # under `set -e`, so the assignment is written as a full conditional.
-    if [ "$dur" -gt "$maxdur" ]; then maxdur=$dur; fi
-    if [ "$dur" -ge 0 ] && [ "$dur" -le "$STUB_SECONDS" ] && [ "$no_inbox" = "1" ]; then
+    if [ "$dur_ms" -gt "$maxdur_ms" ]; then maxdur_ms=$dur_ms; fi
+    if [ "$dur_ms" -le "$stub_ms" ] && [ "$no_inbox" = "1" ]; then
       stubs=$(( stubs + 1 ))
     fi
   done <<EOF
@@ -234,7 +252,7 @@ EOF
 "
     any_dead=1
   else
-    report="${report}  OK  ${id} — ${stubs}/${n} newest settled runs are stubs, longest ${maxdur}s
+    report="${report}  OK  ${id} — ${stubs}/${n} newest settled runs are stubs, longest $(( maxdur_ms / 1000 ))s
 "
   fi
 done <<EOF

--- a/.claude/scripts/codex-lane-liveness.sh
+++ b/.claude/scripts/codex-lane-liveness.sh
@@ -39,7 +39,12 @@
 # legitimately fast run; inbox-presence alone fires on a run that wrote nothing for a benign reason.
 # Requiring both, on consecutive runs, is what keeps a real verdict rare enough to act on.
 
-set -euo pipefail
+set -Eeuo pipefail
+
+# Exit 1 is a VERDICT ("this lane is not producing"), so no internal failure may reach it. Under
+# `set -e` the abort status is the failing command's, and 1 is the commonest — a failing `date` or a
+# closed stdout would otherwise page an operator for a dead lane. Any unhandled error becomes 2.
+trap 'ec=$?; [ "$ec" -eq 0 ] || exit 2' ERR
 
 STORE="${CODEX_HOME:-$HOME/.codex}/sqlite/codex-dev.db"
 AUTOMATION=""
@@ -87,7 +92,13 @@ for pair in "GRACE_SECONDS:$GRACE_SECONDS" "STUB_SECONDS:$STUB_SECONDS" "CONSECU
     ''|*[!0-9]*) die_unknown "$name must be a non-negative integer, got: $val" ;;
   esac
 done
+# All three carry a floor of 1, because 0 defeats the invariant each one exists to hold:
+# --grace-seconds 0 makes settled_before == now, so an in-flight run is classified — the exact trap
+# the settled-window filter exists to close; --stub-seconds 0 makes the stub window unreachable, so
+# the check could only ever return 0 or 2 and never its actual verdict.
 [ "$CONSECUTIVE" -ge 1 ] || die_unknown "--consecutive must be at least 1"
+[ "$GRACE_SECONDS" -ge 1 ] || die_unknown "--grace-seconds must be at least 1"
+[ "$STUB_SECONDS" -ge 1 ] || die_unknown "--stub-seconds must be at least 1"
 
 if [ -n "$NOW_MS" ]; then
   case "$NOW_MS" in
@@ -103,11 +114,22 @@ command -v sqlite3 >/dev/null 2>&1 || die_unknown "sqlite3 is not available"
 
 # Open read-only. The sibling lane may be mid-dispatch, and *Obligations* forbids a change that could
 # break a sibling in flight; a read-only URI cannot create the -wal/-shm files a plain open would.
+#
+# Every output-affecting knob is PINNED and `~/.sqliterc` is refused with `-init /dev/null`. The CLI
+# reads that file at startup, so a user or CI `.headers on` prepends a header row and `.mode column`
+# removes the `|` separator entirely — either one makes the parse below silently mis-read every row
+# as a non-stub, which reports a dead lane as healthy. Asserting column NAMES does not assert the
+# WIRE FORMAT their values arrive in.
 sq() {
-  sqlite3 "file:${STORE}?mode=ro" "$@" 2>/dev/null || return 1
+  sqlite3 -batch -init /dev/null -noheader -list -separator '|' \
+    "file:${STORE}?mode=ro" "$@" 2>/dev/null || return 1
 }
 
 sq 'SELECT 1;' >/dev/null || die_unknown "scheduler store could not be opened read-only: $STORE"
+
+# Prove the wire format really is what the parse assumes, rather than trusting the flags took effect.
+probe=$(sq "SELECT 1,2;") || die_unknown "scheduler store probe query failed"
+[ "$probe" = "1|2" ] || die_unknown "unexpected sqlite3 output format (got '${probe}', want '1|2')"
 
 # Schema is asserted, never assumed. A renamed column would otherwise make every comparison below
 # return empty, and an empty result set reads exactly like "no stubs found" — a silent pass in the
@@ -141,7 +163,16 @@ any_unknown=0
 report=""
 
 while IFS= read -r id; do
-  [ -n "$id" ] || continue
+  # A blank id is recorded, never silently skipped. SQLite permits NULL in a TEXT PRIMARY KEY, so an
+  # ACTIVE automation can enumerate as an empty line — and if that were the dead lane, a bare
+  # `continue` would exit 0 having examined nothing about it. This is the only skip in the file that
+  # would otherwise leave no trace.
+  if [ -z "$id" ]; then
+    report="${report}  UNKNOWN  <blank automation id> — cannot judge
+"
+    any_unknown=1
+    continue
+  fi
   # The id came out of a local store rather than from this script, so it is validated before being
   # interpolated into SQL — the same discipline the contract applies to any value it did not construct.
   case "$id" in
@@ -159,18 +190,27 @@ while IFS= read -r id; do
                     CASE WHEN inbox_title IS NULL OR trim(inbox_title) = '' THEN 1 ELSE 0 END AS no_inbox
              FROM automation_runs
              WHERE automation_id = '${id}' AND updated_at <= ${settled_before}
-             ORDER BY created_at DESC
+             ORDER BY updated_at DESC
              LIMIT ${CONSECUTIVE};") || die_unknown "could not read runs for ${id}"
 
   n=0
   stubs=0
   maxdur=-1
+  malformed=0
   while IFS='|' read -r dur no_inbox; do
     [ -n "$dur" ] || continue
     n=$(( n + 1 ))
-    # A negative or absent duration is not evidence of anything; treat it as non-stub so a clock
-    # anomaly can never manufacture a verdict.
-    case "$dur" in ''|*[!0-9-]*) dur=-1 ;; esac
+    # BOTH fields are validated. An unparsable value must never fall through to the healthy verdict:
+    # `no_inbox` in particular is compared against the literal 1, so without this check every
+    # unexpected value (empty, NULL, a header token, a shifted column) would read as "produced an
+    # inbox item" and therefore as NOT a stub — making the default for "I could not parse this" the
+    # answer that exits 0. Strip at most one leading '-' so forms like `--5` or `1-2` are rejected
+    # rather than reaching `[ ]` and erroring into a false non-stub.
+    case "${dur#-}" in ''|*[!0-9]*) dur=-1 ;; esac
+    case "$no_inbox" in
+      0|1) : ;;
+      *) malformed=1; break ;;
+    esac
     # An `[ ... ] && x=y` here would return non-zero whenever the test is false and abort the loop
     # under `set -e`, so the assignment is written as a full conditional.
     if [ "$dur" -gt "$maxdur" ]; then maxdur=$dur; fi
@@ -181,7 +221,11 @@ while IFS= read -r id; do
 $rows
 EOF
 
-  if [ "$n" -lt "$CONSECUTIVE" ]; then
+  if [ "$malformed" -eq 1 ]; then
+    report="${report}  UNKNOWN  ${id} — unparsable run row, cannot judge
+"
+    any_unknown=1
+  elif [ "$n" -lt "$CONSECUTIVE" ]; then
     report="${report}  UNKNOWN  ${id} — only ${n} settled run(s), need ${CONSECUTIVE} to judge
 "
     any_unknown=1

--- a/.claude/scripts/codex-lane-liveness.test.sh
+++ b/.claude/scripts/codex-lane-liveness.test.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# codex-lane-liveness.test.sh — RED/GREEN coverage for the Codex lane liveness check.
+#
+# The check exists because a dead lane looked healthy. So the assertions that matter most are the
+# ones proving it does NOT fire on a healthy lane: a guard that always fires is indistinguishable
+# from decoration, and gets ignored exactly as the signals it replaces were.
+#
+# Fixtures are synthetic stores built to the real schema. Every case pins `--now-ms`, so no assertion
+# depends on wall-clock time.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT="$SCRIPT_DIR/codex-lane-liveness.sh"
+[ -f "$SCRIPT" ] || { echo "FAIL: script not found at $SCRIPT" >&2; exit 1; }
+
+command -v sqlite3 >/dev/null 2>&1 || { echo "SKIP: sqlite3 unavailable" >&2; exit 0; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+NOW_MS=1000000000000        # fixed "now" for every case
+GRACE_MS=300000            # default --grace-seconds 300
+
+fails=0
+asserts=0
+
+note_fail() { echo "FAIL: $1" >&2; fails=$(( fails + 1 )); }
+
+# Build a store with the real schema. Only the columns the script reads are required to match; the
+# extras are present so a fixture cannot accidentally pass by being simpler than reality.
+mkstore() {
+  local db=$1
+  sqlite3 "$db" "
+    CREATE TABLE automations (
+      id TEXT PRIMARY KEY, status TEXT NOT NULL, rrule TEXT,
+      last_run_at INTEGER, updated_at INTEGER);
+    CREATE TABLE automation_runs (
+      thread_id TEXT PRIMARY KEY, automation_id TEXT NOT NULL, status TEXT NOT NULL,
+      thread_title TEXT, inbox_title TEXT, inbox_summary TEXT, last_error TEXT,
+      created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+  "
+}
+
+add_automation() {
+  sqlite3 "$1" "INSERT INTO automations (id,status,rrule,last_run_at,updated_at)
+                VALUES ('$2','$3','RRULE:FREQ=DAILY',$NOW_MS,$NOW_MS);"
+}
+
+# add_run <db> <automation> <ended_ms_ago> <duration_s> <inbox:yes|no>
+add_run() {
+  local db=$1 auto=$2 ago=$3 dur=$4 inbox=$5
+  local ended=$(( NOW_MS - ago )) created
+  created=$(( ended - dur * 1000 ))
+  local title="'an inbox item'"
+  [ "$inbox" = "yes" ] || title=NULL
+  sqlite3 "$db" "INSERT INTO automation_runs
+    (thread_id,automation_id,status,thread_title,inbox_title,inbox_summary,last_error,created_at,updated_at)
+    VALUES ('t-$auto-$RANDOM-$ago-$dur','$auto','PENDING_REVIEW','Run',$title,'sum','PRIVATE-ERROR-PAYLOAD',$created,$ended);"
+}
+
+run_check() {
+  set +e
+  OUT=$(bash "$SCRIPT" --store "$1" --now-ms "$NOW_MS" "${@:2}" 2>&1)
+  RC=$?
+  set -e
+}
+
+expect_rc() {
+  asserts=$(( asserts + 1 ))
+  if [ "$RC" != "$1" ]; then
+    note_fail "$2 (expected exit $1, got $RC)
+--- output ---
+$OUT"
+  fi
+}
+
+expect_out() {
+  asserts=$(( asserts + 1 ))
+  case "$OUT" in
+    *"$1"*) : ;;
+    *) note_fail "$2 (expected output to contain: $1)
+--- output ---
+$OUT" ;;
+  esac
+}
+
+# --- 1. a healthy lane must NOT fire -----------------------------------------------------------
+db=$TMP/healthy.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_run "$db" lane-a $(( GRACE_MS + 60000 ))  900 yes
+add_run "$db" lane-a $(( GRACE_MS + 900000 )) 800 yes
+run_check "$db"
+expect_rc 0 "healthy lane must exit 0"
+expect_out "OK" "healthy lane must report OK"
+
+# --- 2. an all-stub lane must fire -------------------------------------------------------------
+db=$TMP/dead.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_run "$db" lane-a $(( GRACE_MS + 60000 ))  4 no
+add_run "$db" lane-a $(( GRACE_MS + 900000 )) 5 no
+run_check "$db"
+expect_rc 1 "all-stub lane must exit 1"
+expect_out "NOT-PRODUCING" "all-stub lane must report NOT-PRODUCING"
+
+# --- 3. THE fail-open trap: an in-flight run must not be classified -----------------------------
+# The newest run is short because it is still running — the case where a run inspects its own row.
+# Classifying it would fire on a healthy lane on every single invocation.
+# The window must be filled ENTIRELY with unsettled runs, or the fixture cannot flip: one in-flight
+# stub paired with a settled healthy run yields "not all stubs" whether or not the filter exists, so
+# the assertion would pass vacuously. Two unsettled stubs make the filter the only thing deciding.
+db=$TMP/inflight.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_run "$db" lane-a 0     3 no                               # in flight, ends "now"
+add_run "$db" lane-a 60000 4 no                               # ended 60s ago, still inside the grace
+add_run "$db" lane-a $(( GRACE_MS + 60000 ))  900 yes
+add_run "$db" lane-a $(( GRACE_MS + 900000 )) 800 yes
+run_check "$db"
+expect_rc 0 "an in-flight short run must not be classified as a stub"
+
+# --- 4. duration alone is not enough -----------------------------------------------------------
+db=$TMP/fastok.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_run "$db" lane-a $(( GRACE_MS + 60000 ))  4 yes           # fast BUT wrote an inbox item
+add_run "$db" lane-a $(( GRACE_MS + 900000 )) 5 yes
+run_check "$db"
+expect_rc 0 "a fast run that wrote an inbox item is not a stub"
+
+# --- 5. missing inbox alone is not enough ------------------------------------------------------
+db=$TMP/longnoinbox.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_run "$db" lane-a $(( GRACE_MS + 60000 ))  900 no          # long BUT no inbox item
+add_run "$db" lane-a $(( GRACE_MS + 900000 )) 800 no
+run_check "$db"
+expect_rc 0 "a long run with no inbox item is not a stub"
+
+# --- 6. mixed window does not fire (requires ALL runs to be stubs) ------------------------------
+db=$TMP/mixed.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_run "$db" lane-a $(( GRACE_MS + 60000 ))  4 no
+add_run "$db" lane-a $(( GRACE_MS + 900000 )) 900 yes
+run_check "$db"
+expect_rc 0 "a window containing a healthy run must not fire"
+
+# --- 7. too little settled history is UNKNOWN, never OK ----------------------------------------
+db=$TMP/thin.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_run "$db" lane-a $(( GRACE_MS + 60000 )) 900 yes
+run_check "$db"
+expect_rc 2 "too little settled history must be UNKNOWN"
+expect_out "UNKNOWN" "thin history must report UNKNOWN"
+
+# --- 8. a paused automation is skipped ---------------------------------------------------------
+db=$TMP/paused.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE; add_automation "$db" lane-b PAUSED
+add_run "$db" lane-a $(( GRACE_MS + 60000 ))  900 yes
+add_run "$db" lane-a $(( GRACE_MS + 900000 )) 800 yes
+add_run "$db" lane-b $(( GRACE_MS + 60000 ))  4 no
+add_run "$db" lane-b $(( GRACE_MS + 900000 )) 4 no
+run_check "$db"
+expect_rc 0 "a PAUSED automation must not be judged"
+
+# --- 9. a real verdict outranks UNKNOWN --------------------------------------------------------
+db=$TMP/both.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE; add_automation "$db" lane-b ACTIVE
+add_run "$db" lane-a $(( GRACE_MS + 60000 ))  4 no
+add_run "$db" lane-a $(( GRACE_MS + 900000 )) 4 no
+add_run "$db" lane-b $(( GRACE_MS + 60000 ))  900 yes         # only one settled run => UNKNOWN
+run_check "$db"
+expect_rc 1 "a detected dead lane outranks an unjudgeable one"
+
+# --- 10. absent / unreadable store is UNKNOWN --------------------------------------------------
+run_check "$TMP/does-not-exist.db"
+expect_rc 2 "absent store must be UNKNOWN"
+
+# --- 11. unexpected schema is UNKNOWN, never a silent pass --------------------------------------
+# A renamed column makes every comparison return empty, and an empty result set reads exactly like
+# "no stubs found" — so schema drift must be caught explicitly.
+db=$TMP/schema.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_run "$db" lane-a $(( GRACE_MS + 60000 ))  4 no
+add_run "$db" lane-a $(( GRACE_MS + 900000 )) 4 no
+sqlite3 "$db" "ALTER TABLE automation_runs RENAME COLUMN inbox_title TO inbox_heading;"
+run_check "$db"
+expect_rc 2 "a renamed column must be UNKNOWN, not a pass"
+# Assert the CAUSE, not just the exit code. Without the schema check the query fails on the missing
+# column and still exits 2, so an exit-code-only assertion cannot tell a diagnosed schema drift from
+# an opaque query error — and would pass with the schema check removed entirely.
+expect_out "unexpected schema" "schema drift must be diagnosed as such, not as an opaque read failure"
+
+# --- 12. no ACTIVE automations is UNKNOWN ------------------------------------------------------
+db=$TMP/none.db; mkstore "$db"; add_automation "$db" lane-b PAUSED
+run_check "$db"
+expect_rc 2 "a store with no ACTIVE automation must be UNKNOWN"
+
+# --- 13. bad arguments are UNKNOWN -------------------------------------------------------------
+db=$TMP/healthy.db
+run_check "$db" --consecutive 0
+expect_rc 2 "--consecutive 0 must be rejected"
+run_check "$db" --stub-seconds abc
+expect_rc 2 "a non-numeric --stub-seconds must be rejected"
+run_check "$db" --automation 'lane-a; DROP TABLE automations'
+expect_rc 2 "an unusable automation id must be rejected"
+
+# --- 14. PRIVACY: the check must never read a run's payload ------------------------------------
+# The stall's cause is frequently private runtime state. This check is about the deployment being
+# blind, so it must stay generic across causes and must not be able to carry such state outward.
+# Asserted structurally against the script's own source, not against one run's output.
+# Comment LINES are stripped first — the script's own header names these columns precisely to say it
+# does not read them, and matching that prose would fail the check on the documentation of the
+# property it is verifying. Whole lines are dropped rather than truncating at the first '#', because
+# parameter expansions like ${pair#*:} would otherwise mangle real code into a false PASS.
+asserts=$(( asserts + 1 ))
+if grep -vE '^[[:space:]]*#' "$SCRIPT" |
+     grep -Eq '\b(last_error|inbox_summary|thread_title|archived_[a-z_]*)\b'; then
+  note_fail "the script must not read a run's payload columns"
+fi
+
+# The fixtures deliberately carry a payload, so a leak would surface in output.
+asserts=$(( asserts + 1 ))
+db=$TMP/dead.db
+run_check "$db"
+case "$OUT" in
+  *PRIVATE-ERROR-PAYLOAD*) note_fail "a run's error payload reached the check's output" ;;
+esac
+
+echo "codex-lane-liveness.test.sh: $asserts assertions, $fails failure(s)"
+[ "$fails" -eq 0 ] || exit 1
+echo "OK"

--- a/.claude/scripts/codex-lane-liveness.test.sh
+++ b/.claude/scripts/codex-lane-liveness.test.sh
@@ -14,7 +14,14 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 SCRIPT="$SCRIPT_DIR/codex-lane-liveness.sh"
 [ -f "$SCRIPT" ] || { echo "FAIL: script not found at $SCRIPT" >&2; exit 1; }
 
-command -v sqlite3 >/dev/null 2>&1 || { echo "SKIP: sqlite3 unavailable" >&2; exit 0; }
+# A green exit that ran no assertions is the very anti-pattern the script under test exists to fix,
+# so CI may not take it. A developer machine can opt in explicitly; CI cannot opt in by accident.
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  if [ "${ALLOW_SKIP:-0}" = "1" ]; then
+    echo "SKIP: sqlite3 unavailable (ALLOW_SKIP=1)" >&2; exit 0
+  fi
+  echo "FAIL: sqlite3 is required to run this suite (set ALLOW_SKIP=1 to skip locally)" >&2; exit 1
+fi
 
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
@@ -52,8 +59,13 @@ add_run() {
   local db=$1 auto=$2 ago=$3 dur=$4 inbox=$5
   local ended=$(( NOW_MS - ago )) created
   created=$(( ended - dur * 1000 ))
-  local title="'an inbox item'"
-  [ "$inbox" = "yes" ] || title=NULL
+  local title
+  case "$inbox" in
+    yes)   title="'an inbox item'" ;;
+    empty) title="''" ;;            # present but blank — the trim() branch
+    blank) title="'   '" ;;         # spaces only — also the trim() branch
+    *)     title=NULL ;;
+  esac
   sqlite3 "$db" "INSERT INTO automation_runs
     (thread_id,automation_id,status,thread_title,inbox_title,inbox_summary,last_error,created_at,updated_at)
     VALUES ('t-$auto-$RANDOM-$ago-$dur','$auto','PENDING_REVIEW','Run',$title,'sum','PRIVATE-ERROR-PAYLOAD',$created,$ended);"
@@ -191,6 +203,74 @@ run_check "$db" --stub-seconds abc
 expect_rc 2 "a non-numeric --stub-seconds must be rejected"
 run_check "$db" --automation 'lane-a; DROP TABLE automations'
 expect_rc 2 "an unusable automation id must be rejected"
+# A quote is the input that could actually escape a single-quoted SQL literal; the semicolon form
+# above could not, so on its own it never exercised the case it is named for.
+run_check "$db" --automation "x' OR '1'='1"
+expect_rc 2 "a quote-bearing automation id must be rejected"
+asserts=$(( asserts + 1 ))
+sqlite3 "$db" "SELECT count(*) FROM automations;" >/dev/null 2>&1 \
+  || note_fail "the automations table did not survive the injection attempts"
+
+# --- 13b. a blank automation id is recorded, never silently skipped -----------------------------
+# Paired with a VALID automation on purpose: a blank id on its own makes the whole enumeration empty
+# and is caught by the earlier "no ACTIVE automations" guard, so it never reaches the loop branch
+# this case exists to exercise.
+db=$TMP/blankid.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_run "$db" lane-a $(( GRACE_MS + 60000 ))  900 yes
+add_run "$db" lane-a $(( GRACE_MS + 900000 )) 800 yes
+sqlite3 "$db" "INSERT INTO automations (id,status) VALUES ('','ACTIVE');"
+run_check "$db"
+expect_rc 2 "a blank automation id must be UNKNOWN, not an unexamined pass"
+# Assert the CAUSE. A blank id also falls through to a zero-row query and thin-history UNKNOWN, so an
+# exit-code-only assertion passes with the blank-id branch removed entirely.
+expect_out "blank automation id" "a blank id must be reported as such, not as thin history"
+
+# --- 13c. floors: a zero window would defeat the invariant it exists to hold --------------------
+db=$TMP/healthy.db
+run_check "$db" --grace-seconds 0
+expect_rc 2 "--grace-seconds 0 must be rejected (it would classify in-flight runs)"
+run_check "$db" --stub-seconds 0
+expect_rc 2 "--stub-seconds 0 must be rejected (the stub window would be unreachable)"
+
+# --- 13d. a blank-but-present inbox title still counts as no inbox item -------------------------
+# Without this, deleting the `trim(inbox_title) = ''` branch leaves the whole suite green.
+for variant in empty blank; do
+  db=$TMP/inbox-$variant.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+  add_run "$db" lane-a $(( GRACE_MS + 60000 ))  4 "$variant"
+  add_run "$db" lane-a $(( GRACE_MS + 900000 )) 5 "$variant"
+  run_check "$db"
+  expect_rc 1 "a '$variant' inbox title must count as no inbox item"
+done
+
+# --- 13e. the sqlite3 wire format is pinned, and the rc file refused ----------------------------
+# Asserted structurally because the failure needs a hostile ~/.sqliterc, which a test must not write
+# into the invoking user's home. `.headers on` or a non-list mode would make every row mis-parse as
+# a non-stub — a dead lane reported healthy — so silent removal of these flags must fail the suite.
+for flag in '-init /dev/null' '-noheader' '-list' "-separator '|'"; do
+  asserts=$(( asserts + 1 ))
+  grep -qF -- "$flag" "$SCRIPT" || note_fail "sqlite3 invocation must pin $flag"
+done
+asserts=$(( asserts + 1 ))
+grep -qF "want '1|2'" "$SCRIPT" || note_fail "the script must probe the actual sqlite3 output format"
+
+# --- 13f. an internal failure must not be able to reach exit 1 ----------------------------------
+# Exit 1 is a verdict. Under `set -e` the abort status is the failing command's, and 1 is the
+# commonest, so without the ERR trap a failing `date` would be indistinguishable from a dead lane.
+asserts=$(( asserts + 1 ))
+grep -qE 'trap .*(exit 2).* ERR' "$SCRIPT" || note_fail "an ERR trap must map internal failures to UNKNOWN"
+asserts=$(( asserts + 1 ))
+grep -qE '^set -[A-Za-z]*E' "$SCRIPT" || note_fail "set -E is required for the ERR trap to propagate"
+
+# --- 13g. the row parser must fail closed on an unparsable field --------------------------------
+# Structural, and deliberately so: with the wire format pinned above, the SQL CASE can only ever
+# yield 0 or 1, so no fixture can drive this branch. It is defence-in-depth for the case where the
+# format pin itself fails — the direction that matters, because an unvalidated `no_inbox` defaults to
+# "has an inbox item" and therefore to the healthy verdict. Asserting its presence is what stops it
+# being removed as dead code, which is exactly how a fail-open gets reintroduced.
+asserts=$(( asserts + 1 ))
+grep -qF 'malformed=1; break' "$SCRIPT" || note_fail "an unparsable run row must fail closed, not default to healthy"
+asserts=$(( asserts + 1 ))
+grep -qF 'unparsable run row' "$SCRIPT" || note_fail "a malformed window must be reported UNKNOWN"
 
 # --- 14. PRIVACY: the check must never read a run's payload ------------------------------------
 # The stall's cause is frequently private runtime state. This check is about the deployment being
@@ -200,10 +280,33 @@ expect_rc 2 "an unusable automation id must be rejected"
 # does not read them, and matching that prose would fail the check on the documentation of the
 # property it is verifying. Whole lines are dropped rather than truncating at the first '#', because
 # parameter expansions like ${pair#*:} would otherwise mangle real code into a false PASS.
+# NOT a pipeline: `grep -Eq` exits at the first match, the upstream grep dies of SIGPIPE, and under
+# `set -o pipefail` the pipeline reports THAT — so the assertion would report "clean" precisely when
+# it matched. Reproduced 3/3 on a large input with an early match, which is the shape a growing
+# script eventually reaches. A fail-open in the privacy assertion is the exact class this check exists
+# to prevent, so it is written without a pipe.
+# `\b` is a GNU extension, NOT POSIX ERE. On a grep without it the escape degrades to a literal 'b',
+# the alternation stops matching anything, and this assertion passes unconditionally — a vacuous
+# guard over a privacy property, on a suite that must run on both BSD and GNU. An explicit delimiter
+# class is portable, and the positive control below is what proves the matcher is alive at all.
+PAYLOAD_RE='(^|[^A-Za-z0-9_])(last_error|inbox_summary|thread_title|archived_[a-z_]*)([^A-Za-z0-9_]|$)'
+
 asserts=$(( asserts + 1 ))
-if grep -vE '^[[:space:]]*#' "$SCRIPT" |
-     grep -Eq '\b(last_error|inbox_summary|thread_title|archived_[a-z_]*)\b'; then
+if ! grep -Eq "$PAYLOAD_RE" <<<'SELECT last_error FROM automation_runs;'; then
+  note_fail "the privacy matcher is broken — it does not match a known payload reference"
+fi
+
+asserts=$(( asserts + 1 ))
+noncomment=$(grep -vE '^[[:space:]]*#' "$SCRIPT" || true)
+if grep -Eq "$PAYLOAD_RE" <<<"$noncomment"; then
   note_fail "the script must not read a run's payload columns"
+fi
+
+# A column allow-list is defeated by a wildcard: `SELECT *` pulls every payload column into the row
+# buffer without any forbidden name appearing in the source, so the assertion above would pass.
+asserts=$(( asserts + 1 ))
+if grep -Eq 'SELECT[[:space:]]+\*' <<<"$noncomment"; then
+  note_fail "the script must not SELECT * — it would pull payload columns in unnamed"
 fi
 
 # The fixtures deliberately carry a payload, so a leak would surface in output.
@@ -215,5 +318,10 @@ case "$OUT" in
 esac
 
 echo "codex-lane-liveness.test.sh: $asserts assertions, $fails failure(s)"
+# A floor on the count, so deleting a whole section cannot leave the suite green and silent.
+if [ "$asserts" -lt 38 ]; then
+  echo "FAIL: only $asserts assertions ran — a section is missing" >&2
+  exit 1
+fi
 [ "$fails" -eq 0 ] || exit 1
 echo "OK"

--- a/.claude/scripts/codex-lane-liveness.test.sh
+++ b/.claude/scripts/codex-lane-liveness.test.sh
@@ -54,11 +54,26 @@ add_automation() {
                 VALUES ('$2','$3','RRULE:FREQ=DAILY',$NOW_MS,$NOW_MS);"
 }
 
+# `thread_id` is the PRIMARY KEY, so its uniqueness has to be guaranteed rather than likely. A
+# `$RANDOM` component can repeat, which would make two runs sharing an automation/ago/duration
+# collide and abort the whole fixture under `set -e` — a flake with no relation to what is being
+# tested. A monotonic counter also keeps every id reproducible, which the header's "no assertion
+# depends on a non-pinned input" property requires.
+run_seq=0
+
 # add_run <db> <automation> <ended_ms_ago> <duration_s> <inbox:yes|no>
 add_run() {
   local db=$1 auto=$2 ago=$3 dur=$4 inbox=$5
+  add_run_ms "$db" "$auto" "$ago" "$(( dur * 1000 ))" "$inbox"
+}
+
+# add_run_ms <db> <automation> <ended_ms_ago> <duration_MS> <inbox:yes|no>
+# Millisecond-precision variant, so a fixture can sit just above a whole-second stub threshold.
+add_run_ms() {
+  local db=$1 auto=$2 ago=$3 dur_ms=$4 inbox=$5
   local ended=$(( NOW_MS - ago )) created
-  created=$(( ended - dur * 1000 ))
+  created=$(( ended - dur_ms ))
+  run_seq=$(( run_seq + 1 ))
   local title
   case "$inbox" in
     yes)   title="'an inbox item'" ;;
@@ -68,7 +83,7 @@ add_run() {
   esac
   sqlite3 "$db" "INSERT INTO automation_runs
     (thread_id,automation_id,status,thread_title,inbox_title,inbox_summary,last_error,created_at,updated_at)
-    VALUES ('t-$auto-$RANDOM-$ago-$dur','$auto','PENDING_REVIEW','Run',$title,'sum','PRIVATE-ERROR-PAYLOAD',$created,$ended);"
+    VALUES ('t-$auto-$run_seq-$ago-$dur_ms','$auto','PENDING_REVIEW','Run',$title,'sum','PRIVATE-ERROR-PAYLOAD',$created,$ended);"
 }
 
 run_check() {
@@ -317,9 +332,51 @@ case "$OUT" in
   *PRIVATE-ERROR-PAYLOAD*) note_fail "a run's error payload reached the check's output" ;;
 esac
 
+# --- an explicitly EMPTY --automation must not widen to every automation ------------------------
+# The failure this pins is silent: the request was for one automation, and testing the value rather
+# than the flag turned it into a sweep of all of them, reporting on lanes nobody asked about.
+db=$TMP/emptyauto.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_run "$db" lane-a $(( GRACE_MS + 60000 ))  4 no
+add_run "$db" lane-a $(( GRACE_MS + 900000 )) 5 no
+run_check "$db" --automation ""
+expect_rc 2 "an empty --automation must be UNKNOWN, never a silent sweep of every automation"
+expect_out "must not be empty" "the empty --automation refusal must say so"
+
+# --- a NAMED but INACTIVE automation must not be judged ------------------------------------------
+# An inactive lane does not dispatch, so its newest settled runs are old by construction and would
+# classify as a dead lane. That is a false NOT-PRODUCING on the one verdict this check exists to make.
+db=$TMP/inactive.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_automation "$db" lane-b INACTIVE
+add_run "$db" lane-b $(( GRACE_MS + 60000 ))  4 no
+add_run "$db" lane-b $(( GRACE_MS + 900000 )) 5 no
+run_check "$db" --automation lane-b
+expect_rc 2 "an inactive automation must be UNKNOWN, never NOT-PRODUCING"
+expect_out "not an ACTIVE automation" "the inactive refusal must name the reason"
+
+# --- a run just OVER the stub threshold is not a stub --------------------------------------------
+# Whole-second truncation classified `STUB_SECONDS*1000 + 999` ms as exactly STUB_SECONDS, so a run
+# genuinely over the threshold counted as under it. Both runs sit 999 ms over, so the comparison
+# precision is the only thing deciding the verdict.
+db=$TMP/justover.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_run_ms "$db" lane-a $(( GRACE_MS + 60000 ))  60999 no
+add_run_ms "$db" lane-a $(( GRACE_MS + 900000 )) 60999 no
+run_check "$db"
+expect_rc 0 "a run 999ms over the stub threshold must not be counted a stub"
+expect_out "OK" "a just-over-threshold lane must report OK"
+
+# --- a NEGATIVE duration is corrupt timing data, not a long run ----------------------------------
+# updated_at before created_at cannot describe a real run. Treating it as a large duration made it a
+# non-stub, which fed the healthy verdict — the same fall-through the field validation exists to stop.
+db=$TMP/negdur.db; mkstore "$db"; add_automation "$db" lane-a ACTIVE
+add_run_ms "$db" lane-a $(( GRACE_MS + 60000 ))  -5000 no
+add_run_ms "$db" lane-a $(( GRACE_MS + 900000 )) -5000 no
+run_check "$db"
+expect_rc 2 "a negative run duration must be UNKNOWN, never a silent non-stub"
+expect_out "unparsable run row" "a negative duration must report as an unparsable row"
+
 echo "codex-lane-liveness.test.sh: $asserts assertions, $fails failure(s)"
 # A floor on the count, so deleting a whole section cannot leave the suite green and silent.
-if [ "$asserts" -lt 38 ]; then
+if [ "$asserts" -lt 46 ]; then
   echo "FAIL: only $asserts assertions ran — a section is missing" >&2
   exit 1
 fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
       git-safety-contract: ${{ steps.filter.outputs.git-safety-contract }}
       plugin-definition-currency: ${{ steps.filter.outputs.plugin-definition-currency }}
       plugin-definition-refresh: ${{ steps.filter.outputs.plugin-definition-refresh }}
+      codex-lane-liveness: ${{ steps.filter.outputs.codex-lane-liveness }}
       merge-confirmation-read: ${{ steps.filter.outputs.merge-confirmation-read }}
       portfolio-surveyor: ${{ steps.filter.outputs.portfolio-surveyor }}
       product-value: ${{ steps.filter.outputs.product-value }}
@@ -257,6 +258,11 @@ jobs:
               # The refresh script's DEFAULT post-apply verifier. Its exit codes are the verdict, so
               # a change there changes this script's behaviour without touching either file above.
               - '.claude/scripts/plugin-definition-currency.sh'
+              - '.github/workflows/ci.yaml'
+            codex-lane-liveness:
+              - 'AGENTS.md'
+              - '.claude/scripts/codex-lane-liveness.sh'
+              - '.claude/scripts/codex-lane-liveness.test.sh'
               - '.github/workflows/ci.yaml'
             self-review-contract:
               - 'AGENTS.md'
@@ -968,6 +974,21 @@ jobs:
       - name: Verify the plugin definition currency check
         run: bash .claude/scripts/plugin-definition-currency.test.sh
 
+  test-codex-lane-liveness:
+    name: Test codex lane liveness
+    needs: changes
+    if: needs.changes.outputs.codex-lane-liveness == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify the codex lane liveness check
+        run: bash .claude/scripts/codex-lane-liveness.test.sh
+
   test-plugin-definition-refresh:
     name: Test plugin definition refresh
     needs: changes
@@ -1123,6 +1144,7 @@ jobs:
       - test-git-safety-contract
       - test-plugin-definition-currency
       - test-plugin-definition-refresh
+      - test-codex-lane-liveness
       - test-self-review-contract
       - test-review-provider-loop-contract
       - test-agent-role-delivery-contract
@@ -1164,6 +1186,7 @@ jobs:
             ${{ needs.test-git-safety-contract.result }}
             ${{ needs.test-plugin-definition-currency.result }}
             ${{ needs.test-plugin-definition-refresh.result }}
+            ${{ needs.test-codex-lane-liveness.result }}
             ${{ needs.test-self-review-contract.result }}
             ${{ needs.test-review-provider-loop-contract.result }}
             ${{ needs.test-agent-role-delivery-contract.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -572,6 +572,31 @@ pointer and must equal that scheduler record before the drift check reports `MAT
 ambiguous store, missing baseline, marker that did not advance, or incomplete recurrence rule is
 `UNKNOWN`, never `MATCH`.
 
+🔴 **`last_run_at` is a DISPATCH marker, never a LIVENESS signal — a fully dead lane advances it
+exactly like a healthy one.** The scheduler records when it *started* a run, not whether the run did
+anything, so when every dispatched turn dies seconds in, `last_run_at` and `next_run_at` both stay
+perfectly healthy and this drift check reports `MATCH` over a lane producing nothing. Measured
+2026-08-17: **32 consecutive dead dispatches over ~29h across BOTH Codex automations** (3
+`agent-improver`, 29 `daily-ai-engineer`), undetected. Two other signals fail with it — the scheduler
+records these runs `PENDING_REVIEW`, the **same** status healthy runs carry, so status cannot
+discriminate and `notification_policy = "failed_runs_only"` never fires.
+
+⚠️ **The Improver's mandated sibling cross-read is what this silently corrupts.** A frozen ledger is
+indistinguishable from an ordinary quiet period, so a sibling's pending hypotheses read as merely
+un-advanced rather than *unable* to advance, and any telemetry mined for that lane over the window is
+an artifact of the outage rather than agent behaviour — a naive read scores the dead lane as having
+**improved**, because its error count falls to zero. Record such hypotheses as blocked by the outage;
+never as a verdict, a directional reading, or a "no movement" inference.
+
+Run [`.claude/scripts/codex-lane-liveness.sh`](.claude/scripts/codex-lane-liveness.sh) for the
+liveness question. It classifies each ACTIVE automation's newest **settled** runs by run duration and
+inbox-item presence — the discriminators that actually separate the two states (healthy runs measured
+768–24,428 s with an inbox item, against 4-second stubs with none) — and exits `0` producing, `1` not
+producing, `2` **UNKNOWN**. It reads only timings and an inbox-presence flag, never a run's error
+payload, so it stays generic across causes and cannot carry private runtime state into an artifact.
+A `1` is reported and its cause pursued; it is never a run-stopper, and the remedy may lie outside
+agent authority.
+
 The deployed Cursor Automation has no supported local write surface. Its reviewed source is
 `.claude/loaders/cursor-daily-ai-engineer.md`; after that source merges, use a declared Maintainer
 channel for the UI paste rather than claiming the server-side prompt changed. Marketplace/plugin


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The Codex lane can dispatch on time, look healthy on every signal we check, and produce nothing at
all. Measured 2026-08-17: **32 consecutive dead dispatches over ~29 hours across both Codex
automations**, entirely undetected. The scheduler's own marker advances normally, because it records
that a run *started*, not that it ran.

That blindness costs more than the outage itself: the Agent Improver's sibling cross-read returns a
frozen ledger that looks like an ordinary quiet period, and any telemetry from that lane over the
window scores it as having **improved** — its error count falls to zero because nothing ran.

### What

Adds a liveness check that asks the question the existing signals cannot, and names it in the
contract beside the marker that misleads. It reports whether a lane is producing work; it does not
diagnose why, and it reads no run payload, so it stays generic across causes and keeps private
runtime state out of any artifact.

The root cause of this particular outage is external and outside agent authority — this change is
strictly about no longer being blind to it.

Fixes #2885
