### PR TITLE
fix(agents): select rungs 2 and 3 with an unquoted issue-type filter

### DIFF
--- a/.claude/scripts/rung-type-filter-contract.test.sh
+++ b/.claude/scripts/rung-type-filter-contract.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Guards the rung-2/3 type filter in *The work-selection ladder*.
+#
+# Why this needs a guard. `gh search issues` returns ZERO rows for a QUOTED issue-type filter and
+# exits 0 while doing it. Measured across the portfolio on 2026-08-18: `type:"Security"` returned 0
+# against 73 genuinely open, and `type:"Bug"` returned 0 against 269. A run that builds its rung-2/3
+# query by retyping a quoted literal therefore descends straight past every open Security and Bug
+# issue and reports a clean sweep — and nothing in gh's exit status distinguishes that from an empty
+# queue, which is what makes it silent rather than merely wrong.
+#
+# The contract itself was the source of that literal: rungs 2 and 3 wrote `type:"Security"` and
+# `type:"Bug"`, so following the ladder as written produced the failure. That is why the assertion
+# is on the LADDER ROWS specifically and not on the file: the quoted form is still correct English
+# elsewhere in the contract when naming a type rather than issuing a query (`type:"Spike"` in the
+# Spike carve-out, `type:"Epic"` in the hierarchy section), and a whole-file ban would either fail
+# on those or force them into a query form they are not.
+#
+# Assertion 3 pins the measurement rather than only the fix. Without it the warning can decay into
+# "use the unquoted form" with no evidence, and the next reader who finds a quoted literal that
+# happens to work on some other surface has nothing to weigh it against.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+constitution="${repo_root}/AGENTS.md"
+
+fail() {
+  echo "rung type-filter contract: FAIL — $*" >&2
+  exit 1
+}
+
+[ -r "${constitution}" ] || fail "cannot read ${constitution}"
+
+# Extract ONLY the ladder's rung rows. Anchored on the table's own row markers so an unrelated
+# section mentioning a type filter cannot satisfy — or break — these assertions.
+rows="$(
+  awk '
+    /^\| \*\*2\*\* \| \*\*Security issues\*\*/ { print }
+    /^\| \*\*3\*\* \| \*\*Bugs\*\*/            { print }
+  ' "${constitution}"
+)"
+
+[ -n "${rows}" ] ||
+  fail "could not locate the rung-2/rung-3 ladder rows — the anchor moved, so every assertion below would be vacuous"
+
+# Both rows, and only those two. A changed table shape that matched more rows would widen the scope
+# silently; one that matched fewer would make an assertion pass by absence.
+row_count="$(printf '%s\n' "${rows}" | wc -l | tr -d ' ')"
+[ "${row_count}" = "2" ] ||
+  fail "expected exactly 2 ladder rows (rung 2 and rung 3), found ${row_count} — the extraction anchor is wrong"
+
+# 1. The rung rows must not carry a quoted type filter. This is the regression itself.
+case "${rows}" in
+  *'type:"'*)
+    fail 'a rung row writes a QUOTED type filter (type:"X"). gh search issues returns 0 rows for that form and exits 0, so a run following the ladder skips every open Security and Bug issue. Use the unquoted type:Security / type:Bug.'
+    ;;
+esac
+
+# 2. Both rows must still actually name their type filter — otherwise assertion 1 passes by absence.
+printf '%s\n' "${rows}" | grep -q 'type:Security' ||
+  fail "the rung-2 row no longer names type:Security, so assertion 1 would pass with no filter present at all"
+printf '%s\n' "${rows}" | grep -q 'type:Bug' ||
+  fail "the rung-3 row no longer names type:Bug, so assertion 1 would pass with no filter present at all"
+
+# 3. The warning that explains WHY must survive, with its measurement. Flattened, because the
+# sentences wrap across source lines.
+warning="$(
+  awk '
+    /^🔴 \*\*Write that type filter UNQUOTED/ { inw = 1 }
+    inw && /^Then \*\*capture any new finds/  { inw = 0 }
+    inw                                       { print }
+  ' "${constitution}" | tr '\n' ' ' | tr -s '[:space:]' ' '
+)"
+
+[ -n "${warning}" ] ||
+  fail "the unquoted-type-filter warning is gone; the rung rows would then be a bare convention with nothing recording why"
+
+case "${warning}" in
+  *'returns ZERO rows'*) ;;
+  *) fail "the warning no longer states that the quoted form returns zero rows — the trap it exists to name" ;;
+esac
+
+case "${warning}" in
+  *'73'*) ;;
+  *) fail "the warning no longer carries its measured Security count, so the claim is unfalsifiable" ;;
+esac
+
+case "${warning}" in
+  *'269'*) ;;
+  *) fail "the warning no longer carries its measured Bug count, so the claim is unfalsifiable" ;;
+esac
+
+# 4. The standing generalisation must stay attached: this is one instance of it, not a one-off.
+case "${warning}" in
+  *'empty FILTERED read is a claim about the FILTER'*) ;;
+  *) fail "the warning no longer ties back to the standing rule that an empty filtered read is a claim about the filter" ;;
+esac
+
+echo "rung type-filter contract: OK — rungs 2/3 use the unquoted form, and the measured warning is intact"

--- a/.claude/scripts/rung-type-filter-contract.test.sh
+++ b/.claude/scripts/rung-type-filter-contract.test.sh
@@ -57,11 +57,25 @@ case "${rows}" in
     ;;
 esac
 
-# 2. Both rows must still actually name their type filter — otherwise assertion 1 passes by absence.
-printf '%s\n' "${rows}" | grep -q 'type:Security' ||
+# 2. Each row must name ITS OWN filter. Searching the combined output would accept the two filters
+# swapped between the rungs — a table that still contains both strings, still satisfies assertion 1,
+# and inverts the Security-before-Bug order the ladder exists to impose.
+rung2_row="$(printf '%s\n' "${rows}" | grep -F '| **2** | **Security issues**')"
+rung3_row="$(printf '%s\n' "${rows}" | grep -F '| **3** | **Bugs**')"
+[ -n "${rung2_row}" ] || fail "could not isolate the rung-2 row"
+[ -n "${rung3_row}" ] || fail "could not isolate the rung-3 row"
+
+printf '%s\n' "${rung2_row}" | grep -q 'type:Security' ||
   fail "the rung-2 row no longer names type:Security, so assertion 1 would pass with no filter present at all"
-printf '%s\n' "${rows}" | grep -q 'type:Bug' ||
+printf '%s\n' "${rung3_row}" | grep -q 'type:Bug' ||
   fail "the rung-3 row no longer names type:Bug, so assertion 1 would pass with no filter present at all"
+
+# ...and only its own. Without these, a row naming BOTH filters satisfies the two assertions above
+# while still pointing that rung at the wrong type.
+! printf '%s\n' "${rung2_row}" | grep -q 'type:Bug' ||
+  fail "the rung-2 (Security) row also names type:Bug — the rung filters are crossed"
+! printf '%s\n' "${rung3_row}" | grep -q 'type:Security' ||
+  fail "the rung-3 (Bug) row also names type:Security — the rung filters are crossed"
 
 # 3. The warning that explains WHY must survive, with its measurement. Flattened, because the
 # sentences wrap across source lines.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
       one-verb-per-bash-call-contract: ${{ steps.filter.outputs.one-verb-per-bash-call-contract }}
       bash-call-timeout-budget-contract: ${{ steps.filter.outputs.bash-call-timeout-budget-contract }}
       git-safety-contract: ${{ steps.filter.outputs.git-safety-contract }}
+      rung-type-filter-contract: ${{ steps.filter.outputs.rung-type-filter-contract }}
       plugin-definition-currency: ${{ steps.filter.outputs.plugin-definition-currency }}
       plugin-definition-refresh: ${{ steps.filter.outputs.plugin-definition-refresh }}
       codex-lane-liveness: ${{ steps.filter.outputs.codex-lane-liveness }}
@@ -250,6 +251,10 @@ jobs:
             git-safety-contract:
               - 'AGENTS.md'
               - '.claude/scripts/git-safety-contract.test.sh'
+              - '.github/workflows/ci.yaml'
+            rung-type-filter-contract:
+              - 'AGENTS.md'
+              - '.claude/scripts/rung-type-filter-contract.test.sh'
               - '.github/workflows/ci.yaml'
             plugin-definition-currency:
               - 'AGENTS.md'
@@ -934,6 +939,21 @@ jobs:
       - name: Verify the control character command contract
         run: bash .claude/scripts/control-character-command-contract.test.sh
 
+  test-rung-type-filter-contract:
+    name: Test rung type filter contract
+    needs: changes
+    if: needs.changes.outputs.rung-type-filter-contract == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify the rung type filter contract
+        run: bash .claude/scripts/rung-type-filter-contract.test.sh
+
   test-one-verb-per-bash-call-contract:
     name: Test one verb per bash call contract
     needs: changes
@@ -1163,6 +1183,7 @@ jobs:
       - test-one-verb-per-bash-call-contract
       - test-bash-call-timeout-budget-contract
       - test-git-safety-contract
+      - test-rung-type-filter-contract
       - test-plugin-definition-currency
       - test-plugin-definition-refresh
       - test-codex-lane-liveness
@@ -1206,6 +1227,7 @@ jobs:
             ${{ needs.test-one-verb-per-bash-call-contract.result }}
             ${{ needs.test-bash-call-timeout-budget-contract.result }}
             ${{ needs.test-git-safety-contract.result }}
+            ${{ needs.test-rung-type-filter-contract.result }}
             ${{ needs.test-plugin-definition-currency.result }}
             ${{ needs.test-plugin-definition-refresh.result }}
             ${{ needs.test-codex-lane-liveness.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -914,9 +914,23 @@ actionable work**:
 |---|---|---|
 | **0** | **Live breakage** | CI red on `main`, a broken build or site, an urgent security fix. Preempts everything and is the one exception to capture-before-you-build. **A failing GitHub-*managed* run is NOT breakage** — identify the class by the **property, never by an enumerated path**: `event: dynamic` with a `path` under `dynamic/`, meaning **no workflow file exists in the repository** to fix and GitHub refuses to re-run it (`403`). That covers `dynamic/github-code-scanning/*` **and** `dynamic/dependabot/*` and whatever GitHub adds next; each is reported `GITHUB-MANAGED (NO-ACTION)` and never counts against `nothing_on_fire`. **Only the first failure of a streak** — a managed run still red (`failure`, `timed_out` or `startup_failure`) on the next run of `main` is ours to repair (the build, the scanning or dependency configuration, or moving off default setup) and IS actionable (see the surveyor). |
 | **1** | **Open PRs — INCLUDING your own drafts** | Every actionable open PR in the portfolio, **draft and non-draft alike**, whoever authored it — your own lane, a sibling lane, the maintainer's interactive sessions, our bots, and external contributors — driven to a terminal state: merged, closed with the reason recorded, or parked on a **named, live-verified** blocker. Exact `renovate[bot]`/`dependabot[bot]` dependency PRs stay automation-owned and excluded (see *Merge policy*). An external branch is still never run locally (see *You own EVERY pull request in the portfolio*). |
-| **2** | **Security issues** | `type:"Security"`, regardless of age. |
-| **3** | **Bugs** | `type:"Bug"`, regardless of age. |
+| **2** | **Security issues** | `type:Security`, regardless of age. |
+| **3** | **Bugs** | `type:Bug`, regardless of age. |
 | **4** | **Oldest actionable issue** | Everything else, oldest-first (see *Drain oldest-first*). |
+
+🔴 **Write that type filter UNQUOTED — `gh search issues` returns ZERO rows for the quoted
+form, and exits 0 while doing it.** Measured across the portfolio 2026-08-18:
+`gh search issues --owner devantler-tech --state open 'type:"Security"'` returns **0** while the
+unquoted `type:Security` returns **73**, and the same split holds for `type:"Bug"`, which returns
+**0** against **269** genuinely open. So a run building its rung-2/3 query by retyping a quoted literal
+descends straight past every open Security and Bug issue and reports a clean sweep — and
+nothing in the exit status distinguishes that from a genuinely empty queue. The raw REST
+surface is indifferent (`gh api "search/issues?q=…type:Security"` returns the same count either
+way), which is why the surveyor is safe: it queries that surface, unquoted. Prefer running the
+surveyor or the REST form over retyping either literal. This is the standing rule that **an
+empty FILTERED read is a claim about the FILTER** — run the unfiltered control before believing
+a zero. Scoped to issue search: the project board's own view filters are a different surface and
+are not measured here.
 
 Then **capture any new finds as issues** (see *Issue-driven → Capture before you build*), and **keep
 going** — don't stop after a few items; work until actionable work is exhausted or blocked (see
@@ -2478,7 +2492,7 @@ dates/iterations only — grouping by `Parent issue` yields flat groups, not nes
 parent is **not documented** to cascade to children in either direction — never assume it does.
 
 **EVERY issue carries an Issue Type — no exceptions** (maintainer direction 2026-07-18). Types are
-org-wide, exactly **one per issue**, filterable as `type:"Bug"`, and they are the structured
+org-wide, exactly **one per issue**, filterable as `type:Bug` (unquoted — see the ladder's warning), and they are the structured
 replacement for type-labels. An untyped issue is an incomplete issue: fix it at triage. Set it at
 creation — `gh issue create --repo devantler-tech/<repo> --type "Feature"` — or retrofit with
 `gh issue edit <N> --repo devantler-tech/<repo> --type "Bug"`. **Always name the repo** (or pass the


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The work-selection ladder told each run to pick up security issues and bugs using a query form that silently returns **nothing**. Measured today: the form written in the contract returns 0 results, while the portfolio actually has 73 open security issues and 269 open bugs. The command succeeds and reports an empty queue, so a run following the instructions skipped both of those priority tiers and looked like it had swept them clean.

### What

Corrects the two ladder rows to the form that works, and records the measurement next to them so the trap is visible rather than rediscovered. A new check fails the build if the broken form ever comes back, or if the evidence behind it is dropped.

The old form is left alone in the places where it names an issue type rather than issuing a query, so the fix is scoped to the rows that are actually executed.

Fixes #2890