### PR TITLE
feat(agents): surface a stale submodule pin before a new work branch is cut

### DIFF
--- a/.claude/scripts/submodule-pin-currency.sh
+++ b/.claude/scripts/submodule-pin-currency.sh
@@ -19,7 +19,8 @@
 #
 #   exit 0  CURRENT   the pin is the tip of the product's default branch
 #   exit 1  BEHIND    the pin is N commits behind; base a new work branch on origin/<branch>
-#   exit 2  UNKNOWN   no verdict produced — never read this as CURRENT
+#   exit 2  UNKNOWN   no verdict produced, or the pin is AHEAD of the branch tip —
+#                     never read either as CURRENT
 set -euo pipefail
 
 usage() {
@@ -73,8 +74,21 @@ super="$(git rev-parse --show-toplevel 2>/dev/null)" ||
 
 # Tracked-submodule check. Without it a plain directory would be compared against its PARENT
 # repository's history, because `git -C <not-a-repo>` silently resolves upward.
-git -C "$super" config -f .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null |
-  awk '{print $2}' | grep -qxF -- "$sub" ||
+#
+# Parsed NUL-delimited, which is the only space-safe form. `--get-regexp` prints
+# `submodule.<name>.path <value>` on one line, and BOTH halves can contain a space — the section
+# name is the submodule's name, not a slug. So a `.gitmodules` entry of `path = my sub` prints
+# `submodule.my sub.path my sub`, where `awk '{print $2}'` yields `sub` and stripping to the first
+# space yields `sub.path my sub`. Either way a legitimate submodule is rejected as untracked, and
+# the run dies naming the wrong cause. With `-z` git emits `key\nvalue\0`, so the value is
+# unambiguous however many spaces it holds.
+found=0
+while IFS= read -r -d '' record; do
+  [ "${record#*$'\n'}" = "$sub" ] || continue
+  found=1
+  break
+done < <(git -C "$super" config -z -f .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null)
+[ "$found" -eq 1 ] ||
   die_unknown "$sub is not a submodule path in .gitmodules"
 
 [ -d "$super/$sub" ] ||
@@ -113,6 +127,12 @@ tip="$(git -C "$subabs" rev-parse FETCH_HEAD 2>/dev/null)" ||
 # The pin must be an object this clone actually has, or the count below is about nothing.
 git -C "$subabs" cat-file -e "${pin}^{commit}" 2>/dev/null ||
   die_unknown "the pinned commit $pin is not present in $sub"
+# Shell-quote a value for the copy-paste command emitted below. The submodule path comes from
+# .gitmodules and is attacker-influenceable in principle; a bare %s would emit a command that does
+# something other than what it appears to when the path carries a space or a metacharacter.
+shq() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
 
 # Order is load-bearing: `<pin>..<tip>` counts commits on the tip that the pin lacks. The reverse
 # reports 0 for a pin that is behind, which is a false CURRENT.
@@ -127,12 +147,28 @@ printf 'pinned gitlink   : %s\n' "$pin"
 printf 'default branch   : origin/%s (%s)\n' "$branch" "$tip"
 
 if [ "$behind" -eq 0 ]; then
-  printf '\nCURRENT — the pin is the tip of origin/%s.\n' "$branch"
-  exit 0
+  # A zero count is NOT the same as "the pin is the tip". `<pin>..<tip>` counts commits reachable
+  # from the tip but not the pin, so it is also zero when the pin is AHEAD of the tip — a gitlink
+  # carrying commits that are not on the default branch. Reporting CURRENT there would state
+  # something false ("the pin is the tip") in the one direction this script exists to prevent:
+  # a confident verdict that sends a run off to build on a tree it has not actually checked.
+  # Only SHA equality establishes CURRENT.
+  if [ "$pin" = "$tip" ]; then
+    printf '\nCURRENT — the pin is the tip of origin/%s.\n' "$branch"
+    exit 0
+  fi
+
+  ahead="$(git -C "$subabs" rev-list --count "${tip}..${pin}" 2>/dev/null)" ||
+    die_unknown "cannot count $tip..$pin in $sub"
+  printf '\nAHEAD — the pin is not behind origin/%s, but it is not that tip either' "$branch"
+  printf ' (%s commit(s) the branch does not carry).\n' "$ahead"
+  printf 'This is a real state to resolve, not a stale pin: the gitlink points at work that is not\n'
+  printf 'on the default branch. Establish why before basing anything on it.\n'
+  exit 2
 fi
 
 printf '\nBEHIND — the pin is %s commit(s) behind origin/%s.\n' "$behind" "$branch"
 printf 'Base a NEW work branch on origin/%s, not on the checked-out pin:\n' "$branch"
-printf '  git -C %s checkout -b <lane>/<area>-<desc>-<issue> %s\n' "$sub" "$tip"
+printf '  git -C %s checkout -b <lane>/<area>-<desc>-<issue> %s\n' "$(shq "$sub")" "$tip"
 printf 'Reading a pinned plugin definition is UNCHANGED and must still use the gitlink.\n'
 exit 1

--- a/.claude/scripts/submodule-pin-currency.sh
+++ b/.claude/scripts/submodule-pin-currency.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Is the submodule gitlink pin still current with the product's own default branch?
+#
+# WHY THIS EXISTS
+# `submodule-init.sh` checks a submodule out at the SUPERPROJECT'S GITLINK PIN, and that is correct
+# behaviour: reading a reviewed plugin definition at a known revision depends on exactly it. But a
+# NEW product work branch cut from whatever that left checked out is based on the pin too — and the
+# pin lags the product's `main` by however long it has been since a bump merged.
+#
+# The failure is silent and expensive. Every local measurement is internally consistent and
+# externally wrong: a scanner genuinely reports findings at the pin, the repository's own scan
+# script agrees because it also runs at the pin, and the build is green — all correct about a tree
+# that is not the one the PR merges into. Nothing surfaces until `mergeStateStatus` resolves DIRTY,
+# by which point a full claim -> build -> validate -> PR cycle has been spent reproducing work that
+# already merged. It degrades exactly when dependency automation is unhealthy, because that is when
+# pins sit still (see #2779).
+#
+# This answers the question BEFORE the work starts, with a fetch and a rev-list.
+#
+#   exit 0  CURRENT   the pin is the tip of the product's default branch
+#   exit 1  BEHIND    the pin is N commits behind; base a new work branch on origin/<branch>
+#   exit 2  UNKNOWN   no verdict produced — never read this as CURRENT
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: submodule-pin-currency.sh <submodule-path> [--branch <name>]
+
+  <submodule-path>  path of a submodule tracked in .gitmodules, relative to the superproject root
+  --branch <name>   default branch to compare against (default: resolved from origin/HEAD, else main)
+USAGE
+}
+
+die_unknown() {
+  printf 'submodule-pin-currency: UNKNOWN — %s\n' "$1" >&2
+  exit 2
+}
+
+sub=""
+branch=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --branch)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      branch="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 2
+      ;;
+    -*)
+      usage
+      exit 2
+      ;;
+    *)
+      [ -z "$sub" ] || { usage; exit 2; }
+      sub="$1"
+      shift
+      ;;
+  esac
+done
+[ -n "$sub" ] || { usage; exit 2; }
+
+# Strip a trailing slash so `platform/` and `platform` name the same submodule.
+sub="${sub%/}"
+
+super="$(git rev-parse --show-toplevel 2>/dev/null)" ||
+  die_unknown "not inside a git working tree"
+
+[ -f "$super/.gitmodules" ] ||
+  die_unknown "no .gitmodules at $super"
+
+# Tracked-submodule check. Without it a plain directory would be compared against its PARENT
+# repository's history, because `git -C <not-a-repo>` silently resolves upward.
+git -C "$super" config -f .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null |
+  awk '{print $2}' | grep -qxF -- "$sub" ||
+  die_unknown "$sub is not a submodule path in .gitmodules"
+
+[ -d "$super/$sub" ] ||
+  die_unknown "$sub is not present on disk — run .claude/scripts/submodule-init.sh $sub first"
+
+# The submodule must be its OWN working tree. An uninitialised path resolves to the superproject,
+# which would then be compared against itself and report a confident, meaningless CURRENT.
+subtop="$(git -C "$super/$sub" rev-parse --show-toplevel 2>/dev/null)" ||
+  die_unknown "$sub is not populated — run .claude/scripts/submodule-init.sh $sub first"
+subabs="$(cd "$super/$sub" && pwd -P)"
+[ "$(cd "$subtop" && pwd -P)" = "$subabs" ] ||
+  die_unknown "$sub is not an isolated working tree (resolves to $subtop) — run .claude/scripts/submodule-init.sh $sub"
+
+# The pin, read from THIS commit. --no-replace-objects so a refs/replace entry cannot make the
+# gitlink resolve through a replacement commit while HEAD still prints the expected value.
+pin="$(git -C "$super" --no-replace-objects rev-parse "HEAD:$sub" 2>/dev/null)" ||
+  die_unknown "cannot resolve the gitlink for $sub at HEAD"
+[ -n "$pin" ] || die_unknown "empty gitlink for $sub"
+
+if [ -z "$branch" ]; then
+  # origin/HEAD when the clone recorded it; otherwise main. Never guessed from local branches,
+  # which say what this checkout happens to hold rather than what the product's default branch is.
+  if head_ref="$(git -C "$subabs" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null)"; then
+    branch="${head_ref#refs/remotes/origin/}"
+  else
+    branch="main"
+  fi
+fi
+
+git -C "$subabs" fetch --quiet origin "$branch" 2>/dev/null ||
+  die_unknown "cannot fetch origin/$branch in $sub"
+
+tip="$(git -C "$subabs" rev-parse FETCH_HEAD 2>/dev/null)" ||
+  die_unknown "cannot resolve origin/$branch in $sub"
+
+# The pin must be an object this clone actually has, or the count below is about nothing.
+git -C "$subabs" cat-file -e "${pin}^{commit}" 2>/dev/null ||
+  die_unknown "the pinned commit $pin is not present in $sub"
+
+# Order is load-bearing: `<pin>..<tip>` counts commits on the tip that the pin lacks. The reverse
+# reports 0 for a pin that is behind, which is a false CURRENT.
+behind="$(git -C "$subabs" rev-list --count "${pin}..${tip}" 2>/dev/null)" ||
+  die_unknown "cannot count $pin..origin/$branch in $sub"
+case "$behind" in
+  '' | *[!0-9]*) die_unknown "non-numeric commit count for $sub" ;;
+esac
+
+printf 'submodule        : %s\n' "$sub"
+printf 'pinned gitlink   : %s\n' "$pin"
+printf 'default branch   : origin/%s (%s)\n' "$branch" "$tip"
+
+if [ "$behind" -eq 0 ]; then
+  printf '\nCURRENT — the pin is the tip of origin/%s.\n' "$branch"
+  exit 0
+fi
+
+printf '\nBEHIND — the pin is %s commit(s) behind origin/%s.\n' "$behind" "$branch"
+printf 'Base a NEW work branch on origin/%s, not on the checked-out pin:\n' "$branch"
+printf '  git -C %s checkout -b <lane>/<area>-<desc>-<issue> %s\n' "$sub" "$tip"
+printf 'Reading a pinned plugin definition is UNCHANGED and must still use the gitlink.\n'
+exit 1

--- a/.claude/scripts/submodule-pin-currency.test.sh
+++ b/.claude/scripts/submodule-pin-currency.test.sh
@@ -224,7 +224,7 @@ expect_match "AHEAD" "the ahead state must be named explicitly, not folded into 
 expect_match "3 commit" "the ahead distance must be reported from <tip>..<pin>"
 expect_no_match "BEHIND" "an ahead pin must never read as BEHIND"
 
-# ------------------------------------------------------ PATH QUOTING (BEHIND) --
+# ------------------------------------------- PATH QUOTING + SPLICE (BEHIND) --
 # The BEHIND verdict emits a copy-paste `git -C <path> checkout -b ...`. The path comes from
 # .gitmodules, so a bare %s emits a command that does something other than it appears to when the
 # path carries a space or a shell metacharacter. Assert the emitted path is quoted.
@@ -248,19 +248,38 @@ mkfixture_spacepath() {
   pin=$(git_q -C "$root/product" rev-list --reverse main | sed -n '2p')
 
   git_q init -q "$root/super"
-  git_q -c protocol.file.allow=always -C "$root/super" submodule -q add "$root/origin.git" 'my sub'
-  git_q -C "$root/super" -c protocol.file.allow=always submodule -q update --init 'my sub'
-  git_q -C "$root/super/my sub" checkout -q "$pin"
-  git_q -C "$root/super" add .gitmodules 'my sub'
+  git_q -c protocol.file.allow=always -C "$root/super" submodule -q add "$root/origin.git" "$SPACED"
+  git_q -C "$root/super" -c protocol.file.allow=always submodule -q update --init "$SPACED"
+  git_q -C "$root/super/$SPACED" checkout -q "$pin"
+  git_q -C "$root/super" add .gitmodules "$SPACED"
   git_q -C "$root/super" commit -q -m "pin spaced sub at $pin"
 
   printf '%s\n' "$root/super"
 }
 
+# A space alone only proves the path was wrapped in quotes. The hard case for a single-quote
+# wrapper is a path containing a SINGLE QUOTE, which must be emitted as the '\''
+# splice — a wrapper that merely adds outer quotes yields a command that no longer parses as the
+# same word. The fixture path therefore carries BOTH a space and a quote.
+SPACED="my 'sub"
 super=$(mkfixture_spacepath)
-run_check "$super" 'my sub'
+run_check "$super" "$SPACED"
 expect_rc 1 "a spaced submodule path must still produce the BEHIND verdict"
-expect_match "git -C 'my sub'" "the emitted command must shell-quote the submodule path"
+expect_match "git -C" "the emitted command must name the branch-from command"
+
+# A space only proves the path was wrapped. The hard case for a single-quote wrapper is a path
+# containing a SINGLE QUOTE, which must be emitted as the `'\''` splice — a wrapper that merely
+# adds outer quotes produces a command that no longer parses, or worse, one that parses as
+# something else. Asserted as a round-trip through the shell rather than as a literal, so the test
+# pins the PROPERTY (the emitted word re-reads as the original path) and not one spelling of it.
+emitted_path=$(printf '%s\n' "$OUT" | sed -n "s/^  git -C \(.*\) checkout -b .*/\1/p")
+asserts=$(( asserts + 1 ))
+if [ -n "$emitted_path" ] && [ "$(eval "printf '%s' $emitted_path")" = "$SPACED" ]; then
+  :
+else
+  fails=$(( fails + 1 ))
+  echo "FAIL: the emitted path must re-read as the original through the shell (got [$emitted_path])"
+fi
 
 # ------------------------------------------------------------------ report --
 if [ "$fails" -ne 0 ]; then

--- a/.claude/scripts/submodule-pin-currency.test.sh
+++ b/.claude/scripts/submodule-pin-currency.test.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# submodule-pin-currency.test.sh — RED/GREEN coverage for the submodule pin currency pre-flight.
+#
+# The defect this guards against is a FALSE CURRENT: a check that reports the pin is up to date when
+# it is not sends a run off to build against a stale tree, which is the exact failure the script
+# exists to prevent (#2891). So the assertions are weighted toward the two ways a false CURRENT can
+# be manufactured — comparing the revision range in the wrong order, and resolving an uninitialised
+# submodule to its PARENT repository — rather than toward the happy path.
+#
+# Fixtures are real git repositories built in a scratch dir: a submodule with its own history, a
+# bare "origin" for it to fetch from, and a superproject pinning a chosen commit. Nothing depends on
+# the network, the surrounding checkout, or wall-clock time.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT="$SCRIPT_DIR/submodule-pin-currency.sh"
+[ -f "$SCRIPT" ] || { echo "FAIL: script not found at $SCRIPT" >&2; exit 1; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+fails=0
+asserts=0
+note_fail() { echo "FAIL: $1" >&2; fails=$(( fails + 1 )); }
+
+git_q() { git -c init.defaultBranch=main -c user.name=t -c user.email=t@e -c commit.gpgsign=false "$@"; }
+
+# Build: an upstream product repo with <n> commits, a bare origin, and a superproject whose gitlink
+# pins commit <pin_index> (1-based). Returns the superproject path on stdout.
+# mkfixture <name> <n_commits> <pin_index>
+mkfixture() {
+  local name=$1 n=$2 pin_index=$3
+  local root="$TMP/$name"
+  mkdir -p "$root"
+
+  git_q init -q "$root/product"
+  local i
+  for i in $(seq 1 "$n"); do
+    echo "commit $i" >"$root/product/file.txt"
+    git_q -C "$root/product" add file.txt
+    git_q -C "$root/product" commit -q -m "c$i"
+  done
+
+  git_q init -q --bare "$root/origin.git"
+  git_q -C "$root/product" remote add origin "$root/origin.git"
+  git_q -C "$root/product" push -q origin main
+
+  local pin
+  pin=$(git_q -C "$root/product" rev-list --reverse main | sed -n "${pin_index}p")
+
+  git_q init -q "$root/super"
+  # `protocol.file.allow` — git refuses local-path submodules by default (CVE-2022-39253).
+  git_q -c protocol.file.allow=always -C "$root/super" submodule -q add "$root/origin.git" sub
+  git_q -C "$root/super" -c protocol.file.allow=always submodule -q update --init sub
+  git_q -C "$root/super/sub" checkout -q "$pin"
+  git_q -C "$root/super" add .gitmodules sub
+  git_q -C "$root/super" commit -q -m "pin sub at $pin"
+
+  printf '%s\n' "$root/super"
+}
+
+# run_check <cwd> [args...] -> sets OUT and RC
+run_check() {
+  local cwd=$1; shift
+  set +e
+  OUT=$(cd "$cwd" && "$SCRIPT" "$@" 2>&1)
+  RC=$?
+  set -e
+}
+
+expect_rc() {
+  asserts=$(( asserts + 1 ))
+  [ "$RC" = "$1" ] || note_fail "$2 (expected exit $1, got $RC)
+--- output ---
+$OUT"
+}
+
+expect_match() {
+  asserts=$(( asserts + 1 ))
+  printf '%s' "$OUT" | grep -q -- "$1" || note_fail "$2 (output lacks '$1')
+--- output ---
+$OUT"
+}
+
+expect_no_match() {
+  asserts=$(( asserts + 1 ))
+  printf '%s' "$OUT" | grep -q -- "$1" && note_fail "$2 (output wrongly contains '$1')
+--- output ---
+$OUT"
+  return 0
+}
+
+# ------------------------------------------------------------------ BEHIND --
+# The case that motivated the script: the pin is real, the submodule is healthy, and the product has
+# simply moved on. Anything other than exit 1 here means a run would build on the stale tree.
+super=$(mkfixture behind 5 2)
+run_check "$super" sub
+expect_rc 1 "a pin 3 commits behind must exit 1"
+expect_match "BEHIND" "the behind verdict must be named"
+expect_match "3 commit" "the exact distance must be reported"
+expect_no_match "CURRENT" "a behind pin must never print CURRENT"
+
+# The remedy has to be actionable, or the check is a nag: it must name the tip to branch from.
+tip=$(git_q -C "$super/sub" rev-parse FETCH_HEAD)
+expect_match "$tip" "the branch-from revision must be printed"
+# ...and it must NOT tell the reader to change how pinned definitions are read.
+expect_match "UNCHANGED" "the plugin-definition carve-out must be restated"
+
+# ----------------------------------------------------------------- CURRENT --
+# The complementary half. A guard that fires on a current pin would be turned off within a week.
+super=$(mkfixture current 4 4)
+run_check "$super" sub
+expect_rc 0 "a pin at the tip must exit 0"
+expect_match "CURRENT" "the current verdict must be named"
+expect_no_match "BEHIND" "a current pin must never print BEHIND"
+
+# A one-commit lag is still a lag — the boundary, where an off-by-one would hide a real drift.
+super=$(mkfixture boundary 4 3)
+run_check "$super" sub
+expect_rc 1 "a pin 1 commit behind must exit 1"
+expect_match "1 commit" "the single-commit distance must be reported"
+
+# ------------------------------------------------- ORDER-OF-RANGE REGRESSION --
+# `rev-list --count <tip>..<pin>` is 0 for a pin that is behind, so the reversed range yields a
+# confident false CURRENT. This asserts the script does not merely exit non-zero, but reports the
+# distance the CORRECT order produces — a reversed implementation would print 0 and exit 0 above.
+super=$(mkfixture order 6 1)
+run_check "$super" sub
+expect_rc 1 "a pin 5 commits behind must exit 1"
+expect_match "5 commit" "the distance must come from <pin>..<tip>, not the reverse"
+
+# -------------------------------------------------------- UNPOPULATED SUBMODULE --
+# The parent-resolution trap: `git -C <uninitialised path>` resolves UPWARD to the superproject, so
+# a naive check compares the superproject against itself and reports CURRENT. Nothing has been
+# verified in that case, so the only safe verdict is UNKNOWN.
+super=$(mkfixture empty 4 2)
+rm -rf "${super:?}/sub"
+mkdir -p "$super/sub"
+run_check "$super" sub
+expect_rc 2 "an unpopulated submodule must exit 2"
+expect_match "UNKNOWN" "the unknown verdict must be named"
+# `expect_rc 2` alone cannot pin THIS check: with the isolation test removed the run still
+# exits 2, because the later fetch fails inside the superproject it wrongly resolved to. The
+# reason is therefore the assertion — it is what distinguishes the guard from its shadow.
+expect_match "isolated working tree" "the parent-resolution trap must be named specifically"
+expect_no_match "CURRENT" "an unpopulated submodule must never read as CURRENT"
+
+# ------------------------------------------------------------------ UNKNOWN --
+# A path that is not a tracked submodule at all. Same reasoning: no verdict is possible.
+super=$(mkfixture untracked 3 2)
+mkdir -p "$super/not-a-sub"
+run_check "$super" not-a-sub
+expect_rc 2 "a non-submodule path must exit 2"
+# Same over-determination as the unpopulated case: with this check removed the isolation test
+# downstream also yields 2, so only the reason distinguishes them.
+expect_match "not a submodule path" "the tracked-submodule check must be named specifically"
+expect_no_match "CURRENT" "a non-submodule path must never read as CURRENT"
+
+# Usage errors are UNKNOWN too, never a pass.
+run_check "$super"
+expect_rc 2 "no argument must exit 2"
+run_check "$super" sub --branch
+expect_rc 2 "a --branch with no value must exit 2"
+
+# A trailing slash names the same submodule — a path copied from shell completion must not be
+# reported as untracked.
+super=$(mkfixture slash 4 4)
+run_check "$super" sub/
+expect_rc 0 "a trailing slash must resolve to the same submodule"
+
+# An explicit --branch that does not exist cannot be fetched: UNKNOWN, never CURRENT.
+run_check "$super" sub --branch no-such-branch
+expect_rc 2 "an unfetchable branch must exit 2"
+expect_no_match "CURRENT" "an unfetchable branch must never read as CURRENT"
+
+# ------------------------------------------------------------------ report --
+if [ "$fails" -ne 0 ]; then
+  echo "submodule-pin-currency.test.sh: $fails failure(s) across $asserts assertion(s)" >&2
+  exit 1
+fi
+echo "submodule-pin-currency.test.sh: all $asserts assertion(s) passed"

--- a/.claude/scripts/submodule-pin-currency.test.sh
+++ b/.claude/scripts/submodule-pin-currency.test.sh
@@ -174,6 +174,94 @@ run_check "$super" sub --branch no-such-branch
 expect_rc 2 "an unfetchable branch must exit 2"
 expect_no_match "CURRENT" "an unfetchable branch must never read as CURRENT"
 
+# -------------------------------------------------------------------- AHEAD --
+# The third way to manufacture a false CURRENT, and the one a commit COUNT cannot see.
+# `<pin>..<tip>` counts commits reachable from the tip but not the pin, so it is zero when the pin
+# is the tip AND when the pin is AHEAD of it. Testing `behind -eq 0` alone therefore prints
+# "CURRENT — the pin is the tip", which is simply false for an ahead pin: the gitlink carries work
+# that is not on the default branch. Only SHA equality establishes CURRENT.
+# mkfixture_ahead <name> <n_commits> <pushed_index> — origin/main stops at <pushed_index>, the
+# superproject pins the final commit, so the pin leads the branch.
+mkfixture_ahead() {
+  local name=$1 n=$2 pushed=$3
+  local root="$TMP/$name"
+  mkdir -p "$root"
+
+  git_q init -q "$root/product"
+  local i
+  for i in $(seq 1 "$n"); do
+    echo "commit $i" >"$root/product/file.txt"
+    git_q -C "$root/product" add file.txt
+    git_q -C "$root/product" commit -q -m "c$i"
+  done
+
+  git_q init -q --bare "$root/origin.git"
+  git_q -C "$root/product" remote add origin "$root/origin.git"
+
+  # Publish only the first <pushed> commits as the branch; the rest stay local and become the pin.
+  local pushed_sha pin
+  pushed_sha=$(git_q -C "$root/product" rev-list --reverse main | sed -n "${pushed}p")
+  git_q -C "$root/product" push -q origin "${pushed_sha}:refs/heads/main"
+  pin=$(git_q -C "$root/product" rev-parse main)
+
+  git_q init -q "$root/super"
+  git_q -c protocol.file.allow=always -C "$root/super" submodule -q add "$root/origin.git" sub
+  git_q -C "$root/super" -c protocol.file.allow=always submodule -q update --init sub
+  # Fetch the unpublished commits into the submodule clone so the gitlink can name one.
+  git_q -C "$root/super/sub" fetch -q "$root/product" main
+  git_q -C "$root/super/sub" checkout -q "$pin"
+  git_q -C "$root/super" add .gitmodules sub
+  git_q -C "$root/super" commit -q -m "pin sub ahead at $pin"
+
+  printf '%s\n' "$root/super"
+}
+
+super=$(mkfixture_ahead ahead 5 2)
+run_check "$super" sub
+expect_no_match "CURRENT" "a pin AHEAD of the branch tip must never read as CURRENT"
+expect_rc 2 "an ahead pin has no CURRENT/BEHIND verdict and must exit 2"
+expect_match "AHEAD" "the ahead state must be named explicitly, not folded into UNKNOWN"
+expect_match "3 commit" "the ahead distance must be reported from <tip>..<pin>"
+expect_no_match "BEHIND" "an ahead pin must never read as BEHIND"
+
+# ------------------------------------------------------ PATH QUOTING (BEHIND) --
+# The BEHIND verdict emits a copy-paste `git -C <path> checkout -b ...`. The path comes from
+# .gitmodules, so a bare %s emits a command that does something other than it appears to when the
+# path carries a space or a shell metacharacter. Assert the emitted path is quoted.
+mkfixture_spacepath() {
+  local root="$TMP/spacepath"
+  mkdir -p "$root"
+
+  git_q init -q "$root/product"
+  local i
+  for i in $(seq 1 4); do
+    echo "commit $i" >"$root/product/file.txt"
+    git_q -C "$root/product" add file.txt
+    git_q -C "$root/product" commit -q -m "c$i"
+  done
+
+  git_q init -q --bare "$root/origin.git"
+  git_q -C "$root/product" remote add origin "$root/origin.git"
+  git_q -C "$root/product" push -q origin main
+
+  local pin
+  pin=$(git_q -C "$root/product" rev-list --reverse main | sed -n '2p')
+
+  git_q init -q "$root/super"
+  git_q -c protocol.file.allow=always -C "$root/super" submodule -q add "$root/origin.git" 'my sub'
+  git_q -C "$root/super" -c protocol.file.allow=always submodule -q update --init 'my sub'
+  git_q -C "$root/super/my sub" checkout -q "$pin"
+  git_q -C "$root/super" add .gitmodules 'my sub'
+  git_q -C "$root/super" commit -q -m "pin spaced sub at $pin"
+
+  printf '%s\n' "$root/super"
+}
+
+super=$(mkfixture_spacepath)
+run_check "$super" 'my sub'
+expect_rc 1 "a spaced submodule path must still produce the BEHIND verdict"
+expect_match "git -C 'my sub'" "the emitted command must shell-quote the submodule path"
+
 # ------------------------------------------------------------------ report --
 if [ "$fails" -ne 0 ]; then
   echo "submodule-pin-currency.test.sh: $fails failure(s) across $asserts assertion(s)" >&2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
       branch-cleanup: ${{ steps.filter.outputs.branch-cleanup }}
       worktree-cleanup: ${{ steps.filter.outputs.worktree-cleanup }}
       submodule-init: ${{ steps.filter.outputs.submodule-init }}
+      submodule-pin-currency: ${{ steps.filter.outputs.submodule-pin-currency }}
       maintainer-preflight: ${{ steps.filter.outputs.maintainer-preflight }}
       self-review-contract: ${{ steps.filter.outputs.self-review-contract }}
       review-provider-loop-contract: ${{ steps.filter.outputs.review-provider-loop-contract }}
@@ -126,6 +127,11 @@ jobs:
             submodule-init:
               - '.claude/scripts/submodule-init.sh'
               - '.claude/scripts/submodule-init.test.sh'
+            submodule-pin-currency:
+              - 'AGENTS.md'
+              - '.claude/scripts/submodule-pin-currency.sh'
+              - '.claude/scripts/submodule-pin-currency.test.sh'
+              - '.github/workflows/ci.yaml'
             memory-hygiene:
               - 'AGENTS.md'
               - '.claude/scripts/memory-hygiene.sh'
@@ -635,6 +641,28 @@ jobs:
       # guard resolves worktree paths with `pwd -P` (macOS /private/tmp symlinks).
       - name: Self-test the submodule-init isolation guard
         run: bash .claude/scripts/submodule-init.test.sh
+
+  test-submodule-pin-currency:
+    name: Test submodule pin currency
+    needs: changes
+    if: needs.changes.outputs.submodule-pin-currency == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # Throwaway git fixtures only (file:// remotes, hermetic config) — no network and no real
+      # submodule touched. Both OSes because the check compares resolved worktree paths with
+      # `pwd -P`, which differs under macOS /private/tmp symlinks.
+      - name: Verify the submodule pin currency check
+        run: bash .claude/scripts/submodule-pin-currency.test.sh
 
   test-pipefail-grep-guard:
     name: Test pipefail grep guard
@@ -1151,6 +1179,7 @@ jobs:
       - test-branch-cleanup
       - test-worktree-cleanup
       - test-submodule-init
+      - test-submodule-pin-currency
       - test-pipefail-grep-guard
       - test-maintainer-preflight
       - test-memory-hygiene
@@ -1194,6 +1223,7 @@ jobs:
             ${{ needs.test-branch-cleanup.result }}
             ${{ needs.test-worktree-cleanup.result }}
             ${{ needs.test-submodule-init.result }}
+            ${{ needs.test-submodule-pin-currency.result }}
             ${{ needs.test-pipefail-grep-guard.result }}
             ${{ needs.test-maintainer-preflight.result }}
             ${{ needs.test-memory-hygiene.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3377,6 +3377,39 @@ verified per-submodule fix are in
 [`.claude/worktree-isolation.md`](.claude/worktree-isolation.md). If a repo's working area is
 unexpectedly dirty or you can't get an isolated tree, do GitHub-API-only work (triage/comment) there.
 
+🔴 **`submodule-init.sh` leaves you on the GITLINK PIN, so a NEW product work branch cut from it is
+based on the pin — not on the product's `main`.** That is correct behaviour for the helper, and the
+plugin-definition rules depend on it: reading a reviewed definition **at the pinned revision** is the
+whole point there, and it is **unchanged**. But a *product* work branch wants the product's current
+tip, and the pin lags it by however long it has been since a bump merged.
+
+**The failure is silent, and every local measurement agrees with itself.** Measured 2026-08-18: a run
+selected the oldest open Security issue, cut a branch from the pin, fixed a `checkov` finding, and
+drove it to a draft PR with RED/GREEN, a negative control and a build — for work that had **merged
+nine hours earlier**. The pin was 6 commits behind and one of those six was the fix. `checkov`
+genuinely reported the finding at the pin, and the repository's own scan script agreed **because it
+also ran at the pin**. Nothing in the scan, the controls, or the build could have revealed it: they
+were all correct about a tree that is not the one the PR merges into. The only signal was
+`mergeStateStatus: DIRTY`, after the whole claim → build → validate → PR cycle was spent
+([#2891](https://github.com/devantler-tech/monorepo/issues/2891)).
+
+⚠️ **It degrades exactly when dependency automation is unhealthy** — pins move by bump PRs, so a
+stalled ecosystem ([#2779](https://github.com/devantler-tech/monorepo/issues/2779) records six days)
+freezes every pin and widens this for every submodule at once.
+
+So **before building a new slice in a submodule, ask how stale the pin is** — a fetch and a
+`rev-list`, seconds:
+
+```sh
+.claude/scripts/submodule-pin-currency.sh <path>   # 0 CURRENT · 1 BEHIND (prints the tip to branch from) · 2 UNKNOWN
+```
+
+On `BEHIND`, base the new branch on the product's own default branch rather than the checked-out pin
+(the script prints the exact revision). ⚠️ **`2` is UNCHECKED, never CURRENT** — report it and resolve
+what it names rather than proceeding as if the pin were fresh. This is about **new work branches
+only**: an existing branch is landed on its own `headRefOid` per *Git safety*, and a pinned definition
+is still read at the gitlink.
+
 ### Git safety
 Never `git reset --hard`, `git stash`, force-push, or discard changes you did not author. Never
 `git add -A` / `git add .` — stage only files you edited. Never stage submodule-pointer bumps unless


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

A run that starts new work inside a submodule can silently build against a tree that is weeks old,
and nothing tells it until the very end.

On 2026-08-18 a run picked the oldest open Security issue, fixed the finding, and drove it to a full
draft PR with tests and controls — for work that had already merged nine hours earlier. Every
measurement it made was correct, and all of them were about the wrong tree. The only signal came
when the PR turned up conflicting, after the whole cycle had been spent.

It gets worse when dependency automation stalls, because that is exactly when these pointers stop
moving.

### What

Adds a seconds-long check that answers "how stale is this product's pointer?" before work starts,
and says plainly in the engineering contract what a new work branch should be based on.

Reading a reviewed agent definition still uses the pinned pointer deliberately — that path is called
out as unchanged, so the two cases cannot be confused.

Fixes #2891