### PR TITLE
docs(agents): settle whether a lane outage's cause may be named publicly

### DIFF
--- a/.claude/scripts/lane-outage-disclosure-contract.test.sh
+++ b/.claude/scripts/lane-outage-disclosure-contract.test.sh
@@ -89,7 +89,7 @@ privacy="$(extract_section '### Sensitive information stays private' '### Local 
 # assert real content was captured before testing it.
 [ "${#privacy}" -gt 400 ] || fail "privacy section captured only ${#privacy} chars — extraction is broken"
 
-assert_contains "${privacy}" 'Provider and account posture' \
+assert_contains "${privacy}" 'provider and account posture' \
   'the doctrine must state that provider/account posture is governed by this rule'
 
 for cls in 'quota/billing' 'credentials/auth' 'runtime/config'; do
@@ -111,7 +111,7 @@ assert_contains "${privacy}" 'across vendors' \
 # tightening and every blocker line becomes under-specified for skip clause (b).
 assert_contains "${privacy}" 'never withheld' \
   'the doctrine must state that a cause CLASS is never withheld'
-assert_contains "${privacy}" 'skip clause (b)' \
+assert_contains "${privacy}" 'under-specified for **skip clause (b)**' \
   'the doctrine must tie the publishable class back to the blocker-line requirement'
 
 # ---------------------------------------------------------------------------

--- a/.claude/scripts/lane-outage-disclosure-contract.test.sh
+++ b/.claude/scripts/lane-outage-disclosure-contract.test.sh
@@ -107,6 +107,7 @@ assert_contains "${privacy}" 'agent-actionable or maintainer-only' \
   'remediation ownership must stay publishable — it decides escalate vs act'
 assert_contains "${privacy}" 'last-verified <date>: <result>' \
   'the blocker line verification record must stay publishable'
+
 # The private side. Each is a distinct disclosure, so each is pinned separately — a single
 # catch-all phrase could be narrowed later without any assertion noticing.
 assert_contains "${privacy}" 'reset or retry timestamps' \

--- a/.claude/scripts/lane-outage-disclosure-contract.test.sh
+++ b/.claude/scripts/lane-outage-disclosure-contract.test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# Guards the disclosure rule for a lane / provider outage's CAUSE.
+#
+# Why this needs a guard. Two parts of the definition answered one question in opposite directions,
+# and the deployment did both:
+#
+#   - `codex-lane-liveness.sh` treats "billing, credentials, account posture" as private runtime
+#     state it "must not be able to carry into a repository artifact or a run report".
+#   - *Issue-driven → Drain oldest-first* skip clause (b) REQUIRES a public `**Blocker:**` line
+#     naming the blocker and its last-verified result, and calls a merely-prose note
+#     under-specified. `devantler-tech/monorepo` is public, so that record is a public artifact.
+#
+# Measured 2026-08-18: an open blocked issue in this repo carried provider account posture — a
+# cross-vendor exhaustion correlation and an exact reset timestamp — while the check that detects
+# the same condition was forbidden from reading its cause at all.
+#
+# The resolution splits by GRANULARITY, as *Sensitive information stays private* already does for a
+# security finding: the bounded cause CLASS is publishable, the supporting DETAIL is not. Both
+# halves need pinning, and the second is the one a well-meaning tightening would delete:
+#
+#   1. the detail list must stay private, and
+#   2. the cause class must stay PUBLISHABLE — resolving the contradiction by making everything
+#      private would silently break every blocker line, which is the failure mode clause (b) exists
+#      to prevent. A guard on half of a two-sided rule invites exactly the wrong repair.
+#
+# Assertions are scoped to their own section rather than the whole file: an unrelated section
+# carrying a phrase would otherwise satisfy the check while the real passage stayed wrong.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+constitution="${repo_root}/AGENTS.md"
+
+fail() {
+  echo "lane-outage-disclosure contract: FAIL — $*" >&2
+  exit 1
+}
+
+[ -r "${constitution}" ] || fail "cannot read ${constitution}"
+
+# Extract one section and flatten it. Sentences wrap across source lines, so a fragment spanning a
+# line break would never match and the test would be always-red regardless of content. A sentinel
+# marks that the END anchor was actually seen, so a missing anchor is detected DIRECTLY instead of
+# being inferred from how much text got captured — an unanchored capture would otherwise run to EOF
+# and match fragments belonging to entirely different sections.
+#
+# Anchors are matched as LITERAL line PREFIXES via index(), never as regexes. `awk -v` applies its
+# own escape processing to a variable's value, so a regex anchor containing `\[` or `\.` arrives
+# mangled and silently matches nothing — which is exactly how this test first failed against a file
+# that already contained the text it was looking for.
+extract_section() {
+  start_lit="$1"
+  end_lit="$2"
+  sentinel='@@END-ANCHOR-SEEN@@'
+
+  raw="$(
+    awk -v s="${sentinel}" -v st="${start_lit}" -v en="${end_lit}" '
+      index($0, st) == 1 { ins = 1 }
+      ins && seen_first && index($0, en) == 1 { ins = 0; print s }
+      ins { seen_first = 1; print }
+    ' "${constitution}"
+  )"
+
+  case "${raw}" in
+    *"${sentinel}"*) ;;
+    *) fail "could not locate section bounded by '${start_lit}' … '${end_lit}' (end anchor never seen)" ;;
+  esac
+
+  # `sed` rather than `grep -v`: grep exits 1 when it emits no lines, and under `set -e` +
+  # `pipefail` that would abort mid-assignment, killing the test instead of reaching a real failure.
+  printf '%s\n' "${raw}" | sed "/^${sentinel}\$/d" | tr '\n' ' ' | tr -s '[:space:]' ' '
+}
+
+assert_contains() {
+  haystack="$1"; needle="$2"; label="$3"
+  case "${haystack}" in
+    *"${needle}"*) ;;
+    *) fail "${label} — expected to find: ${needle}" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# 1. The doctrine itself, inside *Sensitive information stays private*.
+# ---------------------------------------------------------------------------
+privacy="$(extract_section '### Sensitive information stays private' '### Local agent host')"
+
+# A flattened empty capture becomes a single space, which would silently satisfy nothing below;
+# assert real content was captured before testing it.
+[ "${#privacy}" -gt 400 ] || fail "privacy section captured only ${#privacy} chars — extraction is broken"
+
+assert_contains "${privacy}" 'Provider and account posture' \
+  'the doctrine must state that provider/account posture is governed by this rule'
+
+for cls in 'quota/billing' 'credentials/auth' 'runtime/config'; do
+  assert_contains "${privacy}" "${cls}" "the publishable cause classes must be enumerated (${cls})"
+done
+
+# The private side. Each is a distinct disclosure, so each is pinned separately — a single
+# catch-all phrase could be narrowed later without any assertion noticing.
+assert_contains "${privacy}" 'reset or retry timestamps' \
+  'exact reset/retry timestamps must be named as private'
+assert_contains "${privacy}" 'credit, or balance figures' \
+  'quota/credit/balance figures must be named as private'
+assert_contains "${privacy}" 'subscription identity' \
+  'plan/tier/subscription identity must be named as private'
+assert_contains "${privacy}" 'across vendors' \
+  'cross-vendor correlation of posture must be named as private'
+
+# The other half of the two-sided rule. Without this, "make it all private" reads as a valid
+# tightening and every blocker line becomes under-specified for skip clause (b).
+assert_contains "${privacy}" 'never withheld' \
+  'the doctrine must state that a cause CLASS is never withheld'
+assert_contains "${privacy}" 'skip clause (b)' \
+  'the doctrine must tie the publishable class back to the blocker-line requirement'
+
+# ---------------------------------------------------------------------------
+# 2. The liveness clause must no longer read as forbidding what the doctrine permits,
+#    while its factual description of the script stays accurate.
+# ---------------------------------------------------------------------------
+liveness="$(extract_section 'Run [`.claude/scripts/codex-lane-liveness.sh`]' \
+                            'The deployed Cursor Automation has no supported local write surface')"
+
+[ "${#liveness}" -gt 200 ] || fail "liveness paragraph captured only ${#liveness} chars — extraction is broken"
+
+# The factual description is TRUE of the script as it stands and must not be quietly dropped:
+# deleting it would let a later reader assume the check already reports a cause.
+assert_contains "${liveness}" 'reads only timings and an inbox-presence flag' \
+  'the accurate description of what the script reads must survive'
+
+assert_contains "${liveness}" 'defence in depth' \
+  'the clause must say its narrowness is defence in depth, not a bar on naming the cause'
+
+assert_contains "${liveness}" 'codex_error_info' \
+  'the clause must name the per-turn field that carries the cause, so a NOT-PRODUCING verdict is not re-diagnosed by hand each time'
+
+echo "lane-outage-disclosure contract: PASS"

--- a/.claude/scripts/lane-outage-disclosure-contract.test.sh
+++ b/.claude/scripts/lane-outage-disclosure-contract.test.sh
@@ -92,10 +92,21 @@ privacy="$(extract_section '### Sensitive information stays private' '### Local 
 assert_contains "${privacy}" 'provider and account posture' \
   'the doctrine must state that provider/account posture is governed by this rule'
 
-for cls in 'quota/billing' 'credentials/auth' 'runtime/config'; do
+# Backticked so each match is unambiguous: bare `unknown` could be satisfied by a future sentence,
+# and an assertion a passing sentence satisfies by accident guards nothing.
+for cls in '`quota/billing`' '`credentials/auth`' '`runtime/config`' '`unknown`'; do
   assert_contains "${privacy}" "${cls}" "the publishable cause classes must be enumerated (${cls})"
 done
 
+# The remaining publishable rows. Without these the table's LEFT column could be emptied row by row —
+# reaching the same "make it all private" end state the two-sided assertions below guard against, but
+# by deleting rows rather than by deleting the rule, so those assertions would not notice.
+assert_contains "${privacy}" 'named lane or provider is degraded' \
+  'the degraded lane/provider fact must stay publishable'
+assert_contains "${privacy}" 'agent-actionable or maintainer-only' \
+  'remediation ownership must stay publishable — it decides escalate vs act'
+assert_contains "${privacy}" 'last-verified <date>: <result>' \
+  'the blocker line verification record must stay publishable'
 # The private side. Each is a distinct disclosure, so each is pinned separately — a single
 # catch-all phrase could be narrowed later without any assertion noticing.
 assert_contains "${privacy}" 'reset or retry timestamps' \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
       one-verb-per-bash-call-contract: ${{ steps.filter.outputs.one-verb-per-bash-call-contract }}
       bash-call-timeout-budget-contract: ${{ steps.filter.outputs.bash-call-timeout-budget-contract }}
       codex-dispatch-supersession-contract: ${{ steps.filter.outputs.codex-dispatch-supersession-contract }}
+      lane-outage-disclosure-contract: ${{ steps.filter.outputs.lane-outage-disclosure-contract }}
       git-safety-contract: ${{ steps.filter.outputs.git-safety-contract }}
       rung-type-filter-contract: ${{ steps.filter.outputs.rung-type-filter-contract }}
       plugin-definition-currency: ${{ steps.filter.outputs.plugin-definition-currency }}
@@ -258,6 +259,10 @@ jobs:
             codex-dispatch-supersession-contract:
               - 'AGENTS.md'
               - '.claude/scripts/codex-dispatch-supersession-contract.test.sh'
+              - '.github/workflows/ci.yaml'
+            lane-outage-disclosure-contract:
+              - 'AGENTS.md'
+              - '.claude/scripts/lane-outage-disclosure-contract.test.sh'
               - '.github/workflows/ci.yaml'
             git-safety-contract:
               - 'AGENTS.md'
@@ -1032,6 +1037,21 @@ jobs:
       - name: Verify the codex dispatch supersession contract
         run: bash .claude/scripts/codex-dispatch-supersession-contract.test.sh
 
+  test-lane-outage-disclosure-contract:
+    name: Test lane outage disclosure contract
+    needs: changes
+    if: needs.changes.outputs.lane-outage-disclosure-contract == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify the lane outage disclosure contract
+        run: bash .claude/scripts/lane-outage-disclosure-contract.test.sh
+
   test-git-safety-contract:
     name: Test git safety contract
     needs: changes
@@ -1232,6 +1252,7 @@ jobs:
       - test-one-verb-per-bash-call-contract
       - test-bash-call-timeout-budget-contract
       - test-codex-dispatch-supersession-contract
+      - test-lane-outage-disclosure-contract
       - test-git-safety-contract
       - test-rung-type-filter-contract
       - test-plugin-definition-currency
@@ -1278,6 +1299,7 @@ jobs:
             ${{ needs.test-one-verb-per-bash-call-contract.result }}
             ${{ needs.test-bash-call-timeout-budget-contract.result }}
             ${{ needs.test-codex-dispatch-supersession-contract.result }}
+            ${{ needs.test-lane-outage-disclosure-contract.result }}
             ${{ needs.test-git-safety-contract.result }}
             ${{ needs.test-rung-type-filter-contract.result }}
             ${{ needs.test-plugin-definition-currency.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3291,8 +3291,7 @@ not a public tracking epic. If you are unsure whether something is safe to publi
 sensitive and keep it private. *(Maintainer
 direction 2026-07-11: "We generally do not want to share sensitive information publicly.")*
 
-
-**Provider and account posture is this same rule's third case — and the one where the deployment
+**This rule extends to provider and account posture — the case where the deployment
 contradicted itself.** A lane, review provider, or other vendor dependency that stops serving must be
 reported through the mandated `**Blocker:**` line (*Issue-driven → Drain oldest-first*, skip clause
 (b)), which on a public repository is a **public** artifact — while
@@ -3309,9 +3308,11 @@ half of it, so the split is by **granularity**, exactly as it already is for a s
 | | correlation of posture **across vendors** |
 
 The right-hand column is what turns an outage note into a map of the deployment's dependencies and
-their failure windows. The bare fact that a lane is down is not the disclosure that matters here — a
-published *availability window* is: it names the interval during which review independence is
-degraded and scrutiny on incoming changes is weakest.
+their failure windows. Note which half of the window each column holds: *degraded since* is
+publishable because triage needs to know whether a blocker is current or stale, and it says nothing
+about when the gap closes. A *reset or retry time* is the other half, and it is the sensitive one —
+it advertises in advance exactly how long review independence stays degraded and scrutiny on
+incoming changes stays weakest.
 
 🔴 **A cause CLASS is never withheld to satisfy this, and "make it all private" is NOT a valid
 tightening.** An issue whose blocker cannot be named at all is under-specified for **skip clause (b)**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -594,6 +594,15 @@ inbox-item presence — the discriminators that actually separate the two states
 768–24,428 s with an inbox item, against 4-second stubs with none) — and exits `0` producing, `1` not
 producing, `2` **UNKNOWN**. It reads only timings and an inbox-presence flag, never a run's error
 payload, so it stays generic across causes and cannot carry private runtime state into an artifact.
+⚠️ **That narrowness is defence in depth, NOT a claim that the cause may never be named.**
+*Sensitive information stays private* governs what may be published, and it permits — and the
+`**Blocker:**` line requires — the bounded **cause class**. So diagnose a `1` from the runtime's own
+per-turn outcome record rather than the scheduler's: each rollout's `task_complete` event carries a
+`codex_error_info` classifier naming the cause (`usage_limit_exceeded`, …) beside the operator-facing
+message. That classifier is ground truth, where duration-plus-inbox-presence is only a proxy and
+cannot separate a short *healthy* run from a stub — a start time derived from the proxy was measured
+wrong by ~2.7 hours. Report at **class** granularity; the message beside it carries reset times and
+account detail that stay in the private operator notes.
 A `1` is reported and its cause pursued; it is never a run-stopper, and the remedy may lie outside
 agent authority.
 
@@ -3281,6 +3290,34 @@ sensitive detail. Drive fixes through
 not a public tracking epic. If you are unsure whether something is safe to publish, treat it as
 sensitive and keep it private. *(Maintainer
 direction 2026-07-11: "We generally do not want to share sensitive information publicly.")*
+
+
+**Provider and account posture is this same rule's third case — and the one where the deployment
+contradicted itself.** A lane, review provider, or other vendor dependency that stops serving must be
+reported through the mandated `**Blocker:**` line (*Issue-driven → Drain oldest-first*, skip clause
+(b)), which on a public repository is a **public** artifact — while
+[`codex-lane-liveness.sh`](.claude/scripts/codex-lane-liveness.sh) treats "billing, credentials,
+account posture" as private runtime state it must never carry into an artifact. Each is right about
+half of it, so the split is by **granularity**, exactly as it already is for a security finding:
+
+| Publishable — this is what triage acts on | Private operator notes only |
+|---|---|
+| the **cause class**: `quota/billing`, `credentials/auth`, `runtime/config`, `unknown` | exact reset or retry timestamps |
+| that a named lane or provider is degraded, and since when | quota, credit, or balance figures |
+| whether the remedy is **agent-actionable or maintainer-only** | plan, tier, or subscription identity |
+| the `last-verified <date>: <result>` the blocker line requires | account, organisation, or billing identifiers |
+| | correlation of posture **across vendors** |
+
+The right-hand column is what turns an outage note into a map of the deployment's dependencies and
+their failure windows. The bare fact that a lane is down is not the disclosure that matters here — a
+published *availability window* is: it names the interval during which review independence is
+degraded and scrutiny on incoming changes is weakest.
+
+🔴 **A cause CLASS is never withheld to satisfy this, and "make it all private" is NOT a valid
+tightening.** An issue whose blocker cannot be named at all is under-specified for **skip clause (b)**
+— which then either parks the issue permanently or lets a run skip it with no live-verified reason.
+Silence there is the failure mode that clause exists to prevent, so the class is published and only
+the detail is held back.
 
 ### Local agent host — least-privilege runtime (part of the portfolio)
 The machine that runs the scheduled AI engineers (this Claude Code agent and the Codex sibling) is


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

When one of our lanes or review providers stops serving, the contract told us two opposite things about how to report it — and we were doing both. One rule treats a provider's account state as private and says our liveness check must never let it reach a repository artifact. Another rule *requires* a public "here's what's blocking this and when I last checked" line on any blocked issue. This repo is public, so those cannot both hold.

The result was live: an open blocked issue here is currently more specific about our provider account state than triage needs, while the tool that detects the very same condition is barred from reading its cause at all — so each outage gets re-diagnosed by hand instead.

### What

Settles it by granularity, reusing the split the contract already applies to security findings: the **cause class** (quota/billing, credentials/auth, runtime/config, unknown) is publishable, because that is what tells us whether we can act or only the maintainer can — and the blocker line needs it. The supporting detail stays in the private operator notes.

Also pins the other half, which matters more than it looks: "just make it all private" would read as a sensible tightening while quietly breaking every blocked issue's required record. A contract test guards both directions.

Deliberately **not** included: teaching the liveness check to emit that cause class. That is filed separately so the disclosure rule is settled before a tool starts depending on it.

Fixes #2906
Part of #2626
