### PR TITLE
ci(security): audit docs dependencies on a cadence, not only when a PR touches them

### DIFF
--- a/.github/workflows/audit-docs.yaml
+++ b/.github/workflows/audit-docs.yaml
@@ -1,0 +1,52 @@
+name: Audit - Docs Dependencies
+
+# Observes the docs dependency tree on a cadence, independent of whether any pull
+# request touched docs dependencies.
+#
+# The `audit-docs` job in ci.yaml runs only when a change touches docs deps, so on an
+# ordinary day nothing audits the lockfile at all. Advisories therefore accumulate
+# unseen and first surface by blocking an automated dependency pull request — which
+# agents may not touch — at which point no single-package bump can clear them.
+#
+# The audit step below is deliberately IDENTICAL to the `Audit` step of ci.yaml's
+# `audit-docs` job. That is what makes this run predict the gate: a weaker audit here
+# would pass while the gate still blocks, recreating exactly the deadlock this exists
+# to prevent. Keep the two in lockstep.
+#
+# This workflow gates nothing. It has no pull_request trigger, is absent from the
+# "CI - Required Checks" aggregation, and adds no latency to any pull request.
+
+on:
+  schedule:
+    - cron: "23 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: "audit-docs"
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  audit-docs:
+    name: "Audit docs dependencies"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: docs/package-lock.json
+      - name: Install dependencies
+        working-directory: docs
+        run: npm ci
+      - name: Audit
+        working-directory: docs
+        run: npm audit --omit=dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -418,6 +418,9 @@ jobs:
         working-directory: docs
         run: npm run build
 
+  # The Audit step below is mirrored by .github/workflows/audit-docs.yaml, which runs it
+  # on a cadence so advisories surface before they can block an automated dependency PR.
+  # Keep the two in lockstep: a change to the Audit step here needs the same change there.
   audit-docs:
     needs: changes
     if: needs.changes.outputs.docs-deps == 'true'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Nothing in our own CI ever looks at the docs dependency tree unless a pull request happens to touch it. So advisories build up silently while `main` stays green, and the first anyone hears about them is an automated dependency PR going red — a PR agents are not allowed to touch. That is how the docs lockfile ended up frozen for a month: by the time it surfaced, no single-package bump could clear it.

### Changes

A scheduled workflow now runs the same docs audit once a day, so a new advisory shows up while it is still one or two, and while a normal bump can still fix it.

It deliberately runs the *identical* audit the pull-request gate runs — a gentler one here would pass while the gate still blocked, which would just recreate the deadlock.

It gates nothing: no pull-request trigger, not part of "CI - Required Checks", and no extra wait on anyone's PR. When it does fail, it fails on the default branch, where our existing surveyor already treats that as work to pick up.

The `ci.yaml` edit is a comment only — verified as semantically identical to `main`.

Fixes #2912