### PR TITLE
fix(telemetry): state extraction failure instead of reporting zero busy-waiting

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -250,6 +250,12 @@ PROVTMP=$(mktemp "${TMPDIR:-/tmp}/.agtel_prov.XXXXXXXX") || { echo "cannot creat
 CONCTMP=$(mktemp "${TMPDIR:-/tmp}/.agtel_conc.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
 CREDCONC=$(mktemp "${TMPDIR:-/tmp}/.agtel_credconc.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
 CREDPROV=$(mktemp "${TMPDIR:-/tmp}/.agtel_credprov.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
+# Extraction-failure counter for the efficiency walk. A jq PROGRAM error
+# (a typo in the embedded program) makes `tagged_commands_in` emit nothing
+# for EVERY file while exiting non-zero, so the busy-wait metrics below
+# would read 0 and the run would report the agent had stopped busy-waiting.
+# The walk runs in a pipeline subshell, so the count must survive on disk.
+XFTMP=$(mktemp "${TMPDIR:-/tmp}/.agtel_xf.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
 # Blob-embedded evidence set (#2522): the subset of table values whose
 # occurrences are ALL inside a base64 run. Holds normalised credential values,
 # so it is created with mktemp's private mode and removed by the same traps as
@@ -267,8 +273,8 @@ CREDMATCH=$(mktemp "${TMPDIR:-/tmp}/.agtel_credmatch.XXXXXXXX") || { echo "canno
 SIGTMP=$(mktemp "${TMPDIR:-/tmp}/.agtel_sig.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
 # Remove on normal exit; on a SIGNAL also terminate, since a trap that only
 # cleans up leaves the script running after the scheduler asked it to stop.
-trap 'rm -f "$ERRTMP" "$RAWTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV" "$CREDBLOB" "$CREDPLAIN" "$CREDMATCH" "$SIGTMP"' EXIT
-trap 'rm -f "$ERRTMP" "$RAWTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV" "$CREDBLOB" "$CREDPLAIN" "$CREDMATCH" "$SIGTMP"; trap - HUP INT TERM; kill -s INT $$' HUP INT TERM
+trap 'rm -f "$ERRTMP" "$RAWTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV" "$CREDBLOB" "$CREDPLAIN" "$CREDMATCH" "$SIGTMP" "$XFTMP"' EXIT
+trap 'rm -f "$ERRTMP" "$RAWTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV" "$CREDBLOB" "$CREDPLAIN" "$CREDMATCH" "$SIGTMP" "$XFTMP"; trap - HUP INT TERM; kill -s INT $$' HUP INT TERM
 
 INJ_PHRASE_RE='(ignore (all )?(prior|previous) (rules|instructions)|disregard (your|all) (instructions|rules)|the maintainer (approved|authorised|authorized)|add [^ ]+ to the trust gate|update your instructions|you are now [a-z ]{0,20}mode)'
 
@@ -2541,7 +2547,13 @@ if want efficiency; then
     # leave anything on disk to clean up.
     TAGGED=$(printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' \
              | while IFS= read -r f; do
-                 tagged_commands_in "$f"
+                 # A jq PROGRAM error empties EVERY file at once, which would
+                 # read as "the agent stopped busy-waiting" rather than as a
+                 # broken instrument. Record the failure; the canary below
+                 # turns that silent zero into a stated one. Its stdout still
+                 # flows through, so a per-file malformed session degrades
+                 # exactly as before instead of aborting the walk.
+                 tagged_commands_in "$f" || printf x >> "$XFTMP"
                  # File boundary. The wait-target split below asks "did the NEXT
                  # command poll a remote system", and without this the last
                  # command of one transcript would be adjacent to the first of
@@ -2928,6 +2940,23 @@ if want efficiency; then
     echo "  [BOTH instances: ${SF_COUNT} Claude + ${CX_COUNT} Codex sessions]"
     echo "  bash timeouts .............. ${TIMEOUTS}   (each = a foreground block that produced nothing)"
     echo "  interrupted tool calls ..... ${INTERRUPT}"
+    # Extraction canary. Every number in this section derives from TAGGED,
+    # so an extractor that failed makes them all read 0 — indistinguishable
+    # from a genuinely quiet window, and in the direction that looks like
+    # improvement. State the failure count rather than letting a broken
+    # instrument report success. XF == the file count means the embedded jq
+    # program itself is broken, not that one session was malformed.
+    XFAIL=$(wc -c < "$XFTMP" | tr -d " ")
+    XTOTAL=$(printf "%s\\n%s\\n" "$SF_CACHE" "$CX_CACHE" | grep -cv '^$' || true)
+    if [ "${XFAIL:-0}" -gt 0 ]; then
+      if [ "${XFAIL:-0}" -ge "${XTOTAL:-0}" ] && [ "${XTOTAL:-0}" -gt 0 ]; then
+        echo "  ⚠️  EXTRACTION FAILED on ALL ${XTOTAL} file(s) — the embedded jq program is broken."
+        echo "      Every efficiency number below is 0 because NOTHING WAS READ, not because"
+        echo "      the agent stopped busy-waiting. Do not record these as a measurement."
+      else
+        echo "  ⚠️  extraction failed on ${XFAIL} of ${XTOTAL} file(s) — numbers below UNDER-COUNT."
+      fi
+    fi
     echo "  explicit sleep/poll calls .. ${SLEEPS}   (contract: arm a watcher, never busy-wait)"
     # The raw total above cannot answer the question the contract actually asks,
     # because it scores a CONTRACT-COMPLIANT backgrounded watcher (`sleep N &&

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -6072,6 +6072,62 @@ else
 fi
 
 echo
+echo "── extraction canary: a broken embedded jq must not read as improvement ──"
+# The efficiency section's numbers ALL derive from TAGGED. A jq PROGRAM error
+# (one `?//` typo — the exact bug that produced a silent `errors=0` over 182
+# sessions on 2026-08-19) empties every file at once, so the busy-wait metrics
+# read 0. That is indistinguishable from a quiet window and points in the
+# direction that looks like success, which is why it is guarded rather than
+# left to reviewer vigilance.
+XFX="$FIX/xfcanary"
+mkdir -p "$XFX/nest/sub/deep" "$XFX/cxnest/sessions" "$XFX/empty"
+printf '%s\n' "{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"$XFX/nest/sub/deep\"}}" \
+  > "$XFX/cxnest/sessions/r.jsonl"
+printf '%s\n' '{"type":"response_item","payload":{"type":"function_call","arguments":"{\"command\":\"sleep 11\"}"}}' \
+  >> "$XFX/cxnest/sessions/r.jsonl"
+
+xf_run() { # $1 = script to run
+  CLAUDE_PROJECTS_DIR="$XFX/empty" CODEX_HOME="$XFX/cxnest" MONOREPO_DIR="$XFX/nest" \
+    PORTFOLIO_PATHS="$XFX/nest:$XFX/nest/sub" HOME="$XFX" \
+    bash "$1" --since-days 3650 --section efficiency 2>&1
+}
+
+# Baseline: the healthy extractor reads the sleep AND stays silent. Both halves
+# matter — a canary that always fires guards nothing.
+XF_BASE=$(xf_run "$TARGET")
+if grep -qE 'sleep/poll calls \.\. 1' <<<"$XF_BASE" \
+   && ! grep -qiE 'EXTRACTION FAILED|extraction failed' <<<"$XF_BASE"; then
+  ok "healthy extractor reads the sleep and raises no canary"
+else
+  bad "healthy extractor reads the sleep and raises no canary" \
+      "got: $(grep -E 'sleep/poll calls|extraction' <<<"$XF_BASE" | head -2)"
+fi
+
+# Ablation: break ONLY the embedded jq program in tagged_commands_in.
+XF_AB="$FIX/xf_ablate.sh"
+cp "$TARGET" "$XF_AB"
+sed -i.bak 's#(\.id? // "") as \$i#(.id?//"") as $i#' "$XF_AB"; rm -f "$XF_AB.bak"
+xf_changed=$(diff "$TARGET" "$XF_AB" | grep -c '^<')
+if [ "$xf_changed" -ne 1 ]; then
+  # A mutation that did not land makes the arm judge nothing. Withhold the
+  # verdict rather than report a pass the run never earned.
+  bad "ablation: a broken extractor jq raises the canary" \
+      "sed changed $xf_changed lines, expected 1 — VACUOUS MUTATION, arm cannot judge"
+else
+  XF_OUT=$(xf_run "$XF_AB")
+  # The number must still collapse to 0 (proving the arm really broke the
+  # extractor) AND the canary must say so. Asserting only the canary would pass
+  # even if the mutation had been harmless.
+  if grep -qE 'sleep/poll calls \.\. 0' <<<"$XF_OUT" \
+     && grep -qF 'EXTRACTION FAILED on ALL' <<<"$XF_OUT" \
+     && grep -qF 'Do not record these as a measurement' <<<"$XF_OUT"; then
+    ok "ablation: a broken extractor jq collapses the count AND raises the canary"
+  else
+    bad "ablation: a broken extractor jq collapses the count AND raises the canary" \
+        "got: $(grep -E 'sleep/poll calls|EXTRACTION' <<<"$XF_OUT" | head -3)"
+  fi
+fi
+
 echo "──────────────────────────────"
 echo "  passed: $PASS   failed: $FAIL"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The telemetry miner is how this agent decides whether its own fixes worked. Its efficiency section — every busy-wait number in it — comes from a single extraction pass. If the jq program inside that pass has a syntax error, jq compiles nothing, its message goes to a suppressed stderr, and **every** file yields nothing. The section then reported `0` busy-wait calls and exited successfully.

`0` is indistinguishable from a genuinely quiet window, and it points the way that looks like success. So a one-character typo in the instrument read as "the agent stopped busy-waiting" — which is how a broken measurement becomes a wrong verdict on an open hypothesis.

It happened during this run: a `?//` typo made a mining pass report 0 tool errors across 182 sessions when one file alone held 187.

### What

The efficiency walk now records extraction failures and states them. When every file failed, it says plainly that the numbers are not a measurement rather than printing zeros. A healthy run is unchanged and silent.

Fixes #2914