### PR TITLE
fix(telemetry): pair a private-key closer to its opener label

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -652,6 +652,26 @@ function mask_line(s) {
 # wide window can push hundreds of thousands of tagged rows through here, so the
 # footprint scales with the SELECTED WINDOW, not with the report size.
 { L[NR] = $0 }
+# 🔴 A CLOSER PAIRS TO ITS OPENER LABEL, NEVER TO ANY `PRIVATE KEY` MARKER.
+# Treating every label ending in PRIVATE KEY as a closer let an UNRELATED label
+# terminate a span: `BEGIN RSA` / body / `END EC` closed at the EC marker and
+# emitted everything after it VERBATIM — the under-mask direction the governing
+# asymmetry of this file forbids. Reproduced on the shipped program (#2662).
+#
+# ⚠️ NO SINGLE QUOTES BELOW: this program is a single-quoted shell string, so an
+# apostrophe here terminates it and the rest of the file becomes shell code.
+#
+# The key is the label text alone, so BEGIN and END are comparable. Runs of
+# spaces collapse because the marker regex tolerates a repeated space before the
+# label, so `RSA  PRIVATE KEY` must still pair with `RSA PRIVATE KEY`. A label
+# that fails to pair does not close, so the span runs on and masks MORE — the
+# safe side, and why this needs no character-class widening to be correct.
+function labelkey(m) {
+  sub(/^-----(BEGIN|END) */, "", m)
+  sub(/-----$/, "", m)
+  gsub(/  +/, " ", m)
+  return m
+}
 END {
   n = NR
   # Pass A — collapse every span COMPLETE ON ONE LINE, closing each BEGIN at the
@@ -674,6 +694,7 @@ END {
     while (match(s, /-----BEGIN ([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?-----/)) {
       bs = RSTART; bl = RLENGTH
       head = substr(s, 1, bs - 1)
+      oplbl = labelkey(substr(s, bs, bl))
       # `scan`, deliberately NOT `tail`: pass B owns a global of that name. It
       # assigns before every use today, so sharing it is not a live defect —
       # but a value from pass A surviving into pass B is the same class as the
@@ -683,6 +704,9 @@ END {
       while (depth > 0 && match(scan, /-----(BEGIN|END) ([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?-----/)) {
         mark = substr(scan, RSTART, RLENGTH)
         scan = substr(scan, RSTART + RLENGTH)
+        # Only the label of this opener may move its depth; any other label is a
+        # different span and is left to its own walk.
+        if (labelkey(mark) != oplbl) continue
         if (mark ~ /^-----BEGIN/) depth++
         else if (--depth == 0) closed = 1
       }
@@ -702,6 +726,7 @@ END {
         # reached through pass A folding two openers into one line.
         s = ""
         U[i] = depth
+        ULBL[i] = oplbl
         break
       }
     }
@@ -775,8 +800,10 @@ END {
         # balanced the depth, not the first one on the line — closing at the
         # first would mask LESS than the nesting requires, which is the wrong
         # side of the governing asymmetry.
+        bmark = substr(bscan, RSTART, RLENGTH)
         bdrop += RSTART + RLENGTH - 1
         bscan = substr(bscan, RSTART + RLENGTH)
+        if (labelkey(bmark) != ULBL[i]) continue
         if (--bdepth == 0) { close_at = j; close_end = bdrop; break }
       }
       if (close_at == 0) bdepth += U[j]

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -704,11 +704,14 @@ END {
       while (depth > 0 && match(scan, /-----(BEGIN|END) ([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?-----/)) {
         mark = substr(scan, RSTART, RLENGTH)
         scan = substr(scan, RSTART + RLENGTH)
-        # Only the label of this opener may move its depth; any other label is a
-        # different span and is left to its own walk.
-        if (labelkey(mark) != oplbl) continue
+        # 🔴 ANY opener DEEPENS the span, whatever its label; only a MATCHING closer
+        # may end it. Skipping a nested opener of another label was a regression:
+        # `BEGIN RSA` .. `BEGIN EC` .. `END RSA` on ONE line then closed at depth 0
+        # and the tail printed VERBATIM, where the depth-only walk had masked it.
+        # An unclosed nested block means what follows this closer is still key
+        # material, so the conservative count is the correct one.
         if (mark ~ /^-----BEGIN/) depth++
-        else if (--depth == 0) closed = 1
+        else if (labelkey(mark) == oplbl && --depth == 0) closed = 1
       }
       out = out head PH
       if (closed) {

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -5513,6 +5513,36 @@ nocheck "shape 9 control: a PROSE end-marker does not close a key span (no leak)
 OUT=$(printf -- 'boom -----%s  PRIVATE KEY-----\nMIISECRET_EXTRASPACE\n' 'BEGIN' | awk "$AWK_PROG")
 nocheck "shape 9 control: an extra space before the label still masks (no narrowing)" "$OUT" "SECRET_EXTRASPACE"
 
+# 🔴 REGRESSION CONTROL 4 — a closer pairs to its OPENER LABEL (#2662).
+# Every control above varies what a label may SAY. This one varies which label
+# the closer carries, which no other row constrains: the walker treated any
+# marker ending in PRIVATE KEY as a closer, so an UNRELATED label terminated a
+# live span. Reproduced on the shipped program before the fix — `BEGIN RSA`,
+# body, `END EC` closed at the EC marker and everything after it printed
+# VERBATIM. That is the UNDER-mask direction the governing asymmetry forbids.
+#
+# Both passes are covered because each owns a different shape and each was
+# independently confirmed load-bearing by neutralising it alone: pass B resolves
+# the LINE-CROSSING span (4a) and pass A the SINGLE-LINE one (4b). A suite
+# carrying only one of these reports green with the other guard removed.
+ECE=$(printf -- '-----%s EC PRIVATE KEY-----' 'END')
+OUT=$(printf 'boom %s\nMIIEvgSECRETXLABEL\n%s\nMIIEvgAFTERXLABEL\n' "$RB" "$ECE" | awk "$AWK_PROG")
+nocheck "shape 9 control 4a: an unrelated END label does not close a line-crossing span" "$OUT" "AFTERXLABEL"
+OUT=$(printf 'boom %s MIIEvgSAMELINEX %s TAILXSAMELINE\n' "$RB" "$ECE" | awk "$AWK_PROG")
+nocheck "shape 9 control 4b: an unrelated END label does not close a single-line span" "$OUT" "TAILXSAMELINE"
+
+# CONTROL, opposite direction — pairing must not make a span UNCLOSEABLE.
+# If the key were compared to the whole marker rather than its label, or the
+# space normalisation were dropped, a legitimate closer would stop matching and
+# every stream would mask to EOF — over-masking so total that rows 4a/4b above
+# would still pass. These two rows are what keep this fix from being vacuous.
+OUT=$(printf 'boom %s\nMIIEvgSECRETPAIRED\n%s\nAFTER-PAIRED-KEEP\n' "$RB" "$RE" | awk "$AWK_PROG")
+check   "shape 9 control 4c: the MATCHING closer still closes the span" "$OUT" "AFTER-PAIRED-KEEP"
+nocheck "shape 9 control 4c: and its body is still masked"              "$OUT" "SECRETPAIRED"
+OUT=$(printf -- 'boom -----%s RSA  PRIVATE KEY-----\nMIIEvgSECRETSPPAIR\n%s\nAFTER-SPPAIR-KEEP\n' 'BEGIN' "$RE" | awk "$AWK_PROG")
+check   "shape 9 control 4d: a repeated-space label still pairs with its closer" "$OUT" "AFTER-SPPAIR-KEEP"
+nocheck "shape 9 control 4d: and its body is still masked"                       "$OUT" "SECRETSPPAIR"
+
 # ── SHAPE 9 (structural) — ONE label expression, at EVERY marker site ─────────
 # The defect was never a single bad regex: the same label class was spelled out
 # at nine independent sites (four awk regexes, three marker `sed` rules, and the

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -5543,6 +5543,29 @@ OUT=$(printf -- 'boom -----%s RSA  PRIVATE KEY-----\nMIIEvgSECRETSPPAIR\n%s\nAFT
 check   "shape 9 control 4d: a repeated-space label still pairs with its closer" "$OUT" "AFTER-SPPAIR-KEEP"
 nocheck "shape 9 control 4d: and its body is still masked"                       "$OUT" "SECRETSPPAIR"
 
+# 🔴 REGRESSION CONTROL 4e — a NESTED opener of ANOTHER label still deepens the span.
+# Found by review on #2925 and REPRODUCED before accepting it. The first draft of
+# the pairing skipped any marker whose label differed, which silently reintroduced
+# an under-mask one shape over: `BEGIN RSA` .. `BEGIN EC` .. `END RSA` on a single
+# line closed at depth 0 and printed the tail VERBATIM, where the original
+# depth-only walk had masked it. Controls 4a/4b cannot see this — neither carries a
+# nested opener — which is exactly the "fixing one shape is not fixing the defect"
+# lesson this file already records for 5c/5d.
+#
+# The rule that resolves both directions: ANY opener deepens the span whatever its
+# label, and only a MATCHING closer may end it. An unclosed nested block means the
+# material after this closer is still key material.
+ECB=$(printf -- '-----%s EC PRIVATE KEY-----' 'BEGIN')
+OUT=$(printf 'boom %s K1 %s MIIEvgNEST1 %s TAILNESTED\n' "$RB" "$ECB" "$RE" | awk "$AWK_PROG")
+nocheck "shape 9 control 4e: a nested other-label opener keeps a single-line span open" "$OUT" "TAILNESTED"
+OUT=$(printf 'boom %s\nB1\n%s\nMIIEvgNEST2\n%s\nMIIEvgAFTERNEST\n' "$RB" "$ECB" "$RE" | awk "$AWK_PROG")
+nocheck "shape 9 control 4e: and the same holds across lines" "$OUT" "AFTERNEST"
+
+# CONTROL — nesting of the SAME label must still close normally, or 4e is satisfied
+# by the walker simply never closing anything.
+OUT=$(printf 'boom %s K1 %s K2 %s %s TAILSAMENEST\n' "$RB" "$RB" "$RE" "$RE" | awk "$AWK_PROG")
+check "shape 9 control 4e: same-label nesting still closes at depth 0" "$OUT" "TAILSAMENEST"
+
 # ── SHAPE 9 (structural) — ONE label expression, at EVERY marker site ─────────
 # The defect was never a single bad regex: the same label class was spelled out
 # at nine independent sites (four awk regexes, three marker `sed` rules, and the


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The telemetry redactor is what keeps private-key material out of the reports this suite publishes. It decided where a key block ended by accepting **any** closing marker whose label ended in `PRIVATE KEY` — so a closer belonging to a *different* key could end an unrelated block early, and everything after it was written out unmasked.

That is the failure direction this component treats as its worst: material is emitted in the clear, and the leak detector reports the file clean. Reproduced against the shipped program before the fix.

### What

A closing marker now has to belong to the block it closes. A marker that does not match is no longer treated as the end of that block, so the redactor keeps masking instead of stopping early — the safe side of the trade.

This is the structural half of #2662. Widening which key labels are recognised in the first place is the remaining half and needs this pairing to be in place before it is safe to do; it follows separately.

Part of #2662
