### PR TITLE
test(agents): pin the surveyor read vocabulary against the forge guard

### DIFF
--- a/.claude/scripts/surveyor-forge-vocabulary.test.sh
+++ b/.claude/scripts/surveyor-forge-vocabulary.test.sh
@@ -18,6 +18,16 @@
 #          ALLOWED — which is the signal that the upstream fix has landed and
 #          this entry should be promoted to `allow`.
 #
+# On `git status`: the surveyor definition names `git log/status` among its read
+# verbs, but only the hardened invocation is actually a read, and the guard is
+# right to insist on it. Bare `git status` is pinned as `deny` for two reasons
+# the guard states: without `-c core.fsmonitor=` repository configuration can
+# name a hook program git executes (arbitrary execution while merely looking at
+# a repo), and without `--no-optional-locks` the "read" rewrites the index. The
+# allow/deny pair therefore pins BOTH halves: the form a surveyor may run, and
+# the form it may not. A definition that tells a surveyor to run the bare form
+# would fail closed mid-run — see the note in the corpus's companion issue.
+#
 # Exit: 0 all entries match · 1 a mismatch · 2 UNKNOWN (guard unavailable).
 # UNKNOWN is never reported as success: an unverifiable boundary is unproven.
 set -uo pipefail
@@ -82,6 +92,10 @@ deny	gh api repos/devantler-tech/monorepo/issues -f title=pwned
 deny	gh api -X GET repos/devantler-tech/monorepo/issues -F body=@/etc/passwd
 deny	gh api --input /etc/passwd repos/devantler-tech/monorepo/issues
 deny	gh api graphql -f query='mutation { addComment(input:{subjectId:"x", body:"y"}) { clientMutationId } }'
+allow	git log --oneline -20
+allow	git log -1 --format=%cI
+allow	git --no-optional-locks -c core.fsmonitor= status --porcelain
+deny	git status --porcelain
 deny	git push origin HEAD
 deny	git ls-remote origin refs/heads/main
 deny	gh project item-add 5 --owner devantler-tech --url https://github.com/x/y/issues/1

--- a/.claude/scripts/surveyor-forge-vocabulary.test.sh
+++ b/.claude/scripts/surveyor-forge-vocabulary.test.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
-# Pins THIS deployment's portfolio-surveyor read vocabulary against the plugin's
-# read-only forge guard, so enabling the guard can never silently remove a
-# mandated survey dimension.
+# Pins the corpus of survey commands below against the plugin's read-only forge
+# guard, so a guard revision cannot silently start refusing one of them.
+#
+# SCOPE, precisely: this pins CORPUS -> GUARD. It does NOT pin SOURCES -> CORPUS.
+# The corpus is hand-maintained, so a mandated read added to the surveyor
+# definition or its run loop is not classified here merely because those files
+# are watched: the job runs, re-checks this unchanged list, and stays green. The
+# path filter decides WHEN this runs; it cannot decide WHAT it knows about.
+# Closing that second half needs a source-to-corpus coverage check or a
+# machine-readable command inventory -- monorepo#2936. Until it lands, adding a
+# survey command means adding its row here by hand.
 #
 # Why this exists. `plugins/agentic-engineering/README.md` makes the wiring the
 # consumer's step and says plainly: "run your own deployment's survey vocabulary

--- a/.claude/scripts/surveyor-forge-vocabulary.test.sh
+++ b/.claude/scripts/surveyor-forge-vocabulary.test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Pins THIS deployment's portfolio-surveyor read vocabulary against the plugin's
+# read-only forge guard, so enabling the guard can never silently remove a
+# mandated survey dimension.
+#
+# Why this exists. `plugins/agentic-engineering/README.md` makes the wiring the
+# consumer's step and says plainly: "run your own deployment's survey vocabulary
+# through it before turning it on: a read it does not yet recognise fails closed,
+# which is the intended direction but is better discovered deliberately than
+# mid-run." This file IS that check, kept executable so it also catches the
+# reverse drift — a guard revision that starts allowing a mutation.
+#
+# Dispositions:
+#   allow  the guard must permit it; a deny would break a mandated survey read
+#   deny   the guard must refuse it; an allow is a security regression
+#   gap    denied TODAY by a guard defect, tracked upstream. Asserted as deny so
+#          the suite is green on main, and it FAILS THE MOMENT IT STARTS BEING
+#          ALLOWED — which is the signal that the upstream fix has landed and
+#          this entry should be promoted to `allow`.
+#
+# Exit: 0 all entries match · 1 a mismatch · 2 UNKNOWN (guard unavailable).
+# UNKNOWN is never reported as success: an unverifiable boundary is unproven.
+set -uo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd) || exit 2
+guard="$repo_root/libraries/agent-plugins/plugins/agentic-engineering/scripts/forge-readonly-guard.sh"
+
+if [ ! -f "$guard" ]; then
+  echo "surveyor-forge-vocabulary: UNKNOWN — guard not found at $guard" >&2
+  echo "  (populate the submodule: .claude/scripts/submodule-init.sh libraries/agent-plugins)" >&2
+  exit 2
+fi
+if [ ! -x "$guard" ]; then
+  echo "surveyor-forge-vocabulary: UNKNOWN — guard is not executable: $guard" >&2
+  exit 2
+fi
+
+# Prove the guard answers at all before trusting any verdict it gives. Without
+# this, a guard that errored on every input would mark the whole corpus "deny"
+# and the suite would pass vacuously on its deny entries.
+if ! "$guard" --command 'gh pr list --repo devantler-tech/monorepo --state open' >/dev/null 2>&1; then
+  echo "surveyor-forge-vocabulary: UNKNOWN — guard denied its own smoke-test read" >&2
+  exit 2
+fi
+if "$guard" --command 'gh pr merge 1 --repo devantler-tech/monorepo --squash' >/dev/null 2>&1; then
+  echo "surveyor-forge-vocabulary: UNKNOWN — guard allowed a merge; it is not discriminating" >&2
+  exit 2
+fi
+
+# ── Corpus ───────────────────────────────────────────────────────────────────
+# Tab-separated: <disposition>\t<command>. Tabs are safe here (no raw control
+# bytes in the source) and no command below contains one.
+corpus=$(cat <<'CORPUS'
+allow	gh pr list --repo devantler-tech/monorepo --state open --limit 100 --json number,title,isDraft,headRefName
+allow	gh pr view 2927 --repo devantler-tech/monorepo --json number,isDraft,headRefOid,mergeStateStatus,state
+allow	gh issue view 108 --repo devantler-tech/agent-plugins --json number,title,state
+allow	gh search prs --owner devantler-tech --state open --limit 100
+allow	gh search issues --owner devantler-tech --state open --limit 100
+allow	gh run list --repo devantler-tech/monorepo --branch main --limit 50 --json conclusion,path,event
+allow	gh repo list devantler-tech --limit 100 --json name,isArchived,visibility
+allow	gh api repos/devantler-tech/monorepo/pulls/2927/reviews --paginate
+allow	gh api repos/devantler-tech/monorepo/pulls/2927/comments --paginate
+allow	gh api repos/devantler-tech/monorepo/pulls/2927/commits
+allow	gh api repos/devantler-tech/monorepo/commits/cc7ac05bf8/check-runs
+allow	gh api repos/devantler-tech/monorepo/issues/2927/timeline --paginate
+allow	gh api repos/devantler-tech/platform/rulesets
+allow	gh api repos/devantler-tech/platform/rules/branches/main
+allow	gh api "repos/devantler-tech/agent-plugins/contents/plugins/agentic-engineering/agents/portfolio-surveyor.agent.md?ref=a0add262"
+allow	gh api "orgs/devantler-tech/repos?type=private" --paginate
+allow	gh api rate_limit --jq .resources
+allow	gh api graphql -f query='query { repository(owner:"devantler-tech", name:"monorepo") { pullRequest(number:2927) { reviewThreads(first:100) { nodes { isResolved } } } } }'
+deny	gh pr merge 2927 --repo devantler-tech/monorepo --squash
+deny	gh pr create --repo devantler-tech/monorepo --title x --body y
+deny	gh pr review 2927 --repo devantler-tech/monorepo --approve
+deny	gh pr edit 2927 --repo devantler-tech/monorepo --add-label x
+deny	gh issue comment 2927 --repo devantler-tech/monorepo --body x
+deny	gh issue close 2927 --repo devantler-tech/monorepo
+deny	gh api repos/devantler-tech/monorepo/issues --method POST
+deny	gh api -X PATCH repos/devantler-tech/monorepo/issues/2927
+deny	gh api -X DELETE repos/devantler-tech/monorepo/git/refs/heads/x
+deny	gh api repos/devantler-tech/monorepo/issues -f title=pwned
+deny	gh api -X GET repos/devantler-tech/monorepo/issues -F body=@/etc/passwd
+deny	gh api --input /etc/passwd repos/devantler-tech/monorepo/issues
+deny	gh api graphql -f query='mutation { addComment(input:{subjectId:"x", body:"y"}) { clientMutationId } }'
+deny	git push origin HEAD
+deny	git ls-remote origin refs/heads/main
+deny	gh project item-add 5 --owner devantler-tech --url https://github.com/x/y/issues/1
+gap	gh api -X GET "repos/devantler-tech/monorepo/activity" -f per_page=100 -f "ref=refs/heads/main"
+gap	gh api --method GET "repos/devantler-tech/monorepo/activity" -f per_page=100
+gap	gh api -X GET search/issues -f q=org:devantler-tech --paginate
+CORPUS
+)
+
+pass=0; fail=0; gaps=0
+while IFS=$'\t' read -r want cmd; do
+  [ -n "${want:-}" ] || continue
+  "$guard" --command "$cmd" >/dev/null 2>&1 && got=allow || got=deny
+  case "$want" in
+    allow|deny) expect=$want ;;
+    gap)        expect=deny ;;
+    *) echo "BAD-DISPOSITION '$want'" >&2; fail=$((fail+1)); continue ;;
+  esac
+  if [ "$got" = "$expect" ]; then
+    pass=$((pass+1))
+    [ "$want" = gap ] && gaps=$((gaps+1))
+  else
+    fail=$((fail+1))
+    if [ "$want" = gap ]; then
+      echo "PROMOTE  (upstream fix appears to have landed — change 'gap' to 'allow'):"
+      echo "         $cmd"
+    else
+      echo "MISMATCH want=$want got=$got"
+      echo "         $cmd"
+      [ "$got" = deny ] && echo "         reason: $("$guard" --command "$cmd" 2>&1)"
+    fi
+  fi
+done <<< "$corpus"
+
+total=$((pass + fail))
+echo "surveyor-forge-vocabulary: $pass/$total matched ($gaps tracked gap(s) still denied)"
+[ "$fail" -eq 0 ] || exit 1
+exit 0

--- a/.claude/scripts/surveyor-forge-vocabulary.test.sh
+++ b/.claude/scripts/surveyor-forge-vocabulary.test.sh
@@ -99,9 +99,9 @@ deny	git status --porcelain
 deny	git push origin HEAD
 deny	git ls-remote origin refs/heads/main
 deny	gh project item-add 5 --owner devantler-tech --url https://github.com/x/y/issues/1
-gap	gh api -X GET "repos/devantler-tech/monorepo/activity" -f per_page=100 -f "ref=refs/heads/main"
-gap	gh api --method GET "repos/devantler-tech/monorepo/activity" -f per_page=100
-gap	gh api -X GET search/issues -f q=org:devantler-tech --paginate
+allow	gh api -X GET "repos/devantler-tech/monorepo/activity" -f per_page=100 -f "ref=refs/heads/main"
+allow	gh api --method GET "repos/devantler-tech/monorepo/activity" -f per_page=100
+allow	gh api -X GET search/issues -f q=org:devantler-tech --paginate
 CORPUS
 )
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -836,7 +836,16 @@ jobs:
   test-surveyor-forge-vocabulary:
     name: Test surveyor forge vocabulary conformance
     needs: changes
-    if: needs.changes.outputs.surveyor-forge-vocabulary == 'true'
+    # The guard this job EXECUTES is checked out at a gitlink read from the
+    # PR's own tree, so a fork could repoint it at any commit in agent-plugins
+    # and run that code here. Restrict the job to branches in this repository,
+    # which is the same trust boundary AGENTS.md sets for external branches:
+    # review them statically, never execute them. merge_group carries no
+    # pull_request payload and is already past that gate.
+    if: >-
+      needs.changes.outputs.surveyor-forge-vocabulary == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,6 +181,12 @@ jobs:
               - '.claude/scripts/surveyor-forge-vocabulary.test.sh'
               - '.gitmodules'
               - 'libraries/agent-plugins'
+              # The surveyor definition and its run loop are what DEFINE the
+              # vocabulary this job pins. A PR that adds or changes a survey
+              # command in either of them must run the conformance test, or the
+              # guard can start refusing a newly mandated read with CI silent.
+              - '.claude/agents/portfolio-surveyor.md'
+              - '.claude/skills/portfolio-maintenance/SKILL.md'
               # Self-gate on the workflow too, so a change that breaks this
               # job's own wiring still runs the test it gates.
               - '.github/workflows/ci.yaml'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,7 @@ jobs:
       comment-disclosure-drift: ${{ steps.filter.outputs.comment-disclosure-drift }}
       pr-ownership-disclosure: ${{ steps.filter.outputs.pr-ownership-disclosure }}
       pipefail-grep-guard: ${{ steps.filter.outputs.pipefail-grep-guard }}
+      surveyor-forge-vocabulary: ${{ steps.filter.outputs.surveyor-forge-vocabulary }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -173,6 +174,13 @@ jobs:
               - '.claude/scripts/memory-backup.sh'
               - '.claude/scripts/memory-backup.test.sh'
               - '.claude/scripts/memory-backup-go/**'
+              # Self-gate on the workflow too, so a change that breaks this
+              # job's own wiring still runs the test it gates.
+              - '.github/workflows/ci.yaml'
+            surveyor-forge-vocabulary:
+              - '.claude/scripts/surveyor-forge-vocabulary.test.sh'
+              - '.gitmodules'
+              - 'libraries/agent-plugins'
               # Self-gate on the workflow too, so a change that breaks this
               # job's own wiring still runs the test it gates.
               - '.github/workflows/ci.yaml'
@@ -825,6 +833,38 @@ jobs:
       - name: Verify the comment disclosure drift guard
         run: bash .claude/scripts/comment-disclosure-drift.test.sh
 
+  test-surveyor-forge-vocabulary:
+    name: Test surveyor forge vocabulary conformance
+    needs: changes
+    if: needs.changes.outputs.surveyor-forge-vocabulary == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # The guard under test lives in the pinned plugin submodule, whose .gitmodules
+      # URL is SSH — unusable on a runner. Check the pinned revision out over HTTPS
+      # instead, so the test runs against exactly the reviewed commit this repo pins.
+      - name: Resolve the pinned agent-plugins revision
+        id: pin
+        # --no-replace-objects: a refs/replace entry would otherwise resolve the
+        # gitlink through a replacement commit while HEAD still looks correct.
+        run: echo "sha=$(git --no-replace-objects rev-parse HEAD:libraries/agent-plugins)" >> "$GITHUB_OUTPUT"
+      - name: Check out the guard at that revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: devantler-tech/agent-plugins
+          ref: ${{ steps.pin.outputs.sha }}
+          path: libraries/agent-plugins
+          persist-credentials: false
+      # The guard is a pure argv classifier: the test makes no API call and
+      # contacts no forge. The checkout above is this job's only network use.
+      - name: Verify the surveyor read vocabulary against the forge guard
+        run: bash .claude/scripts/surveyor-forge-vocabulary.test.sh
+
   test-pr-ownership-disclosure:
     name: Test PR ownership disclosure classifier
     needs: changes
@@ -1259,6 +1299,7 @@ jobs:
       - test-agent-telemetry
       - test-board-add
       - test-comment-disclosure-drift
+      - test-surveyor-forge-vocabulary
       - test-pr-ownership-disclosure
       - test-worktree-claim
       - test-flow-scorecard
@@ -1307,6 +1348,7 @@ jobs:
             ${{ needs.test-agent-telemetry.result }}
             ${{ needs.test-board-add.result }}
             ${{ needs.test-comment-disclosure-drift.result }}
+            ${{ needs.test-surveyor-forge-vocabulary.result }}
             ${{ needs.test-pr-ownership-disclosure.result }}
             ${{ needs.test-worktree-claim.result }}
             ${{ needs.test-flow-scorecard.result }}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The plugin ships a guard meant to make it impossible for the portfolio surveyor to write anything to GitHub — it should only ever read. Installing the plugin does not switch that on, and this deployment never wired it up. The plugin's own instructions say to check our survey commands against the guard *before* enabling it, because anything it does not recognise gets refused.

### What

Records the surveyor's read commands as a standing check, so we can tell in advance whether enabling the guard would remove a survey capability — and so a future guard change that starts permitting writes is caught here rather than in a live run.

Three reads the guard refused were recorded as known gaps designed to turn green by themselves once the upstream fix landed. It has now landed and shipped here via #2934, and they did exactly that — so they are promoted, and the check is fully green with no outstanding gaps.

**Scope, stated plainly in the file:** this pins our recorded command list against the guard. It does **not** yet verify that the list covers every command the surveyor's own instructions prescribe, so adding a survey command still means adding it here by hand. Closing that second half needs a different mechanism and is filed as #2936 rather than rushed in here.

Fixes #2930
Part of devantler-tech/agent-plugins#108