### PR TITLE
fix(agents): close the merge preflight's blind spot on unresolved threads

### DIFF
--- a/.claude/scripts/merge-preflight-thread-gate.test.sh
+++ b/.claude/scripts/merge-preflight-thread-gate.test.sh
@@ -41,6 +41,7 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+self_basename="$(basename "${BASH_SOURCE[0]}")"
 constitution="${repo_root}/AGENTS.md"
 
 fail() {
@@ -215,6 +216,33 @@ plugin_defs="${repo_root}/libraries/agent-plugins/plugins/agentic-engineering"
   fail "pinned plugin definitions are absent at ${plugin_defs}, so they cannot be scanned and an OK here would be vacuous
   populate them:  git -c 'url.https://github.com/.insteadOf=git@github.com:' submodule update --init libraries/agent-plugins"
 
+# "PINNED" is a REVISION, not a directory — and a nonempty directory is the weaker claim.
+# A shared checkout sits at whatever revision it was last left on, which is the dangerous case: it
+# returns plausible definitions and the scan passes while inspecting a revision this commit does not
+# pin. So resolve the gitlink and require the populated tree to match it, with a clean worktree.
+# `--no-replace-objects` on the gitlink read for the reason AGENTS.md gives: a `refs/replace` entry
+# for HEAD makes `HEAD:<path>` resolve through the replacement while `rev-parse HEAD` still prints
+# the expected commit, so the pin would silently name a revision nobody reviewed.
+pinned_rev="$(git -C "${repo_root}" --no-replace-objects rev-parse HEAD:libraries/agent-plugins 2>/dev/null)" ||
+  fail "could not resolve this commit's libraries/agent-plugins gitlink, so the scanned revision cannot be verified"
+[ -n "${pinned_rev}" ] ||
+  fail "this commit's libraries/agent-plugins gitlink resolved empty — unproven is not proven"
+actual_rev="$(git -C "${repo_root}/libraries/agent-plugins" rev-parse HEAD 2>/dev/null)" ||
+  fail "could not read the populated libraries/agent-plugins revision, so the scan target is unverified"
+[ "${actual_rev}" = "${pinned_rev}" ] ||
+  fail "libraries/agent-plugins is at ${actual_rev} but this commit pins ${pinned_rev} — the scan would
+  inspect a revision this commit does not pin, which passes while proving nothing about the pinned definitions"
+# A matching revision still does not establish the CONTENT: a modified tracked file survives with HEAD
+# equal to the pin, and `assume-unchanged`/`skip-worktree` hide a modification from `status` entirely.
+sub_status="$(git -C "${repo_root}/libraries/agent-plugins" status --porcelain 2>/dev/null)" ||
+  fail "could not read libraries/agent-plugins worktree status, so its content is unverified"
+[ -z "${sub_status}" ] ||
+  fail "libraries/agent-plugins has uncommitted changes, so the scanned definitions are not the pinned ones"
+hidden="$(git -C "${repo_root}/libraries/agent-plugins" ls-files -v 2>/dev/null | awk '$1 ~ /^[a-z]$/ || $1 == "S"')" ||
+  fail "could not read libraries/agent-plugins index flags, so a hidden modification cannot be ruled out"
+[ -z "${hidden}" ] ||
+  fail "libraries/agent-plugins carries assume-unchanged/skip-worktree entries, which hide a modification from status"
+
 # `ci.yaml` is a definition surface in its own right, not just the thing that decides WHEN this job
 # runs. AGENTS.md classifies it as one, and the paths-filter below already triggers on it — so leaving
 # it out of the SCAN meant an edit there ran the guard against every file except the one that
@@ -244,10 +272,36 @@ while IFS= read -r surface; do
   esac
   found="$(bad_lists_in "${surface}")"
   [ -n "${found}" ] && offenders="${offenders}${surface}:"$'\n'"${found}"
+# 🔴 The block below is a PROCESS SUBSTITUTION, and on bash 3.2 (the macOS default, and what this
+# repository runs) a comment inside `<( ... )` breaks it AT RUNTIME while `bash -n` still passes:
+# the parser rescans the body for the closing paren, and an apostrophe or an unbalanced paren in a
+# comment sends it past the `)`. It fails as `bad substitution: no closing ")" in <(`, which names
+# neither the comment nor its line. Both forms were reproduced on 3.2.57. So every explanation for
+# that block lives HERE, outside it — do not move these lines back inside.
+#
+# WHY THE SURFACES ARE WHAT THEY ARE.
+# The enforcement SCRIPTS are definition surfaces too (AGENTS.md, *Agent definition locations*),
+# and prescriptions live in their comments and failure messages, not only in prose. Discovering
+# only .md/.json left a sibling `*.test.sh` free to add a `--json ...reviewThreads` prescription
+# with this control neither running nor inspecting it.
+#
+# THIS file is the one exclusion, and it is structural rather than a convenience: the extractor
+# self-test above holds deliberate BAD forms as fixtures, so scanning itself would report its own
+# fixtures as offenders and fail on a correct tree. Measured across `.claude/scripts/*.sh`, it is
+# the ONLY file carrying such a literal, so excluding it costs no real coverage today — and the
+# positive control below refuses if the exclusion ever swallows the whole class.
+#
+# The exclusion is built from `repo_root`, not from `BASH_SOURCE[0]` directly: the latter is
+# whatever path the caller typed, while `find` emits absolute paths, so a direct comparison
+# silently matches nothing and the file reports its own fixtures as offenders. That was observed,
+# not predicted. `repo_root` is itself derived from this file location, so the constructed path is
+# exact rather than a basename guess.
 done < <(
   {
     printf '%s\n' "${constitution}" "${workflow}"
     find "${repo_root}/.claude" -type f \( -name '*.md' -o -name '*.json' \) 2>/dev/null
+    find "${repo_root}/.claude/scripts" -type f -name '*.sh' \
+      ! -path "${repo_root}/.claude/scripts/${self_basename}" 2>/dev/null
     find "${plugin_defs}" -type f \( -name '*.md' -o -name '*.json' \) 2>/dev/null
   } | sort -u
 )
@@ -261,6 +315,13 @@ done < <(
 # loudly instead of quietly narrowing what the guard sees.
 printf '%s' "${scanned_list}" | grep -qxF -- "${workflow}" ||
   fail "ci.yaml was not among the ${scanned} scanned surfaces — the guard triggers on it but would not inspect it"
+
+# The self-exclusion above is one path; this refuses if it ever becomes the whole class. Without it,
+# a mistyped `find` or a widened `! -path` would silently scan no enforcement script at all and the
+# size check would still pass on the ~40 `.claude` Markdown files.
+other_scripts=$(printf '%s' "${scanned_list}" | grep -cE '\.claude/scripts/.*\.sh$' || true)
+[ "${other_scripts}" -gt 0 ] ||
+  fail "no enforcement script under .claude/scripts was scanned — the self-exclusion has swallowed the whole surface class"
 
 if [ -n "${offenders}" ]; then
   printf 'merge-preflight thread gate: FAIL — a thread field is prescribed in a `gh pr view --json` list.\n' >&2
@@ -309,7 +370,7 @@ for trigger in \
   "              - 'AGENTS.md'" \
   "              - '.claude/**/*.md'" \
   "              - '.claude/**/*.json'" \
-  "              - '.claude/scripts/merge-preflight-thread-gate.test.sh'" \
+  "              - '.claude/**/*.sh'" \
   "              - 'libraries/agent-plugins'" \
   "              - '.gitmodules'" \
   "              - '.github/workflows/ci.yaml'"; do

--- a/.claude/scripts/merge-preflight-thread-gate.test.sh
+++ b/.claude/scripts/merge-preflight-thread-gate.test.sh
@@ -27,7 +27,9 @@
 #
 # Guarded properties:
 #   1. the mechanism is named, so a reader can verify the rule themselves;
-#   2. a WORKING vocabulary for the thread read is prescribed (GraphQL — see 4);
+#   2. a WORKING vocabulary for the thread read is prescribed — GraphQL (see 5), and PAGINATED: a
+#      first-page-only `reviewThreads(first:100)` under-counts a PR with >100 threads, so the gate's
+#      single number can read 0 while unresolved threads remain;
 #   3. exception (a) cannot swallow this class: unresolved threads are a real blocker, not staleness;
 #   4. a merge refusal is DIAGNOSED before it is escalated as a maintainer blocker;
 #   5. NEGATIVE CONTROL: no `gh pr view --json` list in ANY definition surface names a thread field.
@@ -80,10 +82,18 @@ assert_prose 'required_review_thread_resolution' \
 # ── 2. a WORKING vocabulary is prescribed ───────────────────────────────────────────────────────────
 # Assert the GraphQL shape, not a bare mention of threads: the whole lesson of the post-merge `merged`
 # field is that an unprescribed read gets improvised into an invalid one.
-assert_prose 'reviewThreads(first:100)' \
-  "Merge policy does not prescribe the GraphQL reviewThreads read for pre-merge thread state"
+assert_prose 'reviewThreads(first:100,after:$endCursor)' \
+  "Merge policy does not prescribe the paginated GraphQL reviewThreads read for pre-merge thread state"
 assert_prose 'isResolved==false' \
   "Merge policy does not prescribe selecting UNRESOLVED threads — a bare thread count is not the gate"
+# PAGINATION is part of the working vocabulary, not tidiness: `reviewThreads(first:100)` alone returns
+# one page, so a PR with >100 threads reports a PARTIAL count and this gate's single number can read 0
+# while unresolved threads remain — the same "authoritative-looking but wrong read" the rule exists to
+# prevent. Require both the cursor plumbing and the page-walk.
+assert_prose 'pageInfo{hasNextPage endCursor}' \
+  "Merge policy prescribes a thread read without the pageInfo cursor — a first-page-only count"
+assert_prose 'gh api graphql --paginate' \
+  "Merge policy prescribes a thread read that does not walk every page"
 # The invalid improvisation is named explicitly, exactly as `merged` is for the post-merge read.
 assert_prose '`reviewThreads` is NOT a valid `gh pr view --json` field' \
   "Merge policy does not state that reviewThreads is not a gh pr view --json field"
@@ -105,7 +115,7 @@ decode_surface() {
     # A scalar boundary is a HARD boundary: `jq -r '.. | strings'` emits one line per decoded value and
     # flattening would otherwise weld the end of one value onto the start of the next. `%` is outside
     # `[A-Za-z,]`, so it terminates a field list wherever it lands.
-    *.json) jq -r '.. | strings | ., "%"' "$1" 2>/dev/null || true ;;
+    *.json) jq -r '.. | strings | ., "%"' "$1" ;;
     *)      cat "$1" ;;
   esac
 }
@@ -182,6 +192,16 @@ scanned=0
 while IFS= read -r surface; do
   [ -r "${surface}" ] || continue
   scanned=$((scanned + 1))
+  # VALIDATE a JSON surface HERE, in the MAIN shell, before it is scanned. `bad_lists_in` reads its
+  # input through process substitution (`< <(...)`), whose failure `set -e` does NOT catch — so a
+  # `fail` inside the extraction chain leaves the loop with empty output and exit 0, and the surface is
+  # counted as scanned while nothing was inspected. Reproduced: a malformed `.json` planted under
+  # `.claude/` raised `scanned` from 28 to 29 and the control still reported OK. Validating in the main
+  # shell is what makes the failure actually abort.
+  case "${surface}" in
+    *.json) jq empty "${surface}" >/dev/null 2>&1 ||
+      fail "cannot decode JSON definition surface, so it cannot be scanned: ${surface}" ;;
+  esac
   found="$(bad_lists_in "${surface}")"
   [ -n "${found}" ] && offenders="${offenders}${surface}:"$'\n'"${found}"
 done < <(
@@ -200,4 +220,4 @@ if [ -n "${offenders}" ]; then
   exit 1
 fi
 
-echo "merge-preflight thread gate: OK — 5 properties held; negative control scanned ${scanned} surfaces."
+echo "merge-preflight thread gate: OK — 8 prose properties held; negative control scanned ${scanned} surfaces."

--- a/.claude/scripts/merge-preflight-thread-gate.test.sh
+++ b/.claude/scripts/merge-preflight-thread-gate.test.sh
@@ -81,7 +81,7 @@ assert_prose 'reviewThreads(first:100)' \
 assert_prose 'isResolved==false' \
   "Merge policy does not prescribe selecting UNRESOLVED threads — a bare thread count is not the gate"
 # The invalid improvisation is named explicitly, exactly as `merged` is for the post-merge read.
-assert_prose 'is NOT a valid `gh pr view --json` field' \
+assert_prose '`reviewThreads` is NOT a valid `gh pr view --json` field' \
   "Merge policy does not state that reviewThreads is not a gh pr view --json field"
 
 # ── 3. exception (a) cannot swallow this class ──────────────────────────────────────────────────────

--- a/.claude/scripts/merge-preflight-thread-gate.test.sh
+++ b/.claude/scripts/merge-preflight-thread-gate.test.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+#
+# Guards the PRE-merge read in Merge policy against a blocker class its field list cannot observe.
+#
+# Why this needs enforcing rather than merely being correct once: `required_review_thread_resolution`
+# is `true` on ALL ELEVEN portfolio repositories checked (2026-08-20: monorepo, platform, ksail,
+# world-at-ruin, actions, agent-skills, agent-plugins, kyverno-policies, homebrew-tap, dotnet-template,
+# go-template), so an unresolved review thread blocks a merge exactly like a failing required check.
+# But NO `gh pr view --json` field carries thread-resolution state, so the prescribed preflight
+# — number,isDraft,author,title,headRefOid,mergeStateStatus,statusCheckRollup — is structurally blind
+# to it, and `mergeStateStatus` reports it only as a bare `BLOCKED`.
+#
+# That produces the exact signature documented exception (a) tells a run to DISMISS as staleness:
+# `BLOCKED` while every check-run and status on the head is `success`/`skipped`. Measured live on
+# monorepo#2927 at head cc7ac05b (2026-08-20): mergeable MERGEABLE, mergeStateStatus BLOCKED, 0 failing
+# checks, 0 open code-scanning alerts repo-wide (unfiltered control), no CHANGES_REQUESTED — and 2
+# unresolved `coderabbitai` threads. Promoted 05:59:20Z, still unmerged hours later.
+#
+# The pentad's zero-unresolved-threads item is evaluated BEFORE promotion, and every review lane
+# re-reviews on each push, so a thread routinely arrives AFTER a PR is promoted (on #2927 the blocking
+# review landed at 07:32:06Z, 93 minutes after `ready_for_review`). The final pre-merge read is the only
+# gate left that could catch it, and it cannot.
+#
+# Guarded properties:
+#   1. the mechanism is named, so a reader can verify the rule themselves;
+#   2. a WORKING vocabulary for the thread read is prescribed (GraphQL — see 4);
+#   3. exception (a) cannot swallow this class: unresolved threads are a real blocker, not staleness;
+#   4. a merge refusal is DIAGNOSED before it is escalated as a maintainer blocker;
+#   5. NEGATIVE CONTROL: no `gh pr view --json` list in ANY definition surface names a thread field.
+#      `reviewThreads` is NOT a valid `gh pr view --json` field (verified against the live CLI), and
+#      `--json` is all-or-nothing, so "helpfully" adding it to the preflight would void the ENTIRE
+#      merge-evidence read — blinding the gate completely. This is the assertion with teeth: (1)-(4)
+#      are prose and can be satisfied by wording, (5) constrains every future prescription.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+constitution="${repo_root}/AGENTS.md"
+
+fail() {
+  echo "merge-preflight thread gate: FAIL — $*" >&2
+  exit 1
+}
+
+[ -r "${constitution}" ] || fail "cannot read ${constitution}"
+
+# Scope prose assertions to the MERGE POLICY SECTION. Against the whole file each phrase passes as long
+# as it survives anywhere — an example, a telemetry note — so a later edit could delete the instruction
+# from its point of use while this job still reported the merge procedure guarded.
+merge_policy="$(awk '
+  /^### Merge policy/ { inside = 1; print; next }
+  inside && /^### /   { exit }
+  inside              { print }
+' "${constitution}")"
+
+# Fail closed if the section vanished or was renamed — otherwise every assertion below checks an empty
+# string and passes vacuously, which is this control's own failure mode.
+[ "$(printf '%s' "${merge_policy}" | wc -c)" -gt 500 ] ||
+  fail "could not locate a '### Merge policy' section in AGENTS.md — assertions would be vacuous"
+
+# Markdown prose is hard-wrapped, so a guarded sentence routinely spans two lines and exists on NO
+# single line. Flatten once and match substrings against the flattened copy.
+merge_policy_flat="$(printf '%s' "${merge_policy}" | tr '\n' ' ' | tr -s '[:space:]' ' ')"
+
+assert_prose() {
+  case "${merge_policy_flat}" in
+    *"$1"*) ;;
+    *) fail "$2" ;;
+  esac
+}
+
+# ── 1. the mechanism is named ───────────────────────────────────────────────────────────────────────
+assert_prose 'required_review_thread_resolution' \
+  "Merge policy does not name the ruleset parameter that makes an unresolved thread block a merge"
+
+# ── 2. a WORKING vocabulary is prescribed ───────────────────────────────────────────────────────────
+# Assert the GraphQL shape, not a bare mention of threads: the whole lesson of the post-merge `merged`
+# field is that an unprescribed read gets improvised into an invalid one.
+assert_prose 'reviewThreads(first:100)' \
+  "Merge policy does not prescribe the GraphQL reviewThreads read for pre-merge thread state"
+assert_prose 'isResolved==false' \
+  "Merge policy does not prescribe selecting UNRESOLVED threads — a bare thread count is not the gate"
+# The invalid improvisation is named explicitly, exactly as `merged` is for the post-merge read.
+assert_prose 'is NOT a valid `gh pr view --json` field' \
+  "Merge policy does not state that reviewThreads is not a gh pr view --json field"
+
+# ── 3. exception (a) cannot swallow this class ──────────────────────────────────────────────────────
+assert_prose 'real blocker, never staleness' \
+  "Merge policy does not exclude unresolved threads from the BLOCKED-is-stale carve-out"
+
+# ── 4. a refusal is diagnosed before it is escalated ────────────────────────────────────────────────
+assert_prose 'DIAGNOSE the refusal before escalating' \
+  "Merge policy does not require diagnosing a merge refusal before surfacing it to the maintainer"
+
+# ── 5. NEGATIVE CONTROL — no `gh pr view --json` list may name a thread field ────────────────────────
+#
+# DISCOVER surfaces; never enumerate. A hand-written list drifts the moment a definition file is added,
+# and the drift is invisible because the control still reports success over the surfaces it knows.
+decode_surface() {
+  case "$1" in
+    # A scalar boundary is a HARD boundary: `jq -r '.. | strings'` emits one line per decoded value and
+    # flattening would otherwise weld the end of one value onto the start of the next. `%` is outside
+    # `[A-Za-z,]`, so it terminates a field list wherever it lands.
+    *.json) jq -r '.. | strings | ., "%"' "$1" 2>/dev/null || true ;;
+    *)      cat "$1" ;;
+  esac
+}
+
+normalise_and_extract() {           # $1 = file; emits one `--json <fields>` per line
+  # ONE canonicalisation, not a rule per formatting. Code delimiters are NOT flattened: a backtick or
+  # quote must TERMINATE a field list, or Markdown prose following an inline command joins across a
+  # comma into a false positive. A comma is joined to what follows ONLY across a line break — that is
+  # the one place a real field list is ever split.
+  decode_surface "$1" \
+    | sed -E -e 's/\\[nrt]/ /g' -e 's/\\/ /g' \
+    | awk '{
+        line = $0; sub(/[[:space:]]+$/, "", line)
+        if (NR > 1 && buf ~ /,$/) { sub(/^[[:space:]]+/, "", line); buf = buf line }
+        else { if (NR > 1) print buf; buf = line }
+      } END { if (NR > 0) print buf }' \
+    | tr '\n' ' ' \
+    | sed -E -e 's/…/,/g' -e 's/\.\.\./,/g' \
+             -e 's/[[:space:]]+/ /g' \
+             -e 's/--json[[:space:]]*[=,]*[[:space:]]*[`"'"'"']?[[:space:]]*/--json /g' \
+    | grep -o -- '--json [A-Za-z,]*' | sort -u
+}
+
+# Report every `--json` list in $1 that names a thread field. Whole-element comparison, not substring:
+# a future valid field could legitimately contain these as a prefix.
+bad_lists_in() {
+  local list fields out=""
+  while IFS= read -r list; do
+    fields="${list#--json }"
+    fields="${fields%%[\` \"]*}"
+    case ",${fields}," in
+      *,reviewThreads,*|*,isResolved,*) out="${out}--json ${fields}"$'\n' ;;
+    esac
+  done < <(normalise_and_extract "$1")
+  printf '%s' "${out}"
+}
+
+# ── 5a. SELF-TEST THE EXTRACTOR FIRST — otherwise this whole control is vacuous ─────────────────────
+# `scanned` counts readable FILES, not successfully parsed field lists. If the extraction pattern ever
+# stops matching, every surface yields nothing, no offender is found, and the control prints OK over
+# every surface while detecting nothing at all. So exercise it against fixtures before trusting it.
+self_test_dir="$(mktemp -d)"
+trap 'rm -rf "${self_test_dir}"' EXIT
+
+# Each BAD form pairs the offending field with a DIFFERENT valid field on purpose: the extractor ends in
+# `sort -u`, so fixtures normalising to the same string would collapse and under-report detection.
+cat > "${self_test_dir}/bad.md" <<'FIXTURE'
+plain: gh pr view 1 --json number,reviewThreads
+equals: gh pr view 1 --json=isDraft,reviewThreads
+quoted: gh pr view 1 --json "title,reviewThreads"
+wrapped: gh pr view 1 --json headRefOid,
+  reviewThreads
+elided: gh pr view 1 --json …,isResolved
+FIXTURE
+
+cat > "${self_test_dir}/good.md" <<'FIXTURE'
+the prescribed preflight: --json number,isDraft,author,title,headRefOid,mergeStateStatus,statusCheckRollup
+the post-merge read: --json state,mergedAt
+prose after a command: `--json comments`, reviewThreads are read over GraphQL instead
+graphql is not a --json list: reviewThreads(first:100){nodes{isResolved}}
+FIXTURE
+
+bad_found="$(bad_lists_in "${self_test_dir}/bad.md" | grep -c . || true)"
+[ "${bad_found}" -eq 5 ] ||
+  fail "extractor self-test: caught ${bad_found}/5 planted bad forms — the control would scan vacuously"
+
+good_found="$(bad_lists_in "${self_test_dir}/good.md" | grep -c . || true)"
+[ "${good_found}" -eq 0 ] ||
+  fail "extractor self-test: flagged ${good_found} VALID form(s) — the control would condemn correct content"
+
+# ── 5b. scan the real definition surfaces ───────────────────────────────────────────────────────────
+offenders=""
+scanned=0
+while IFS= read -r surface; do
+  [ -r "${surface}" ] || continue
+  scanned=$((scanned + 1))
+  found="$(bad_lists_in "${surface}")"
+  [ -n "${found}" ] && offenders="${offenders}${surface}:"$'\n'"${found}"
+done < <(
+  {
+    printf '%s\n' "${constitution}"
+    find "${repo_root}/.claude" -type f \( -name '*.md' -o -name '*.json' \) 2>/dev/null
+  } | sort -u
+)
+
+[ "${scanned}" -gt 5 ] ||
+  fail "only ${scanned} definition surface(s) discovered — the negative control would be vacuous"
+
+if [ -n "${offenders}" ]; then
+  printf 'merge-preflight thread gate: FAIL — a thread field is prescribed in a `gh pr view --json` list.\n' >&2
+  printf '`--json` is all-or-nothing, so this voids the ENTIRE merge-evidence read:\n%s' "${offenders}" >&2
+  exit 1
+fi
+
+echo "merge-preflight thread gate: OK — 5 properties held; negative control scanned ${scanned} surfaces."

--- a/.claude/scripts/merge-preflight-thread-gate.test.sh
+++ b/.claude/scripts/merge-preflight-thread-gate.test.sh
@@ -215,11 +215,23 @@ plugin_defs="${repo_root}/libraries/agent-plugins/plugins/agentic-engineering"
   fail "pinned plugin definitions are absent at ${plugin_defs}, so they cannot be scanned and an OK here would be vacuous
   populate them:  git -c 'url.https://github.com/.insteadOf=git@github.com:' submodule update --init libraries/agent-plugins"
 
+# `ci.yaml` is a definition surface in its own right, not just the thing that decides WHEN this job
+# runs. AGENTS.md classifies it as one, and the paths-filter below already triggers on it — so leaving
+# it out of the SCAN meant an edit there ran the guard against every file except the one that
+# changed. Watching a source decides when a job runs, never what it knows about.
+workflow="${repo_root}/.github/workflows/ci.yaml"
+# FAIL, never skip: `ci.yaml` is a fixed path, so guarding these with `if [ -r … ]` would turn a
+# missing workflow into a silent pass — the exact vacuity this file exists to prevent.
+[ -r "${workflow}" ] ||
+  fail "ci.yaml is missing or unreadable at ${workflow} — this job's own wiring cannot be verified, so an OK here would be vacuous"
+
 offenders=""
 scanned=0
+scanned_list=""
 while IFS= read -r surface; do
   [ -r "${surface}" ] || continue
   scanned=$((scanned + 1))
+  scanned_list="${scanned_list}${surface}"$'\n'
   # VALIDATE a JSON surface HERE, in the MAIN shell, before it is scanned. `bad_lists_in` reads its
   # input through process substitution (`< <(...)`), whose failure `set -e` does NOT catch — so a
   # `fail` inside the extraction chain leaves the loop with empty output and exit 0, and the surface is
@@ -234,7 +246,7 @@ while IFS= read -r surface; do
   [ -n "${found}" ] && offenders="${offenders}${surface}:"$'\n'"${found}"
 done < <(
   {
-    printf '%s\n' "${constitution}"
+    printf '%s\n' "${constitution}" "${workflow}"
     find "${repo_root}/.claude" -type f \( -name '*.md' -o -name '*.json' \) 2>/dev/null
     find "${plugin_defs}" -type f \( -name '*.md' -o -name '*.json' \) 2>/dev/null
   } | sort -u
@@ -242,6 +254,13 @@ done < <(
 
 [ "${scanned}" -gt 5 ] ||
   fail "only ${scanned} definition surface(s) discovered — the negative control would be vacuous"
+
+# A POSITIVE control on the surface set, not just its size. `${scanned} -gt 5` is satisfied by the
+# ~40 `.claude` files alone, so `ci.yaml` could be dropped from the generator — or made unreadable —
+# and the count would still sail past. Name the surface that has to be there, so its removal fails
+# loudly instead of quietly narrowing what the guard sees.
+printf '%s' "${scanned_list}" | grep -qxF -- "${workflow}" ||
+  fail "ci.yaml was not among the ${scanned} scanned surfaces — the guard triggers on it but would not inspect it"
 
 if [ -n "${offenders}" ]; then
   printf 'merge-preflight thread gate: FAIL — a thread field is prescribed in a `gh pr view --json` list.\n' >&2
@@ -260,11 +279,6 @@ echo "merge-preflight thread gate: OK — ${ASSERTED} prose properties held; neg
 # longer gate the required check. In every one of those cases this script still exits 0 — it cannot
 # detect its own disconnection unless it looks. `merge-confirmation-read.test.sh` guards the identical
 # five-point mode for the same reason; this is that pattern, not a new idea.
-workflow="${repo_root}/.github/workflows/ci.yaml"
-# FAIL, never skip: `ci.yaml` is a fixed path, so guarding these with `if [ -r … ]` would turn a
-# missing workflow into a silent pass — the exact vacuity this file exists to prevent.
-[ -r "${workflow}" ] ||
-  fail "ci.yaml is missing or unreadable at ${workflow} — this job's own wiring cannot be verified, so an OK here would be vacuous"
 
 for spec in \
   '            merge-preflight-thread-gate:|paths-filter entry' \

--- a/.claude/scripts/merge-preflight-thread-gate.test.sh
+++ b/.claude/scripts/merge-preflight-thread-gate.test.sh
@@ -18,10 +18,12 @@
 # checks, 0 open code-scanning alerts repo-wide (unfiltered control), no CHANGES_REQUESTED — and 2
 # unresolved `coderabbitai` threads. Promoted 05:59:20Z, still unmerged hours later.
 #
-# The pentad's zero-unresolved-threads item is evaluated BEFORE promotion, and every review lane
-# re-reviews on each push, so a thread routinely arrives AFTER a PR is promoted (on #2927 the blocking
-# review landed at 07:32:06Z, 93 minutes after `ready_for_review`). The final pre-merge read is the only
-# gate left that could catch it, and it cannot.
+# The survey pentad DOES carry unresolved threads, so the gap is not that no thread check exists — it
+# is that thread state comes only from a SNAPSHOT taken earlier in the run, while the fresh pre-merge
+# read (which exists precisely for state that moves after that snapshot, and re-validates `title` for
+# exactly that reason) omits it. Every review lane re-reviews on each push and can post at any moment:
+# on #2927 the blocking review landed at 07:32:06Z, 93 minutes after `ready_for_review`. So a
+# survey-time zero is not evidence at merge time, and the final read cannot supply one.
 #
 # Guarded properties:
 #   1. the mechanism is named, so a reader can verify the rule themselves;

--- a/.claude/scripts/merge-preflight-thread-gate.test.sh
+++ b/.claude/scripts/merge-preflight-thread-gate.test.sh
@@ -243,6 +243,42 @@ hidden="$(git -C "${repo_root}/libraries/agent-plugins" ls-files -v 2>/dev/null 
 [ -z "${hidden}" ] ||
   fail "libraries/agent-plugins carries assume-unchanged/skip-worktree entries, which hide a modification from status"
 
+# The three checks above answer "is the tree unmodified AS GIT SEES IT", which is weaker than "are
+# these the reviewed bytes" — and it is the weaker claim that is easy to mistake for proof. A
+# clean/smudge filter assigned to these paths through the repository, a global, or
+# $GIT_DIR/info/attributes makes git compare the CLEANED form, so the file on disk can carry
+# different instructions while status prints nothing and ls-files -v reports an ordinary entry.
+# This scanner then reads the worktree bytes directly (`cat`), so a forbidden thread field would be
+# scanned from altered bytes with every check above passing. Assert byte identity against the pinned
+# blobs, which no filter can launder because --no-filters bypasses the clean stage.
+#
+# Every guard below closes a path where the naive form reports success on a check that never ran:
+# piping ls-tree straight into the loop takes the WHILE's status, so an enumeration failure runs the
+# body zero times and prints nothing — indistinguishable from a verified tree. An uninitialised
+# submodule makes rev-parse and hash-object both return empty, and [ "$want" = "$got" ] then compares
+# EQUAL, so the emptiest possible evidence would read as the strongest. --no-replace-objects belongs
+# on ls-tree too, or the enumeration walks a replaced tree while the lookups beside it do not.
+# printf '%s\n' is required: command substitution strips the trailing newline, so a bare printf '%s'
+# makes read return false on the final entry and drops the last file unchecked.
+byte_files="$(git -C "${repo_root}/libraries/agent-plugins" --no-replace-objects ls-tree -r --name-only HEAD -- plugins/agentic-engineering 2>/dev/null)" ||
+  fail "could not enumerate the pinned plugin definition blobs, so their bytes are unverified — unproven is not proven"
+[ -n "${byte_files}" ] ||
+  fail "the pinned plugin definition enumeration came back empty, so a byte check here would pass vacuously"
+byte_mismatch="$(printf '%s\n' "${byte_files}" | while IFS= read -r bf; do
+  [ -n "${bf}" ] || continue
+  want="$(git -C "${repo_root}/libraries/agent-plugins" --no-replace-objects rev-parse "HEAD:${bf}" 2>/dev/null)" ||
+    { printf 'BYTES-UNKNOWN %s\n' "${bf}"; continue; }
+  got="$(git -C "${repo_root}/libraries/agent-plugins" hash-object --no-filters -- "${bf}" 2>/dev/null)" ||
+    { printf 'BYTES-UNKNOWN %s\n' "${bf}"; continue; }
+  { [ -n "${want}" ] && [ -n "${got}" ]; } ||
+    { printf 'BYTES-UNKNOWN %s\n' "${bf}"; continue; }
+  [ "${want}" = "${got}" ] || printf 'BYTES-DIFFER %s\n' "${bf}"
+done)"
+[ -z "${byte_mismatch}" ] ||
+  fail "the plugin definition worktree bytes are not the pinned blobs, so the scan would inspect
+  unreviewed content while revision, status and index flags all read clean:
+${byte_mismatch}"
+
 # `ci.yaml` is a definition surface in its own right, not just the thing that decides WHEN this job
 # runs. AGENTS.md classifies it as one, and the paths-filter below already triggers on it — so leaving
 # it out of the SCAN meant an edit there ran the guard against every file except the one that

--- a/.claude/scripts/merge-preflight-thread-gate.test.sh
+++ b/.claude/scripts/merge-preflight-thread-gate.test.sh
@@ -94,6 +94,13 @@ assert_prose 'pageInfo{hasNextPage endCursor}' \
   "Merge policy prescribes a thread read without the pageInfo cursor — a first-page-only count"
 assert_prose 'gh api graphql --paginate' \
   "Merge policy prescribes a thread read that does not walk every page"
+# FAIL-CLOSED is part of the vocabulary too. Without `pipefail` the prescribed pipeline prints the
+# ALL-CLEAR value on a broken read: `false | jq -s '[.[]]|length'` emits 0 and exits 0 (reproduced), so
+# an auth/network/API failure would satisfy the gate hardest exactly when it can see least.
+assert_prose 'set -o pipefail' \
+  "Merge policy prescribes a thread read whose pipeline can print 0 from a FAILED read"
+assert_prose 'UNKNOWN, never as zero' \
+  "Merge policy does not say a failed thread read is UNKNOWN rather than zero"
 # The invalid improvisation is named explicitly, exactly as `merged` is for the post-merge read.
 assert_prose '`reviewThreads` is NOT a valid `gh pr view --json` field' \
   "Merge policy does not state that reviewThreads is not a gh pr view --json field"
@@ -124,7 +131,11 @@ normalise_and_extract() {           # $1 = file; emits one `--json <fields>` per
   # ONE canonicalisation, not a rule per formatting. Code delimiters are NOT flattened: a backtick or
   # quote must TERMINATE a field list, or Markdown prose following an inline command joins across a
   # comma into a false positive. A comma is joined to what follows ONLY across a line break — that is
-  # the one place a real field list is ever split.
+  # the one place a real field list is ever split. Whitespace AROUND COMMAS is collapsed last: the
+  # extractor ends at any character outside `[A-Za-z,]`, so `--json "number, reviewThreads"` would
+  # otherwise yield `--json number,` and the thread field would escape the control entirely. Collapsing
+  # after the delimiter strip keeps the quote/backtick terminator intact, so prose that merely follows
+  # an inline command across a comma still cannot join into a false positive.
   decode_surface "$1" \
     | sed -E -e 's/\\[nrt]/ /g' -e 's/\\/ /g' \
     | awk '{
@@ -136,6 +147,7 @@ normalise_and_extract() {           # $1 = file; emits one `--json <fields>` per
     | sed -E -e 's/…/,/g' -e 's/\.\.\./,/g' \
              -e 's/[[:space:]]+/ /g' \
              -e 's/--json[[:space:]]*[=,]*[[:space:]]*[`"'"'"']?[[:space:]]*/--json /g' \
+             -e 's/[[:space:]]*,[[:space:]]*/,/g' \
     | grep -o -- '--json [A-Za-z,]*' | sort -u
 }
 
@@ -169,6 +181,8 @@ quoted: gh pr view 1 --json "title,reviewThreads"
 wrapped: gh pr view 1 --json headRefOid,
   reviewThreads
 elided: gh pr view 1 --json …,isResolved
+spaced-after: gh pr view 1 --json "author, reviewThreads"
+spaced-before: gh pr view 1 --json "mergedAt ,isResolved"
 FIXTURE
 
 cat > "${self_test_dir}/good.md" <<'FIXTURE'
@@ -179,14 +193,28 @@ graphql is not a --json list: reviewThreads(first:100){nodes{isResolved}}
 FIXTURE
 
 bad_found="$(bad_lists_in "${self_test_dir}/bad.md" | grep -c . || true)"
-[ "${bad_found}" -eq 5 ] ||
-  fail "extractor self-test: caught ${bad_found}/5 planted bad forms — the control would scan vacuously"
+[ "${bad_found}" -eq 7 ] ||
+  fail "extractor self-test: caught ${bad_found}/7 planted bad forms — the control would scan vacuously"
 
 good_found="$(bad_lists_in "${self_test_dir}/good.md" | grep -c . || true)"
 [ "${good_found}" -eq 0 ] ||
   fail "extractor self-test: flagged ${good_found} VALID form(s) — the control would condemn correct content"
 
 # ── 5b. scan the real definition surfaces ───────────────────────────────────────────────────────────
+#
+# The PINNED plugin definitions are consumed definition surfaces too — AGENTS.md classifies the
+# plugin-authored agent files as version-controlled definition surfaces, and every run loads its role
+# from them. Scanning only `AGENTS.md` and `.claude` leaves a gitlink advance free to reintroduce the
+# exact blind spot this guard exists to close, with the guard still green.
+#
+# FAIL, never skip, when they are absent. `find` on a missing directory prints nothing and exits
+# quietly, so an unpopulated submodule would make this addition a silent no-op — the vacuity the whole
+# file is written against. The message names the fix, so the failure is actionable rather than a wall.
+plugin_defs="${repo_root}/libraries/agent-plugins/plugins/agentic-engineering"
+[ -d "${plugin_defs}" ] && [ -n "$(find "${plugin_defs}" -type f -name '*.md' 2>/dev/null | head -1)" ] ||
+  fail "pinned plugin definitions are absent at ${plugin_defs}, so they cannot be scanned and an OK here would be vacuous
+  populate them:  git -c 'url.https://github.com/.insteadOf=git@github.com:' submodule update --init libraries/agent-plugins"
+
 offenders=""
 scanned=0
 while IFS= read -r surface; do
@@ -208,6 +236,7 @@ done < <(
   {
     printf '%s\n' "${constitution}"
     find "${repo_root}/.claude" -type f \( -name '*.md' -o -name '*.json' \) 2>/dev/null
+    find "${plugin_defs}" -type f \( -name '*.md' -o -name '*.json' \) 2>/dev/null
   } | sort -u
 )
 
@@ -220,4 +249,56 @@ if [ -n "${offenders}" ]; then
   exit 1
 fi
 
-echo "merge-preflight thread gate: OK — 8 prose properties held; negative control scanned ${scanned} surfaces."
+ASSERTED=$(grep -c '^assert_prose ' "${BASH_SOURCE[0]}")
+echo "merge-preflight thread gate: OK — ${ASSERTED} prose properties held; negative control scanned ${scanned} surfaces."
+
+# ── 6. THIS JOB'S OWN CI WIRING — five edits, and a job can ship with four ──────────────────────────
+#
+# Wiring a contract test into `ci.yaml` takes FIVE edits. Drop the `changes` output and
+# `needs.changes.outputs.…` is empty, so the `if:` never matches and the job SKIPS SILENTLY. Drop it
+# from the `status` job's `needs:`/`job-results:` and it runs and prints OK while its failures no
+# longer gate the required check. In every one of those cases this script still exits 0 — it cannot
+# detect its own disconnection unless it looks. `merge-confirmation-read.test.sh` guards the identical
+# five-point mode for the same reason; this is that pattern, not a new idea.
+workflow="${repo_root}/.github/workflows/ci.yaml"
+# FAIL, never skip: `ci.yaml` is a fixed path, so guarding these with `if [ -r … ]` would turn a
+# missing workflow into a silent pass — the exact vacuity this file exists to prevent.
+[ -r "${workflow}" ] ||
+  fail "ci.yaml is missing or unreadable at ${workflow} — this job's own wiring cannot be verified, so an OK here would be vacuous"
+
+for spec in \
+  '            merge-preflight-thread-gate:|paths-filter entry' \
+  '      merge-preflight-thread-gate: ${{ steps.filter.outputs.merge-preflight-thread-gate }}|changes-job outputs declaration (its absence makes the job skip silently)' \
+  '  test-merge-preflight-thread-gate:|job definition' \
+  '      - test-merge-preflight-thread-gate|status job needs: entry (its absence stops the job gating the merge)' \
+  '            ${{ needs.test-merge-preflight-thread-gate.result }}|status job job-results entry'; do
+  line="${spec%%|*}"; what="${spec#*|}"
+  grep -qxF -- "${line}" "${workflow}" ||
+    fail "ci.yaml is missing this job's ${what} — the guard would not gate"
+done
+
+# The scan of the pinned plugin definitions only happens if CI populates that submodule. Without the
+# init step the job fails closed rather than passing vacuously, but it fails on EVERY run — so assert
+# the step is wired, and the failure names the cause instead of leaving a red job to be diagnosed.
+#
+# SCOPED TO THIS JOB'S BLOCK, deliberately. A whole-file grep is vacuous here: the delivery-contract
+# job carries the identical init line, so the assertion would pass with this job's step deleted — and
+# it passed against the revision that predates this step entirely. Slice the block, then look inside it.
+job_block=$(awk '/^  test-merge-preflight-thread-gate:$/{f=1;next} f&&/^  [a-z]/{exit} f' "${workflow}")
+[ -n "${job_block}" ] ||
+  fail "could not locate the test-merge-preflight-thread-gate job block in ci.yaml — its wiring cannot be verified"
+printf '%s\n' "${job_block}" | grep -qF -- 'submodule update --init libraries/agent-plugins' ||
+  fail "this job does not initialise libraries/agent-plugins — the pinned plugin definitions could not be scanned"
+
+# The filter must cover every surface the scan discovers, or an edit to an unlisted one skips the job.
+for trigger in \
+  "              - 'AGENTS.md'" \
+  "              - '.claude/**/*.md'" \
+  "              - '.claude/**/*.json'" \
+  "              - '.claude/scripts/merge-preflight-thread-gate.test.sh'" \
+  "              - 'libraries/agent-plugins'" \
+  "              - '.gitmodules'" \
+  "              - '.github/workflows/ci.yaml'"; do
+  grep -qxF -- "${trigger}" "${workflow}" ||
+    fail "ci.yaml filter is missing ${trigger# *} — an edit there would not run this guard"
+done

--- a/.claude/scripts/merge-preflight-thread-gate.test.sh
+++ b/.claude/scripts/merge-preflight-thread-gate.test.sh
@@ -3,9 +3,11 @@
 # Guards the PRE-merge read in Merge policy against a blocker class its field list cannot observe.
 #
 # Why this needs enforcing rather than merely being correct once: `required_review_thread_resolution`
-# is `true` on ALL ELEVEN portfolio repositories checked (2026-08-20: monorepo, platform, ksail,
+# is `true` on ALL NINETEEN portfolio repositories (2026-08-20: monorepo, platform, ksail,
 # world-at-ruin, actions, agent-skills, agent-plugins, kyverno-policies, homebrew-tap, dotnet-template,
-# go-template), so an unresolved review thread blocks a merge exactly like a failing required check.
+# go-template, platform-template, platform-tenant-template, provider-upjet-unifi, unifi, wedding-app,
+# ascoachingogvaner, doggy-countdown, .github) — every repo in the Portfolio map, no exception — so an
+# unresolved review thread blocks a merge exactly like a failing required check.
 # But NO `gh pr view --json` field carries thread-resolution state, so the prescribed preflight
 # — number,isDraft,author,title,headRefOid,mergeStateStatus,statusCheckRollup — is structurally blind
 # to it, and `mergeStateStatus` reports it only as a bare `BLOCKED`.

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -553,7 +553,34 @@ slice. Record the product's `last_value_review` cursor, not live metrics, in nat
    showing the same
    `headRefOid`, `isDraft:false`, owner `devantler-tech`, and `CLEAN`; merge only when the pentad also has zero
    findings and a green review at that
-   head. 🔴 **Do not re-add a `trusted author` condition here** — trust gates **execution**, never the
+   head.
+   🔴 **That field list CANNOT see unresolved review threads, and thread resolution is a REQUIRED
+   merge rule on every repository here** (contract *Merge policy*, `required_review_thread_resolution`
+   on all nineteen). `reviewThreads` is **not** a valid `gh pr view --json` field, so adding it would
+   void the whole read. Take it over GraphQL as its own call, **immediately before the merge** — the
+   survey pentad carries a thread count, but it is a snapshot from earlier in the run and every lane
+   can post at any moment (on monorepo#2927 the blocking review landed 93 minutes after promotion):
+
+   ```sh
+   unresolved=$(
+     set -o pipefail   # WITHOUT this a FAILED read prints the ALL-CLEAR value: `false | jq -s …` → 0, exit 0
+     gh api graphql --paginate -f owner=devantler-tech -f name=<repo> -F number=<n> -f query='
+   query($owner:String!,$name:String!,$number:Int!,$endCursor:String){
+     repository(owner:$owner,name:$name){
+       pullRequest(number:$number){
+         reviewThreads(first:100,after:$endCursor){
+           nodes{isResolved}
+           pageInfo{hasNextPage endCursor}
+         }}}}' |
+       jq -s '[.[].data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
+   ) || { echo "thread read FAILED — UNKNOWN, never 0" >&2; exit 1; }
+   ```
+
+   Merge only on a `0` a **successful** read produced; treat any non-zero exit as UNKNOWN, never as
+   zero. `--paginate` and the cursor are required — a first-page-only read silently under-counts on a
+   PR with more than 100 threads. Without this, a bare `BLOCKED` from an unresolved thread is
+   indistinguishable from the stale `mergeStateStatus` that exception (a) tells you to merge through,
+   and the refusal that follows gets escalated as a maintainer gate. 🔴 **Do not re-add a `trusted author` condition here** — trust gates **execution**, never the
    merge (contract *Trust gate*), so an external PR that has cleared every evaluation and review gate
    would otherwise be refused at the last step for being external, which is the whole class the
    2026-08-08 widening exists to admit. Exact `renovate[bot]`/`dependabot[bot]` PRs stay excluded as

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -584,7 +584,16 @@ slice. Record the product's `last_value_review` cursor, not live metrics, in nat
    merge (contract *Trust gate*), so an external PR that has cleared every evaluation and review gate
    would otherwise be refused at the last step for being external, which is the whole class the
    2026-08-08 widening exists to admit. Exact `renovate[bot]`/`dependabot[bot]` PRs stay excluded as
-   automation-owned. A refused
+   automation-owned. 🔴 **DIAGNOSE a refused merge before escalating it — a one-click is for what you
+   cannot fix, never for what you did not look at.** The thread read above is taken *immediately*
+   before the merge, but "immediately" is not "atomically": a lane can post a thread in the gap, and
+   a ruleset condition the pentad never modelled can refuse just as easily. Both surface as a bare
+   refusal, and both are agent-fixable. So on a refusal, **re-read the unresolved-thread count and
+   the head's check state, then name the cause** — a thread that landed in the gap gets fixed and
+   resolved, a newly-red check gets root-caused, and only a cause that is genuinely outside agent
+   authority is escalated. Escalating an undiagnosed refusal converts your own unfinished hygiene
+   into a maintainer gate, which is the passive self-blocking the contract forbids everywhere else.
+   Once diagnosed and genuinely not agent-fixable, a refused
    merge is a **rare fallback** — surface the PR for a one-click instead of burning the run on
    variant-evidence retries. **On merge-queue repos, root-cause a stall/kick-out before re-queuing**
    (contract *Merge policy → Merge-queue repos*): a PR that "was queued" but didn't merge has usually been

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -366,6 +366,10 @@ jobs:
               - '.claude/**/*.md'
               - '.claude/**/*.json'
               - '.claude/scripts/merge-preflight-thread-gate.test.sh'
+              # the PINNED plugin definitions are scanned too, so a gitlink advance that
+              # reintroduces a thread field must run this guard rather than sail past it
+              - 'libraries/agent-plugins'
+              - '.gitmodules'
               - '.github/workflows/ci.yaml'
             portfolio-surveyor:
               - 'AGENTS.md'
@@ -1252,6 +1256,18 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # The negative control scans the PINNED plugin definitions as well, so that one submodule
+      # must be present — without it the test fails closed rather than skipping, because `find` on a
+      # missing directory prints nothing and the added surfaces would be a silent no-op. Only this
+      # submodule is initialised (not `submodules: true`, which would also try the private ones), over
+      # HTTPS because .gitmodules uses SSH and no deploy key exists in CI. The rewrite is
+      # command-scoped and carries no credential: agent-plugins is public and this is an anonymous
+      # read. NOT shallow — `--depth 1` resolves the pin only while it equals the branch tip, so every
+      # upstream merge past the pin would turn an unrelated PR red.
+      - name: Initialise the agent-plugins submodule
+        run: |
+          git -c 'url.https://github.com/.insteadOf=git@github.com:' \
+            submodule update --init libraries/agent-plugins
       - name: Verify the merge-preflight thread gate
         run: bash .claude/scripts/merge-preflight-thread-gate.test.sh
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
       plugin-definition-refresh: ${{ steps.filter.outputs.plugin-definition-refresh }}
       codex-lane-liveness: ${{ steps.filter.outputs.codex-lane-liveness }}
       merge-confirmation-read: ${{ steps.filter.outputs.merge-confirmation-read }}
+      merge-preflight-thread-gate: ${{ steps.filter.outputs.merge-preflight-thread-gate }}
       portfolio-surveyor: ${{ steps.filter.outputs.portfolio-surveyor }}
       product-value: ${{ steps.filter.outputs.product-value }}
       agent-telemetry: ${{ steps.filter.outputs.agent-telemetry }}
@@ -357,6 +358,14 @@ jobs:
               - '.claude/**/*.md'
               - '.claude/**/*.json'
               - '.claude/scripts/merge-confirmation-read.test.sh'
+              - '.github/workflows/ci.yaml'
+            merge-preflight-thread-gate:
+              - 'AGENTS.md'
+              # every Markdown/JSON definition surface, matching the test's own discovery — an
+              # enumerated subset would let a change to an unlisted surface skip the negative control
+              - '.claude/**/*.md'
+              - '.claude/**/*.json'
+              - '.claude/scripts/merge-preflight-thread-gate.test.sh'
               - '.github/workflows/ci.yaml'
             portfolio-surveyor:
               - 'AGENTS.md'
@@ -1231,6 +1240,21 @@ jobs:
       - name: Verify the merge-confirmation read contract
         run: bash .claude/scripts/merge-confirmation-read.test.sh
 
+  test-merge-preflight-thread-gate:
+    name: Test merge-preflight thread gate
+    needs: changes
+    if: needs.changes.outputs.merge-preflight-thread-gate == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify the merge-preflight thread gate
+        run: bash .claude/scripts/merge-preflight-thread-gate.test.sh
+
   test-portfolio-surveyor-contract:
     name: Test portfolio surveyor contract
     needs: changes
@@ -1291,6 +1315,7 @@ jobs:
       - test-agent-role-delivery-contract
       - test-work-priority-ladder
       - test-merge-confirmation-read
+      - test-merge-preflight-thread-gate
       - test-portfolio-surveyor-contract
       - test-product-value-contract
     permissions: {}
@@ -1339,5 +1364,6 @@ jobs:
             ${{ needs.test-agent-role-delivery-contract.result }}
             ${{ needs.test-work-priority-ladder.result }}
             ${{ needs.test-merge-confirmation-read.result }}
+            ${{ needs.test-merge-preflight-thread-gate.result }}
             ${{ needs.test-portfolio-surveyor-contract.result }}
             ${{ needs.test-product-value-contract.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -379,7 +379,9 @@ jobs:
               # enumerated subset would let a change to an unlisted surface skip the negative control
               - '.claude/**/*.md'
               - '.claude/**/*.json'
-              - '.claude/scripts/merge-preflight-thread-gate.test.sh'
+              # the enforcement SCRIPTS are scanned too: a prescription can live in a sibling
+              # guard's comments or failure messages, so an edit there must run this control
+              - '.claude/**/*.sh'
               # the PINNED plugin definitions are scanned too, so a gitlink advance that
               # reintroduces a thread field must run this guard rather than sail past it
               - 'libraries/agent-plugins'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2265,9 +2265,12 @@ gh api graphql -f query='{repository(owner:"devantler-tech",name:"<repo>"){pullR
   --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
 ```
 
-**That must read `0` before the merge.** The pentad's zero-unresolved-threads item is evaluated
-**before promotion**, and every review lane re-reviews on each push, so a thread routinely arrives
-*after* a PR is promoted — this final read is the only gate left that can catch it.
+**That must read `0` immediately before the merge — not once, earlier, from the survey.** The survey
+pentad does carry unresolved threads, but it is a **snapshot taken earlier in the run**, and this
+fresh read exists precisely for state that moves after that snapshot — the same reason `title` is
+re-validated above. Every review lane re-reviews on each push and can post at any moment: on
+monorepo#2927 the blocking review landed **93 minutes after** the PR was promoted. So a survey-time
+zero is not evidence at merge time.
 ⚠️ **`--repo` is part of the prescription, not an optional convenience** —
 none of those fields carries the *base* repository's identity (`headRepositoryOwner`, where it exists,
 names the contributor's **fork**), so without the flag the command resolves against whatever checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2261,7 +2261,9 @@ the post-merge `merged` field causes, in the one place the merge gate cannot aff
 it over GraphQL, as its own call:
 
 ```sh
-gh api graphql --paginate -f owner=devantler-tech -f name=<repo> -F number=<n> -f query='
+unresolved=$(
+  set -o pipefail   # WITHOUT this a failed read prints the ALL-CLEAR value: `false | jq -s …` emits 0, exit 0
+  gh api graphql --paginate -f owner=devantler-tech -f name=<repo> -F number=<n> -f query='
 query($owner:String!,$name:String!,$number:Int!,$endCursor:String){
   repository(owner:$owner,name:$name){
     pullRequest(number:$number){
@@ -2269,7 +2271,8 @@ query($owner:String!,$name:String!,$number:Int!,$endCursor:String){
         nodes{isResolved}
         pageInfo{hasNextPage endCursor}
       }}}}' |
-  jq -s '[.[].data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
+    jq -s '[.[].data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
+) || { echo "thread read FAILED — UNKNOWN, never 0" >&2; exit 1; }
 ```
 
 **That must read `0` immediately before the merge — not once, earlier, from the survey.** The survey
@@ -2278,6 +2281,13 @@ fresh read exists precisely for state that moves after that snapshot — the sam
 re-validated above. Every review lane re-reviews on each push and can post at any moment: on
 monorepo#2927 the blocking review landed **93 minutes after** the PR was promoted. So a survey-time
 zero is not evidence at merge time.
+
+🔴 **A FAILED read must never satisfy this gate — that is why the command captures and checks instead
+of piping straight to `jq`.** Without `pipefail`, `gh api … | jq -s …` on an auth, network, or API
+failure leaves an empty stream, `jq -s` evaluates it as `[]`, prints **`0`**, and exits **`0`** —
+reproduced directly (`false | jq -s '[.[]]|length'` → `0`, rc `0`). The all-clear value and the
+broken-read value are the same character, so the gate would pass hardest exactly when it can see least.
+Treat a non-zero exit as **UNKNOWN, never as zero**, and merge only on a `0` a successful read produced.
 
 🔴 **`--paginate` and the `pageInfo` cursor are REQUIRED, not tidiness — a first-page-only read
 silently under-counts.** `reviewThreads(first:100)` returns at most one page, so a long-lived PR whose

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2261,8 +2261,15 @@ the post-merge `merged` field causes, in the one place the merge gate cannot aff
 it over GraphQL, as its own call:
 
 ```sh
-gh api graphql -f query='{repository(owner:"devantler-tech",name:"<repo>"){pullRequest(number:<n>){reviewThreads(first:100){nodes{isResolved}}}}}' \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
+gh api graphql --paginate -f owner=devantler-tech -f name=<repo> -F number=<n> -f query='
+query($owner:String!,$name:String!,$number:Int!,$endCursor:String){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      reviewThreads(first:100,after:$endCursor){
+        nodes{isResolved}
+        pageInfo{hasNextPage endCursor}
+      }}}}' |
+  jq -s '[.[].data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
 ```
 
 **That must read `0` immediately before the merge — not once, earlier, from the survey.** The survey
@@ -2271,6 +2278,13 @@ fresh read exists precisely for state that moves after that snapshot — the sam
 re-validated above. Every review lane re-reviews on each push and can post at any moment: on
 monorepo#2927 the blocking review landed **93 minutes after** the PR was promoted. So a survey-time
 zero is not evidence at merge time.
+
+🔴 **`--paginate` and the `pageInfo` cursor are REQUIRED, not tidiness — a first-page-only read
+silently under-counts.** `reviewThreads(first:100)` returns at most one page, so a long-lived PR whose
+threads exceed 100 reports a **partial** count, and the one number this gate depends on reads `0` while
+unresolved threads remain. That is the same failure the rule exists to prevent, one level down: a read
+that looks authoritative and is not. Note `--slurp` is **not** usable here — `gh` rejects it together
+with `--jq` — so the pages are slurped with `jq -s` instead.
 ⚠️ **`--repo` is part of the prescription, not an optional convenience** —
 none of those fields carries the *base* repository's identity (`headRepositoryOwner`, where it exists,
 names the contributor's **fork**), so without the flag the command resolves against whatever checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2250,7 +2250,8 @@ against Conventional Commits in this final read**, not only when you set it.
 
 🔴 **The preflight field list CANNOT see review-thread resolution — and an unresolved thread is a
 REQUIRED merge rule on every repository here.** `required_review_thread_resolution: true` is set on
-**all eleven** portfolio repositories checked (2026-08-20), via one of the `pull_request` rules on
+**all nineteen** portfolio repositories (2026-08-20 — every repo in the Portfolio map, no
+exception), via one of the `pull_request` rules on
 `main`, so an unresolved thread blocks the merge exactly like a failing required check. Yet
 `mergeStateStatus` reports it only as a bare `BLOCKED`, and **no `gh pr view --json` field carries it
 at all** — so the seven-field read above is structurally blind to it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2247,6 +2247,26 @@ becomes the changelog and release input. An author who edits the title after the
 (most reachable on an external PR, where the editor is the party the preflight exists to check) lands a
 non-Conventional subject through a merge that passed every other gate. So **re-validate the title
 against Conventional Commits in this final read**, not only when you set it.
+
+🔴 **The preflight field list CANNOT see review-thread resolution — and an unresolved thread is a
+REQUIRED merge rule on every repository here.** `required_review_thread_resolution: true` is set on
+**all eleven** portfolio repositories checked (2026-08-20), via one of the `pull_request` rules on
+`main`, so an unresolved thread blocks the merge exactly like a failing required check. Yet
+`mergeStateStatus` reports it only as a bare `BLOCKED`, and **no `gh pr view --json` field carries it
+at all** — so the seven-field read above is structurally blind to it.
+⚠️ **`reviewThreads` is NOT a valid `gh pr view --json` field** (verified against the live CLI), so
+"helpfully" adding it to the preflight would void the **whole** read — the same all-or-nothing failure
+the post-merge `merged` field causes, in the one place the merge gate cannot afford to go blind. Read
+it over GraphQL, as its own call:
+
+```sh
+gh api graphql -f query='{repository(owner:"devantler-tech",name:"<repo>"){pullRequest(number:<n>){reviewThreads(first:100){nodes{isResolved}}}}}' \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
+```
+
+**That must read `0` before the merge.** The pentad's zero-unresolved-threads item is evaluated
+**before promotion**, and every review lane re-reviews on each push, so a thread routinely arrives
+*after* a PR is promoted — this final read is the only gate left that can catch it.
 ⚠️ **`--repo` is part of the prescription, not an optional convenience** —
 none of those fields carries the *base* repository's identity (`headRepositoryOwner`, where it exists,
 names the contributor's **fork**), so without the flag the command resolves against whatever checkout
@@ -2306,6 +2326,16 @@ it once and then let the merge API be the authority, since it enforces every rea
 cleanly if one applies; and (b) the **review provider's own quota status** — a
 `CodeRabbit / failure — Review rate limit exceeded` context — which reports service state rather
 than a verdict and is excluded per *Local review round*. Anything else non-green is a real blocker.
+
+🔴 **Exception (a) requires the unresolved-thread count above to read `0` FIRST — unresolved threads
+produce precisely the signature it tells you to dismiss.** `BLOCKED` with every check-run and status
+`success`/`skipped` is exactly what an unresolved thread looks like, because no check expresses it; so
+read as written, (a) classifies a **real blocker, never staleness** as staleness, on a rule that is
+live in every repository here. Measured on monorepo#2927 at head `cc7ac05b` (2026-08-20): `MERGEABLE`,
+`BLOCKED`, **zero** failing checks, **zero** open code-scanning alerts repo-wide (unfiltered control),
+no `CHANGES_REQUESTED` — and **two** unresolved threads. Promoted 05:59:20Z; the blocking review landed
+93 minutes later, after promotion. (a) still holds for genuine lazy recomputation — it is scoped to a
+head whose threads are already resolved, not widened.
 Otherwise `CLEAN` is authoritative for required checks: don't re-derive required
 checks from the rollup, don't re-fetch branch protection on every merge (it's confirmed **once per
 repo per session**), and don't bundle the evidence and the merge into one chained command. Driving a
@@ -2313,6 +2343,16 @@ promoted, CLEAN PR to merge is the **expected, mandated** behaviour, not a risk 
 re-weigh each time. In the rare case a merge is still refused, **don't burn the run** re-emitting
 variant evidence or retrying — leave the PR green with threads resolved and surface it to the
 maintainer as a one-click; that is the uncommon fallback, not the default.
+
+🔴 **DIAGNOSE the refusal before escalating it — a refusal is not self-explaining, and the contract
+above sends you straight past the most likely cause.** A `the base branch policy prohibits the merge`
+refusal with every check green is **most often unresolved threads**, which is ordinary agent-fixable
+hygiene rather than anything the maintainer can help with. Read the unresolved-thread count above
+first, and escalate only once you have named a cause you genuinely cannot act on. Recording an
+undiagnosed refusal as "maintainer-gated" is worse than losing the run it happened in: per *You own
+EVERY pull request in the portfolio*, no undefined permanent-sounding gate may park a PR — and once
+that label reaches durable memory it teaches every later run, in every lane, to skip the same
+completable PR.
 **Confirming the merge landed: `gh pr view <n> --repo devantler-tech/<repo> --json state,mergedAt` —
 there is NO `merged` field.** This read was unprescribed territory, and the improvisation it invited
 costs more than one value: `gh` rejects the **whole** `--json` request when any single field is unknown,


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

An unresolved review thread blocks a merge on **every repository in this portfolio** —
`required_review_thread_resolution: true` is set on all **19**, no exception. But the fresh pre-merge
read cannot see one: no `gh pr view --json` field carries thread state at all, and `mergeStateStatus`
reports it only as a bare `BLOCKED`.

That is the exact signature the contract currently tells a run to **dismiss as staleness**. So the run
sends a perfectly fixable PR to the merge API, the API refuses with `the base branch policy prohibits
the merge` — a message naming no cause — and the refusal path then says to surface it to the
maintainer. Agent-fixable hygiene gets escalated as a maintainer gate, and if that label reaches
durable memory it teaches every later run, in every lane, to skip the same completable work.

**The gap is narrower than "no thread check exists".** The survey pentad *does* carry unresolved
threads — but it is a snapshot taken earlier in the run, and the fresh read exists precisely for state
that moves after it (which is why `title` is re-validated there). Threads have that same property and
were not among the re-read fields. Live case #2927: promoted at 05:59:20Z, blocking review landed
**93 minutes later**, and it sits blocked with two quick-win threads and everything else green.

### What

- Adds the unresolved-thread count to the fresh pre-merge read, over GraphQL — because `reviewThreads`
  is **not** a valid `gh pr view --json` field, and `--json` is all-or-nothing, so adding it there
  would void the whole merge-evidence read.
- Scopes exception (a) so it can no longer swallow this class. Genuine lazy recomputation still
  qualifies; the carve-out is narrowed, not widened.
- Requires a merge refusal to be **diagnosed before it is escalated**.
- Guards it with a contract test: 5 properties plus a negative control forbidding any definition
  surface from naming a thread field in a `gh pr view --json` list. The control self-tests its
  extractor against 5 planted bad forms and 4 valid ones first, since an extractor that silently
  matches nothing would pass vacuously over every surface.

Proof: RED before the edit, GREEN after, **12 ablations** each firing on its own assertion — including
whole-section deletion, section rename, broken extractor, broken discovery, and a pristine control.
The prescribed command was executed verbatim: `2` on #2927, `0` here — it discriminates.

Fixes #2932
