### PR TITLE
fix(agents): require proven reuse before sharing automation

### DIFF
--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -612,6 +612,19 @@ refute_prose 'The Agent Improver is otherwise unaffected' \
 refute_prose 'next scheduled tick is always one hour later' \
   "cadence still asserts an unconditional hourly next tick alongside its own refutation"
 
+# Shared automation is a reuse boundary, not a centralisation target. A product's own
+# action or workflow belongs beside that product until a second real repository consumes
+# the same product-neutral contract. Pin all three parts so "this might be reusable later"
+# cannot silently move product policy into an organisation-wide repository.
+assert_prose 'demonstrated consumers in at least two repositories' \
+  "shared automation does not require demonstrated multi-repository consumption"
+assert_prose 'Product-specific actions, workflows, paths, permissions, secrets, release semantics, and policy stay in the product repository they serve' \
+  "consumer contract does not keep product-specific automation close to its source"
+assert_prose 'Possible future reuse, superficial similarity, or a desire to centralise is not evidence' \
+  "consumer contract still permits speculative workflow centralisation"
+assert_prose 'World at Ruin-specific automation therefore stays in `devantler-tech/world-at-ruin`' \
+  "consumer contract does not pin the named World at Ruin locality example"
+
 # --- The merged spend mandate -------------------------------------------------
 # Spend is a dimension of the Agentic Engineer. The consumer must supply the Spend
 # contract the plugin entrypoint resolves, and must keep the money boundary that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,9 @@ cross-tool agent skills) + `devantler-tech/agent-plugins` (a tool-neutral market
 for VS Code / Copilot CLI / Claude Code), and the cluster-guardrail
 catalog `devantler-tech/kyverno-policies` (shared, tested Kyverno policies the platform and
 platform-template consume instead of vendoring copies). A generic pattern proven in one
-product belongs in a shared library so *every* product inherits it — keep them **industry-standard and
-tool-neutral** (the portability principle).
+product remains owned by that product. Move it into a shared library only after demonstrated use in
+at least two repositories proves a product-neutral contract worth inheriting — keep shared components
+**industry-standard and tool-neutral** (the portability principle).
 
 ## Stack map
 
@@ -4262,10 +4263,21 @@ quietly defaulting to another easy artifact.
 Most runs are bottom-up (one product at a time). **Periodically (~monthly, on rotation) step back and
 look at the whole repertoire top-down** — across *every* product at once — to catch what per-product
 work misses:
-- **Emergent generic patterns.** When the same approach (a CI step, a release config, a workflow, a
-  lint/test setup, an agent skill, a docs convention) has independently appeared in 2+ products, it has
-  become *generic* — extract it into the right **shared library** so every product inherits it instead
-  of drifting: CI → `devantler-tech/actions` (composite actions + reusable workflows); agent skills →
+- **Sharing is earned; local ownership is the default.** `devantler-tech/actions` and organization-wide
+  `.github` automation surfaces exist only for actions and workflows whose reuse across repositories is
+  already real. Extraction requires **all** of the following: demonstrated consumers in at least two
+  repositories; one product-neutral behaviour and interface; less real duplication or drift after the
+  move; and a thin local caller wherever repository-specific triggers or context remain. Product-specific
+  actions, workflows, paths, permissions, secrets, release semantics, and policy stay in the product
+  repository they serve. Possible future reuse, superficial similarity, or a desire to centralise is not
+  evidence. If any condition is missing, fail closed to local ownership — never move the first consumer
+  merely to manufacture a shared abstraction. World at Ruin-specific automation therefore stays in
+  `devantler-tech/world-at-ruin` unless a second repository demonstrates the same product-neutral need.
+- **Emergent generic patterns.** Once that sharing boundary is met, an approach (a CI step, a release
+  config, a workflow, a lint/test setup, an agent skill, a docs convention) that independently appears
+  in 2+ products has become *generic* — extract the reusable mechanism into the right **shared library**
+  so its actual consumers inherit it instead of drifting: CI → `devantler-tech/actions` (composite actions
+  + reusable workflows); agent skills →
   `devantler-tech/agent-skills`; (plugins → `devantler-tech/agent-plugins` once created); cluster
   guardrail / admission / generation policies → `devantler-tech/kyverno-policies`. Then propagate consumers
   to the shared version.
@@ -4274,8 +4286,9 @@ work misses:
 - **Industry-standard vs. native** (per *Design principles*): anything generic should sit in a portable,
   standard form (e.g. `AGENTS.md`); only genuinely Claude-specific power should rely on Claude-native
   primitives.
-Each finding becomes a `roadmap`/`enhancement` issue (or a draft PR if small and confident), on the
-owning shared-library repo, with consumers updated additively & backward-compatibly. The
+Each demonstrated multi-repository finding becomes a `roadmap`/`enhancement` issue (or a draft PR if
+small and confident) on the owning shared-library repo, with consumers updated additively &
+backward-compatibly. A single-product finding stays in that product's repository. The
 [`product-engineering`](.claude/skills/product-engineering/SKILL.md) skill carries the how-to.
 
 ### Durable memory — your native memory + the run report


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Direct maintainer direction on 2026-08-20 clarified that shared automation repositories are reuse libraries, not centralisation targets.

- Keep product-specific actions and workflows beside the product they serve.
- Require demonstrated consumers in at least two repositories plus a product-neutral contract before extraction.
- Keep repository-specific triggers, permissions, paths, secrets, release semantics, and policy in thin local callers.
- Pin World at Ruin as the concrete locality example.
- Add RED/GREEN delivery-contract assertions against speculative centralisation.

Validation:
- `bash .claude/scripts/agent-role-delivery-contract.test.sh`
- `bash -n .claude/scripts/agent-role-delivery-contract.test.sh`
- `shellcheck --severity=error .claude/scripts/agent-role-delivery-contract.test.sh`
- `git diff --check`