### PR TITLE
fix(telemetry): recognise the wider private-key label grammar

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -691,7 +691,7 @@ END {
   # over-masking, which is the direction the governing asymmetry above demands.
   for (i = 1; i <= n; i++) {
     s = L[i]; out = ""
-    while (match(s, /-----BEGIN ([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?-----/)) {
+    while (match(s, /-----BEGIN ([A-Z0-9]([A-Z0-9. ]|\/|-[A-Z0-9])*)? *PRIVATE KEY( BLOCK)?-----/)) {
       bs = RSTART; bl = RLENGTH
       head = substr(s, 1, bs - 1)
       oplbl = labelkey(substr(s, bs, bl))
@@ -701,7 +701,7 @@ END {
       # U[] flag below, and this program has paid for that class enough times.
       scan = substr(s, bs + bl)
       depth = 1; closed = 0
-      while (depth > 0 && match(scan, /-----(BEGIN|END) ([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?-----/)) {
+      while (depth > 0 && match(scan, /-----(BEGIN|END) ([A-Z0-9]([A-Z0-9. ]|\/|-[A-Z0-9])*)? *PRIVATE KEY( BLOCK)?-----/)) {
         mark = substr(scan, RSTART, RLENGTH)
         scan = substr(scan, RSTART + RLENGTH)
         # 🔴 ANY opener DEEPENS the span, whatever its label; only a MATCHING closer
@@ -797,7 +797,7 @@ END {
     close_at = 0; close_end = 0; bdepth = U[i]
     for (j = i + 1; j <= n && close_at == 0; j++) {
       bscan = L[j]; bdrop = 0
-      while (match(bscan, /-----END ([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?-----/)) {
+      while (match(bscan, /-----END ([A-Z0-9]([A-Z0-9. ]|\/|-[A-Z0-9])*)? *PRIVATE KEY( BLOCK)?-----/)) {
         # Absolute end offset of this marker in L[j], accumulated as `bscan` is
         # consumed. The closing line is masked UP TO the marker that actually
         # balanced the depth, not the first one on the line — closing at the
@@ -907,9 +907,9 @@ redact() {
     -e 's/(gh[pousr]_[A-Za-z0-9]{4})[A-Za-z0-9]+/\1…<redacted>/g' \
     -e 's/(AKIA[0-9A-Z]{4})[0-9A-Z]+/\1…<redacted>/g' \
     -e 's/(xox[baprs]-[A-Za-z0-9]{4})[A-Za-z0-9-]+/\1…<redacted>/g' \
-    -e 's/-----BEGIN ([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?-----([^-]|-[^-])*(-----END ([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?-----)?/<redacted-private-key>/g' \
-    -e 's/-----(BEGIN|END) ([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?-----/<redacted-private-key>/g' \
-    -e 's/(-----BEGIN ([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?-----)[^-]*/\1<redacted-key-material>/g' \
+    -e 's/-----BEGIN ([A-Z0-9]([A-Z0-9. ]|\/|-[A-Z0-9])*)? *PRIVATE KEY( BLOCK)?-----([^-]|-[^-])*(-----END ([A-Z0-9]([A-Z0-9. ]|\/|-[A-Z0-9])*)? *PRIVATE KEY( BLOCK)?-----)?/<redacted-private-key>/g' \
+    -e 's/-----(BEGIN|END) ([A-Z0-9]([A-Z0-9. ]|\/|-[A-Z0-9])*)? *PRIVATE KEY( BLOCK)?-----/<redacted-private-key>/g' \
+    -e 's/(-----BEGIN ([A-Z0-9]([A-Z0-9. ]|\/|-[A-Z0-9])*)? *PRIVATE KEY( BLOCK)?-----)[^-]*/\1<redacted-key-material>/g' \
     -e 's/(eyJ[A-Za-z0-9_-]{6})[A-Za-z0-9_.-]{20,}/\1…<redacted-jwt>/g' \
     -e 's/((secret|token|password|passwd|api[_-]?key)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?)[^"'"'"'[:space:],}]{8,}/\1<redacted>/gI'
 }
@@ -938,7 +938,7 @@ sha256_digest() {
 # form), each time reporting a real leak as "clean". The test suite asserts a
 # sample of EVERY numbered shape is both detected AND redacted; add to both
 # lists together or the test fails.
-CRED_RE='(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{12,}|-----BEGIN ([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?-----|xox[baprs]-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|(secret|token|password|passwd|api[_-]?key)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?[^"'"'"'[:space:],}]{8,})'
+CRED_RE='(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{12,}|-----BEGIN ([A-Z0-9]([A-Z0-9. ]|/|-[A-Z0-9])*)? *PRIVATE KEY( BLOCK)?-----|xox[baprs]-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|(secret|token|password|passwd|api[_-]?key)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?[^"'"'"'[:space:],}]{8,})'
 
 # TABLE variant of CRED_RE — identical shapes, but the prefix-identified ones
 # (gh?_ / github_pat_ / AKIA / xox / eyJ) are BOUNDARY-ANCHORED: the char before
@@ -955,7 +955,7 @@ CRED_RE='(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{1
 # between the detector and redact() has already broken twice; a second hand-kept
 # copy of this alternation would be the third.
 CRED_PREFIX_SHAPES_RE='(github_pat_[A-Za-z0-9_]{20,}\**|gh[pousr]_[A-Za-z0-9]{16,}\**|AKIA[0-9A-Z]{12,}\**|xox[baprs]-[A-Za-z0-9-]{10,}\**|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})'
-CRED_TABLE_RE='((^|[^A-Za-z0-9_-])'"$CRED_PREFIX_SHAPES_RE"'|-----BEGIN ([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?-----|(secret|token|password|passwd|api[_-]?key)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?[^"'"'"'[:space:],}]{8,})'
+CRED_TABLE_RE='((^|[^A-Za-z0-9_-])'"$CRED_PREFIX_SHAPES_RE"'|-----BEGIN ([A-Z0-9]([A-Z0-9. ]|/|-[A-Z0-9])*)? *PRIVATE KEY( BLOCK)?-----|(secret|token|password|passwd|api[_-]?key)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?[^"'"'"'[:space:],}]{8,})'
 
 # BLOB-EMBEDDED EVIDENCE (#2522). The boundary anchor above rejects a token
 # preceded by [A-Za-z0-9_-]. It cannot reject one whose boundary char is `+`,

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -797,6 +797,21 @@ parity_case "pgp_armor" \
   "$(printf -- 'boom -----%s PGP PRIVATE KEY BLOCK----- SECRETPGPARMOR' 'BEGIN')" "SECRETPGPARMOR"
 parity_case "rfc7468_punct" \
   "$(printf -- 'boom -----%s X9.42 DH PRIVATE KEY----- SECRETDHLABEL' 'BEGIN')" "SECRETDHLABEL"
+# RFC 7468 `labelchar` is wider than the registered label families: it admits
+# punctuation such as `/`, and the grammar permits an INTERNAL hyphen-minus. Both
+# shapes were matched by neither the redactor nor the detector (monorepo#2662),
+# so such a key was emitted unmasked AND reported clean — the silent-failure mode
+# this component treats as its worst. Asserted through parity_case, per shape, so
+# a future narrowing that breaks only ONE leg still fails here.
+#
+# Safe to widen only because the span walker now pairs each END to its opener's
+# LABEL (#2662, above): a label that fails to pair does not close, so it masks
+# MORE. The hyphen is admitted only when immediately followed by an alphanumeric,
+# which is what makes it structurally unable to swallow the `-----` delimiters.
+parity_case "rfc7468_solidus" \
+  "$(printf -- 'boom -----%s FOO/BAR PRIVATE KEY----- SECRETSOLIDUSLABEL' 'BEGIN')" "SECRETSOLIDUSLABEL"
+parity_case "rfc7468_inner_hyphen" \
+  "$(printf -- 'boom -----%s FOO-BAR PRIVATE KEY----- SECRETHYPHENLABEL' 'BEGIN')" "SECRETHYPHENLABEL"
 
 # Codex image tools persist rendered images as very large `data:` strings in
 # custom tool outputs. Those strings are encoded binary, not transcript text;
@@ -5578,8 +5593,17 @@ check "shape 9 control 4e: same-label nesting still closes at depth 0" "$OUT" "T
 # lines reports 8 for the 9 real sites, so a line-based floor of 9 can only be
 # satisfied by adding a tenth site. This assertion caught exactly that mistake
 # in its own first draft.
-SITES_NEW=$(grep -oF -- '([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?' "$TARGET" | grep -c '' || true)
-# THREE rejected spellings are pinned, not just the original: `[A-Z ]*` is the
+# The label admits `/` and an INTERNAL hyphen (one immediately followed by an
+# alphanumeric, so it can never eat the `-----` fence). That expression has TWO
+# spellings by CONTEXT, not by choice: awk regex literals and the marker `sed`
+# rules must escape the solidus, while the two detector variables are plain
+# shell strings with no delimiter to escape. BSD awk rejects a bare `/` inside a
+# bracket expression outright (`nonterminated character class`), and this suite
+# runs on macOS as well as Linux, so the escape is required rather than
+# cosmetic. Pin the fragment the two spellings SHARE, so one count still covers
+# all nine sites without forcing a single spelling on both contexts.
+SITES_NEW=$(grep -oF -- '-[A-Z0-9])*)? *PRIVATE KEY( BLOCK)?' "$TARGET" | grep -c '' || true)
+# FOUR rejected spellings are pinned, not just the original: `[A-Z ]*` is the
 # narrow class that could not reach either real family, `[^-]*…[^-]*` is the
 # over-wide one that leaked, and the ` *`-less optional group is the one that
 # NARROWED (regression control 3). A site left on any of them is a defect, and
@@ -5587,7 +5611,11 @@ SITES_NEW=$(grep -oF -- '([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY( BLOCK)?' "$TARGET"
 SITES_OLD=$(grep -oF -- '[A-Z ]*PRIVATE KEY' "$TARGET" | grep -c '' || true)
 SITES_BAD=$(grep -oF -- '[^-]*PRIVATE KEY[^-]*' "$TARGET" | grep -c '' || true)
 SITES_NARROW=$(grep -oF -- '([A-Z0-9][A-Z0-9. ]*)?PRIVATE KEY' "$TARGET" | grep -c '' || true)
-SITES_OLD=$((SITES_OLD + SITES_BAD + SITES_NARROW))
+# FOURTH rejected spelling: the pre-#2662 class, which could reach neither a
+# solidus nor an internal hyphen — masked-but-undetected territory if a site is
+# left on it.
+SITES_PRE7468=$(grep -oF -- '([A-Z0-9][A-Z0-9. ]*)? *PRIVATE KEY' "$TARGET" | grep -c '' || true)
+SITES_OLD=$((SITES_OLD + SITES_BAD + SITES_NARROW + SITES_PRE7468))
 if [ "$SITES_NEW" -ge 9 ] && [ "$SITES_OLD" -eq 0 ]; then
   ok "shape 9 structural: every private-key marker site uses the one widened label expression"
 else


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The telemetry redactor masks private keys by recognising their PEM label. It only recognised the
label families we happen to have registered — so a spec-legal label the standard allows, such as
`FOO/BAR PRIVATE KEY` or `FOO-BAR PRIVATE KEY`, was recognised by **neither the redactor nor the
leak detector**. A key with such a label would be written out unmasked *and* reported clean.

Reported clean is the part that matters. An unmasked key we know about is an incident; an unmasked
key the detector calls clean is a silent one, which this component treats as its worst failure mode.

No known tool emits these labels today, so this closes a residual gap rather than a live leak.

## What

Widens the label the redactor and detector accept, so both cover the wider grammar. Both sides move
together — a shape that is masked but undetected still reads as clean, so they are asserted as a
pair, per shape.

The widening is deliberately conservative: punctuation is admitted, and a hyphen is admitted **only
when a letter or digit immediately follows it**. That is what makes it structurally impossible for a
label to swallow the `-----` fence around it, which is how a previous attempt at this went wrong.

This was only safe to do now because the closing-marker fix landed first: a label that fails to pair
no longer ends a span, so anything unrecognised masks *more* rather than less.

Fixes #2662
