### PR TITLE
fix(agents): drop the surveyor's stale repository-visibility markers

### DIFF
--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -1315,7 +1315,7 @@ intentional tombstone, never drift.) The list:
 `ksail`, `platform`, `monorepo`, `.github`, `go-template`, `dotnet-template`,
 `platform-tenant-template`, `platform-template`, `actions`, `homebrew-tap`, `agent-skills`,
 `agent-plugins`, `provider-upjet-unifi`, `kyverno-policies`, `maintenance`, `fleet-gitops`, `aws`,
-`world-at-ruin`, `wedding-app` (private), `ascoachingogvaner` (private), `unifi` (private),
+`world-at-ruin`, `wedding-app`, `ascoachingogvaner`, `unifi`,
 `doggy-countdown`.
 Archived repos (currently `reusable-workflows`, `data-product`) are read-only: skip them entirely —
 no CI-red pass, no actionable signal (their stale bot PRs are unmergeable by design).


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The portfolio surveyor's own repo list claimed three products were private. All three are public, and have been for some time. That label is not decorative — it feeds the decision about which issues may be added to the shared public project board, where a genuinely private repo's issue must never appear.

The main engineering guide already refuses to record this kind of label anywhere, for exactly this reason: it goes out of date on its own, without anyone touching the file, while still reading as authoritative.

### Changes

Remove the three stale labels. The surveyor already looks this up live wherever it actually matters, so nothing needed replacing — and removing them is better than correcting them, since a corrected label goes stale the same way next time.

Deliberately no explanatory note added in their place: this file is read on almost every background survey, and the rule it would restate is already written down in the main guide.
