### PR TITLE
fix(agents): scope the --since re-verification to the lane that can be cleared

### DIFF
--- a/.claude/scripts/comment-disclosure-drift.test.sh
+++ b/.claude/scripts/comment-disclosure-drift.test.sh
@@ -91,11 +91,11 @@ sweep_rule="$({
   ' "$constitution"
 } | tr '\n' ' ' | tr -s '[:space:]' ' ')"
 reverify_scope='Re-verify ONLY a body that is exactly `@cursor review`'
-violation_on_sight='a violation on sight'
+non_bugbot_scope='A bare `@coderabbitai review` or `@codex review` is a violation on sight'
 no_carveout_reason='`--issue` reports them violating even when a canonical disclosure comment sits immediately before them'
 if [[ -n "$sweep_rule" ]] &&
    [[ "$sweep_rule" == *"$reverify_scope"* ]] &&
-   [[ "$sweep_rule" == *"$violation_on_sight"* ]] &&
+   [[ "$sweep_rule" == *"$non_bugbot_scope"* ]] &&
    [[ "$sweep_rule" == *"$no_carveout_reason"* ]]; then
   echo "ok    --since re-verification is scoped to the Bugbot body, non-Bugbot triggers violate on sight"
 else

--- a/.claude/scripts/comment-disclosure-drift.test.sh
+++ b/.claude/scripts/comment-disclosure-drift.test.sh
@@ -82,6 +82,27 @@ else
   failures=$((failures + 1))
 fi
 
+echo "== consumer contract: --since re-verification is lane-scoped =="
+sweep_rule="$({
+  awk '
+    /^  🔴 \*\*On `--since`, read the findings/ { in_section = 1 }
+    in_section && /^  It reports \*\*positive evidence of agent authorship only\*\*/ { exit }
+    in_section { print }
+  ' "$constitution"
+} | tr '\n' ' ' | tr -s '[:space:]' ' ')"
+reverify_scope='Re-verify ONLY a body that is exactly `@cursor review`'
+violation_on_sight='a violation on sight'
+no_carveout_reason='`--issue` reports them violating even when a canonical disclosure comment sits immediately before them'
+if [[ -n "$sweep_rule" ]] &&
+   [[ "$sweep_rule" == *"$reverify_scope"* ]] &&
+   [[ "$sweep_rule" == *"$violation_on_sight"* ]] &&
+   [[ "$sweep_rule" == *"$no_carveout_reason"* ]]; then
+  echo "ok    --since re-verification is scoped to the Bugbot body, non-Bugbot triggers violate on sight"
+else
+  echo "FAIL  --since rule does not scope re-verification to the exact @cursor review body"
+  failures=$((failures + 1))
+fi
+
 echo "== Go classifier suite =="
 if (cd "$script_dir/comment-disclosure-drift-go" && go test -race -cover ./...); then
   echo "ok    go test"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4093,8 +4093,19 @@ root-cause fixing, and every guardrail are unaffected; the point is to stop payi
   🔴 **On `--since`, read the findings, not the exit code.** A sweep's per-discussion history is
   incomplete (`since` selects by *updated* time), so it never grants Bugbot's bare-trigger carve-out and
   reports **every** bare `@cursor review` — exit 1 is therefore routine on a repo that uses Bugbot and
-  does not by itself mean drift. Verify each reported bare trigger with `--repo <owner>/<repo> --issue
-  <n>`, where the full comment list is present and a legitimate pairing resolves clean. Every other
+  does not by itself mean drift. **Re-verify ONLY a body that is exactly `@cursor review`**, with
+  `--repo <owner>/<repo> --issue <n>`, where the full comment list is present and a legitimate pairing
+  resolves clean.
+  🔴 **A bare `@coderabbitai review` or `@codex review` is a violation on sight — never bare-trigger
+  noise to re-check.** Those lanes have no carve-out, so `--issue` reports them violating even when a
+  canonical disclosure comment sits immediately before them. Scoping the re-check by the *shape*
+  ("a bare trigger") instead of the *lane* therefore costs a round-trip that cannot change the verdict —
+  and, far worse, files the real violations inside the Bugbot pile where they read as known noise — a
+  misread [#2965](https://github.com/devantler-tech/monorepo/issues/2965) records making. Measured
+  2026-08-21 across six repositories and 1,745 `devantler` comments in a 7-day window: **67 findings —
+  56 re-verifiable `@cursor review`, 11 violations on sight**, spread over three repositories and two
+  separate episodes, and **5 of the 11 had posted the disclosure as its own preceding comment** — the
+  Bugbot two-comment shape applied to a lane that has none. Every other
   shape it reports is a real finding. [#2781](https://github.com/devantler-tech/monorepo/issues/2781)
   restores the precision.
   It reports **positive evidence of agent authorship only** — a `devantler`


### PR DESCRIPTION
> 🤖 Generated by the Agent Improver

### Why

Our own disclosure-drift sweep reports two very different kinds of finding under one name, and the
rule for reading it told a run to treat them the same. The result is that real violations get filed
as known noise: an agent comment with no disclosure reads as the **maintainer's** instruction, so
each one quietly publishes our own output into his control channel.

Measured across six repositories and 1,745 comments in a 7-day window: 67 findings, of which **56 are
expected noise and 11 are real** — spread over three repositories and two separate episodes, so this
is a standing habit rather than a one-off.

### What

The rule now names the review lane instead of describing a comment shape: only the Cursor trigger is
worth re-checking, and a bare CodeRabbit or Codex trigger is a violation on sight. An enforcement
test pins both halves so the distinction cannot quietly drop out again.

No tooling changes and nothing is filtered out — the checker was already correct; only the
instruction for reading it was wrong.

Fixes #2968
