### PR TITLE
security(telemetry): keep credential values out of scan scratch files

### DIFF
--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -3384,6 +3384,25 @@ if want safety; then
     # fraction of the input. The batching contract test pins this: it asserts
     # exactly ONE credential-table jq invocation, and it caught the two-pass
     # version of this change.
+    # 🔴 SUPPRESS xtrace ACROSS THE CREDENTIAL-BEARING REGION. `set -x` prints an
+    # assignment's EXPANDED value, and every later `"$var"` expansion, to STDERR —
+    # and stderr does NOT pass through the `main | redact` boundary that every
+    # other output path here goes through. Verified directly: `v=$(printf 'ghp_X')`
+    # traces as `+ v=ghp_X`, and a later `printf '%s\n' "$v"` as `++ printf ghp_X`.
+    #
+    # That matters more here than it would elsewhere. An operator running
+    # `bash -x` to diagnose this scanner would write raw credential matches into
+    # their terminal AND into the invoking agent's transcript — which is the very
+    # corpus this scanner reads on its next run, so a diagnostic session would
+    # seed the leak it was called in to investigate.
+    #
+    # The scratch files this region replaced (#2712) leaked only a PATH under
+    # xtrace, so moving the values into shell variables is what introduced this;
+    # the guard is part of that move, not an unrelated hardening. Restore the
+    # caller's setting exactly — never unconditionally `set +x`/`set -x`, which
+    # would silently turn tracing ON for a caller that never asked for it.
+    cred_trace_was=off
+    case $- in *x*) cred_trace_was=on; set +x ;; esac
     cred_match_data=$(printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | tr '\n' '\000' \
       | xargs -0 -n "$CREDENTIAL_SCAN_BATCH_FILES" bash -c \
           'awk "{ print }" "$@" | jq -Rr "$CRED_DECODE_FILTER" --' _ 2>/dev/null \
@@ -3538,6 +3557,9 @@ if want safety; then
         if ($0 in blob) s = s " [blob-embedded: inside a base64 run, likely a chance substring]"
         print s
       }' | sort | uniq -c | sort -rn | sed 's/^/    /'
+    # End of the credential-value region — restore the caller's tracing exactly.
+    if [ "$cred_trace_was" = on ]; then set -x; fi
+    cred_trace_was=off
     # Concentration, mirroring the injection detector and placed directly under
     # the table it qualifies. The TABLE counts distinct VALUES on purpose (one
     # leak pasted into fifty transcripts is one credential to rotate); this

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -256,25 +256,33 @@ CREDPROV=$(mktemp "${TMPDIR:-/tmp}/.agtel_credprov.XXXXXXXX") || { echo "cannot 
 # would read 0 and the run would report the agent had stopped busy-waiting.
 # The walk runs in a pipeline subshell, so the count must survive on disk.
 XFTMP=$(mktemp "${TMPDIR:-/tmp}/.agtel_xf.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
-# Blob-embedded evidence set (#2522): the subset of table values whose
-# occurrences are ALL inside a base64 run. Holds normalised credential values,
-# so it is created with mktemp's private mode and removed by the same traps as
-# every other scratch.
-CREDBLOB=$(mktemp "${TMPDIR:-/tmp}/.agtel_credblob.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
-# Plain-occurrence set: the values seen OUTSIDE any base64 run. Subtracted from
-# the blob set above so a value seen both ways keeps its plain high-signal row.
-# Same value class as $CREDBLOB, so it gets the same private mode and traps.
-CREDPLAIN=$(mktemp "${TMPDIR:-/tmp}/.agtel_credplain.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
-# Raw credential-table matches from the SINGLE decode pass, partitioned after
-# the fact into the plain and blob-embedded sets (#2522).
-CREDMATCH=$(mktemp "${TMPDIR:-/tmp}/.agtel_credmatch.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
+# The credential-table working sets are held IN MEMORY, never in a scratch file
+# (#2712). Every other scratch here holds derived or already-redacted text; these
+# three would hold credential VALUES — the raw matches from the decode pass, and
+# the normalised plain and blob-embedded sets partitioned from them (#2522).
+#
+# A scratch file is removed by the traps below, and those traps run on EXIT and
+# on HUP/INT/TERM — never on SIGKILL, an OOM kill, or power loss. Anything these
+# sets held would therefore survive an abnormal exit as credential material at
+# rest, which inverts the purpose of a leak detector: this scan exists to find
+# values that escaped into transcripts, so it must not write them back out.
+#
+# Held as shell variables rather than passed on a command line: a variable is
+# process memory that dies with the process, whereas an `awk -v value=...`
+# argument would be world-readable in `ps` output for the life of the call. The
+# consumers below read them through process substitution, so the awk programs
+# keep their existing `getline < file` idiom and the values still never land in
+# a filesystem object or in argv.
+cred_match_data=''
+cred_plain_set=''
+cred_blob_set=''
 # Its OWN scratch, never $CONCTMP. The injection-concentration pass owns that
 # one, and sharing it would make two sections' results depend on which ran last.
 SIGTMP=$(mktemp "${TMPDIR:-/tmp}/.agtel_sig.XXXXXXXX") || { echo "cannot create temp file" >&2; exit 3; }
 # Remove on normal exit; on a SIGNAL also terminate, since a trap that only
 # cleans up leaves the script running after the scheduler asked it to stop.
-trap 'rm -f "$ERRTMP" "$RAWTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV" "$CREDBLOB" "$CREDPLAIN" "$CREDMATCH" "$SIGTMP" "$XFTMP"' EXIT
-trap 'rm -f "$ERRTMP" "$RAWTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV" "$CREDBLOB" "$CREDPLAIN" "$CREDMATCH" "$SIGTMP" "$XFTMP"; trap - HUP INT TERM; kill -s INT $$' HUP INT TERM
+trap 'rm -f "$ERRTMP" "$RAWTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV" "$SIGTMP" "$XFTMP"' EXIT
+trap 'rm -f "$ERRTMP" "$RAWTMP" "$INJTMP" "$PROVTMP" "$CONCTMP" "$CREDCONC" "$CREDPROV" "$SIGTMP" "$XFTMP"; trap - HUP INT TERM; kill -s INT $$' HUP INT TERM
 
 INJ_PHRASE_RE='(ignore (all )?(prior|previous) (rules|instructions)|disregard (your|all) (instructions|rules)|the maintainer (approved|authorised|authorized)|add [^ ]+ to the trust gate|update your instructions|you are now [a-z ]{0,20}mode)'
 
@@ -3376,11 +3384,11 @@ if want safety; then
     # fraction of the input. The batching contract test pins this: it asserts
     # exactly ONE credential-table jq invocation, and it caught the two-pass
     # version of this change.
-    printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | tr '\n' '\000' \
+    cred_match_data=$(printf '%s\n%s\n' "$SF_CACHE" "$CX_CACHE" | grep -v '^$' | tr '\n' '\000' \
       | xargs -0 -n "$CREDENTIAL_SCAN_BATCH_FILES" bash -c \
           'awk "{ print }" "$@" | jq -Rr "$CRED_DECODE_FILTER" --' _ 2>/dev/null \
       | sed -E "s/$(printf '\033')\[[0-9;:]*[A-Za-z]//g" \
-      | grep -ahoEi "$CRED_TABLE_SCAN_RE" 2>/dev/null > "$CREDMATCH"
+      | grep -ahoEi "$CRED_TABLE_SCAN_RE" 2>/dev/null)
     # Shared normaliser. BOTH the value list and the blob set run through THIS
     # function, so the two can never normalise differently — a divergence would
     # attach the label to the wrong row, which is worse than no label at all.
@@ -3395,9 +3403,11 @@ if want safety; then
     # A blob match carries its run; stripping run+boundary yields the identical
     # string the plain leg produces for the same credential (whose single
     # boundary char cred_normalise removes), so the two sets are comparable.
-    cred_blob_matches() { grep -aEi "$CRED_BLOB_ANCHORED_RE" "$CREDMATCH" 2>/dev/null \
+    cred_blob_matches() { printf '%s\n' "$cred_match_data" \
+                          | grep -aEi "$CRED_BLOB_ANCHORED_RE" 2>/dev/null \
                           | sed -E "s|$CRED_BLOB_STRIP_RE||"; }
-    cred_plain_matches() { grep -avEi "$CRED_BLOB_ANCHORED_RE" "$CREDMATCH" 2>/dev/null; }
+    cred_plain_matches() { printf '%s\n' "$cred_match_data" \
+                          | grep -avEi "$CRED_BLOB_ANCHORED_RE" 2>/dev/null; }
     # The label needs the ABSENCE of a plain occurrence, not the presence of a
     # blob one. `cred_normalise` ends in `sort -u`, so a credential seen both
     # inside an encoded blob and plainly collapses to ONE row; membership in the
@@ -3408,7 +3418,7 @@ if want safety; then
     # the set what its name claims: values whose occurrences are ALL blob-embedded.
     # This is the ambiguity-falls-through-to-the-plain-row rule the label's own
     # contract states, enforced rather than assumed.
-    cred_plain_matches | cred_normalise > "$CREDPLAIN"
+    cred_plain_set=$(cred_plain_matches | cred_normalise)
     # Derived from the SAME extracted matches as the table — so a complete image
     # payload, excluded upstream by the decode filter, can no more manufacture a
     # blob label than it can manufacture a table row.
@@ -3420,14 +3430,14 @@ if want safety; then
     # on an empty or missing file simply yields nothing, whereas the NR==FNR
     # idiom would silently eat the first data line when the plain set is empty —
     # which here would drop a real credential's label).
-    cred_blob_matches | cred_normalise \
-      | awk -v plainfile="$CREDPLAIN" '
+    cred_blob_set=$(cred_blob_matches | cred_normalise \
+      | awk -v plainfile=<(printf '%s\n' "$cred_plain_set") '
           BEGIN {
             while ((getline _p < plainfile) > 0) if (_p != "") plain[_p] = 1
             close(plainfile)
           }
           !($0 in plain)
-        ' > "$CREDBLOB"
+        ')
     { cred_blob_matches; cred_plain_matches; } \
       | cred_normalise |
       # Normalise every match to its UNDERLYING VALUE before any dedup:
@@ -3467,7 +3477,7 @@ if want safety; then
       #     weak-bucket rows; the asymmetry is chosen — a splittable fragment
       #     only ever reaches a high-signal row by passing a FULL shape regex,
       #     while not splitting silently drops a real second credential.
-    awk -v blobfile="$CREDBLOB" '
+    awk -v blobfile=<(printf '%s\n' "$cred_blob_set") '
       # Blob-evidence set read as a FILE, never with a here-doc join: getline on
       # a missing or EMPTY file simply yields nothing, whereas the NR==FNR idiom
       # silently consumes the first DATA line when the joined file is empty —

--- a/.claude/scripts/agent-telemetry.sh
+++ b/.claude/scripts/agent-telemetry.sh
@@ -3388,7 +3388,19 @@ if want safety; then
       | xargs -0 -n "$CREDENTIAL_SCAN_BATCH_FILES" bash -c \
           'awk "{ print }" "$@" | jq -Rr "$CRED_DECODE_FILTER" --' _ 2>/dev/null \
       | sed -E "s/$(printf '\033')\[[0-9;:]*[A-Za-z]//g" \
-      | grep -ahoEi "$CRED_TABLE_SCAN_RE" 2>/dev/null)
+      | grep -ahoEi "$CRED_TABLE_SCAN_RE" 2>/dev/null \
+      | tr '\000' '\n')
+    # NUL is translated to a newline BEFORE the capture, never left to the
+    # command substitution. A decoded string can legitimately carry `\u0000`,
+    # which jq emits as a real NUL byte, and `$(...)` DELETES NUL rather than
+    # preserving it — so the scratch file this replaced kept the byte while the
+    # variable would silently splice the fragments on either side into one value
+    # that never existed in the corpus. That is the JOIN direction, and it is the
+    # harmful one: a spliced string can reach a high-signal row by spanning a
+    # boundary, manufacturing a credential. Splitting is the safe asymmetry the
+    # compound-value handling below already chose for `;&|` — a fragment only
+    # ever reaches a high-signal row by passing a FULL shape regex on its own,
+    # so a split costs no true positive while a splice invents a false one.
     # Shared normaliser. BOTH the value list and the blob set run through THIS
     # function, so the two can never normalise differently — a divergence would
     # attach the label to the wrong row, which is worse than no label at all.

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -6350,6 +6350,63 @@ else
   ok "a NUL between two fragments does not manufacture a token"
 fi
 
+# --- xtrace must not carry credential VALUES to stderr (#2712, Codex P1) -----
+# `set -x` prints an assignment's expanded value, and every later `"$var"`
+# expansion, to STDERR — which does NOT pass through the `main | redact` boundary
+# that guards stdout. Moving the plain/blob sets off scratch files and into shell
+# variables is what created this path: a scratch file leaked only its PATH under
+# xtrace. So an operator running `bash -x` to diagnose the scanner would write raw
+# credentials into their terminal and into the invoking agent's transcript — the
+# corpus this scanner reads next run.
+mkdir -p "$FIX/credxtrace"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"token=__GHPA__"}]}}\n' \
+  > "$FIX/credxtrace/s.jsonl"
+subst "$FIX/credxtrace/s.jsonl"
+XT_OUT="$FIX/credxtrace.out"; XT_ERR="$FIX/credxtrace.err"
+CLAUDE_PROJECTS_DIR="$FIX/credxtrace" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+  bash -x "$TARGET" --since-days 3650 --section safety >"$XT_OUT" 2>"$XT_ERR"
+
+# POSITIVE CONTROL 1 — tracing really was ON for this run. Without this, a run
+# that silently failed to enable xtrace would leak nothing and the guard
+# assertion below would pass having observed nothing at all.
+if grep -q '^+' "$XT_ERR" 2>/dev/null; then
+  ok "control: xtrace was active for the traced run"
+else
+  bad "control: xtrace was active for the traced run" \
+      "no trace lines on stderr — the leak assertion below would be VACUOUS"
+fi
+
+# POSITIVE CONTROL 2 — the credential table really was REACHED, so the guarded
+# region actually executed. A corpus that produced no table would also produce no
+# leak, for the wrong reason.
+if grep -q 'credential-shaped' "$XT_OUT" 2>/dev/null; then
+  ok "control: the credential table was reached under xtrace"
+else
+  bad "control: the credential table was reached under xtrace" \
+      "no credential table in the traced run — the leak assertion would be VACUOUS"
+fi
+
+# THE GUARD — no raw credential value on stderr.
+if ! grep -qF "$S_GHPA" "$XT_ERR" 2>/dev/null; then
+  ok "no credential value reaches stderr under xtrace"
+else
+  bad "no credential value reaches stderr under xtrace" \
+      "a fixture credential was printed by xtrace, bypassing the redact boundary"
+fi
+
+# The guard must RESTORE the caller's setting, not merely disable tracing: a run
+# that never turned xtrace back on would hide the rest of the script from
+# diagnosis, trading one defect for another. The script does substantial work
+# after the credential region, so trace lines must still be arriving at the end.
+XT_TAIL=$(tail -20 "$XT_ERR" 2>/dev/null)
+if grep -q '^+' <<<"$XT_TAIL"; then
+  ok "xtrace is restored after the credential region"
+else
+  bad "xtrace is restored after the credential region" \
+      "no trace lines at the end of the run — the guard left tracing off"
+fi
+
+
 echo "──────────────────────────────"
 echo "  passed: $PASS   failed: $FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -6209,6 +6209,96 @@ else
   fi
 fi
 
+
+# ── 6d⁴. credential values never reach a scratch file (#2712) ─────────────────
+# The traps that remove the credential scratch run on EXIT and on HUP/INT/TERM.
+# None of them runs on SIGKILL, an OOM kill, or power loss, so anything these
+# files hold is credential material at rest the moment the process dies
+# abnormally. This is a leak DETECTOR: writing the very values it exists to find
+# to disk inverts its own intent.
+#
+# Asserted at the moment the files are LIVE, not after cleanup — the same
+# instrumentation shape the provenance-scratch row above uses. The reporting awk
+# is shimmed because it is invoked with the blob set while all three credential
+# scratches hold their final contents, so the observation window is exact rather
+# than raced.
+echo
+echo "credential scratch holds no credential values (#2712)"
+
+mkdir -p "$FIX/credtmp" "$FIX/credawk" "$FIX/credscratch"
+# Two shapes so every leg is exercised: a PLAIN occurrence (which reaches the
+# plain set) and one inside a base64 run (which reaches the blob set). A fixture
+# covering only one leg would leave the other's file unasserted.
+printf '{"type":"user","message":{"content":[{"type":"text","text":"export GITHUB_TOKEN=__GHPA__"}]}}\n' \
+  > "$FIX/credscratch/s.jsonl"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"sig=QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlq/__GHPD__zz"}]}}\n' \
+  >> "$FIX/credscratch/s.jsonl"
+subst "$FIX/credscratch/s.jsonl"
+
+cat > "$FIX/credawk/awk" <<'EOF'
+#!/usr/bin/env bash
+# Fires on the reporting awk that receives the blob set. At that instant every
+# credential scratch this scan created holds its final contents.
+case " $* " in
+  *'blobfile='*)
+    printf 'fired\n' >> "$CRED_SCRATCH_TRACE"
+    for _v in $CRED_SCRATCH_VALUES; do
+      if grep -rqF "$_v" "$CRED_SCRATCH_TMPDIR"/.agtel_* 2>/dev/null; then
+        printf 'raw\n' >> "$CRED_SCRATCH_TRACE"
+      fi
+    done
+    ;;
+esac
+exec "$REAL_AWK" "$@"
+EOF
+chmod +x "$FIX/credawk/awk"
+: > "$FIX/cred-scratch-trace"
+PATH="$FIX/credawk:$PATH" REAL_AWK="$real_awk" \
+  CRED_SCRATCH_VALUES="$S_GHPA $S_GHPD" \
+  CRED_SCRATCH_TMPDIR="$FIX/credtmp" CRED_SCRATCH_TRACE="$FIX/cred-scratch-trace" \
+  TMPDIR="$FIX/credtmp" \
+  CLAUDE_PROJECTS_DIR="$FIX/credscratch" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+  bash "$TARGET" --since-days 3650 --section safety >/dev/null 2>&1
+
+# POSITIVE CONTROL FIRST. A shim that never matched, or a scan that never
+# reached the credential table, leaves an empty trace — and the leak assertion
+# below would then pass having observed nothing at all. Assert the observation
+# happened before believing its result.
+if grep -qFx 'fired' "$FIX/cred-scratch-trace" 2>/dev/null; then
+  ok "control: the credential-table reporting pass was observed"
+else
+  bad "control: the credential-table reporting pass was observed" \
+      "shim never fired — the leak assertion below would be VACUOUS"
+fi
+if ! grep -qFx 'raw' "$FIX/cred-scratch-trace" 2>/dev/null; then
+  ok "no credential value is written to any scan scratch file"
+else
+  bad "no credential value is written to any scan scratch file" \
+      "a fixture credential was readable in \$TMPDIR/.agtel_* during the scan"
+fi
+
+# SEAM PARITY (#2712 AC2). Moving the plain/blob sets off disk changes how the
+# two legs EXCHANGE identity, so the exchange itself is asserted rather than
+# inferred from the end-to-end rows: a value whose normalisation is non-trivial
+# — an assignment wrapper the table leg strips — must still match the blob set's
+# key. If the legs normalised differently the lookup would miss and the label
+# would silently vanish, which reads as "this credential was plainly exposed".
+mkdir -p "$FIX/credparity"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"token=QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlq/__GHPE__zz"}]}}\n' \
+  > "$FIX/credparity/s.jsonl"
+subst "$FIX/credparity/s.jsonl"
+OUT=$(CLAUDE_PROJECTS_DIR="$FIX/credparity" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+TABLE=$(printf '%s' "$OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+# Both halves, together: the row must EXIST (so the table leg produced the
+# value) and carry the label (so the blob leg's key matched that same value).
+# Asserting only the label would pass if the row vanished entirely.
+if grep -qE '^[[:space:]]+1 github-token' <<<"$TABLE" && grep -q 'blob-embedded' <<<"$TABLE"; then
+  ok "table leg and blob leg agree on identity through the assignment wrapper"
+else
+  bad "table leg and blob leg agree on identity through the assignment wrapper" "$TABLE"
+fi
+
 echo "──────────────────────────────"
 echo "  passed: $PASS   failed: $FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/.claude/scripts/agent-telemetry.test.sh
+++ b/.claude/scripts/agent-telemetry.test.sh
@@ -6299,6 +6299,57 @@ else
   bad "table leg and blob leg agree on identity through the assignment wrapper" "$TABLE"
 fi
 
+
+# -- a NUL inside a match must not SPLICE two fragments (#2712) ----------------
+# Holding the matches in a variable rather than a file introduced one byte-level
+# difference: a decoded string can legitimately carry a JSON unicode escape for
+# the zero byte, jq emits it as a real NUL, and $(...) DELETES NUL rather than
+# preserving it. The scratch file this replaced kept the byte, so without an
+# explicit translation the fragments on either side splice into a single value
+# that never occurred in the corpus.
+#
+# The splice is the harmful direction, not merely a different one: two strings
+# that are individually too short to be credentials can join into something that
+# passes a FULL shape regex, so the table manufactures a credential -- a false
+# positive in a leak detector, which costs a rotation. Translating the zero byte
+# to a newline instead splits them, the same asymmetry the compound `;&|`
+# handling already chose, where a fragment only reaches a high-signal row on its
+# own merits.
+echo
+echo "a NUL inside a match splits rather than splices (#2712)"
+
+# CONTROL corpus -- the identical fragments with NO separator between them. This
+# proves the spliced form IS detectable and that the fixture reaches the scanner
+# at all; without it, the property assertion below would pass vacuously on any
+# corpus the harness failed to read.
+mkdir -p "$FIX/nulctl" "$FIX/nulsplit"
+printf '{"type":"user","message":{"content":[{"type":"text","text":"export GITHUB_TOKEN=%s_AAAAAAAAAABBBBBBBBBB"}]}}\n' 'ghp' \
+  > "$FIX/nulctl/s.jsonl"
+CTL_OUT=$(CLAUDE_PROJECTS_DIR="$FIX/nulctl" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+CTL_TABLE=$(printf '%s' "$CTL_OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if grep -q 'github-token' <<<"$CTL_TABLE"; then
+  ok "control: the spliced fragment pair IS detected as a token when adjacent"
+else
+  bad "control: the spliced fragment pair IS detected as a token when adjacent" \
+      "fixture never reached the scanner -- the assertion below would be VACUOUS: $CTL_TABLE"
+fi
+
+# THE PROPERTY -- the same two fragments separated by a real zero byte.
+# Byte-identical to the control apart from that separator, so a difference in
+# outcome can only come from how that byte is handled.
+printf '{"type":"user","message":{"content":[{"type":"text","text":"export GITHUB_TOKEN=%s_AAAAAAAAAA\\u0000BBBBBBBBBB"}]}}\n' 'ghp' \
+  > "$FIX/nulsplit/s.jsonl"
+NUL_OUT=$(CLAUDE_PROJECTS_DIR="$FIX/nulsplit" CODEX_HOME="$FIX/nocodex" MONOREPO_DIR="$FIX/monorepo" HOME="$FIX" \
+      bash "$TARGET" --since-days 3650 --section safety 2>&1)
+NUL_TABLE=$(printf '%s' "$NUL_OUT" | sed -n '/credential-shaped/,/rotate the credential/p')
+if grep -q 'github-token' <<<"$NUL_TABLE"; then
+  bad "a NUL between two fragments does not manufacture a token" \
+      "the fragments were spliced and reported as a credential: $NUL_TABLE"
+else
+  ok "a NUL between two fragments does not manufacture a token"
+fi
+
 echo "──────────────────────────────"
 echo "  passed: $PASS   failed: $FAIL"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The agent telemetry scan is a **credential-leak detector**: it reads the session corpus to find credential material that escaped into transcripts. While it worked, it wrote that same material into three temporary files.

Those files are cleaned up by traps that run on a normal exit or an ordinary signal — but not on a SIGKILL, an out-of-memory kill, or power loss. So whenever the scan died abnormally, credential values it had recovered were left sitting on disk. The tool inverted its own purpose in exactly the situation where something had already gone wrong.

### What changed

The three working sets are now held in memory for the life of the scan and never reach a file, so an abnormal exit leaves nothing behind. Reported shapes, counts and labels are unchanged.

Fixes #2712