### PR TITLE
fix(agents): stop the unreachable default branch poisoning the sweep's exit code

### DIFF
--- a/.claude/scripts/branch-cleanup.sh
+++ b/.claude/scripts/branch-cleanup.sh
@@ -284,6 +284,27 @@ DEFAULT="${DEFAULT:-main}"
 # detached at its superproject pin, and checking out the default branch there
 # would silently move it off the pin (superproject drift).
 START_BRANCH=$(git branch --show-current 2>/dev/null)
+# Is the default branch checked out in some worktree? Only ever consulted after a
+# return-to-default checkout has already FAILED, and only while this checkout sits
+# on some other branch — so a hit is necessarily a DIFFERENT worktree, and no
+# fragile path comparison is needed (macOS resolves /var and /tmp through symlinks,
+# so comparing worktree paths would be the unreliable half of this test).
+#
+# monorepo#2489: every run works in a per-run worktree while the primary checkout
+# holds the default branch, and git refuses one branch in two worktrees. So the
+# return-to-default checkout can NEVER succeed from a session worktree. That is the
+# documented steady state — the scheduled worktree sweep reaps the session worktree
+# and frees its branch — not a fault, so it must not poison the exit code. A
+# checkout that fails for any OTHER reason still must.
+#
+# Fails closed: a failed enumeration (pipefail is on) returns non-zero, so the
+# caller reports the error rather than silently suppressing it.
+default_checked_out_somewhere() {
+  git worktree list --porcelain 2>/dev/null | awk -v want="refs/heads/$DEFAULT" '
+    /^branch / { if (substr($0, 8) == want) found = 1 }
+    END { exit found ? 0 : 1 }
+  '
+}
 return_to_default() {
   local cur
   cur=$(git branch --show-current 2>/dev/null)
@@ -296,6 +317,8 @@ return_to_default() {
     local now
     now=$(git branch --show-current 2>/dev/null)
     if [ "$now" = "$DEFAULT" ]; then sw="-> $DEFAULT";
+    elif default_checked_out_somewhere; then
+      sw="$DEFAULT held by another worktree — left on '${now:-detached}'"
     else sw="FAILED to reach $DEFAULT (on '${now:-detached}')"; errors=$((errors+1)); fi
   else sw="already on $DEFAULT"; fi
 }

--- a/.claude/scripts/branch-cleanup.test.sh
+++ b/.claude/scripts/branch-cleanup.test.sh
@@ -485,6 +485,65 @@ report "control: an unclaimed branch is still deleted at the same list size (#26
 unset WT_SHIM_STATE WT_SHIM_INJECT
 rm -f "$tmp/bin/git"
 
+
+# --- 8. The default branch held by ANOTHER worktree is not an error (#2489) --
+# Every run works in a per-run worktree, and the primary checkout holds the
+# default branch, so `git checkout <default>` inside that worktree can never
+# succeed — git refuses one branch in two worktrees. The sweep itself is
+# unaffected (keep-sets computed, deletions correct), but the unreachable
+# checkout used to set FAILED and increment `errors`, so the helper exited 3 on
+# EVERY per-run-worktree invocation and its exit code carried no signal.
+git -C "$work" checkout -q main >/dev/null 2>&1
+: >"$OPEN_HEADS_FILE"; : >"$PR_EVIDENCE_FILE"
+
+sess="$tmp/session-2489"
+git -C "$work" worktree add -q "$sess" -b claude/session-2489 >/dev/null 2>&1
+
+# ARM 1 — the guard: run from the linked worktree, whose default branch is held
+# by the primary checkout. The sweep must succeed and the exit code must be 0.
+manifest="$tmp/manifest-2489a"; : >"$manifest"
+out="$("$helper" "$sess" "monorepo" "$manifest" dry-run 2>&1)" && rc=0 || rc=$?
+report "default branch held by another worktree is not an error (#2489)" \
+  "$([ "$rc" -eq 0 ] && echo yes || echo no)" "rc=$rc out=$out"
+report "…and the run says so instead of reporting FAILED (#2489)" \
+  "$(printf '%s' "$out" | grep -q 'held by another worktree' && \
+     ! printf '%s' "$out" | grep -q 'FAILED to reach' && echo yes || echo no)" \
+  "out=$out"
+
+git -C "$work" worktree remove --force "$sess" >/dev/null 2>&1 || true
+
+# ARM 2 — control: from the PRIMARY checkout the default IS reachable, so the
+# ordinary return-to-default path must still run and still move the checkout.
+# Without this the fix could have simply stopped returning the checkout at all.
+git -C "$work" checkout -q -B claude/reachable-2489 main >/dev/null 2>&1
+manifest="$tmp/manifest-2489b"; : >"$manifest"
+out="$("$helper" "$work" "monorepo" "$manifest" dry-run 2>&1)" && rc=0 || rc=$?
+report "control: a reachable default is still returned to (#2489)" \
+  "$([ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q -- "-> main" && echo yes || echo no)" \
+  "rc=$rc out=$out"
+report "control: the primary checkout really did move back to main (#2489)" \
+  "$([ "$(git -C "$work" branch --show-current)" = "main" ] && echo yes || echo no)" \
+  "on=$(git -C "$work" branch --show-current)"
+
+# ARM 3 — negative control: a checkout that fails for a reason OTHER than another
+# worktree holding the branch must STILL be an error. This is what stops the fix
+# from being a blanket suppression of the failure path. Staged so the checkout is
+# refused by an untracked file that the default branch would overwrite.
+blocked_base=$(git -C "$work" rev-parse main)
+git -C "$work" checkout -q main >/dev/null 2>&1
+printf 'tracked-on-default\n' >"$work/blocker-2489.txt"
+git -C "$work" add blocker-2489.txt >/dev/null 2>&1
+git -C "$work" commit -q -m "main tracks the blocker" >/dev/null 2>&1
+git -C "$work" checkout -q -B claude/blocked-2489 "$blocked_base" >/dev/null 2>&1
+printf 'untracked-would-be-overwritten\n' >"$work/blocker-2489.txt"
+manifest="$tmp/manifest-2489c"; : >"$manifest"
+out="$("$helper" "$work" "monorepo" "$manifest" dry-run 2>&1)" && rc=0 || rc=$?
+report "negative control: a genuinely failed return to default is still an error (#2489)" \
+  "$([ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'FAILED to reach' && echo yes || echo no)" \
+  "rc=$rc out=$out"
+
+rm -f "$work/blocker-2489.txt"
+git -C "$work" checkout -q -f main >/dev/null 2>&1
 if [[ "$fail" -ne 0 ]]; then
   echo "branch-cleanup contract: FAILED"
   exit 1


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Tidying up spent branches is meant to happen at the end of every run. It has not been happening on
this repository, and the reason is structural rather than a mistake anyone made: each run works in
its own private copy of the repository, while the shared copy holds the main branch — and the tool
we use cannot put the same branch in two places at once.

The clean-up itself worked fine. What failed was the very last step, "put the copy back on the main
branch", which simply cannot succeed from a private copy. The tool counted that as a fault and
reported failure every single time, so its success/failure signal became meaningless — a run that
did everything right looked exactly like a run that had genuinely broken. Nearly a thousand old
branches have accumulated behind that noise.

### What this changes

The tool now recognises the difference between "I could not go back to the main branch because
another copy is using it" — which is the normal, expected situation and is left to the scheduled
clean-up to resolve — and "I could not go back for some other reason", which is still reported as a
real failure. Nothing about which branches get kept or removed changes.

Verified on this repository: the same sweep that previously reported failure now reports success,
with an identical list of branches kept and removed.

Fixes #2489
