### PR TITLE
fix(agents): draft adapted dependency PRs

### DIFF
--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -428,6 +428,10 @@ assert_prose 'An untouched bot-generated head keeps the repository automation' \
   "consumer does not preserve the existing untouched-bot automation path"
 assert_prose 'Any agent-authored adaptation commit restores the ordinary current-head semantic-review gate' \
   "consumer lets agent adaptations bypass semantic review"
+assert_prose 'convert the PR to draft before the first adaptation push' \
+  "consumer lacks a durable draft fence for dependency-PR adaptations"
+assert_prose 'Draft state is the durable fence' \
+  "consumer trusts reversible auto-merge disarming as the adaptation fence"
 assert_prose 'never select, triage-as-work, edit, or close an issue authored by one of those exact identities' \
   "consumer no longer protects dependency-automation control issues"
 refute_prose 'One bot PR being red, stale, conflicting or review-less remains none of our business' \

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -215,6 +215,10 @@ grep -Fq 'bot-generated head keeps the repository automation' "${constitution}" 
   fail "constitution does not preserve the existing untouched-bot review path"
 grep -Fq 'adaptation commit restores the ordinary current-head semantic-review gate' "${constitution}" ||
   fail "constitution lets an adapted dependency PR bypass semantic review"
+grep -Fq 'convert the PR to draft before the first adaptation push' "${constitution}" ||
+  fail "constitution does not draft-fence adapted dependency PRs before a push"
+grep -Fq 'Draft state is the durable fence' "${constitution}" ||
+  fail "constitution relies on reversible auto-merge disarming for adaptations"
 grep -Fq 'collect complete commit provenance' "${surveyor}" ||
   fail "surveyor cannot distinguish untouched bot output from an agent adaptation"
 grep -Fq 'arm or execute the repository' "${constitution}" ||
@@ -494,6 +498,8 @@ grep -Fq 'dependency-automation PR that lacks positive self-progressing evidence
 # shellcheck disable=SC2016
 grep -Fq '`agent-plugins` updater PRs require semantic review' "${maintenance_skill}" ||
   fail "portfolio-maintenance skill can still exempt marketplace instruction updates from review"
+grep -Fq 'convert it to draft before the first adaptation push' "${maintenance_skill}" ||
+  fail "portfolio-maintenance skill does not draft-fence dependency-PR adaptations"
 grep -Fq 'Compatibility overlay' "${maintenance_skill}" ||
   fail "plugin surveyor can run without the hardened local behavior before digest parity"
 grep -Fq 'read and follow the local' "${maintenance_skill}" ||

--- a/.claude/scripts/work-priority-ladder.test.sh
+++ b/.claude/scripts/work-priority-ladder.test.sh
@@ -355,10 +355,12 @@ assert_prose 'self-progressing only while' \
   "${constitution_flat}" "contract cannot distinguish healthy dependency automation from a stalled PR"
 assert_prose 'unable to reach merge without a new agent action' \
   "${constitution_flat}" "contract does not define the dependency-PR intervention boundary"
-assert_prose 'disarm any existing auto-merge request before the adaptation push' \
-  "${constitution_flat}" "contract lets an adapted bot head merge before semantic review"
-assert_prose 'Re-arm only after the adapted head satisfies that review gate' \
-  "${constitution_flat}" "contract can re-arm an adapted bot PR before semantic review"
+assert_prose 'convert the PR to draft before the first adaptation push' \
+  "${constitution_flat}" "contract lacks a durable draft fence for an adapted bot head"
+assert_prose 'Draft state is the durable fence' \
+  "${constitution_flat}" "contract relies on auto-merge disarming that automation can reverse"
+assert_prose 'Promote from draft and re-arm only after the adapted head satisfies that review gate' \
+  "${constitution_flat}" "contract can promote an adapted bot PR before semantic review"
 assert_absent '**Automation-owned Renovate/Dependabot PRs stay excluded**' \
   "${constitution_flat}" "retired unconditional dependency-PR exclusion is still present"
 assert_absent '**Dependency automation is hands-off.**' \

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -587,9 +587,10 @@ slice. Record the product's `last_value_review` cursor, not live metrics, in nat
    merge (contract *Trust gate*), so an external PR that has cleared every evaluation and review gate
    would otherwise be refused at the last step for being external, which is the whole class the
    2026-08-08 widening exists to admit. Exact `renovate[bot]`/`dependabot[bot]` PRs follow the same
-   head-pinned merge preflight after their self-progressing evidence fails. Before pushing an adaptation
-   to an armed dependency PR, disable auto-merge and confirm it is off; re-arm only after the adapted
-   head has fresh semantic review. 🔴 **DIAGNOSE a refused merge before escalating it — a one-click is for what you
+   head-pinned merge preflight after their self-progressing evidence fails. Before adapting one,
+   convert it to draft before the first adaptation push, disable auto-merge, and confirm both; draft
+   is the durable fence against repository automation re-arming after the push. Promote and re-arm
+   only after the adapted head has fresh semantic review. 🔴 **DIAGNOSE a refused merge before escalating it — a one-click is for what you
    cannot fix, never for what you did not look at.** The thread read above is taken *immediately*
    before the merge, but "immediately" is not "atomically": a lane can post a thread in the gap, and
    a ruleset condition the pentad never modelled can refuse just as easily. Both surface as a bare

--- a/.claude/skills/product-engineering/SKILL.md
+++ b/.claude/skills/product-engineering/SKILL.md
@@ -195,7 +195,8 @@ Issues are the unit of work (contract *Issue-driven*) — this is where new work
    nobody else is mid-flight. Three boundaries survive that widening.
    Exact `renovate[bot]`/`dependabot[bot]` PRs stay with repository automation only while live
    evidence proves them self-progressing; when they cannot finish autonomously they return to the
-   ordinary rung-one repair and merge queue. An **external
+   ordinary rung-one repair and merge queue; any adaptation starts in draft and stays there through
+   fresh current-head semantic review. An **external
    contribution** is driven and merged but its branch is **never run locally** — static review only,
    CI is the execution surface, with extra scrutiny on workflow, permission, dependency and
    secret-touching changes; and on the maintainer's **interactive** PRs his comments are him steering

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1539,10 +1539,11 @@ retrying; rerun only a demonstrated transient once; request the bot's update/reb
 succeed; push a minimal adaptation commit to the trusted bot branch when the dependency change itself
 needs it; and arm or execute the repository's head-pinned merge path when readiness holds. An untouched
 bot-generated head keeps the repository automation's existing no-agent-review path. Any agent-authored
-adaptation commit restores the ordinary current-head semantic-review gate before merge. If the PR is
-already armed, disarm any existing auto-merge request before the adaptation push and confirm it is off;
-otherwise fresh green CI can merge the adapted head before that review exists. Re-arm only after the
-adapted head satisfies that review gate. Major-version
+adaptation commit restores the ordinary current-head semantic-review gate before merge. Always
+convert the PR to draft before the first adaptation push, disable any existing auto-merge request,
+and confirm both states. Draft state is the durable fence: repository automation can re-arm
+auto-merge after a push. Promote from draft and re-arm only after the adapted head satisfies that
+review gate. Major-version
 bumps are included; difficulty changes the work, not ownership. If a merged dependency bump breaks
 `main`, repair that resulting breakage normally as well.
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Repository automation re-armed auto-merge after an adapted dependency PR was pushed. Disabling auto-merge before the push was therefore not a durable review fence: the adapted head merged 31 seconds after its final push, before a fresh exact-head semantic review could complete.

## What

- Convert a dependency PR to draft before the first agent adaptation push.
- Disable auto-merge and verify both draft and disarmed state before pushing.
- Treat draft state as the durable fence against repository workflows re-arming auto-merge.
- Promote and re-arm only after fresh semantic review of the adapted current head.
- Pin the rule in the consumer contract, operate/advance procedures, and regression tests.

## Verification

- `work-priority-ladder.test.sh`
- `portfolio-surveyor.test.sh`
- `agent-role-delivery-contract.test.sh`
- `shellcheck` (pre-existing SC2016 informational findings only)
- `git diff --check`

Part of #2779
