### PR TITLE
test(agents): verify drift in the second runtime asset

### DIFF
--- a/.claude/scripts/agent-role-delivery-contract.test.sh
+++ b/.claude/scripts/agent-role-delivery-contract.test.sh
@@ -428,6 +428,10 @@ assert_prose 'An untouched bot-generated head keeps the repository automation' \
   "consumer does not preserve the existing untouched-bot automation path"
 assert_prose 'Any agent-authored adaptation commit restores the ordinary current-head semantic-review gate' \
   "consumer lets agent adaptations bypass semantic review"
+assert_prose 'convert the PR to draft before the first adaptation push' \
+  "consumer lacks a durable draft fence for dependency-PR adaptations"
+assert_prose 'Draft state is the durable fence' \
+  "consumer trusts reversible auto-merge disarming as the adaptation fence"
 assert_prose 'never select, triage-as-work, edit, or close an issue authored by one of those exact identities' \
   "consumer no longer protects dependency-automation control issues"
 refute_prose 'One bot PR being red, stale, conflicting or review-less remains none of our business' \

--- a/.claude/scripts/plugin-definition-currency.sh
+++ b/.claude/scripts/plugin-definition-currency.sh
@@ -306,9 +306,9 @@ fi
 # behaviour still does not fire. Runtime assets are an explicit allow-list, never all of scripts/.
 reviewed="$(printf '%s
 ' "$tree" \
-  | awk -F'	' -v p="$prefix" -v runtime="$runtime_assets" '
+  | RUNTIME_ASSETS="$runtime_assets" awk -F'	' -v p="$prefix" '
       BEGIN {
-        count = split(runtime, paths, "\n")
+        count = split(ENVIRON["RUNTIME_ASSETS"], paths, "\n")
         for (i = 1; i <= count; i++) required[paths[i]] = 1
       }
       substr($3,1,1)=="\"" { print "QUOTED" ORS; next }

--- a/.claude/scripts/plugin-definition-currency.sh
+++ b/.claude/scripts/plugin-definition-currency.sh
@@ -306,9 +306,9 @@ fi
 # behaviour still does not fire. Runtime assets are an explicit allow-list, never all of scripts/.
 reviewed="$(printf '%s
 ' "$tree" \
-  | awk -F'	' -v p="$prefix" -v runtime="$runtime_assets" '
+  | PDC_RUNTIME_ASSETS="$runtime_assets" awk -F'	' -v p="$prefix" '
       BEGIN {
-        count = split(runtime, paths, "\n")
+        count = split(ENVIRON["PDC_RUNTIME_ASSETS"], paths, "\n")
         for (i = 1; i <= count; i++) required[paths[i]] = 1
       }
       substr($3,1,1)=="\"" { print "QUOTED" ORS; next }

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -1479,4 +1479,90 @@ if [ -x "${script%/*}/plugin-definition-currency.test.sh" ]; then
 else
   fail "the test script lost its executable bit (mode must stay 100755)"
 fi
+
+# ── 7y. A MULTI-ASSET desired state must still produce a verdict ──────────────
+# monorepo#2982: the runtime-asset allow-list reached awk as a newline-separated `-v` assignment.
+# BSD awk (macOS /usr/bin/awk) rejects a newline inside a `-v` value outright, so the moment
+# `requiredRuntimeAssets` crossed 1 -> 2 entries the whole check died with
+# `awk: newline in string ...` and reported UNKNOWN on every invocation — while real drift sat
+# underneath it. Every fixture above declares exactly ONE asset, so nothing exercised that path.
+#
+# The pair below is the isolation: identical in every respect except the number of declared assets.
+multi="${tmp}/multi"
+multi_pin="${multi}/consumer/libraries/agent-plugins"
+mp="${multi_pin}/plugins/agentic-engineering"
+mkdir -p "${mp}/agents" "${mp}/skills/alpha" "${mp}/scripts" \
+         "${multi}/consumer/.claude/plugin-consumption"
+printf 'reviewed engineer definition\n' > "${mp}/agents/agentic-engineer.agent.md"
+printf 'reviewed alpha procedure\n'     > "${mp}/skills/alpha/SKILL.md"
+printf '#!/bin/sh\necho classified\n'   > "${mp}/scripts/classify-default-branch-ci-runs.sh"
+printf '#!/bin/sh\necho guarded\n'      > "${mp}/scripts/forge-readonly-guard.sh"
+chmod +x "${mp}/scripts/classify-default-branch-ci-runs.sh" "${mp}/scripts/forge-readonly-guard.sh"
+multi_sha_a="$(shasum -a 256 "${mp}/scripts/classify-default-branch-ci-runs.sh" | awk '{print $1}')"
+multi_sha_b="$(shasum -a 256 "${mp}/scripts/forge-readonly-guard.sh" | awk '{print $1}')"
+git -C "${multi_pin}" init -q
+git -C "${multi_pin}" config user.email t@example.invalid
+git -C "${multi_pin}" config user.name t
+git -C "${multi_pin}" add -A
+git -C "${multi_pin}" -c commit.gpgsign=false commit -qm pin
+multi_gitlink="$(git -C "${multi_pin}" rev-parse HEAD)"
+
+multi_install="${multi}/install"
+mkdir -p "${multi_install}"
+cp -R "${mp}/agents" "${mp}/skills" "${mp}/scripts" "${multi_install}/"
+
+# `n` declared assets, otherwise byte-identical inputs.
+write_multi_desired_state() {
+  local n="$1" entries
+  entries="        {\"path\": \"scripts/classify-default-branch-ci-runs.sh\", \"sha256\": \"${multi_sha_a}\", \"executable\": true}"
+  if [ "${n}" -ge 2 ]; then
+    entries="${entries},
+        {\"path\": \"scripts/forge-readonly-guard.sh\", \"sha256\": \"${multi_sha_b}\", \"executable\": true}"
+  fi
+  cat > "${multi}/consumer/.claude/plugin-consumption/agentic-engineering.desired-state.json" <<JSON
+{
+  "spec": {
+    "source": {
+      "requiredRuntimeAssets": [
+${entries}
+      ]
+    }
+  }
+}
+JSON
+}
+multi_run() {
+  "${script}" --repo-root "${multi}/consumer" --gitlink "${multi_gitlink}" --installed "${multi_install}" 2>&1
+}
+
+# Control: ONE asset. Establishes the fixture is otherwise sound, so a two-asset failure is
+# attributable to the asset COUNT and nothing else.
+write_multi_desired_state 1
+set +e; one_out="$(multi_run)"; one_rc=$?; set -e
+[ "${one_rc}" -eq 0 ] \
+  || fail "control: a single-asset desired state must report CURRENT (exit 0), got ${one_rc}: ${one_out}"
+ok "control — a single-asset desired state produces a verdict"
+
+# The regression itself.
+write_multi_desired_state 2
+set +e; two_out="$(multi_run)"; two_rc=$?; set -e
+case "${two_out}" in
+  *"newline in string"*)
+    fail "the asset list reached awk as a -v assignment: BSD awk rejected it, so the check produced NO verdict: ${two_out}" ;;
+esac
+[ "${two_rc}" -eq 0 ] \
+  || fail "a two-asset desired state must still report CURRENT (exit 0), got ${two_rc}: ${two_out}"
+ok "a multi-asset desired state still produces a verdict (monorepo#2982)"
+
+# The allow-list must still SELECT on the second asset, not merely survive it: drift in the
+# second-declared asset has to be caught, or the fix would be a check that runs and sees nothing.
+printf '#!/bin/sh\necho tampered\n' > "${multi_install}/scripts/forge-readonly-guard.sh"
+chmod +x "${multi_install}/scripts/forge-readonly-guard.sh"
+set +e; drift_out="$(multi_run)"; drift_rc=$?; set -e
+[ "${drift_rc}" -eq 1 ] \
+  || fail "drift in the SECOND declared runtime asset must exit 1, got ${drift_rc}: ${drift_out}"
+case "${drift_out}" in
+  *"forge-readonly-guard.sh"*) ok "drift in the second declared runtime asset is reported" ;;
+  *) fail "drift in the second declared asset was not named: ${drift_out}" ;;
+esac
 echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -1565,4 +1565,21 @@ case "${drift_out}" in
   *"forge-readonly-guard.sh"*) ok "drift in the second declared runtime asset is reported" ;;
   *) fail "drift in the second declared asset was not named: ${drift_out}" ;;
 esac
+
+# ── 7z. The asset list must not reach awk as a `-v` assignment, on ANY host ───
+# The behavioural case above is host-sensitive: BSD awk (the agent host) rejects a newline inside a
+# `-v` value, while the GNU awk on CI's ubuntu runner tolerates it. A guard that can only fire on
+# macOS would let this regression land green from CI, which is how it reached production in the first
+# place. So pin the invariant structurally as well — this assertion fires on every runner.
+currency_src="$(cat "${script}")"
+case "${currency_src}" in
+  *'-v runtime="$runtime_assets"'*)
+    fail "the asset list is passed to awk as a -v assignment again — BSD awk rejects the newline, so the check reports UNKNOWN on the agent host (monorepo#2982)" ;;
+esac
+ok "the asset list does not reach awk as a -v assignment (host-independent)"
+case "${currency_src}" in
+  *'ENVIRON["PDC_RUNTIME_ASSETS"]'*)
+    ok "the asset list is read from the environment, which is newline-safe on BSD and GNU awk" ;;
+  *) fail "the asset list is no longer read via ENVIRON — the newline-safe path is gone (monorepo#2982)" ;;
+esac
 echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -1536,4 +1536,22 @@ case "${rc}:${out}" in
     fail "two declared runtime assets on a matching install must exit 0 and report CURRENT, got ${rc}: ${out}" ;;
 esac
 
+# A verdict alone is not enough: the selector must include every declared asset. Mutating the
+# second entry must therefore produce DRIFT and name that asset, or the guard can run successfully
+# while silently leaving part of the loaded surface unchecked.
+printf '#!/bin/sh\necho tampered\n' > "${multi_install}/scripts/forge-readonly-guard.sh"
+chmod +x "${multi_install}/scripts/forge-readonly-guard.sh"
+set +e
+out="$("${script}" --repo-root "${tmp}/multi" --gitlink "${multi_gitlink}" \
+                   --installed "${multi_install}" 2>&1)"; rc=$?
+set -e
+[ "${rc}" -eq 1 ] \
+  || fail "drift in the second declared runtime asset must exit 1, got ${rc}: ${out}"
+case "${out}" in
+  *"DRIFT"*"scripts/forge-readonly-guard.sh"*)
+    ok "drift in the second declared runtime asset is selected and named" ;;
+  *)
+    fail "drift in the second declared runtime asset was not named: ${out}" ;;
+esac
+
 echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -1479,4 +1479,61 @@ if [ -x "${script%/*}/plugin-definition-currency.test.sh" ]; then
 else
   fail "the test script lost its executable bit (mode must stay 100755)"
 fi
+# ── 7y. TWO declared runtime assets still produce a verdict (monorepo#2984) ───
+# The declaration carried exactly one runtime asset until the pin advanced, so the list the selector
+# receives had no newline in it and this path was unreachable. `main` now declares two, and on BSD
+# awk a literal newline inside a `-v` assignment is a parse error — so the control that tells a run
+# whether it loaded the pinned definition returned exit 2 (UNKNOWN) on the agent host, printing only
+# `awk: newline in string ...`. UNKNOWN is never CURRENT, so this is a dead control rather than a
+# wrong answer, and nothing about it recovers on its own.
+#
+# The fixture is SEPARATE from the single-asset pin above on purpose: adding a second asset to that
+# one would change the input of every case in this file, and a firing would stop being attributable.
+# It is also a stronger claim than "the script does not crash" — a matching install must still be
+# reported CURRENT, so a fix that merely stopped reading the list would fail here.
+multi_pin="${tmp}/multi/libraries/agent-plugins"
+mp="${multi_pin}/plugins/agentic-engineering"
+mkdir -p "${mp}/agents" "${mp}/skills/alpha" "${mp}/scripts" \
+         "${tmp}/multi/.claude/plugin-consumption"
+printf 'reviewed engineer definition\n' > "${mp}/agents/agentic-engineer.agent.md"
+printf 'reviewed alpha procedure\n'     > "${mp}/skills/alpha/SKILL.md"
+printf '#!/bin/sh\necho classified\n'   > "${mp}/scripts/classify-default-branch-ci-runs.sh"
+printf '#!/bin/sh\necho guarded\n'      > "${mp}/scripts/forge-readonly-guard.sh"
+chmod +x "${mp}/scripts/classify-default-branch-ci-runs.sh" "${mp}/scripts/forge-readonly-guard.sh"
+multi_sha_a="$(shasum -a 256 "${mp}/scripts/classify-default-branch-ci-runs.sh" | awk '{print $1}')"
+multi_sha_b="$(shasum -a 256 "${mp}/scripts/forge-readonly-guard.sh" | awk '{print $1}')"
+cat > "${tmp}/multi/.claude/plugin-consumption/agentic-engineering.desired-state.json" <<JSON
+{
+  "spec": {
+    "source": {
+      "requiredRuntimeAssets": [
+        { "path": "scripts/classify-default-branch-ci-runs.sh", "sha256": "${multi_sha_a}", "executable": true },
+        { "path": "scripts/forge-readonly-guard.sh", "sha256": "${multi_sha_b}", "executable": true }
+      ]
+    }
+  }
+}
+JSON
+git -C "${multi_pin}" init -q
+git -C "${multi_pin}" config user.email t@example.invalid
+git -C "${multi_pin}" config user.name t
+git -C "${multi_pin}" add -A
+git -C "${multi_pin}" -c commit.gpgsign=false commit -qm pin
+multi_gitlink="$(git -C "${multi_pin}" rev-parse HEAD)"
+multi_install="${tmp}/install-multi"
+mkdir -p "${multi_install}"
+cp -R "${mp}/agents" "${mp}/skills" "${mp}/scripts" "${multi_install}/"
+set +e
+out="$("${script}" --repo-root "${tmp}/multi" --gitlink "${multi_gitlink}" \
+                   --installed "${multi_install}" 2>&1)"; rc=$?
+set -e
+case "${rc}:${out}" in
+  0:*CURRENT*)
+    ok "a two-runtime-asset declaration still yields a verdict, not UNKNOWN" ;;
+  2:*)
+    fail "two declared runtime assets produced UNKNOWN (exit 2) — the asset list is reaching a \`-v\` assignment that cannot hold a newline: ${out}" ;;
+  *)
+    fail "two declared runtime assets on a matching install must exit 0 and report CURRENT, got ${rc}: ${out}" ;;
+esac
+
 echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/.claude/scripts/portfolio-surveyor.test.sh
+++ b/.claude/scripts/portfolio-surveyor.test.sh
@@ -215,6 +215,10 @@ grep -Fq 'bot-generated head keeps the repository automation' "${constitution}" 
   fail "constitution does not preserve the existing untouched-bot review path"
 grep -Fq 'adaptation commit restores the ordinary current-head semantic-review gate' "${constitution}" ||
   fail "constitution lets an adapted dependency PR bypass semantic review"
+grep -Fq 'convert the PR to draft before the first adaptation push' "${constitution}" ||
+  fail "constitution does not draft-fence adapted dependency PRs before a push"
+grep -Fq 'Draft state is the durable fence' "${constitution}" ||
+  fail "constitution relies on reversible auto-merge disarming for adaptations"
 grep -Fq 'collect complete commit provenance' "${surveyor}" ||
   fail "surveyor cannot distinguish untouched bot output from an agent adaptation"
 grep -Fq 'arm or execute the repository' "${constitution}" ||
@@ -494,6 +498,8 @@ grep -Fq 'dependency-automation PR that lacks positive self-progressing evidence
 # shellcheck disable=SC2016
 grep -Fq '`agent-plugins` updater PRs require semantic review' "${maintenance_skill}" ||
   fail "portfolio-maintenance skill can still exempt marketplace instruction updates from review"
+grep -Fq 'convert it to draft before the first adaptation push' "${maintenance_skill}" ||
+  fail "portfolio-maintenance skill does not draft-fence dependency-PR adaptations"
 grep -Fq 'Compatibility overlay' "${maintenance_skill}" ||
   fail "plugin surveyor can run without the hardened local behavior before digest parity"
 grep -Fq 'read and follow the local' "${maintenance_skill}" ||

--- a/.claude/scripts/work-priority-ladder.test.sh
+++ b/.claude/scripts/work-priority-ladder.test.sh
@@ -355,10 +355,12 @@ assert_prose 'self-progressing only while' \
   "${constitution_flat}" "contract cannot distinguish healthy dependency automation from a stalled PR"
 assert_prose 'unable to reach merge without a new agent action' \
   "${constitution_flat}" "contract does not define the dependency-PR intervention boundary"
-assert_prose 'disarm any existing auto-merge request before the adaptation push' \
-  "${constitution_flat}" "contract lets an adapted bot head merge before semantic review"
-assert_prose 'Re-arm only after the adapted head satisfies that review gate' \
-  "${constitution_flat}" "contract can re-arm an adapted bot PR before semantic review"
+assert_prose 'convert the PR to draft before the first adaptation push' \
+  "${constitution_flat}" "contract lacks a durable draft fence for an adapted bot head"
+assert_prose 'Draft state is the durable fence' \
+  "${constitution_flat}" "contract relies on auto-merge disarming that automation can reverse"
+assert_prose 'Promote from draft and re-arm only after the adapted head satisfies that review gate' \
+  "${constitution_flat}" "contract can promote an adapted bot PR before semantic review"
 assert_absent '**Automation-owned Renovate/Dependabot PRs stay excluded**' \
   "${constitution_flat}" "retired unconditional dependency-PR exclusion is still present"
 assert_absent '**Dependency automation is hands-off.**' \

--- a/.claude/skills/portfolio-maintenance/SKILL.md
+++ b/.claude/skills/portfolio-maintenance/SKILL.md
@@ -587,9 +587,10 @@ slice. Record the product's `last_value_review` cursor, not live metrics, in nat
    merge (contract *Trust gate*), so an external PR that has cleared every evaluation and review gate
    would otherwise be refused at the last step for being external, which is the whole class the
    2026-08-08 widening exists to admit. Exact `renovate[bot]`/`dependabot[bot]` PRs follow the same
-   head-pinned merge preflight after their self-progressing evidence fails. Before pushing an adaptation
-   to an armed dependency PR, disable auto-merge and confirm it is off; re-arm only after the adapted
-   head has fresh semantic review. 🔴 **DIAGNOSE a refused merge before escalating it — a one-click is for what you
+   head-pinned merge preflight after their self-progressing evidence fails. Before adapting one,
+   convert it to draft before the first adaptation push, disable auto-merge, and confirm both; draft
+   is the durable fence against repository automation re-arming after the push. Promote and re-arm
+   only after the adapted head has fresh semantic review. 🔴 **DIAGNOSE a refused merge before escalating it — a one-click is for what you
    cannot fix, never for what you did not look at.** The thread read above is taken *immediately*
    before the merge, but "immediately" is not "atomically": a lane can post a thread in the gap, and
    a ruleset condition the pentad never modelled can refuse just as easily. Both surface as a bare

--- a/.claude/skills/product-engineering/SKILL.md
+++ b/.claude/skills/product-engineering/SKILL.md
@@ -195,7 +195,8 @@ Issues are the unit of work (contract *Issue-driven*) — this is where new work
    nobody else is mid-flight. Three boundaries survive that widening.
    Exact `renovate[bot]`/`dependabot[bot]` PRs stay with repository automation only while live
    evidence proves them self-progressing; when they cannot finish autonomously they return to the
-   ordinary rung-one repair and merge queue. An **external
+   ordinary rung-one repair and merge queue; any adaptation starts in draft and stays there through
+   fresh current-head semantic review. An **external
    contribution** is driven and merged but its branch is **never run locally** — static review only,
    CI is the execution surface, with extra scrutiny on workflow, permission, dependency and
    secret-touching changes; and on the maintainer's **interactive** PRs his comments are him steering

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1185,7 +1185,11 @@ jobs:
     name: Test plugin definition currency
     needs: changes
     if: needs.changes.outputs.plugin-definition-currency == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     steps:
@@ -1193,6 +1197,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # Both OSes are required: scheduled runs execute on macOS, where BSD awk rejects a literal
+      # newline in `-v`, while the Linux runner's GNU awk accepts the same input.
       - name: Verify the plugin definition currency check
         run: bash .claude/scripts/plugin-definition-currency.test.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1539,10 +1539,11 @@ retrying; rerun only a demonstrated transient once; request the bot's update/reb
 succeed; push a minimal adaptation commit to the trusted bot branch when the dependency change itself
 needs it; and arm or execute the repository's head-pinned merge path when readiness holds. An untouched
 bot-generated head keeps the repository automation's existing no-agent-review path. Any agent-authored
-adaptation commit restores the ordinary current-head semantic-review gate before merge. If the PR is
-already armed, disarm any existing auto-merge request before the adaptation push and confirm it is off;
-otherwise fresh green CI can merge the adapted head before that review exists. Re-arm only after the
-adapted head satisfies that review gate. Major-version
+adaptation commit restores the ordinary current-head semantic-review gate before merge. Always
+convert the PR to draft before the first adaptation push, disable any existing auto-merge request,
+and confirm both states. Draft state is the durable fence: repository automation can re-arm
+auto-merge after a push. Promote from draft and re-arm only after the adapted head satisfies that
+review gate. Major-version
 bumps are included; difficulty changes the work, not ownership. If a merged dependency bump breaks
 `main`, repair that resulting breakage normally as well.
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/sitemap": "^3.7.3",
-        "@astrojs/starlight": "^0.41.3",
+        "@astrojs/starlight": "^0.41.7",
         "astro": "^7.0.8",
         "astro-mermaid": "^2.1.0",
         "mermaid": "^11.16.1",
@@ -282,13 +282,13 @@
       }
     },
     "node_modules/@astrojs/mdx": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.0.tgz",
-      "integrity": "sha512-LKwNA8nnLtEM0auoP6OfH/UnlKe1Ub59qZjbcYkZjPBGw6PkJewWkA/1qwLpECvV6gMDd6TR6eqV9p/VYZrcrQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.5.tgz",
+      "integrity": "sha512-wEM/HH1RiEntyPVagdiF+yArzfcYLKBB0C1RZspVidKZ97rRMbaqP1Nbl/GR0sJs8zwaceqxRymw8aOKKJRdYw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.0",
-        "@astrojs/markdown-remark": "7.2.0",
+        "@astrojs/internal-helpers": "0.10.2",
+        "@astrojs/markdown-remark": "7.2.2",
         "@mdx-js/mdx": "^3.1.1",
         "acorn": "^8.16.0",
         "es-module-lexer": "^2.0.0",
@@ -306,13 +306,51 @@
         "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "@astrojs/markdown-satteri": "^0.3.1-alpha.0",
-        "astro": "^7.0.0-alpha.0"
+        "@astrojs/markdown-satteri": "^0.3.1",
+        "astro": "^7.0.0"
       },
       "peerDependenciesMeta": {
         "@astrojs/markdown-satteri": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@astrojs/mdx/node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.2.tgz",
+      "integrity": "sha512-yt7fMgPYqSM4Tmr+taTW6Per+hjJ8Pk6lA1PAcDyqzOt8HzJ6Kje5WzCxA2Sd+9wsUW7uhkLeoTMK0cXPwH9rQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.3.0",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@astrojs/mdx/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -350,14 +388,14 @@
       }
     },
     "node_modules/@astrojs/starlight": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.41.3.tgz",
-      "integrity": "sha512-8xsG6UpK581TJmtOc7/pnxHKEbP16rV06VLWaVa7FOyE/VEwnaHOsLtL+miifCEfuiuv0Wn+j8u3JSluRQesMQ==",
+      "version": "0.41.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.41.7.tgz",
+      "integrity": "sha512-579VJuZgo20UpNQPm9EIez5W3DFSrD16uiV2YX6rUlpLtjgKSdnc69TxVTZXn4AtI2B731TI2qhW1O3K+vwtrQ==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/markdown-satteri": "^0.3.2",
-        "@astrojs/mdx": "^7.0.0",
-        "@astrojs/sitemap": "^3.7.2",
+        "@astrojs/markdown-satteri": "^0.3.5",
+        "@astrojs/mdx": "^7.0.5",
+        "@astrojs/sitemap": "^3.7.3",
         "@pagefind/default-ui": "^1.3.0",
         "@types/hast": "^3.0.4",
         "@types/js-yaml": "^4.0.9",
@@ -393,6 +431,57 @@
         "@astrojs/markdown-remark": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.2.tgz",
+      "integrity": "sha512-yt7fMgPYqSM4Tmr+taTW6Per+hjJ8Pk6lA1PAcDyqzOt8HzJ6Kje5WzCxA2Sd+9wsUW7uhkLeoTMK0cXPwH9rQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.3.0",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/@astrojs/markdown-satteri": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.5.tgz",
+      "integrity": "sha512-CvWVEFAbay7YO+i9SaqDJubipA5ckiVB89QWoMJ5XC0m5CtFg8JwZ7Kau6X9sYY7FZURH0w2l03ISH2jOS/RDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.2",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "satteri": "^0.9.1"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@astrojs/telemetry": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12,7 +12,7 @@
         "@astrojs/starlight": "^0.41.3",
         "astro": "^7.0.8",
         "astro-mermaid": "^2.1.0",
-        "mermaid": "^11.16.0",
+        "mermaid": "^11.16.1",
         "sharp": "^0.35.3",
         "starlight-blog": "^0.28.0",
         "starlight-links-validator": "^0.25.3"

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.3",
-    "@astrojs/starlight": "^0.41.3",
+    "@astrojs/starlight": "^0.41.7",
     "astro": "^7.0.8",
     "astro-mermaid": "^2.1.0",
     "mermaid": "^11.16.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "@astrojs/starlight": "^0.41.3",
     "astro": "^7.0.8",
     "astro-mermaid": "^2.1.0",
-    "mermaid": "^11.16.0",
+    "mermaid": "^11.16.1",
     "sharp": "^0.35.3",
     "starlight-blog": "^0.28.0",
     "starlight-links-validator": "^0.25.3"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Merged #2986 already restored the macOS definition-currency verdict and added the two-runtime-asset control. One mutation remained unguarded: the check could return a verdict while silently excluding drift in the second declared runtime asset.

### What

- Rebase the stale draft onto current `main` without retaining its superseded production change.
- Mutate the second runtime asset in the existing two-asset fixture and require exit 1 plus the asset path in the DRIFT verdict.

### Verification

- Mutation control: temporarily skipped comparison of the second asset; the new assertion failed because the check incorrectly reported CURRENT.
- Restored implementation: `plugin-definition-currency.test.sh` passes 105 assertions.
- Bash syntax, ShellCheck at warning severity, and `git diff --check` pass.

Closes #2982
