### PR TITLE
fix(agents): keep the currency check working when two runtime assets are declared

### DIFF
--- a/.claude/scripts/plugin-definition-currency.sh
+++ b/.claude/scripts/plugin-definition-currency.sh
@@ -306,9 +306,9 @@ fi
 # behaviour still does not fire. Runtime assets are an explicit allow-list, never all of scripts/.
 reviewed="$(printf '%s
 ' "$tree" \
-  | awk -F'	' -v p="$prefix" -v runtime="$runtime_assets" '
+  | RUNTIME_ASSETS="$runtime_assets" awk -F'	' -v p="$prefix" '
       BEGIN {
-        count = split(runtime, paths, "\n")
+        count = split(ENVIRON["RUNTIME_ASSETS"], paths, "\n")
         for (i = 1; i <= count; i++) required[paths[i]] = 1
       }
       substr($3,1,1)=="\"" { print "QUOTED" ORS; next }

--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -1479,4 +1479,61 @@ if [ -x "${script%/*}/plugin-definition-currency.test.sh" ]; then
 else
   fail "the test script lost its executable bit (mode must stay 100755)"
 fi
+# ── 7y. TWO declared runtime assets still produce a verdict (monorepo#2984) ───
+# The declaration carried exactly one runtime asset until the pin advanced, so the list the selector
+# receives had no newline in it and this path was unreachable. `main` now declares two, and on BSD
+# awk a literal newline inside a `-v` assignment is a parse error — so the control that tells a run
+# whether it loaded the pinned definition returned exit 2 (UNKNOWN) on the agent host, printing only
+# `awk: newline in string ...`. UNKNOWN is never CURRENT, so this is a dead control rather than a
+# wrong answer, and nothing about it recovers on its own.
+#
+# The fixture is SEPARATE from the single-asset pin above on purpose: adding a second asset to that
+# one would change the input of every case in this file, and a firing would stop being attributable.
+# It is also a stronger claim than "the script does not crash" — a matching install must still be
+# reported CURRENT, so a fix that merely stopped reading the list would fail here.
+multi_pin="${tmp}/multi/libraries/agent-plugins"
+mp="${multi_pin}/plugins/agentic-engineering"
+mkdir -p "${mp}/agents" "${mp}/skills/alpha" "${mp}/scripts" \
+         "${tmp}/multi/.claude/plugin-consumption"
+printf 'reviewed engineer definition\n' > "${mp}/agents/agentic-engineer.agent.md"
+printf 'reviewed alpha procedure\n'     > "${mp}/skills/alpha/SKILL.md"
+printf '#!/bin/sh\necho classified\n'   > "${mp}/scripts/classify-default-branch-ci-runs.sh"
+printf '#!/bin/sh\necho guarded\n'      > "${mp}/scripts/forge-readonly-guard.sh"
+chmod +x "${mp}/scripts/classify-default-branch-ci-runs.sh" "${mp}/scripts/forge-readonly-guard.sh"
+multi_sha_a="$(shasum -a 256 "${mp}/scripts/classify-default-branch-ci-runs.sh" | awk '{print $1}')"
+multi_sha_b="$(shasum -a 256 "${mp}/scripts/forge-readonly-guard.sh" | awk '{print $1}')"
+cat > "${tmp}/multi/.claude/plugin-consumption/agentic-engineering.desired-state.json" <<JSON
+{
+  "spec": {
+    "source": {
+      "requiredRuntimeAssets": [
+        { "path": "scripts/classify-default-branch-ci-runs.sh", "sha256": "${multi_sha_a}", "executable": true },
+        { "path": "scripts/forge-readonly-guard.sh", "sha256": "${multi_sha_b}", "executable": true }
+      ]
+    }
+  }
+}
+JSON
+git -C "${multi_pin}" init -q
+git -C "${multi_pin}" config user.email t@example.invalid
+git -C "${multi_pin}" config user.name t
+git -C "${multi_pin}" add -A
+git -C "${multi_pin}" -c commit.gpgsign=false commit -qm pin
+multi_gitlink="$(git -C "${multi_pin}" rev-parse HEAD)"
+multi_install="${tmp}/install-multi"
+mkdir -p "${multi_install}"
+cp -R "${mp}/agents" "${mp}/skills" "${mp}/scripts" "${multi_install}/"
+set +e
+out="$("${script}" --repo-root "${tmp}/multi" --gitlink "${multi_gitlink}" \
+                   --installed "${multi_install}" 2>&1)"; rc=$?
+set -e
+case "${rc}:${out}" in
+  0:*CURRENT*)
+    ok "a two-runtime-asset declaration still yields a verdict, not UNKNOWN" ;;
+  2:*)
+    fail "two declared runtime assets produced UNKNOWN (exit 2) — the asset list is reaching a \`-v\` assignment that cannot hold a newline: ${out}" ;;
+  *)
+    fail "two declared runtime assets on a matching install must exit 0 and report CURRENT, got ${rc}: ${out}" ;;
+esac
+
 echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1185,7 +1185,11 @@ jobs:
     name: Test plugin definition currency
     needs: changes
     if: needs.changes.outputs.plugin-definition-currency == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     steps:
@@ -1193,6 +1197,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # Both OSes are required: scheduled runs execute on macOS, where BSD awk rejects a literal
+      # newline in `-v`, while the Linux runner's GNU awk accepts the same input.
       - name: Verify the plugin definition currency check
         run: bash .claude/scripts/plugin-definition-currency.test.sh
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Each agent run has one check that answers "am I actually running the instructions this deployment
approved?" That check stopped answering on the machine the agents run on. It did not say no — it
said nothing, returning a raw error instead of a verdict, which reads as noise rather than as a dead
safety check.

It broke the moment the approved instruction set started listing a second helper file, which
happened on `main` earlier today. So the failure is permanent and affects every run from now on, and
it is invisible unless someone reads the output closely.

### What

Restores the check so it produces a verdict again, whatever the approved set lists. Adds a
regression test covering the case that broke it — the existing tests all used a single-file list,
which is why nothing caught this.

Running the repaired check against today's approved set immediately surfaced real drift it had been
unable to report: three of the loaded files on this machine are behind what the deployment approved,
including the surveyor definition every run depends on for picking work.

Fixes #2984
