### PR TITLE
test(agents): strengthen runtime drift contract coverage

### DIFF
--- a/.claude/scripts/plugin-definition-currency.test.sh
+++ b/.claude/scripts/plugin-definition-currency.test.sh
@@ -1536,4 +1536,22 @@ case "${rc}:${out}" in
     fail "two declared runtime assets on a matching install must exit 0 and report CURRENT, got ${rc}: ${out}" ;;
 esac
 
+# A verdict alone is not enough: the selector must include every declared asset. Mutating the
+# second entry must therefore produce DRIFT and name that asset, or the guard can run successfully
+# while silently leaving part of the loaded surface unchecked.
+printf '#!/bin/sh\necho tampered\n' > "${multi_install}/scripts/forge-readonly-guard.sh"
+chmod +x "${multi_install}/scripts/forge-readonly-guard.sh"
+set +e
+out="$("${script}" --repo-root "${tmp}/multi" --gitlink "${multi_gitlink}" \
+                   --installed "${multi_install}" 2>&1)"; rc=$?
+set -e
+[ "${rc}" -eq 1 ] \
+  || fail "drift in the second declared runtime asset must exit 1, got ${rc}: ${out}"
+case "${out}" in
+  *"DRIFT"*"scripts/forge-readonly-guard.sh"*)
+    ok "drift in the second declared runtime asset is selected and named" ;;
+  *)
+    fail "drift in the second declared runtime asset was not named: ${out}" ;;
+esac
+
 echo "plugin-definition-currency: ${pass_count} assertions passed"

--- a/.claude/scripts/work-priority-ladder.test.sh
+++ b/.claude/scripts/work-priority-ladder.test.sh
@@ -357,6 +357,8 @@ assert_prose 'unable to reach merge without a new agent action' \
   "${constitution_flat}" "contract does not define the dependency-PR intervention boundary"
 assert_prose 'convert the PR to draft before the first adaptation push' \
   "${constitution_flat}" "contract lacks a durable draft fence for an adapted bot head"
+assert_prose 'disable any existing auto-merge request, and confirm both states' \
+  "${constitution_flat}" "contract does not require auto-merge and draft fences to be confirmed before adaptation"
 assert_prose 'Draft state is the durable fence' \
   "${constitution_flat}" "contract relies on auto-merge disarming that automation can reverse"
 assert_prose 'Promote from draft and re-arm only after the adapted head satisfies that review gate' \


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- prove that drift in the second declared runtime asset exits non-zero and names that asset
- pin the requirement to disable auto-merge and confirm both bot-branch adaptation fences

The production currency fix already landed in #2986. This focused follow-up replaces #2985, whose inherited branch history made GitHub present already-merged files outside the intended test-only boundary.

## Test-first proof

- skipping the second runtime asset in the production comparison loop made the new drift test fail with exit `0`
- removing the auto-merge confirmation sentence from the consumer contract made the ladder test fail on the new assertion

## Validation

- `.claude/scripts/plugin-definition-currency.test.sh` — 105 assertions passed
- `.claude/scripts/work-priority-ladder.test.sh` — all assertions passed
- `bash -n` on both changed test scripts
- `shellcheck --severity=warning` on both changed test scripts
- `git diff --check`

Related: #2982
Supersedes: #2985
