### PR TITLE
fix(agents): correct portfolio repository scope

### DIFF
--- a/.claude/agents/portfolio-surveyor.md
+++ b/.claude/agents/portfolio-surveyor.md
@@ -1297,8 +1297,8 @@ public and private — no per-repo loop needed to enumerate):
 
 Portfolio repos (the org-wide search covers them; this is the canonical list to reason over). The
 **authoritative set is the org's live non-archived repo list**: the monorepo `AGENTS.md` portfolio
-map names the *products*, and org/infra repos outside that map (e.g. `.github`,
-`maintenance`, `fleet-gitops`, `aws`) are in scope too. Reconcile each run with one bounded call —
+map names the *products*, and org/infra repos outside that map (e.g. `maintenance`, `fleet-gitops`,
+`aws`) are in scope too. Reconcile each run with one bounded call —
 `gh repo list devantler-tech --no-archived --limit 100 --json name` — and when that live set
 disagrees with **the list below**, survey the live set and flag the drift in the digest rather than
 dropping any repo. (A live repo absent from the portfolio map is *not* drift — the map intentionally

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,10 +50,9 @@ keeping them healthy *and* moving them forward.
 
 > **Archived repositories are outside the active portfolio.** Determine `.archived` live during
 > discovery and omit archived repositories from every health, PR, issue, and automation census even
-> when stale open artifacts remain. They are read-only historical evidence until the maintainer both
-> unarchives and explicitly restores them to the portfolio; do not infer restoration from an old PR
-> or issue. `devantler-tech/data-product` is archived and must therefore not be considered by future
-> runs.
+> when stale open artifacts remain. They are read-only historical evidence while that live flag is
+> true; never infer current work from an old PR or issue. `devantler-tech/data-product` is archived,
+> so every future run must omit it while it remains archived.
 
 **World at Ruin — newest product, bootstrapped 2026-07-16** (maintainer direction the same day). A
 cloud-native MMORPG the maintainer wants to exist, built **almost entirely by agents** as a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ keeping them healthy *and* moving them forward.
 | KSail (Go CLI) | `devantler-tech/ksail` | `applications/ksail` | [AGENTS.md](https://github.com/devantler-tech/ksail/blob/main/AGENTS.md) |
 | Platform (GitOps) | `devantler-tech/platform` | `platform` | [AGENTS.md](https://github.com/devantler-tech/platform/blob/main/AGENTS.md) |
 | devantler.tech site | `devantler-tech/monorepo` | `docs/` + repo root | this file |
+| GitHub organization defaults | `devantler-tech/.github` | `github/devantler-tech/.github-public` | [AGENTS.md](https://github.com/devantler-tech/.github/blob/main/AGENTS.md) |
 | Go template | `devantler-tech/go-template` | `templates/go-template` | [AGENTS.md](https://github.com/devantler-tech/go-template/blob/main/AGENTS.md) |
 | .NET template | `devantler-tech/dotnet-template` | `templates/dotnet-template` | [AGENTS.md](https://github.com/devantler-tech/dotnet-template/blob/main/AGENTS.md) |
 | Platform-tenant template | `devantler-tech/platform-tenant-template` | `templates/platform-tenant-template` | [AGENTS.md](https://github.com/devantler-tech/platform-tenant-template/blob/main/AGENTS.md) |
@@ -46,6 +47,13 @@ keeping them healthy *and* moving them forward.
 > the public board is a maintainer call (see *Every issue belongs on the board*). Determine it live
 > from `gh api repos/devantler-tech/<repo> --jq .private` at the moment you need it, never from this
 > table.
+
+> **Archived repositories are outside the active portfolio.** Determine `.archived` live during
+> discovery and omit archived repositories from every health, PR, issue, and automation census even
+> when stale open artifacts remain. They are read-only historical evidence until the maintainer both
+> unarchives and explicitly restores them to the portfolio; do not infer restoration from an old PR
+> or issue. `devantler-tech/data-product` is archived and must therefore not be considered by future
+> runs.
 
 **World at Ruin — newest product, bootstrapped 2026-07-16** (maintainer direction the same day). A
 cloud-native MMORPG the maintainer wants to exist, built **almost entirely by agents** as a


### PR DESCRIPTION
## Summary

- add devantler-tech/.github to the canonical Portfolio map
- exclude live-archived repositories from health, PR, issue, and automation censuses
- record data-product as archived and out of future active runs
- remove the stale surveyor example that described .github as outside the map

## Verification

- portfolio-surveyor contract: pass
- agent-role delivery contract from a clean clone at the exact reviewed plugin pin: pass
- live repository metadata: .github archived=false; data-product archived=true
- live non-archived census: includes .github; excludes data-product